### PR TITLE
Allow unicode characters as letters

### DIFF
--- a/grammars/common.lark
+++ b/grammars/common.lark
@@ -1,0 +1,51 @@
+//
+// Numbers
+//
+
+DIGIT: "0".."9"
+HEXDIGIT: "a".."f"|"A".."F"|DIGIT
+
+INT: DIGIT+
+SIGNED_INT: ["+"|"-"] INT
+DECIMAL: INT "." INT? | "." INT
+
+// float = /-?\d+(\.\d+)?([eE][+-]?\d+)?/
+_EXP: ("e"|"E") SIGNED_INT
+FLOAT: INT _EXP | DECIMAL _EXP?
+SIGNED_FLOAT: ["+"|"-"] FLOAT
+
+NUMBER: FLOAT | INT
+SIGNED_NUMBER: ["+"|"-"] NUMBER
+
+//
+// Strings
+//
+_STRING_INNER: /.*?/
+_STRING_ESC_INNER: _STRING_INNER /(?<!\\)(\\\\)*?/ 
+
+ESCAPED_STRING : "\"" _STRING_ESC_INNER "\""
+
+
+//
+// Names (Variables)
+//
+LCASE_LETTER: "a".."z"
+UCASE_LETTER: "A".."Z"
+UNICODE: /[u"\u0080-\u10ffff"]/
+
+LETTER: UCASE_LETTER | LCASE_LETTER | UNICODE
+WORD: LETTER+
+
+CNAME: ("_"|LETTER) ("_"|LETTER|DIGIT)*
+
+
+//
+// Whitespace
+//
+WS_INLINE: (" "|/\t/)+
+WS: /[ \t\f\r\n]/+
+
+CR : /\r/
+LF : /\n/
+NEWLINE: (CR? LF)+
+

--- a/grammars/common.lark
+++ b/grammars/common.lark
@@ -1,5 +1,5 @@
 //
-// Numbers
+/// Numbers
 //
 
 DIGIT: "0".."9"

--- a/grammars/level1.txt
+++ b/grammars/level1.txt
@@ -6,10 +6,11 @@ command: "print " text -> print
                |  textwithoutspaces " " text -> invalid
 
 PUNCTUATION : "!" | "?" | "."  //use uppercase to indicate terminals *will* appear in the tree, lowercase will not!
+
 text: (LETTER | DIGIT | PUNCTUATION | WS_INLINE)+
 textwithoutspaces: (LETTER | DIGIT)+ -> text
 
-%import common.LETTER   // imports from terminal library
-%import common.DIGIT   // imports from terminal library
-%import common.WS_INLINE   // imports from terminal library
-%import common.NEWLINE   // imports from terminal library
+%import .grammars.common.LETTER //   imports from terminal library
+%import .grammars.common.DIGIT   // imports from terminal library
+%import .grammars.common.WS_INLINE   // imports from terminal library
+%import .grammars.common.NEWLINE   // imports from terminal library

--- a/grammars/level10.txt
+++ b/grammars/level10.txt
@@ -45,12 +45,12 @@ assignment: NAME "is" expression
 
 _EOL: /(\r?\n[\t ]*)+/
 
-%import common.WS_INLINE
-%import common.SIGNED_INT -> INTEGER
-%import common.FLOAT -> FLOAT
-%import common.CNAME -> NAME
-%import common._STRING_ESC_INNER
-%import common.ESCAPED_STRING -> STRING // TODO: support single quoted strings
+%import .grammars.common.WS_INLINE
+%import .grammars.common.SIGNED_INT -> INTEGER
+%import .grammars.common.FLOAT -> FLOAT
+%import .grammars.common.CNAME -> NAME
+%import .grammars.common._STRING_ESC_INNER
+%import .grammars.common.ESCAPED_STRING -> STRING // TODO: support single quoted strings
 
 %declare INDENT DEDENT
 

--- a/grammars/level11.txt
+++ b/grammars/level11.txt
@@ -45,12 +45,12 @@ assignment: NAME "is" expression
 
 _EOL: /(\r?\n[\t ]*)+/
 
-%import common.WS_INLINE
-%import common.SIGNED_INT -> INTEGER
-%import common.FLOAT -> FLOAT
-%import common.CNAME -> NAME
-%import common._STRING_ESC_INNER
-%import common.ESCAPED_STRING -> STRING // TODO: support single quoted strings
+%import .grammars.common.WS_INLINE
+%import .grammars.common.SIGNED_INT -> INTEGER
+%import .grammars.common.FLOAT -> FLOAT
+%import .grammars.common.CNAME -> NAME
+%import .grammars.common._STRING_ESC_INNER
+%import .grammars.common.ESCAPED_STRING -> STRING // TODO: support single quoted strings
 
 %declare INDENT DEDENT
 

--- a/grammars/level12.txt
+++ b/grammars/level12.txt
@@ -45,12 +45,12 @@ assignment: NAME "is" expression
 
 _EOL: /(\r?\n[\t ]*)+/
 
-%import common.WS_INLINE
-%import common.SIGNED_INT -> INTEGER
-%import common.FLOAT -> FLOAT
-%import common.CNAME -> NAME
-%import common._STRING_ESC_INNER
-%import common.ESCAPED_STRING -> STRING // TODO: support single quoted strings
+%import .grammars.common.WS_INLINE
+%import .grammars.common.SIGNED_INT -> INTEGER
+%import .grammars.common.FLOAT -> FLOAT
+%import .grammars.common.CNAME -> NAME
+%import .grammars.common._STRING_ESC_INNER
+%import .grammars.common.ESCAPED_STRING -> STRING // TODO: support single quoted strings
 
 %declare INDENT DEDENT
 

--- a/grammars/level13.txt
+++ b/grammars/level13.txt
@@ -45,12 +45,12 @@ assignment: NAME "=" expression
 
 _EOL: /(\r?\n[\t ]*)+/
 
-%import common.WS_INLINE
-%import common.SIGNED_INT -> INTEGER
-%import common.FLOAT -> FLOAT
-%import common.CNAME -> NAME
-%import common._STRING_ESC_INNER
-%import common.ESCAPED_STRING -> STRING // TODO: support single quoted strings
+%import .grammars.common.WS_INLINE
+%import .grammars.common.SIGNED_INT -> INTEGER
+%import .grammars.common.FLOAT -> FLOAT
+%import .grammars.common.CNAME -> NAME
+%import .grammars.common._STRING_ESC_INNER
+%import .grammars.common.ESCAPED_STRING -> STRING // TODO: support single quoted strings
 
 %declare INDENT DEDENT
 

--- a/grammars/level2.txt
+++ b/grammars/level2.txt
@@ -15,10 +15,10 @@ textwithspaces: (LETTER | DIGIT | WS_INLINE)+ -> text
 text: (LETTER | DIGIT)+ -> text
 PUNCTUATION: "!" | "?" | "." //uppercase places tokens in tree
 
-%import common.LETTER   // imports from terminal library
-%import common.DIGIT   // imports from terminal library
-%import common.WS_INLINE   // imports from terminal library
-%import common.NEWLINE   // imports from terminal library
+%import .grammars.common.LETTER   // imports from terminal library
+%import .grammars.common.DIGIT   // imports from terminal library
+%import .grammars.common.WS_INLINE   // imports from terminal library
+%import .grammars.common.NEWLINE   // imports from terminal library
 
 
 

--- a/grammars/level3.txt
+++ b/grammars/level3.txt
@@ -18,10 +18,10 @@ QUOTE : "'"
 text: (LETTER | DIGIT)+ -> text
 PUNCTUATION: "!" | "?" | "." //uppercase places tokens in tree
 
-%import common.LETTER   // imports from terminal library
-%import common.DIGIT   // imports from terminal library
-%import common.WS_INLINE   // imports from terminal library
-%import common.NEWLINE   // imports from terminal library
+%import .grammars.common.LETTER   // imports from terminal library
+%import .grammars.common.DIGIT   // imports from terminal library
+%import .grammars.common.WS_INLINE   // imports from terminal library
+%import .grammars.common.NEWLINE   // imports from terminal library
 
 
 

--- a/grammars/level4.txt
+++ b/grammars/level4.txt
@@ -36,12 +36,12 @@ assignment: NAME "is" expression
 
 _EOL: /(\r?\n[\t ]*)+/
 
-%import common.WS_INLINE
-%import common.SIGNED_INT -> INTEGER
-%import common.FLOAT -> FLOAT
-%import common.CNAME -> NAME
-%import common._STRING_ESC_INNER
-%import common.ESCAPED_STRING -> STRING // TODO: support single quoted strings
+%import .grammars.common.WS_INLINE
+%import .grammars.common.SIGNED_INT -> INTEGER
+%import .grammars.common.FLOAT -> FLOAT
+%import .grammars.common.CNAME -> NAME
+%import .grammars.common._STRING_ESC_INNER
+%import .grammars.common.ESCAPED_STRING -> STRING // TODO: support single quoted strings
 
 %declare INDENT DEDENT
 

--- a/grammars/level8.txt
+++ b/grammars/level8.txt
@@ -44,12 +44,12 @@ assignment: NAME "is" expression
 
 _EOL: /(\r?\n[\t ]*)+/
 
-%import common.WS_INLINE
-%import common.SIGNED_INT -> INTEGER
-%import common.FLOAT -> FLOAT
-%import common.CNAME -> NAME
-%import common._STRING_ESC_INNER
-%import common.ESCAPED_STRING -> STRING // TODO: support single quoted strings
+%import .grammars.common.WS_INLINE
+%import .grammars.common.SIGNED_INT -> INTEGER
+%import .grammars.common.FLOAT -> FLOAT
+%import .grammars.common.CNAME -> NAME
+%import .grammars.common._STRING_ESC_INNER
+%import .grammars.common.ESCAPED_STRING -> STRING // TODO: support single quoted strings
 
 %declare INDENT DEDENT
 

--- a/grammars/level9.txt
+++ b/grammars/level9.txt
@@ -45,12 +45,12 @@ assignment: NAME "is" expression
 
 _EOL: /(\r?\n[\t ]*)+/
 
-%import common.WS_INLINE
-%import common.SIGNED_INT -> INTEGER
-%import common.FLOAT -> FLOAT
-%import common.CNAME -> NAME
-%import common._STRING_ESC_INNER
-%import common.ESCAPED_STRING -> STRING // TODO: support single quoted strings
+%import .grammars.common.WS_INLINE
+%import .grammars.common.SIGNED_INT -> INTEGER
+%import .grammars.common.FLOAT -> FLOAT
+%import .grammars.common.CNAME -> NAME
+%import .grammars.common._STRING_ESC_INNER
+%import .grammars.common.ESCAPED_STRING -> STRING // TODO: support single quoted strings
 
 %declare INDENT DEDENT
 

--- a/tests.py
+++ b/tests.py
@@ -54,6 +54,10 @@ echo je lievelingskleur is"""
         result = hedy.transpile("echo Jouw lievelingskleur is dus...", 1)
         self.assertEqual(result, "print('Jouw lievelingskleur is dus...' + answer)")
 
+    def test_transpile_unicode(self):
+        result = hedy.transpile("print Héllo", 1)
+        self.assertEqual(result, "print('Héllo')")
+
 class TestsLevel2(unittest.TestCase):
 
     # some commands should not change:
@@ -71,11 +75,14 @@ class TestsLevel2(unittest.TestCase):
     def test_transpile_ask(self):
         result = hedy.transpile("kleur is ask wat is je lievelingskleur?", 2)
         self.assertEqual(result, "import random\nkleur = input('wat is je lievelingskleur'+'?')")
+    
+    def test_transpile_ask_unicode(self):
+        result = hedy.transpile("é is ask é?", 2)
+        self.assertEqual(result, "import random\né = input('é'+'?')")
 
     def test_transpile_ask_with_print(self):
         result = hedy.transpile("kleur is ask wat is je lievelingskleur?\nprint kleur!", 2)
         self.assertEqual(result, "import random\nkleur = input('wat is je lievelingskleur'+'?')\nprint(kleur+'!')")
-
 
     def test_transpile_print_multiple_lines(self):
         result = hedy.transpile("print Hallo welkom bij Hedy!\nprint Mooi hoor", 2)


### PR DESCRIPTION
I've added a new UNICODE terminal to lark's common terminals which is any character outside of ASCII, and defined it to be an option for the LETTER terminal. This isn't strictly correct (unicode covers many wierd characters!) but allows variable names etc. to contain accents (see #20 ).

I've copied the common terminals file from lark to the 'grammars' directory, and now exclusively import from there - the other option was a mix of importing number-terminals from the old one and string-terminals from the new one and that sounds a terrible idea down the line. It's possible the relative import will break in some circumstances, so worth keeping an eye out for.

I've updated all the grammar files to the new path.