### PR TITLE
Add support for \r\n line endings

### DIFF
--- a/grammars/level1.txt
+++ b/grammars/level1.txt
@@ -1,9 +1,11 @@
 start: program
-program: command (" ")* ("\n"+ command (" ")*)* "\n"* //lines may end on spaces and might be separated by many newlines
+program: command (" ")* (_EOL+ command (" ")*)* _EOL* //lines may end on spaces and might be separated by many newlines
 command: "print " text -> print
                | "ask " text -> ask
                | "echo " text -> echo
                |  textwithoutspaces " " text -> invalid
+
+_EOL: "\r"?"\n"
 
 PUNCTUATION : "!" | "?" | "."  //use uppercase to indicate terminals *will* appear in the tree, lowercase will not!
 text: (LETTER | DIGIT | PUNCTUATION | WS_INLINE | ACCENTED_LETTER)+

--- a/grammars/level2.txt
+++ b/grammars/level2.txt
@@ -1,10 +1,12 @@
 start: program
-program: command (" ")* ("\n"+ command (" ")*)* "\n"* //lines may end on spaces and might be separated by many newlines
+program: command (" ")* (_EOL+ command (" ")*)* _EOL* //lines may end on spaces and might be separated by many newlines
 command: "print " ( list_access | (text punctuation)| text) (" " ( list_access | (text punctuation)| text) )*  -> print
          | text " is ask " textwithspaces punctuation* -> ask
          | text " is " text ((", "|",") text)+  -> assign_list
          | text " is " text -> assign //placing it here means print is will print 'is' and print is Felienne will print 'is Felienne'
          | text " " textwithspaces -> invalid
+
+_EOL: "\r"?"\n"
 
 ACCENTED_LETTER: "á" | "é" | "ó"
 

--- a/grammars/level3.txt
+++ b/grammars/level3.txt
@@ -1,10 +1,12 @@
 start: program
-program: command (" ")* ("\n"+ command (" ")*)* "\n"* //lines may end on spaces and might be separated by many newlines
+program: command (" ")* (_EOL+ command (" ")*)* _EOL* //lines may end on spaces and might be separated by many newlines
 ?command: print
          | ask
          | assign_list
          | assign  //placing it here means print is will print 'is' and print is Felienne will print 'is Felienne'
          | invalid //catch all
+
+_EOL: "\r"?"\n"
 
 print : "print " (quoted_text | list_access | var) (" " (quoted_text | list_access | var))*
 ask : var " is ask " textwithspaces*

--- a/grammars/level4.txt
+++ b/grammars/level4.txt
@@ -1,5 +1,5 @@
 start: program
-program: command (" ")* ("\n"+ command (" ")*)* "\n"* //lines may end on spaces and might be separated by many newlines
+program: command (" ")* (_EOL+ command (" ")*)* _EOL* //lines may end on spaces and might be separated by many newlines
 ?command: print
          | ifelse
          | ifs
@@ -8,6 +8,8 @@ program: command (" ")* ("\n"+ command (" ")*)* "\n"* //lines may end on spaces 
          | list_access_var
          | assign  //placing it here means print is will print 'is' and print is Felienne will print 'is Felienne'
          | invalid
+
+_EOL: "\r"?"\n"
 
 print : "print " (quoted_text | list_access | var) (" " (quoted_text | list_access | var))*
 ask : var " is ask " textwithspaces*

--- a/grammars/level5.txt
+++ b/grammars/level5.txt
@@ -1,5 +1,5 @@
 start: program
-program: command (" ")* ("\n"+ command (" ")*)* "\n"* //lines may end on spaces and might be separated by many newlines
+program: command (" ")* (_EOL+ command (" ")*)* _EOL* //lines may end on spaces and might be separated by many newlines
 ?command: print
          | repeat
          | ifelse
@@ -9,6 +9,8 @@ program: command (" ")* ("\n"+ command (" ")*)* "\n"* //lines may end on spaces 
          | list_access_var
          | assign  //placing it here means print is will print 'is' and print is Felienne will print 'is Felienne'
          | invalid
+
+_EOL: "\r"?"\n"
 
 print : "print " (quoted_text | list_access | var) (" " (quoted_text | list_access | var))*
 ask : var " is ask " textwithspaces*

--- a/grammars/level6.txt
+++ b/grammars/level6.txt
@@ -1,5 +1,5 @@
 start: program
-program: command (" ")* ("\n"+ command (" ")*)* "\n"* //lines may end on spaces and might be separated by many newlines
+program: command (" ")* (_EOL+ command (" ")*)* _EOL* //lines may end on spaces and might be separated by many newlines
 ?command: print
          | repeat
          | ifelse
@@ -9,6 +9,8 @@ program: command (" ")* ("\n"+ command (" ")*)* "\n"* //lines may end on spaces 
          | list_access_var
          | assign  //placing it here means print is will print 'is' and print is Felienne will print 'is Felienne'
          | invalid
+
+_EOL: "\r"?"\n"
 
 print : "print " (quoted_text | list_access | var | sum) (" " (quoted_text | list_access | var | sum))*
 ask : var " is ask " textwithspaces*

--- a/tests.py
+++ b/tests.py
@@ -148,6 +148,9 @@ class TestsLevel2(unittest.TestCase):
 print naam doet mee aan een race hij krijgt een willekeurige auto""",2)
         self.assertEqual("import random\nnaam = input('wat is de naam van de hoofdpersoon')\nprint(naam+' '+'doet'+' '+'mee'+' '+'aan'+' '+'een'+' '+'race'+' '+'hij'+' '+'krijgt'+' '+'een'+' '+'willekeurige'+' '+'auto')",result)
 
+    def test_windows_line_endings(self):
+        result = hedy.transpile("print hallo\r\nprint allemaal", 2)
+        self.assertEqual("import random\nprint('hallo')\nprint('allemaal')", result)
 
 class TestsLevel3(unittest.TestCase):
     def test_transpile_other(self):


### PR DESCRIPTION
Updated the grammars for level 1 - 6 to support `\r\n` as well as `\n`, and included a test for it.

Fixes #53 (or at least part of it)