### PR TITLE
Extend support for if statements; allow in list checks

### DIFF
--- a/grammars/level4.txt
+++ b/grammars/level4.txt
@@ -18,10 +18,12 @@ assign : var " is " textwithspaces
 invalid: /^(?!(print|if|and )).+/ //everything that is not the start of a regular command
 
 // new commands for level 4
-ifelse : "if " equality_check " " command " else " command
-ifs: "if " equality_check " " command //'if' cannot be used in Python, hence the name of the rule is 'ifs'
+ifelse : "if " condition " " command " else " command
+ifs: "if " condition " " command //'if' cannot be used in Python, hence the name of the rule is 'ifs'
+condition: (equality_check|in_list_check) (" and " condition)*
 list_access_var : var " is " var " at " (index | random)
-equality_check: textwithoutspaces " is " textwithoutspaces (" and " equality_check)* -> equality_check
+equality_check: textwithoutspaces " is " textwithoutspaces
+in_list_check: textwithoutspaces " in " var
 
 var: NAME -> var
 list_access : var " at " (index | random) -> list_access //todo: could be merged with list_acces_var?

--- a/grammars/level5.txt
+++ b/grammars/level5.txt
@@ -19,10 +19,12 @@ assign : var " is " textwithspaces
 invalid: /^(?!(repeat|print|if|and )).+/ //everything that is not the start of a regular command
 
 // new commands for level 4
-ifelse : "if " equality_check " " command " else " command
-ifs: "if " equality_check " " command //'if' cannot be used in Python, hence the name of the rule is 'ifs'
+ifelse : "if " condition " " command " else " command
+ifs: "if " condition " " command //'if' cannot be used in Python, hence the name of the rule is 'ifs'
+condition: (equality_check|in_list_check) (" and " condition)*
 list_access_var : var " is " var " at " (index | random)
-equality_check: textwithoutspaces " is " textwithoutspaces (" and " equality_check)* -> equality_check
+equality_check: textwithoutspaces " is " textwithoutspaces
+in_list_check: textwithoutspaces " in " var
 
 //new for level 5
 repeat: "repeat " NUMBER " times " command

--- a/grammars/level6.txt
+++ b/grammars/level6.txt
@@ -22,10 +22,12 @@ assign : var " is " sum
 invalid: /^(?!(repeat|print|if|and )).+/ //everything that is not the start of a regular command
 
 // new commands for level 4
-ifelse : "if " equality_check " " command " else " command
-ifs: "if " equality_check " " command //'if' cannot be used in Python, hence the name of the rule is 'ifs'
+ifelse : "if " condition " " command " else " command
+ifs: "if " condition " " command //'if' cannot be used in Python, hence the name of the rule is 'ifs'
+condition: (equality_check|in_list_check) (" and " condition)*
 list_access_var : var " is " var " at " (index | random)
-equality_check: textwithoutspaces " is " textwithoutspaces (" and " equality_check)* -> equality_check
+equality_check: textwithoutspaces " is " textwithoutspaces
+in_list_check: textwithoutspaces " in " var
 
 //new for level 5
 repeat: "repeat " NUMBER " times " command

--- a/grammars/level7.txt
+++ b/grammars/level7.txt
@@ -7,12 +7,13 @@ command: ifs elses?
          | print _EOL+
          | ask _EOL+
 
-ifs: "if " equality_check _EOL indent command+ dedent
+ifs: "if " condition _EOL indent command+ dedent
 elses: "else" _EOL indent command+ dedent
-equality_check: text " is " text (" and " equality_check)* -> equality_check
+condition: (equality_check|in_list_check) (" and " condition)*
 repeat: "repeat " number " times" _EOL indent command+ dedent
 assign : var " is " expression ((", "|",") expression)*
-
+equality_check: textwithoutspaces " is " textwithoutspaces
+in_list_check: textwithoutspaces " in " var
 
 print: "print " (quoted_text | expression) (" " (quoted_text | expression))*
 ask: var " is ask " textwithspaces -> ask

--- a/hedy.py
+++ b/hedy.py
@@ -136,7 +136,11 @@ class IsValid(Transformer):
         return self.pass_arguments(args)
     def ifelse(self, args):
         return self.pass_arguments(args)
+    def condition(self, args):
+        return self.pass_arguments(args)
     def equality_check(self, args):
+        return self.pass_arguments(args)
+    def in_list_check(self, args):
         return self.pass_arguments(args)
     #level 5 command
     def repeat(self, args):
@@ -259,6 +263,16 @@ class ConvertToPython_4(ConvertToPython_3):
     def ifs(self, args):
         return f"""if {args[0]}:
 {indent(args[1])}"""
+    def ifelse(self, args):
+        return f"""if {args[0]}:
+{indent(args[1])}
+else:
+{indent(args[2])}"""
+    def condition(self, args):
+        if len(args) == 1:
+            return args[0]
+        else:
+            return f"{args[0]} and {args[1]}"
     def equality_check(self, args):
         arg0 = wrap_non_var_in_quotes(args[0], self.lookup)
         arg1 = wrap_non_var_in_quotes(args[1], self.lookup)
@@ -266,11 +280,10 @@ class ConvertToPython_4(ConvertToPython_3):
             return f"{arg0} == {arg1}" #no and statements
         else:
             return f"{arg0} == {arg1} and {args[2]}"
-    def ifelse(self, args):
-        return f"""if {args[0]}:
-{indent(args[1])}
-else:
-{indent(args[2])}"""
+    def in_list_check(self, args):
+        arg0 = wrap_non_var_in_quotes(args[0], self.lookup)
+        arg1 = wrap_non_var_in_quotes(args[1], self.lookup)
+        return f"{arg0} in {arg1}"
 
 class ConvertToPython_5(ConvertToPython_4):
     def number(self, args):

--- a/hedy.py
+++ b/hedy.py
@@ -269,17 +269,11 @@ class ConvertToPython_4(ConvertToPython_3):
 else:
 {indent(args[2])}"""
     def condition(self, args):
-        if len(args) == 1:
-            return args[0]
-        else:
-            return f"{args[0]} and {args[1]}"
+        return ' and '.join(args)
     def equality_check(self, args):
         arg0 = wrap_non_var_in_quotes(args[0], self.lookup)
         arg1 = wrap_non_var_in_quotes(args[1], self.lookup)
-        if len(args) == 2:
-            return f"{arg0} == {arg1}" #no and statements
-        else:
-            return f"{arg0} == {arg1} and {args[2]}"
+        return f"{arg0} == {arg1}" #no and statements
     def in_list_check(self, args):
         arg0 = wrap_non_var_in_quotes(args[0], self.lookup)
         arg1 = wrap_non_var_in_quotes(args[1], self.lookup)

--- a/tests.py
+++ b/tests.py
@@ -333,6 +333,18 @@ if computerkeuze == jouwkeuze:
         self.assertEqual(expected_result, result)
         self.assertEqual(run_code(result),'gelijkspel!')
 
+    def test_if_in_array(self):
+        actual = hedy.transpile("items is red, green\nselected is red\nif selected in items print 'found!'", 4)
+
+        expected = """import random
+items = ['red', 'green']
+selected = 'red'
+if selected in items:
+  print('found!')"""
+
+        self.assertEqual(expected, actual)
+        self.assertEqual('found!', run_code(actual))
+
 class TestsLevel5(unittest.TestCase):
     #print should still work
     def test_print_with_var(self):


### PR DESCRIPTION
Updated grammars for levels 4 - 7 to accept both `foo is bar` and `foo in bar` as conditions for the if-statement. In the latter case `bar` should be a list, because generating lists in place is not supported.

Also the implementation of `ifelse` has been moved so it is closer to the implementation of `if`.

This fixes #41, at least partly. I have opted not to implement `or`, because supporting both `and` and `or` should imo also require support for parentheses.