### PR TITLE
 fixed small textual typos and mistakes in existing docs

### DIFF
--- a/docs/en-level1.md
+++ b/docs/en-level1.md
@@ -3,7 +3,7 @@
 At Level 1, as an example, you can create a story with a different main character that you enter yourself.
 
 ## Example
-This is my story, on the dots the main character that you choose will be placed later.
+This is my story, the main character that you choose will be placed on the dots later.
 
 * The main character of this story is ...
 * He walks in the forest
@@ -13,14 +13,14 @@ This is my story, on the dots the main character that you choose will be placed 
 
 ## Assignment
 
-Now you can try yourself.
+Now you can try for yourself.
 
 1. Write a story of a few sentences about your main character.
 2. Where the name of your main character should be placed, just put ... (see example)
 3. There may also be sentences in the story that do not contain a main character
 4. Now translate your story into Hedy code, here's how:
 
-Line 1: type "ask what is the main character of your story"
+Line 1: type "ask who is the main character of your story"
 
 For all of the following lines:
 
@@ -39,4 +39,4 @@ For all of the following lines:
 
 ## A simple story
 It is a bit of a pity that you can now only create sentences in which the main character is at the end of the sentence right?
-Then, after practicing this story, proceed to level 2 and then level 3, where you can create more and more complicated programs.
+After you have practiced this story, proceed to level 2 and then level 3, where you can create more and more complicated programs.

--- a/docs/nl-level1.md
+++ b/docs/nl-level1.md
@@ -1,6 +1,6 @@
 # Een verhaal
 
-In Level 1 kun je bijvoorbeeld een verhaal met steeds een andere hoofdpersoon die je zelf invoert.
+In Level 1 kun je bijvoorbeeld een verhaal maken met steeds een andere hoofdpersoon die je zelf invoert.
 
 ## Voorbeeld
 Dit is mijn verhaal, op de puntjes komt straks de hoofdpersoon te staan die jij kiest.
@@ -20,7 +20,7 @@ Nu jij!
 3. Er mogen ook zinnen in het verhaal staan waar geen hoofdpersoon in staat
 4. Vertaal je verhaal nu naar Hedy code, dat doe je zo:
 
-Regel 1: typ: `ask wat is de hoofdpersoon van jouw verhaal`
+Regel 1: typ: `ask wie is de hoofdpersoon van jouw verhaal`
 
 Voor alle volgende regels:
 

--- a/docs/nl-level2.md
+++ b/docs/nl-level2.md
@@ -61,7 +61,7 @@ Voor alle volgende regels:
 Type `print` en dan de regel die je verzonnen hebt
 
 ## Voorbeeld Hedy code
-* `naam is Bert`
+* `naam is Henk`
 * `print naam gaat nu in het bos lopen`
 * `print naam is wel een beetje bang`
 * `print Overal hoort hij gekke geluiden`

--- a/docs/nl-level3.md
+++ b/docs/nl-level3.md
@@ -14,7 +14,7 @@ Nu kan dat wel! Je moet nu aanhalingstekens om de tekst zetten die je letterlijk
 In Level 3 kunnen we ook weer steen schaar papier programmeren. Maar als je er tekst bij wilt, moet je ook hier nu aanhalingstekens gebruiken.
 
 * `keuzes is steen, schaar, papier`
-* `print 'de winnaar is' keuzes at random`
+* `print 'de winnaar is ' keuzes at random`
 
 Herinnering: random (je zegt ren-dom) is het Engelse woord voor willekeurig.
 
@@ -33,10 +33,10 @@ Ook je afwasprogramma kun je nu mooier maken met aanhalingstekens.
 Dat doe je zo:
 
 * `mensen is mama, papa, Emma, Sophie`
-* `print 'de afwas wordt gedaan door' mensen at random`
+* `print 'de afwas wordt gedaan door ' mensen at random`
 
 # Een beter verhaal
-Wat je ook kunt doet is je verhaal weer een stukje beter maken, want nu mag je ook gewoon het woord `naam` gebruiken in de tekst.
+Wat je ook kunt doen is je verhaal weer een stukje beter maken, want nu mag je ook gewoon het woord `naam` gebruiken in de tekst.
 
 ##Voorbeeld
 Dit is mijn verhaal, nu komt de hoofdpersoon die jij kiest steeds op de plek van naam te staan. Let goed op dat je alle zinnen tussen aanhalingstekens zet, behalve naam!

--- a/docs/nl-level4.md
+++ b/docs/nl-level4.md
@@ -31,7 +31,7 @@ Je kunt ook in Level 4 weer een dobbelsteen maken en daarbij een if gebruiken. B
 * `keuzes is 1, 2, 3, 4, 5, regenworm`
 * `worp is keuzes at random`
 * `print 'je hebt ' worp ' gegooid'`
-* `if worp is regenworm print 'Je mag stoppen met gooien.' else print 'Je moet nog een keer hoor!`
+* `if worp is regenworm print 'Je mag stoppen met gooien.' else print 'Je moet nog een keer hoor!'`
 
 Maar misschien wil jij wel een dobbelsteen uit een heel ander spel namaken.
 

--- a/docs/nl-level6.md
+++ b/docs/nl-level6.md
@@ -7,7 +7,7 @@ Hier vind je weer een aantal opdrachten om mee aan de slag te gaan.
 
 # Meer regenwormen!
 Je kunt ook in Level 6 weer een regenwormendobbelsteen maken, maar nu kun je ook uitrekenen hoeveel punten er gegooid zijn.
-Je weet misschien dat de worm bij regenworm telt voor 5 punten. Nu kun je een worp gooien, en dan meteen uitrekenen hoeveel punten je dan hebt gegooid.
+Je weet misschien dat de worm bij Regenwormen telt voor 5 punten. Nu kun je een worp gooien, en dan meteen uitrekenen hoeveel punten je dan hebt gegooid.
 Zo doe je dat voor 1 dobbelsteen:
 
 1 `keuzes is 1, 2, 3, 4, 5, regenworm`


### PR DESCRIPTION
Some small Dutch and English language fixes, some apostrophes fixed, etc. 
For example in docs/en-level1.md: '...right? Then, after practicing...': using the word then here is a bit Dunglish. Or if you want to keep the sentence structure, perhaps use 'if so' ?
And in docs/nl-level2.md: Henk is used in all examples except Bert here, so it seems more consistent to work with Henk in this example as well.

// (this is my first ever contribution to open source so if I'm doing any of that wrong, with the fork and pull request etc, please let me know!)