### PR TITLE
Use POST /parse instead of GET /parse to submit programs.

### DIFF
--- a/app.py
+++ b/app.py
@@ -72,12 +72,22 @@ if not os.getenv('HEROKU_RELEASE_CREATED_AT'):
     logging.warning('Cannot determine release; enable Dyno metadata by running "heroku labs:enable runtime-dyno-metadata -a <APP_NAME>"')
 
 
-@app.route('/parse/', methods=['GET'])
+@app.route('/parse', methods=['POST'])
 def parse():
-    # Retrieve the name from url parameter
-    code = request.args.get("code", None)
-    level = int(request.args.get("level", None))
-    email = request.args.get("email", None)
+    body = request.json
+    if not body:
+        return "body must be an object", 400
+    if 'code' not in body:
+        return "body.code must be a string", 400
+    if 'level' not in body:
+        return "body.level must be a string", 400
+
+    code = body ['code']
+    level = int(body ['level'])
+    if 'email' in body:
+       email = body ['email']
+    else:
+       email = None
 
     # For debugging
     print(f"got code {code}")

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -62,11 +62,17 @@ function runit(level, lang, cb) {
 
     console.log('Original program:\n', code);
 
-    $.getJSON('/parse/', {
-      level: level,
-      code: code,
-      lang: lang,
-      email: window.State.email || undefined
+    $.ajax({
+      type: 'POST',
+      url: '/parse',
+      data: JSON.stringify({
+        level: level,
+        code: code,
+        lang: lang,
+        email: window.State.email || undefined
+      }),
+      contentType: 'application/json',
+      dataType: 'json'
     }).done(function(response) {
       console.log('Response', response);
       if (response.Warning) {


### PR DESCRIPTION
Currently we use a GET request to submit a program from the client to the server for parsing (`GET /parse`). GET requests are recommended to not exceed 2048 characters, because of limited support for long URLs on some browsers (such as IE11).

By switching to POST, we can sidestep this problem. It is also somewhat more RESTful to use POST rather than GET for this type of operation, since we're in effect submitting data.

This SO answer has further info on this subject: https://stackoverflow.com/questions/417142/what-is-the-maximum-length-of-a-url-in-different-browsers