### PR TITLE
fix: remove indentation on 'body' block

### DIFF
--- a/coursedata/level-defaults/en.yaml
+++ b/coursedata/level-defaults/en.yaml
@@ -1,138 +1,138 @@
 ---
-  1: 
+  1:
     intro_text: "In Level 1 you can use these commands"
     start_code: "print hello world!"
-    commands: 
-      - 
+    commands:
+      -
         name: "print"
         explanation: "Print something with print."
         example: "Example: print Hello welcome to Hedy!"
         demo_code: "print Hello welcome to Hedy!"
-      - 
+      -
         name: "ask"
         explanation: "Ask something with ask."
         example: "Example: ask What is your favorite color?"
         demo_code: "ask What is your favorite color?"
-      - 
+      -
         name: "echo"
         explanation: "Repeat something using echo."
         example: "Example: echo so your favorite color is..."
         demo_code: "ask What is your favorite color?\necho so your favorite color is..."
-  2: 
+  2:
     intro_text: "Print still works as it did in Level 1, but ask has been changed and now needs a name, which you can then print. Echo is no longer needed. You can now also use these commands:"
     start_code: "print hello world!"
-    commands: 
-      - 
+    commands:
+      -
         name: "is"
         explanation: "Give a word a name to use in the program"
         example: "Example: name is Hedy."
         demo_code: "name is Hedy\nprint welcome name"
-      - 
+      -
         name: "ask"
         explanation: "Ask something with ask. Beware! Ask needs a name now."
         example: "Example: color is ask What is your favorite color?"
         demo_code: "color is ask What is your favorite color?\nprint color is your favorite!"
-      - 
+      -
         name: "choose_random"
         explanation: "Choose a random word from a group with at and random"
         example: "Example: animals is dog, cat, kangaroo."
         demo_code: "animals is dog, cat, kangaroo\nprint animals at random"
-  3: 
+  3:
     start_code: "print 'Hello world'"
     intro_text: "In level 3, you need to use quotation marks around words that you want to print. Echo is no longer needed, you can now print the words with print!"
-    commands: 
-      - 
+    commands:
+      -
         name: "print"
         explanation: "Print exactly using quotation marks"
         example: "Example: print 'Hello welcome to Hedy.'"
         demo_code: "print 'Hello welcome to Hedy.'"
-      - 
+      -
         name: "is"
         explanation: "Give a name to some text and print without quotation marks"
         example: "Example: name is Hedy."
         demo_code: "name is Hedy\nprint 'my name is ' name"
-      - 
+      -
         name: "ask"
         explanation: "Ask something with ask. Beware! Print now needs quotations marks."
         example: "Example: color is ask What is your favorite color?"
         demo_code: "color is ask What is your favorite color?\nprint color ' is your favorite!'"
-  4: 
+  4:
     start_code: "name is ask what is your name?\nif name is Hedy print 'cool!' else print 'meh'"
     intro_text: "ask and print work exactly like they did in Level 3. Level 4 adds the if statement!"
-    commands: 
-      - 
+    commands:
+      -
         name: "print"
         explanation: "Print exactly using quotation marks"
         example: "Example: print 'Hello welcome to Hedy.'"
         demo_code: "print 'Hello welcome to Hedy.'"
-      - 
+      -
         name: "ask"
         explanation: "Ask something with ask. Beware! Print now needs quotations marks."
         example: "Example: color is ask What is your favorite color?"
         demo_code: "color is ask What is your favorite color?\nprint color ' is your favorite!'"
-      - 
+      -
         name: "if"
         explanation: "Make a choice"
         example: "Example: if color is green print 'pretty!' else print 'meh'"
         demo_code: "color is ask What is your favorite color?\nif color is green print 'pretty!' else print 'meh'"
-  5: 
+  5:
     start_code: "repeat 3 times print 'Hedy is fun!'"
     intro_text: "ask, print and if work exactly like they did in Level 4. But Level 5 adds the repeat command. Repeat can be used to execute a line of code multiple times."
-    commands: 
-      - 
+    commands:
+      -
         name: "print"
         explanation: "Print exactly using quotation marks"
         example: "Example: print 'Hello welcome to Hedy.'"
         demo_code: "print 'Hello welcome to Hedy.'"
-      - 
+      -
         name: "ask"
         explanation: "Ask something with ask. Beware! Print now needs quotations marks."
         example: "Example: color is ask What is your favorite color?"
         demo_code: "color is ask What is your favorite color?\nprint color ' is your favorite!'"
-      - 
+      -
         name: "if"
         explanation: "Make a choice"
         example: "Example: if color is green print 'pretty!' else print 'meh'"
         demo_code: "color is ask What is your favorite color?\nif color is green print 'pretty!' else print 'meh'"
-      - 
+      -
         name: "repeat"
         explanation: "Repeat and if combined"
         example: "Example: if color is green repeat 3 times print 'pretty!' else repeat 5 times print 'meh'"
         demo_code: "color is ask What is your favorite color?\nif color is green repeat 3 times print 'pretty!' else repeat 5 times print 'meh'"
-  6: 
+  6:
     start_code: "print '5 times 5 is ' 5 * 5"
     intro_text: "ask, print, if and repeat are still the same as in Level 4 and 5. Level 6 adds something new... You can now calculate. "
-    commands: 
-      - 
+    commands:
+      -
         name: "print"
         explanation: "Print exactly using quotation marks"
         example: "Example: print '5 times 5 is ' 5 * 5"
         demo_code: "print '5 times 5 is ' 5 * 5"
-      - 
+      -
         name: "ask and if with calculations"
         explanation: "Ask for a calculation and compare with if. Beware: Print still needs quotation marks."
         example: "Example: answer is ask What is 10 plus 10?"
         demo_code: "answer is ask What is 10 plus 10?\nif answer is 20 print 'Yes!' else print 'Oops'"
-      - 
+      -
         name: "repeat"
         explanation: "Repeat and if combined"
         example: "Example: if color is green repeat 3 times print 'pretty!' else repeat 5 times print 'meh'"
         demo_code: "color is ask What is your favorite color?\nif color is green repeat 3 times print 'pretty!' else repeat 5 times print 'meh'"
-  7: 
+  7:
     start_code: "repeat 5 times\n    print 'Hello folks'\n    print 'This will be printed 5 times'"
     intro_text: "ask and print still work as you know them. But if and repeat have changed! You can now execute groups of code together, but you will have to indent the code. That means putting four spaces at the beginning of the line. This also holds when you just want to create a block of one line. If you combine a repeat and an if, you will need to indent each block. Have a look at the example code for more details!"
-    commands: 
-      - 
+    commands:
+      -
         name: "print"
         explanation: "Print something. Remember to use a quotation mark for literal printing."
         example: "Example: print '5 times 5 is ' 5 * 5"
         demo_code: "print '5 times 5 is ' 5 * 5"
-      - 
+      -
         name: "if with multiple lines"
         explanation: "Ask for the answer to a sum and check if it is correct. We can now print 2 lines."
         example: "Example: answer is ask What is 5 plus 5?"
         demo_code: "answer is ask What is 5 plus 5?\nif answer is 10\nprint 'Well done!'\nprint 'Indeed, the answer was ' answer\nelse\nprint 'Oops!'\nprint 'The answer is ' answer"
-      - 
+      -
         name: "if and repeat combined"
         explanation: "if and repeat combined"
         example: "Example: if color is green repeat 3 times print 'pretty!' else repeat 5 times print 'meh'"

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -14,7 +14,8 @@
       {% filter indent(width=6) %}{% include "incl-menubar.html" %}{% endfilter %}
       {% endif %}
       <div class="px-8 py-12">
-        {% filter indent(width=8) %}{% block body %}{% endblock %}{% endfilter %}
+        {# Can't reindent this as it may contain preformatted code blocks whose indentation is important. #}
+        {% block body %}{% endblock %}
       </div>
     </div>
     {% filter indent(width=2) %}{% block scripts %}{% endblock %}{% endfilter %}


### PR DESCRIPTION
The 'body' contains preformatted code blocks, rendered like so:

```
   <div>{{start_code}}</div>
```

If `start_code` contains newlines (let's say it's
`"first_line\nsecond_line"`), the template will render as follows:

```
   <div>first_line
second_line</div>
```

Which is fine, but if the `indent` filter is used to reindent this
block, the final HTML changes to:

```
   <div>first_line
     second_line</div>
```

Which means the editor will see the following code:

```
first_line
      second_line
```

First of all this looks ugly, but in a whitespace-sensitive language
this is even a syntax error.

It is therefore not safe to reindent generated HTML code willy-nilly.

If you want to pretty-print HTML, you should use JavaScript to inject
the startup code into the editor (as the pretty-printer will not touch
a string embedded in JavaScript).