### PR TITLE
Add Mailchimp API call to add emails to subscriber list.

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -9,6 +9,8 @@ from functools import wraps
 from config import config
 import boto3
 from botocore.exceptions import ClientError as email_error
+import json
+import requests
 
 cookie_name     = config ['session'] ['cookie_name']
 session_length  = config ['session'] ['session_length'] * 60
@@ -145,7 +147,26 @@ def routes (app, requested_lang):
         email = body ['email'].strip ().lower ()
 
         if env and 'subscribe' in body and body ['subscribe'] == True:
-            send_email (config ['email'] ['sender'], 'Subscription to Hedy newsletter on signup', email, '<p>' + email + '</p>')
+            # If we have a Mailchimp API key, we use it to add the subscriber through the API
+            if os.getenv ('MAILCHIMP_API_KEY') and os.getenv ('MAILCHIMP_AUDIENCE_ID'):
+                # The first domain in the path is the server name, which is contained in the Mailchimp API key
+                request_path = 'https://' + os.getenv ('MAILCHIMP_API_KEY').split ('-') [1] + '.api.mailchimp.com/3.0/lists/' + os.getenv ('MAILCHIMP_AUDIENCE_ID') + '/members'
+                request_headers = {'Content-Type': 'application/json', 'Authorization': 'apikey ' + os.getenv ('MAILCHIMP_API_KEY')}
+                request_body = {'email_address': email, 'status': 'subscribed'}
+                r = requests.post (request_path, headers=request_headers, data=json.dumps (request_body))
+
+                subscription_error = None
+                if r.status_code != 200 and r.status_code != 400:
+                   subscription_error = True
+                # We can get a 400 if the email is already subscribed to the list. We should ignore this error.
+                if r.status_code == 400 and not re.match ('.*already a list member', r.text):
+                   subscription_error = True
+                # If there's an error in subscription through the API, we report it to the main email address
+                if subscription_error:
+                    send_email (config ['email'] ['sender'], 'ERROR - Subscription to Hedy newsletter on signup', email, '<p>' + email + '</p><pre>Status:' + str (r.status_code) + '    Body:' + r.text + '</pre>')
+            # Otherwise, we send an email to notify about this to the main email address
+            else:
+                send_email (config ['email'] ['sender'], 'Subscription to Hedy newsletter on signup', email, '<p>' + email + '</p>')
 
         user = {
             'username': username,

--- a/tests_e2e.py
+++ b/tests_e2e.py
@@ -35,7 +35,7 @@ def request(test, counter):
     if type_check (test[4], 'dict'):
         test[3] ['content-type'] = 'application/json'
         test[4] = json.dumps (test [4])
-    r = getattr (requests, test [1])(host + test [2], headers=test[3], data=test[4])
+    r = getattr (requests, test [1]) (host + test [2], headers=test[3], data=test[4])
 
     if 'Content-Type' in r.headers and r.headers ['Content-Type'] == 'application/json':
         body = r.json ()


### PR DESCRIPTION
- Closes #138
- How to add API key: https://us7.admin.mailchimp.com/account/api/
- Specific API call: https://mailchimp.com/developer/marketing/api/list-members/add-member-to-list/