### PR TITLE
fix: `parse` always uses browser language (instead of selected language)

### DIFF
--- a/app.py
+++ b/app.py
@@ -96,6 +96,10 @@ def parse():
 
     code = body ['code']
     level = int(body ['level'])
+    # Language should come principally from the request body,
+    # but we'll fall back to browser default if it's missing for whatever
+    # reason.
+    lang = body.get('lang', requested_lang())
 
     # For debugging
     print(f"got code {code}")
@@ -109,7 +113,7 @@ def parse():
     # is so, parse
     else:
         try:
-            hedy_errors = TRANSLATIONS.get_translations(requested_lang(), 'HedyErrorMessages')
+            hedy_errors = TRANSLATIONS.get_translations(lang, 'HedyErrorMessages')
             result = hedy.transpile(code, level)
             response["Code"] = "# coding=utf8\n" + result
         except hedy.HedyException as E:
@@ -130,7 +134,7 @@ def parse():
         'session': session_id(),
         'date': str(datetime.datetime.now()),
         'level': level,
-        'lang': requested_lang(),
+        'lang': lang,
         'code': code,
         'server_error': response.get('Error'),
         'version': version(),

--- a/coursedata/texts/fr.yaml
+++ b/coursedata/texts/fr.yaml
@@ -18,7 +18,7 @@ ui:
   assignment_header: "Exercice"
 ClientErrorMessages:
   Transpile_warning: "Attention!"
-  Transpile_error: "Le serveur n’a pas pu traduire ce code Heyd en Python."
+  Transpile_error: "Le serveur n’a pas pu traduire ce code Hedy en Python."
   Connection_error: "Nous n’avons pas réussi à contacter le serveur."
   Other_error: "Oups! Nous avons rencontré une erreur."
   Execute_error: "Quelque chose s’est mal passé en exécutant ce programme."


### PR DESCRIPTION
The `/parse` endpoint code used `requested_lang()`, which looks at the
query string in the URL (or the browser language) to determine the
language.

Instead, `/parse` is POSTed to and the language is in the POST body of
that request. It should be read from there.

Fixes #179.