### PR TITLE
Set English lang query parameter when going to the Hedy editor

### DIFF
--- a/main/start-en.md
+++ b/main/start-en.md
@@ -6,7 +6,7 @@ page_title: Welcome to Hedy!
     <h2 class="font-sans font-light text-white text-shadow-md tracking-wide my-1">A gradual programming language</h2>
   </div>
   <div class="flex-none">
-    <a class="green-btn text-white px-8 py-4" href="/hedy">Try it</a>
+    <a class="green-btn text-white px-8 py-4" href="/hedy?lang=en">Try it</a>
   </div>
 </div>
 


### PR DESCRIPTION
- Set English lang query parameter: useful for when browser has a non-English supported language as default and user changes the language to English.
- Closes #206 