### PR TITLE
Revert "Block Hedy from running in Python < 3.6; update CONTRIBUTING.md"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Contributing to Hedy
 Help Hedy with translations
 ------------
 
-Hedy is now available in Dutch, French, English, Brazilian Portugese and Spanish, but we'd love to support more languages!
+Hedy is now available in Dutch, French, English, Brazilian Portugese and Spanish, but we'd love to support more languages! 
 
 If you would like to add a new translation, there a three places where files that need to be translated:
 
@@ -15,7 +15,7 @@ If you would like to add a new translation, there a three places where files tha
 
 3) The folder [main](https://github.com/Felienne/hedy/tree/master/main) controls the web pages around Hedy. [start](https://github.com/Felienne/hedy/blob/master/main/start-en.md) holds the content of the start page, and there is a page with press, and with contact info too. If you want to, you can skip those pages (people will then see the English version)
 
-Translated all of that?
+Translated all of that? 
 
 Two more small things to do!
 
@@ -37,7 +37,7 @@ In some places, we are missing translations to the existing language. You can fi
 Run Hedy code on your machine
 ------------
 
-If you are going to contribute to the code of Hedy, you will probably want to run the code on your own computer. For this you need to install Python 3.6 or higher. Then, here's how to get started once you have downloaded or cloned the code:
+If you are going to contribute to the code of Hedy, you will probably want to run the code on your own computer. For this you need to install Python 3. Then, here's how to get started once you have downloaded or cloned the code:
 
 ```bash
 $ python3 -m venv .env
@@ -72,7 +72,7 @@ Pre-release environment
 When you push to `master` or have your PR accepted, that version will be deployed on
 [hedy-beta.herokuapp.com](https://hedy-beta.herokuapp.com).
 
-If you want to try experimental versions live, you can use the `development` branch, which will be deployed to [hedy-alpha.herokuapp.com](https://hedy-alpha.herokuapp.com).
+If you want to try experimental versions live, you can use the `development` branch, which will be deployed to [hedy-alpha.herokuapp.com](https://hedy-alpha.herokuapp.com). 
 This branch should be treated as read-only, and is forcibly overwritten to test feature branches locally on the alpha environment.
 
 To push the current commit to the Alpha environment on Heroku:

--- a/app.py
+++ b/app.py
@@ -1,8 +1,3 @@
-import sys
-if (sys.version_info.major < 4 or sys.version_info.minor < 6):
-    print ('Hedy requires Python 3.6 or newer to run. However, your version of Python is', '.'.join ([str (sys.version_info.major), str (sys.version_info.minor), str (sys.version_info.micro)]))
-    quit ()
-
 # coding=utf-8
 import datetime
 import collections


### PR DESCRIPTION
Reverts Felienne/hedy#213

It seems to break on Heroku (not 100% sure this was the cause but rolling it back fixed it) It could also be generic "lots of traffic" because in addition to rolling back, I also upgraded our Heroku account.

Locally it worked for me, so we need to dive into what the issue is.