### PR TITLE
Python 3 is required, not 4!

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,5 @@
 import sys
-if (sys.version_info.major < 4 or sys.version_info.minor < 6):
+if (sys.version_info.major < 3 or sys.version_info.minor < 6):
     print ('Hedy requires Python 3.6 or newer to run. However, your version of Python is', '.'.join ([str (sys.version_info.major), str (sys.version_info.minor), str (sys.version_info.micro)]))
     quit ()
 


### PR DESCRIPTION
Fixes PR #213 . Forgot to change the condition after testing locally the error message yielded by requiring Python 4.