### PR TITLE
chore: deploy to 'alpha' only if the unit test workflow succeeds

### DIFF
--- a/.github/workflows/deploy-to-alpha.yml
+++ b/.github/workflows/deploy-to-alpha.yml
@@ -1,9 +1,16 @@
 name: Automatically deploy to Alpha
 on:
-  push:
+  # Run this AFTER the unit test job finishes
+  workflow_run:
+    # Must be the same as in unittests.yml
+    workflows: ["Unit tests"]
     branches: [master]
+    types:
+      - completed
 jobs:
   deploy:
+    # Deploy ONLY IF the tests actually succeeded (if they failed, we don't wanna deploy)
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -1,7 +1,8 @@
 # This workflow will install Python dependencies, run tests and lint with a single version of Python
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: Python application
+# If you change this name, don't forget to change deploy-to-alpha.yml
+name: Unit tests
 
 on:
   push:


### PR DESCRIPTION
Right now, the "unit test" workflow and the "deploy to alpha" workflow
run in parallel.

This means that the code will get deployed to alpha, even if it doesn't
pass the tests, which is kinda dangerous (on the other hand, it's
alpha so we might not care).

This change links the two workflows together, so that "deploy to alpha"
only runs if the unit tests on master ran successfully.

Feel free to take or close this if you don't care about this!

Two additional notes:

* The tests also run on the PR build, but that's pre-merge and it's not
  necessarily guaranteed that the tests will pass after the merge.
* This has no impact on the "deploy to prod" workflow; it's still
  very well possible to deploy a `master` to production that doesn't
  pass tests. We need to write the workflows slightly differently if
  we also want to protect against that.

Let me know what you'd prefer.