### PR TITLE
Use single secret from environment variable for multiple workers

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -44,6 +44,12 @@ PROXY_TO_TEST_ENV
 IS_TEST_ENV
 ```
 
+App secret (for cookies):
+
+```
+SECRET_KEY
+```
+
 ## Heroku Metadata
 
 This app depends on some environment variables that require Heroku dyno metadata.

--- a/app.py
+++ b/app.py
@@ -133,8 +133,9 @@ if os.getenv ('REDIRECT_HTTP_TO_HTTPS'):
             # We use a 302 in case we need to revert the redirect.
             return redirect(url, code=302)
 
-# Unique random key for sessions
-app.config['SECRET_KEY'] = uuid.uuid4().hex
+# Unique random key for sessions.
+# For settings with multiple workers, an environment variable is required, otherwise cookies will be constantly removed and re-set by different workers.
+app.config['SECRET_KEY'] = os.getenv ('SECRET_KEY') or uuid.uuid4().hex
 
 Compress(app)
 Commonmark(app)


### PR DESCRIPTION
While testing the A/B testing logic, I noticed that sessions in alpha were constantly regenerated - this rendered session_ids useless for tracking purposes, and also performed inconsistent proxying (some requests were proxied to test, other were not).

After extensive debugging, I figured out that this is not because of the A/B testing logic, and that it also happens in prod (beta).

The reason is that currently we have multiple workers in both alpha and beta, but each sets its own `SECRET_KEY`, so the workers don't recognize each other session cookies. So they're constantly re-setting those cookies and the session_id changes constantly. User requests are sent to multiple workers, so this happens all the time.

This PR uses a single secret from the env (if available) as the `SECRET_KEY` so that multiple workers can recognize each others' sessions.

The key to figuring this out was that I *couldn't* reproduce it locally, so the key was to relate this to a deployment, and from there, to multiple workers.

Edit: I just realized that this will also allow session cookies to still remain valid after a server restart.