### PR TITLE
feat: add a page showing version and unreleased changes

### DIFF
--- a/app.py
+++ b/app.py
@@ -229,6 +229,27 @@ def report_error():
 
     return 'logged'
 
+@app.route('/version', methods=['GET'])
+def version_page():
+    """
+    Generate a page with some diagnostic information and a useful GitHub URL on upcoming changes.
+
+    This is an admin-only page, it does not need to be linked.
+    (Also does not have any sensitive information so it's fine to be unauthenticated).
+    """
+    app_name = os.getenv('HEROKU_APP_NAME')
+
+    vrz = os.getenv('HEROKU_RELEASE_CREATED_AT')
+    the_date = datetime.date.fromisoformat(vrz[:10]) if vrz else datetime.date.today()
+
+    commit = os.getenv('HEROKU_SLUG_COMMIT', '????')[0:6]
+
+    return render_template('version-page.html',
+        app_name=app_name,
+        heroku_release_time=the_date,
+        commit=commit)
+
+
 def programs_page (request):
     username = current_user(request) ['username']
     if not username:

--- a/templates/version-page.html
+++ b/templates/version-page.html
@@ -1,0 +1,27 @@
+<html>
+  <head>
+    <title>Hedy version info</title>
+  </head>
+  <body>
+    <h1>Hedy version info</h1>
+
+    <table>
+      <tr>
+        <th>Current App</th>
+        <td>{{app_name}}</td>
+      </tr>
+      <tr>
+        <th>Deployed At</th>
+        <td>{{heroku_release_time}}</td>
+      </tr>
+      <tr>
+        <th>Deployed Commit</th>
+        <td>{{commit}}</td>
+      </tr>
+      <tr>
+        <th>Undeployed Changes</th>
+        <td><a href="https://github.com/Felienne/hedy/compare/{{commit}}...master">GitHub</a></td>
+      </tr>
+    </table>
+  </body>
+</html>


### PR DESCRIPTION
Generates a GitHub link which shows the changes that are on
`master` that haven't been deployed to the current page yet.