### PR TITLE
feat: palette buttons append code instead of replacing

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -128,6 +128,25 @@ function runit(level, lang, cb) {
   }
 }
 
+/**
+ * Called when the user clicks the "Try" button in one of the palette buttons
+ */
+function tryPaletteCode(exampleCode) {
+  var editor = ace.edit("editor");
+  var currentUnsaved = window.State.unsaved_changes;
+  var currentCode = editor.getValue();
+
+  if (!currentCode.endsWith('\n')) { currentCode += '\n'; }
+  currentCode += exampleCode;
+  if (!currentCode.endsWith('\n')) { currentCode += '\n'; }
+
+  var MOVE_CURSOR_TO_END = 1;
+  editor.setValue(currentCode, MOVE_CURSOR_TO_END);
+
+  // Even though the content changed, we leave 'unsaved_changes' the same as it was before
+  window.State.unsaved_changes = currentUnsaved;
+}
+
 window.saveit = function saveit(level, lang, name, code, cb) {
   error.hide();
 

--- a/templates/code-page.html
+++ b/templates/code-page.html
@@ -14,7 +14,7 @@
           {{ command.example|commonmark }}
         </div>
         <button class="btn block flex-none self-end"
-          onclick='function show_demo(){ var editor = ace.edit("editor"); editor.setValue({{ command.demo_code|tojson }})};show_demo(); window.State.unsaved_changes = false;'>{{try_button}}</button>
+          onclick='tryPaletteCode({{command.demo_code|tojson}});'>{{try_button}}</button>
       </div>
     </div>
     {% endfor %}


### PR DESCRIPTION
Right now, clicking a palette button complete replaces whatever
code is in the editor, destroying whatever they might have typed
already and losing their work.

This change will **append** the example code to whatever is in the code
editor, so the user can get the benefit of trying out the code without
destroying what they already have.  Probably goes well together with
PR #315, which really turns the palette into a palette of options to mix
and match.

I can also see a downside: this feature makes it possible to finish
exercises by clicking the right button+lightly editing the example.
Kids might use this to skip having to type out the entire syntax of
the command, thereby not getting the full learning experience.