### PR TITLE
Require utf-8 everywhere for reading files

### DIFF
--- a/app.py
+++ b/app.py
@@ -61,7 +61,7 @@ ONLINE_MASTERS_COURSE = courses.Course('online_masters', 'nl', LEVEL_DEFAULTS['n
 TRANSLATIONS = hedyweb.Translations()
 
 # Load main menu (do it once, can be cached)
-with open(f'main/menu.json', 'r') as f:
+with open(f'main/menu.json', 'r', encoding='utf-8') as f:
     main_menu_json = json.load(f)
 
 
@@ -399,7 +399,7 @@ def main_page(page):
         effective_lang = 'en'
 
     try:
-        with open(f'main/{page}-{effective_lang}.md', 'r') as f:
+        with open(f'main/{page}-{effective_lang}.md', 'r', encoding='utf-8') as f:
             contents = f.read()
     except IOError:
         abort(404)

--- a/courses.py
+++ b/courses.py
@@ -134,7 +134,7 @@ class Doc:
 
 def load_yaml(filename):
   try:
-    with open(filename, 'r') as f:
+    with open(filename, 'r', encoding='utf-8') as f:
       return yaml.safe_load(f)
   except IOError:
     return {}

--- a/docs.py
+++ b/docs.py
@@ -58,7 +58,7 @@ class DocCollection:
 class MarkdownDoc:
   @staticmethod
   def from_file(filename):
-    with open(filename, 'r') as f:
+    with open(filename, 'r', encoding='utf-8') as f:
       contents = f.read()
     parts = re.split('^---+$', contents, maxsplit=1, flags=re.M)
     if len(parts) == 1:

--- a/hedy.py
+++ b/hedy.py
@@ -25,15 +25,15 @@ commands_per_level = {1: ['print', 'ask', 'echo'] ,
                       13: ['print', 'ask', 'is', 'if', 'for', 'elif']
                       }
 
-# 
+#
 #  closest_command() searches for known commands in an invalid command.
 #
 #  It will return the known command which is closest positioned at the beginning.
-#  It will return '' if the invalid command does not contain any known command. 
+#  It will return '' if the invalid command does not contain any known command.
 #
 
 def closest_command(invalid_command, known_commands):
-    
+
     # First search for 100% match of known commands
     min_position = len(invalid_command)
     min_command = ''
@@ -42,7 +42,7 @@ def closest_command(invalid_command, known_commands):
         if position != -1 and position < min_position:
             min_position = position
             min_command = known_command
-            
+
     # If not found, search for partial match of know commands
     if min_command == '':
         min_command = closest_command_with_min_distance(invalid_command, known_commands)
@@ -171,7 +171,7 @@ class AllAssignmentCommands(Transformer):
         return args[0].children
 
 def create_parser(level):
-    with open(f"grammars/level{str(level)}.lark", "r") as file:
+    with open(f"grammars/level{str(level)}.lark", "r", encoding="utf-8") as file:
         grammar = file.read()
     return Lark(grammar)
 
@@ -745,7 +745,7 @@ class ConvertToPython(ConvertTo):
 def create_grammar(level):
     # Load Lark grammars relative to directory of current file
     script_dir = path.abspath(path.dirname(__file__))
-    with open(path.join(script_dir, "grammars", "level" + str(level) + ".lark"), "r") as file:
+    with open(path.join(script_dir, "grammars", "level" + str(level) + ".lark"), "r", encoding="utf-8") as file:
         return file.read()
 
 

--- a/runhedy.py
+++ b/runhedy.py
@@ -9,7 +9,7 @@ def print(uitvoer):
     sys.stdout.write(uitvoer + '\n')
 
 def main():
-    # python3 hedy.py <filename(0)> [levelargument(1)] [level(2)] 
+    # python3 hedy.py <filename(0)> [levelargument(1)] [level(2)]
 
     args = sys.argv[1:]
     args_length = len(args)
@@ -30,9 +30,9 @@ def main():
                         level = 8
                 except ValueError:
                     print("Level argument is not an integer, skipping argument.")
-    
+
     lines = ""
-    with open(filename, 'r') as f:
+    with open(filename, 'r', encoding='utf-8') as f:
         lines = f.readlines()
 
     if level == 0:


### PR DESCRIPTION
Specify utf-8 as the default read encoding for files to avoid problems when Windows defaults to another encoding.

Windows doesn't use utf-8 by default: https://dev.to/methane/python-use-utf-8-mode-on-windows-212i