### PR TITLE
add central security settings for cookies

### DIFF
--- a/app.py
+++ b/app.py
@@ -137,6 +137,14 @@ if os.getenv ('REDIRECT_HTTP_TO_HTTPS'):
 # For settings with multiple workers, an environment variable is required, otherwise cookies will be constantly removed and re-set by different workers.
 app.config['SECRET_KEY'] = os.getenv ('SECRET_KEY') or uuid.uuid4().hex
 
+# Set security attributes for cookies in a central place
+app.config.update(
+    SESSION_COOKIE_SECURE=True,
+    SESSION_COOKIE_HTTPONLY=True,
+    SESSION_COOKIE_SAMESITE='Lax',
+)
+
+
 Compress(app)
 Commonmark(app)
 logger = jsonbin.JsonBinLogger.from_env_vars()

--- a/auth.py
+++ b/auth.py
@@ -100,7 +100,7 @@ def routes (app, requested_lang):
         db_set ('tokens', {'id': cookie, 'username': user ['username'], 'ttl': times () + session_length})
         db_set ('users', {'username': user ['username'], 'last_login': timems ()})
         resp = make_response ({})
-        resp.set_cookie (cookie_name, value=cookie, httponly=True, path='/')
+        resp.set_cookie (cookie_name, value=cookie, path='/')
         return resp
 
     @app.route ('/auth/signup', methods=['POST'])
@@ -202,7 +202,7 @@ def routes (app, requested_lang):
             send_email_template ('welcome_verify', email, requested_lang (), os.getenv ('BASE_URL') + '/auth/verify?username=' + urllib.parse.quote_plus (username) + '&token=' + urllib.parse.quote_plus (hashed_token))
             resp = make_response ({})
 
-        resp.set_cookie (cookie_name, value=cookie, httponly=True, path='/')
+        resp.set_cookie (cookie_name, value=cookie, path='/')
         return resp
 
     @app.route ('/auth/verify', methods=['GET'])


### PR DESCRIPTION
We aren't currenty setting samesite values for cookies, and that would be a good thing to do (https://flask.palletsprojects.com/en/1.1.x/security/).

This commit sets the cookie values for samesite, httponly, and secure in a central place so we don't need to worry about it if we add more cookie values.