### PR TITLE
Do not use security headers on session cookie when running locally

### DIFF
--- a/app.py
+++ b/app.py
@@ -172,13 +172,13 @@ if os.getenv ('REDIRECT_HTTP_TO_HTTPS'):
 # For settings with multiple workers, an environment variable is required, otherwise cookies will be constantly removed and re-set by different workers.
 app.config['SECRET_KEY'] = os.getenv ('SECRET_KEY') or uuid.uuid4().hex
 
-# Set security attributes for cookies in a central place
-app.config.update(
-    SESSION_COOKIE_SECURE=True,
-    SESSION_COOKIE_HTTPONLY=True,
-    SESSION_COOKIE_SAMESITE='Lax',
-)
-
+# Set security attributes for cookies in a central place - but not when running locally, so that session cookies work well without HTTPS
+if not os.getenv ('HEROKU_APP_NAME'):
+    app.config.update(
+        SESSION_COOKIE_SECURE=True,
+        SESSION_COOKIE_HTTPONLY=True,
+        SESSION_COOKIE_SAMESITE='Lax',
+    )
 
 Compress(app)
 Commonmark(app)


### PR DESCRIPTION
Do not use security headers on session cookie when running locally, because it disrupts session variables somehow.

@tibiba this fixes the problem you had yesterday.