### PR TITLE
fix: fix uncaught exception on level 4

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,6 +68,12 @@ If you want to run the website version locally, run:
 (.env)$ python app.py
 ```
 
+To run the unit tests:
+
+```bash
+(.env)$ python -m unittest discover -s tests
+```
+
 To make debugging a lot more convenient, enable **development mode**. If you do this, any HTML templates and Python
 source files you change and save will automatically be reloaded.
 
@@ -80,8 +86,10 @@ you can wrap the command in a loop to restart the server quickly).
 (.env)$ env FLASK_ENV=development python app.py
 # or in a loop if it stops too often
 (.env)$ while true; do env FLASK_ENV=development python app.py; sleep 1; done
+```
 
 If you want to run the website locally, but would prefer to use Docker instead of installing python, you can build a container image and run it like so:
+
 ```bash
 docker build -t hedy .
 ```

--- a/app.py
+++ b/app.py
@@ -15,6 +15,7 @@ import os
 from os import path
 import re
 import requests
+import traceback
 import uuid
 from ruamel import yaml
 from flask_commonmark import Commonmark
@@ -225,6 +226,7 @@ def parse():
             result = hedy.transpile(code, level)
             response["Code"] = "# coding=utf8\nimport random\n" + result
         except hedy.HedyException as E:
+            traceback.print_exc()
             # some 'errors' can be fixed, for these we throw an exception, but also
             # return fixed code, so it can be ran
             if E.args[0] == "Invalid Space":
@@ -244,6 +246,7 @@ def parse():
                 error_template = hedy_errors[E.error_code]
                 response["Error"] = error_template.format(**E.arguments)
         except Exception as E:
+            traceback.print_exc()
             print(f"error transpiling {code}")
             response["Error"] = str(E)
     logger.log ({

--- a/coursedata/adventures/en.yaml
+++ b/coursedata/adventures/en.yaml
@@ -191,7 +191,7 @@ adventures:
 
                     ## Example Hedy code
                     ```
-                    people is mom, dad, Emma, ​​Sophie
+                    people is mom, dad, Emma, Sophie
                     print people at random
                     ```
 
@@ -200,7 +200,7 @@ adventures:
 
                     E.g. `print I chose from these people`. Give it a try if you haven't already.
 
-                    That is not working properly! Then you get: I chose from [daddy, mom, Emma, ​​Sophie]. You can solve that in level 3.
+                    That is not working properly! Then you get: I chose from [daddy, mom, Emma, Sophie]. You can solve that in level 3.
 
                 start_code: "print Who does the dishes?"
             3:
@@ -215,7 +215,7 @@ adventures:
                     Tip: Don't forget the quotation marks!
                     ## Example Hedy code
                     ```
-                    people is mom, dad, Emma, ​​Sophie
+                    people is mom, dad, Emma, Sophie
                     print ... the dishes are done by ...
                     print people at ...
                     ```
@@ -230,7 +230,7 @@ adventures:
 
                     ## Example Hedy code
                     ```
-                    people is mom, dad, Emma, ​​Sophie
+                    people is mom, dad, Emma, Sophie
                     dishwasher is people at random
                     if dishwasher is Sophie print ... too bad I have to do the dishes ... else print 'luckily no dishes because' ... 'is already washing up'
                     ```
@@ -242,7 +242,7 @@ adventures:
 
                     ## Example Hedy code
                     ```
-                    people is mom, dad, Emma, ​​Sophie
+                    people is mom, dad, Emma, Sophie
                     repeat ... ... print 'the dishwasher is' ...
                     ```
                 start_code: "print 'Who does the dishes?'"
@@ -253,7 +253,7 @@ adventures:
 
                     ## Example Hedy code
                     ```
-                    people is mom, dad, Emma, ​​Sophie
+                    people is mom, dad, Emma, Sophie
                     emma_washes is 0
                     dishwasher is people at random
                     print 'The dishwasher is' dishwasher

--- a/hedy.py
+++ b/hedy.py
@@ -35,7 +35,6 @@ commands_per_level = {1: ['print', 'ask', 'echo'] ,
 #
 
 def closest_command(invalid_command, known_commands):
-
     # First search for 100% match of known commands
     min_position = len(invalid_command)
     min_command = ''
@@ -71,6 +70,7 @@ def closest_command_with_min_distance(command, commands):
     return min_command
 
 def minimum_distance(s1, s2):
+    """Return string distance between 2 strings."""
     if len(s1) > len(s2):
         s1, s2 = s2, s1
     distances = range(len(s1) + 1)
@@ -993,21 +993,28 @@ def transpile_inner(input_string, level):
             # this one can't be beautified (for now), so give up :)
             raise e
 
+    # IsValid returns (True,) or (False, args, line)
     is_valid = IsValid().transform(program_root)
-    if not is_valid[0]:
-        if is_valid[1] == ' ':
-            line = is_valid[2]
 
+    if not is_valid[0]:
+        _, args, line = is_valid
+
+        # Apparently, sometimes 'args' is a string, sometimes it's a list of
+        # strings ( are these production rule names?). If it's a list of
+        # strings, just take the first string and proceed.
+        if isinstance(args, list):
+            args = args[0]
+        if args == ' ':
             #the error here is a space at the beginning of a line, we can fix that!
             fixed_code = repair(input_string)
             if fixed_code != input_string: #only if we have made a successful fix
                 result = transpile_inner(fixed_code, level)
             raise HedyException('Invalid Space', level=level, line_number=line, fixed_code = result)
-        elif is_valid[1] == 'print without quotes':
+        elif args == 'print without quotes':
             # grammar rule is ignostic of line number so we can't easily return that here
             raise HedyException('Unquoted Text', level=level)
         else:
-            invalid_command = is_valid[1]
+            invalid_command = args
             closest = closest_command(invalid_command, commands_per_level[level])
             if closest == None: #we couldn't find a suggestion because the command itself was found
                 # clearly the error message here should be better or it should be a different one!


### PR DESCRIPTION
If you run the following code on level 4:

```
people is mom, dad, Emma, Sophie
dishwasher is people at random
if dishwasher is Sophie print ... too bad I have to do the dishes ... else print 'luckily no dishes because' ... 'is already washing up'
```

The following error appears:

> We can't run your program.
>
> 'list' object has no attribute 'find'

This is because the second return value of `IsValid()`,
which is expected to be a string, is all of a sudden
a list of strings. In particular, it's the following list of
strings:

```
['print without quotes', 'print without quotes']
```

This value is passed to `closest_command`, which explodes because
it was expecting a string and not a list, leading to the **list has no
find** error.

Normalize unexpected list back to a string by just taking the first
element.

Also found some accidental nonprintable characters in the YAML, which
I removed.