### PR TITLE
refactor: cache Lark parsers

### DIFF
--- a/app.py
+++ b/app.py
@@ -22,6 +22,7 @@ from werkzeug.urls import url_encode
 from config import config
 from auth import auth_templates, current_user, requires_login, is_admin, is_teacher
 from utils import db_get, db_get_many, db_set, timems, type_check, object_check, db_del, load_yaml, load_yaml_rt, dump_yaml_rt
+import utils
 import hashlib
 
 # app.py
@@ -104,6 +105,7 @@ logging.basicConfig(
 app = Flask(__name__, static_url_path='')
 # Ignore trailing slashes in URLs
 app.url_map.strict_slashes = False
+utils.set_debug_mode_based_on_flask()
 
 
 def hash_user_or_session (string):

--- a/hedy.py
+++ b/hedy.py
@@ -3,6 +3,7 @@ from lark.exceptions import VisitError, LarkError, UnexpectedEOF
 from lark import Tree, Transformer, Visitor
 from os import path
 import sys
+import utils
 
 reserved_words = ['and','except','lambda','with','as','finally','nonlocal','while','assert','false','None','yield','break','for','not','class','from','or','continue','global','pass','def','if','raise','del','import','return','elif','in','True','else','is','try']
 
@@ -182,10 +183,6 @@ class AllAssignmentCommands(Transformer):
     def bigger(self, args):
         return args[0].children
 
-def create_parser(level):
-    with open(f"grammars/level{str(level)}.lark", "r", encoding="utf-8") as file:
-        grammar = file.read()
-    return Lark(grammar)
 
 def are_all_arguments_true(args):
     bool_arguments = [x[0] for x in args]
@@ -849,11 +846,28 @@ class ConvertToPython(ConvertTo):
         args = self._call_children(children)
         return "input("  + " + ".join(args) + ")"
 
+
 def create_grammar(level):
     # Load Lark grammars relative to directory of current file
     script_dir = path.abspath(path.dirname(__file__))
     with open(path.join(script_dir, "grammars", "level" + str(level) + ".lark"), "r", encoding="utf-8") as file:
         return file.read()
+
+
+PARSER_CACHE = {}
+
+
+def get_parser(level):
+    """Return the Lark parser for a given level.
+
+    Uses caching if Hedy is NOT running in development mode.
+    """
+    existing = PARSER_CACHE.get(level)
+    if existing and not utils.is_debug_mode():
+        return existing
+    ret = Lark(create_grammar(level))
+    PARSER_CACHE[level] = ret
+    return ret
 
 
 def transpile(input_string, level):
@@ -971,7 +985,8 @@ def preprocess_blocks(code):
 def transpile_inner(input_string, level):
     punctuation_symbols = ['!', '?', '.']
     level = int(level)
-    parser = Lark(create_grammar(level))
+
+    parser = get_parser(level)
 
     if level >= 8:
         input_string = preprocess_blocks(input_string)

--- a/hedyweb.py
+++ b/hedyweb.py
@@ -16,7 +16,7 @@ class Translations:
   @property
   def data(self):
     # In debug mode, always reload all translations
-    if self._data is None or utils.flask_in_debug_mode():
+    if self._data is None or utils.is_debug_mode():
       translations = glob.glob('coursedata/texts/*.yaml')
       self._data = {}
       for trans_file in translations:


### PR DESCRIPTION
Instead of creating a Lark parser over and over again
every time we go to parse code, cache and reuse the level
parser to get a speed boost.

Reduces parse time from ~60ms to ~10ms (not the best but still helpful!)