### PR TITLE
feat: add CDN for static assets

### DIFF
--- a/hedy.py
+++ b/hedy.py
@@ -1003,7 +1003,7 @@ def transpile_inner(input_string, level):
 
     if level >= 8:
         input_string = preprocess_blocks(input_string)
-        print(input_string)
+        # print(input_string)
 
     try:
         program_root = parser.parse(input_string+ '\n').children[0]  # getting rid of the root could also be done in the transformer would be nicer

--- a/templates/auth.html
+++ b/templates/auth.html
@@ -6,9 +6,9 @@
 </div>
 {% endblock %}
 {% block scripts %}
-  <script src="/vendor/jquery.min.js" type="text/javascript"></script>
-  <script src="/vendor/ace.js" type="text/javascript" charset="utf-8"></script>
-  <script src="/js/app.js" type="text/javascript"></script>
-  <script src="/js/auth.js" type="text/javascript"></script>
+  <script src="{{static('/vendor/jquery.min.js')}}" type="text/javascript"></script>
+  <script src="{{static('/vendor/ace.js')}}" type="text/javascript" charset="utf-8"></script>
+  <script src="{{static('/js/app.js')}}" type="text/javascript"></script>
+  <script src="{{static('/js/auth.js')}}" type="text/javascript"></script>
   <script>window.State = {lang: "{{ lang }}", level: "{{ level }}"}</script>
 {% endblock %}

--- a/templates/code-page.html
+++ b/templates/code-page.html
@@ -204,14 +204,14 @@
 {% endblock %}
 
 {% block scripts %}
-  <script src="/vendor/jquery.min.js" type="text/javascript"></script>
-  <script src="/vendor/ace.js" type="text/javascript" charset="utf-8"></script>
-  <script src="/vendor/skulpt.min.js" type="text/javascript"></script>
-  <script src="/vendor/skulpt-stdlib.js" type="text/javascript"></script>
-  <script src="/error_messages.js?lang={{ lang }}" type="text/javascript"></script>
+  <script src="{{static('/vendor/jquery.min.js')}}" type="text/javascript"></script>
+  <script src="{{static('/vendor/ace.js')}}" type="text/javascript" charset="utf-8"></script>
+  <script src="{{static('/vendor/skulpt.min.js')}}" type="text/javascript"></script>
+  <script src="{{static('/vendor/skulpt-stdlib.js')}}" type="text/javascript"></script>
+  <script src="{{static('/error_messages.js?lang=' + lang)}}" type="text/javascript"></script>
   <script>window.State = {lang: "{{ lang }}", level: "{{ level }}"}</script>
-  <script src="/js/syntaxModesRules.js" type="text/javascript"></script>
-  <script src="/js/app.js" type="text/javascript"></script>
-  <script src="/js/auth.js" type="text/javascript"></script>
-  <script src="/js/tabs.js" type="text/javascript"></script>
+  <script src="{{static('/js/syntaxModesRules.js')}}" type="text/javascript"></script>
+  <script src="{{static('/js/app.js')}}" type="text/javascript"></script>
+  <script src="{{static('/js/auth.js')}}" type="text/javascript"></script>
+  <script src="{{static('/js/tabs.js')}}" type="text/javascript"></script>
 {% endblock %}

--- a/templates/incl-adventure-tabs.html
+++ b/templates/incl-adventure-tabs.html
@@ -15,7 +15,7 @@
         {% for assignment in adventure_assignments %}
           <div data-tabtarget="t-{{assignment.name}}" class="hidden">
             {% if assignment.image %}
-              <img class="float-right w-48" src="/images/{{assignment.image}}">
+              <img class="float-right w-48" src="{{static('/images/' + assignment.image)}}">
             {% endif %}
             <div>
             {{ assignment.text|commonmark }}

--- a/templates/incl-menubar.html
+++ b/templates/incl-menubar.html
@@ -2,7 +2,7 @@
   <div class="-mb-px flex">
     <div class="py-1 mr-6 mt-1">
       <a href="{{localize_link ('/')}}">
-        <img src="/images/Hedy-logo.png" style="width: 2.5em;"/>
+        <img src="{{static('/images/Hedy-logo.png')}}" style="width: 2.5em;"/>
       </a>
     </div>
 

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -3,10 +3,10 @@
   <head>
     <title>{{page_title}}</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Zilla+Slab:ital,wght@0,300;0,400;0,500;0,600;0,700;1,300;1,400;1,600;1,700&display=swap">
-    <link rel="stylesheet" href="/css/generated.css">
-    <link rel="stylesheet" href="/css/additional.css">
-    <link rel="shortcut icon" type="image/png" href="/images/Hedy-logo.png"/>
-    <link rel="stylesheet" href="/vendor/gh-fork-ribbon.min.css"/>
+    <link rel="stylesheet" href="{{static('/css/generated.css')}}">
+    <link rel="stylesheet" href="{{static('/css/additional.css')}}">
+    <link rel="shortcut icon" type="image/png" href="{{static('/images/Hedy-logo.png')}}"/>
+    <link rel="stylesheet" href="{{static('/vendor/gh-fork-ribbon.min.css')}}"/>
   </head>
 
   <body class="bg-gray-400">

--- a/templates/programs.html
+++ b/templates/programs.html
@@ -37,6 +37,6 @@
 </div>
 {% endblock %}
 {% block scripts %}
-  <script src="/vendor/jquery.min.js" type="text/javascript"></script>
+  <script src="{{static('/vendor/jquery.min.js')}}" type="text/javascript"></script>
   <script>window.State = {lang: "{{ lang }}", level: "{{ level }}"}</script>
 {% endblock %}

--- a/templates/translate-fromto.html
+++ b/templates/translate-fromto.html
@@ -2,9 +2,9 @@
 <html>
   <head>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Zilla+Slab:ital,wght@0,300;0,400;0,500;0,600;0,700;1,300;1,400;1,600;1,700&display=swap">
-    <link rel="stylesheet" href="/css/generated.css">
-    <link rel="stylesheet" href="/css/additional.css">
-    <link rel="shortcut icon" type="image/png" href="/images/Hedy-logo.png"/>
+    <link rel="stylesheet" href="{{static('/css/generated.css')}}">
+    <link rel="stylesheet" href="{{static('/css/additional.css')}}">
+    <link rel="shortcut icon" type="image/png" href="{{static('/images/Hedy-logo.png')}}"/>
     <style>
       textarea { width: 100%; }
       th { text-align: left; }
@@ -71,7 +71,7 @@
       {% endfor %}
     </div>
 
-    <script src="/vendor/jquery.min.js" type="text/javascript"></script>
-    <script src="/js/translating.js" type="text/javascript"></script>
+    <script src="{{static('/vendor/jquery.min.js')}}" type="text/javascript"></script>
+    <script src="{{static('/js/translating.js')}}" type="text/javascript"></script>
   </body>
 </html>

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,9 @@
+import unittest
+import utils
+
+
+class TestUtils(unittest.TestCase):
+  def test_slashjoin(self):
+    self.assertEqual('http://hedycode.com/banaan/xyz', utils.slash_join('http://hedycode.com/', '/banaan', '', '/xyz'))
+    self.assertEqual('/one/two', utils.slash_join('/one/two'))
+    self.assertEqual('/one/two', utils.slash_join(None, '/one/two'))

--- a/utils.py
+++ b/utils.py
@@ -242,3 +242,14 @@ def db_scan (table):
 
 def db_describe (table):
     return db.describe_table (TableName = db_prefix + '-' + table)
+
+
+def slash_join(*args):
+    ret = []
+    for arg in args:
+        if not arg: continue
+
+        if ret and not ret[-1].endswith('/'):
+            ret.append('/')
+        ret.append(arg.lstrip('/') if ret else arg)
+    return ''.join(ret)


### PR DESCRIPTION
From now on, all static assets referenced via:

```
{{static('images/bla.png')}}
```

Will be automatically cached via CloudFront CDN. CloudFront
has been configured externally to cache hedycode.com.

We use a commit-based URL to make sure that CloudFront can cache
aggresively, because we can always accurately invalidate the URL.