### PR TITLE
Set max-age on cookies 

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -100,7 +100,9 @@ def routes (app, requested_lang):
         db_set ('tokens', {'id': cookie, 'username': user ['username'], 'ttl': times () + session_length})
         db_set ('users', {'username': user ['username'], 'last_login': timems ()})
         resp = make_response ({})
-        resp.set_cookie (cookie_name, value=cookie, httponly=True, secure=True, samesite='Lax', path='/')
+        # We set the cookie to expire in a year, just so that the browser won't invalidate it if the same cookie gets renewed by constant use.
+        # The server will decide whether the cookie expires.
+        resp.set_cookie (cookie_name, value=cookie, httponly=True, secure=True, samesite='Lax', path='/', max_age=365 * 24 * 60 * 60)
         return resp
 
     @app.route ('/auth/signup', methods=['POST'])
@@ -202,7 +204,9 @@ def routes (app, requested_lang):
             send_email_template ('welcome_verify', email, requested_lang (), os.getenv ('BASE_URL') + '/auth/verify?username=' + urllib.parse.quote_plus (username) + '&token=' + urllib.parse.quote_plus (hashed_token))
             resp = make_response ({})
 
-        resp.set_cookie (cookie_name, value=cookie, httponly=True, secure=True, samesite='Lax', path='/')
+        # We set the cookie to expire in a year, just so that the browser won't invalidate it if the same cookie gets renewed by constant use.
+        # The server will decide whether the cookie expires.
+        resp.set_cookie (cookie_name, value=cookie, httponly=True, secure=True, samesite='Lax', path='/', max_age=365 * 24 * 60 * 60)
         return resp
 
     @app.route ('/auth/verify', methods=['GET'])


### PR DESCRIPTION
Well, this is embarassing.

Ever since implementing auth & users, I forgot to set the `max-age` or the `expires` property on all user cookies. As a result, all our cookies have been session cookies, which means that whenever all the tabs of the browser are closed, the cookie is lost.

Not only this created the need for unnecessarily logging in multiple times for users, it also created performance issues to our server because it had to handle more logins than it should!

Anyway, here goes the fix.