### PR TITLE
feat: add 'query logging', structured logging per request

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,7 +6,6 @@ if (sys.version_info.major < 3 or sys.version_info.minor < 6):
 # coding=utf-8
 import datetime
 import collections
-from functools import wraps
 import hedy
 import json
 import jsonbin
@@ -36,6 +35,7 @@ import courses
 import hedyweb
 import translating
 import querylog
+import aws_helpers
 
 # Define and load all available language data
 ALL_LANGUAGES = {
@@ -215,6 +215,7 @@ if not os.getenv ('HEROKU_APP_NAME'):
 Compress(app)
 Commonmark(app)
 logger = jsonbin.JsonBinLogger.from_env_vars()
+querylog.LOG_QUEUE.set_transmitter(aws_helpers.s3_transmitter_from_env())
 
 # Check that requested language is supported, otherwise return 404
 @app.before_request

--- a/auth.py
+++ b/auth.py
@@ -2,7 +2,8 @@ import os
 import bcrypt
 import re
 import urllib
-from flask import request, make_response, jsonify, redirect, render_template
+from flask import request, make_response, jsonify, redirect
+from flask_helpers import render_template
 from utils import type_check, object_check, timems, times, db_get, db_set, db_del, db_del_many, db_scan, db_describe, db_get_many
 import datetime
 from functools import wraps
@@ -11,23 +12,27 @@ import boto3
 from botocore.exceptions import ClientError as email_error
 import json
 import requests
+import querylog
 
 cookie_name     = config ['session'] ['cookie_name']
 session_length  = config ['session'] ['session_length'] * 60
 
 env = os.getenv ('HEROKU_APP_NAME')
 
+@querylog.timed
 def check_password (password, hash):
     return bcrypt.checkpw (bytes (password, 'utf-8'), bytes (hash, 'utf-8'))
 
 def make_salt ():
     return bcrypt.gensalt ().decode ('utf-8')
 
+@querylog.timed
 def hash (password, salt):
     return bcrypt.hashpw (bytes (password, 'utf-8'), bytes (salt, 'utf-8')).decode ('utf-8')
 
 countries = {'AF':'Afghanistan','AX':'Åland Islands','AL':'Albania','DZ':'Algeria','AS':'American Samoa','AD':'Andorra','AO':'Angola','AI':'Anguilla','AQ':'Antarctica','AG':'Antigua and Barbuda','AR':'Argentina','AM':'Armenia','AW':'Aruba','AU':'Australia','AT':'Austria','AZ':'Azerbaijan','BS':'Bahamas','BH':'Bahrain','BD':'Bangladesh','BB':'Barbados','BY':'Belarus','BE':'Belgium','BZ':'Belize','BJ':'Benin','BM':'Bermuda','BT':'Bhutan','BO':'Bolivia, Plurinational State of','BQ':'Bonaire, Sint Eustatius and Saba','BA':'Bosnia and Herzegovina','BW':'Botswana','BV':'Bouvet Island','BR':'Brazil','IO':'British Indian Ocean Territory','BN':'Brunei Darussalam','BG':'Bulgaria','BF':'Burkina Faso','BI':'Burundi','KH':'Cambodia','CM':'Cameroon','CA':'Canada','CV':'Cape Verde','KY':'Cayman Islands','CF':'Central African Republic','TD':'Chad','CL':'Chile','CN':'China','CX':'Christmas Island','CC':'Cocos (Keeling) Islands','CO':'Colombia','KM':'Comoros','CG':'Congo','CD':'Congo, the Democratic Republic of the','CK':'Cook Islands','CR':'Costa Rica','CI':'Côte d\'Ivoire','HR':'Croatia','CU':'Cuba','CW':'Curaçao','CY':'Cyprus','CZ':'Czech Republic','DK':'Denmark','DJ':'Djibouti','DM':'Dominica','DO':'Dominican Republic','EC':'Ecuador','EG':'Egypt','SV':'El Salvador','GQ':'Equatorial Guinea','ER':'Eritrea','EE':'Estonia','ET':'Ethiopia','FK':'Falkland Islands (Malvinas)','FO':'Faroe Islands','FJ':'Fiji','FI':'Finland','FR':'France','GF':'French Guiana','PF':'French Polynesia','TF':'French Southern Territories','GA':'Gabon','GM':'Gambia','GE':'Georgia','DE':'Germany','GH':'Ghana','GI':'Gibraltar','GR':'Greece','GL':'Greenland','GD':'Grenada','GP':'Guadeloupe','GU':'Guam','GT':'Guatemala','GG':'Guernsey','GN':'Guinea','GW':'Guinea-Bissau','GY':'Guyana','HT':'Haiti','HM':'Heard Island and McDonald Islands','VA':'Holy See (Vatican City State)','HN':'Honduras','HK':'Hong Kong','HU':'Hungary','IS':'Iceland','IN':'India','ID':'Indonesia','IR':'Iran, Islamic Republic of','IQ':'Iraq','IE':'Ireland','IM':'Isle of Man','IL':'Israel','IT':'Italy','JM':'Jamaica','JP':'Japan','JE':'Jersey','JO':'Jordan','KZ':'Kazakhstan','KE':'Kenya','KI':'Kiribati','KP':'Korea, Democratic People\'s Republic of','KR':'Korea, Republic of','KW':'Kuwait','KG':'Kyrgyzstan','LA':'Lao People\'s Democratic Republic','LV':'Latvia','LB':'Lebanon','LS':'Lesotho','LR':'Liberia','LY':'Libya','LI':'Liechtenstein','LT':'Lithuania','LU':'Luxembourg','MO':'Macao','MK':'Macedonia, the Former Yugoslav Republic of','MG':'Madagascar','MW':'Malawi','MY':'Malaysia','MV':'Maldives','ML':'Mali','MT':'Malta','MH':'Marshall Islands','MQ':'Martinique','MR':'Mauritania','MU':'Mauritius','YT':'Mayotte','MX':'Mexico','FM':'Micronesia, Federated States of','MD':'Moldova, Republic of','MC':'Monaco','MN':'Mongolia','ME':'Montenegro','MS':'Montserrat','MA':'Morocco','MZ':'Mozambique','MM':'Myanmar','NA':'Namibia','NR':'Nauru','NP':'Nepal','NL':'Netherlands','NC':'New Caledonia','NZ':'New Zealand','NI':'Nicaragua','NE':'Niger','NG':'Nigeria','NU':'Niue','NF':'Norfolk Island','MP':'Northern Mariana Islands','NO':'Norway','OM':'Oman','PK':'Pakistan','PW':'Palau','PS':'Palestine, State of','PA':'Panama','PG':'Papua New Guinea','PY':'Paraguay','PE':'Peru','PH':'Philippines','PN':'Pitcairn','PL':'Poland','PT':'Portugal','PR':'Puerto Rico','QA':'Qatar','RE':'Réunion','RO':'Romania','RU':'Russian Federation','RW':'Rwanda','BL':'Saint Barthélemy','SH':'Saint Helena, Ascension and Tristan da Cunha','KN':'Saint Kitts and Nevis','LC':'Saint Lucia','MF':'Saint Martin (French part)','PM':'Saint Pierre and Miquelon','VC':'Saint Vincent and the Grenadines','WS':'Samoa','SM':'San Marino','ST':'Sao Tome and Principe','SA':'Saudi Arabia','SN':'Senegal','RS':'Serbia','SC':'Seychelles','SL':'Sierra Leone','SG':'Singapore','SX':'Sint Maarten (Dutch part)','SK':'Slovakia','SI':'Slovenia','SB':'Solomon Islands','SO':'Somalia','ZA':'South Africa','GS':'South Georgia and the South Sandwich Islands','SS':'South Sudan','ES':'Spain','LK':'Sri Lanka','SD':'Sudan','SR':'Suriname','SJ':'Svalbard and Jan Mayen','SZ':'Swaziland','SE':'Sweden','CH':'Switzerland','SY':'Syrian Arab Republic','TW':'Taiwan, Province of China','TJ':'Tajikistan','TZ':'Tanzania, United Republic of','TH':'Thailand','TL':'Timor-Leste','TG':'Togo','TK':'Tokelau','TO':'Tonga','TT':'Trinidad and Tobago','TN':'Tunisia','TR':'Turkey','TM':'Turkmenistan','TC':'Turks and Caicos Islands','TV':'Tuvalu','UG':'Uganda','UA':'Ukraine','AE':'United Arab Emirates','GB':'United Kingdom','US':'United States','UM':'United States Minor Outlying Islands','UY':'Uruguay','UZ':'Uzbekistan','VU':'Vanuatu','VE':'Venezuela, Bolivarian Republic of','VN':'Viet Nam','VG':'Virgin Islands, British','VI':'Virgin Islands, U.S.','WF':'Wallis and Futuna','EH':'Western Sahara','YE':'Yemen','ZM':'Zambia','ZW':'Zimbabwe'};
 
+@querylog.timed
 def current_user (request):
     if request.cookies.get (cookie_name):
         token = db_get ('tokens', {'id': request.cookies.get (cookie_name)})
@@ -307,7 +312,7 @@ def routes (app, requested_lang):
                    # If on local environment, we return email verification token directly instead of emailing it, for test purposes.
                    resp = {'username': user ['username'], 'token': hashed_token}
                 else:
-                    send_email_template ('welcome_verify', email, requested_lang (), os.getenv ('BASE_URL') + '/auth/verify?username=' + urllib.parse.quote_plus (username) + '&token=' + urllib.parse.quote_plus (hashed_token))
+                    send_email_template ('welcome_verify', email, requested_lang (), os.getenv ('BASE_URL') + '/auth/verify?username=' + urllib.parse.quote_plus (user['username']) + '&token=' + urllib.parse.quote_plus (hashed_token))
 
         if 'country' in body:
             db_set ('users', {'username': user ['username'], 'country': body ['country']})
@@ -431,6 +436,7 @@ for name in logging.Logger.manager.loggerDict.keys ():
 # https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-using-sdk-python.html
 email_client = boto3.client ('ses', region_name = config ['email'] ['region'], aws_access_key_id = os.getenv ('AWS_SES_ACCESS_KEY'), aws_secret_access_key = os.getenv ('AWS_SES_SECRET_KEY'))
 
+@querylog.timed
 def send_email (recipient, subject, body_plain, body_html):
     try:
         result = email_client.send_email (

--- a/aws_helpers.py
+++ b/aws_helpers.py
@@ -1,0 +1,39 @@
+"""Routines for interacting with AWS."""
+import boto3
+import os
+import json
+import logging
+import config
+import utils
+
+def s3_transmitter_from_env():
+    """Return an S3 transmitter, or return None."""
+    have_aws_creds = os.getenv('AWS_ACCESS_KEY_ID') and os.getenv('AWS_SECRET_ACCESS_KEY')
+
+    if not have_aws_creds:
+        logging.warning('Unable to initialize S3 querylogger (missing AWS_ACCESS_KEY_ID or AWS_SECRET_ACCESS_KEY)')
+        return None
+
+    return transmit_to_s3
+
+
+def transmit_to_s3(timestamp, records):
+    """Transmit logfiles to S3 with default config."""
+    s3config = config.config['s3-query-logs']
+
+    # No need to configure credentials, we've already confirmed they are in the environment.
+    s3 = boto3.client('s3', region_name=s3config['region'])
+
+    # Grouping in the key is important, we need this to zoom into an interesting
+    # log period.
+    key = s3config['prefix'] + utils.isoformat(timestamp) + s3config['postfix'] + '.jsonl'
+
+    # Store as json-lines format
+    body = '\n'.join(json.dumps(r) for r in records)
+
+    s3.put_object(
+        Bucket=s3config['bucket'],
+        Key=key,
+        StorageClass='STANDARD_IA', # Cheaper, applicable for logs
+        Body=body)
+    logging.debug(f'Wrote {len(records)} query logs to s3://{s3config["bucket"]}/{key}')

--- a/config.py
+++ b/config.py
@@ -1,3 +1,9 @@
+import os
+import socket
+
+app_name = os.getenv('HEROKU_APP_NAME', socket.gethostname())
+dyno = os.getenv('DYNO')
+
 config = {
     'port': 5000,
     'session': {
@@ -11,5 +17,12 @@ config = {
     },
     'dynamodb': {
         'region': 'eu-central-1'
-    }
+    },
+    's3-query-logs': {
+        'bucket': 'hedy-query-logs',
+        'prefix': app_name + '/',
+        # Make logs from different instances unique
+        'postfix': '.' + dyno if dyno else '',
+        'region': 'eu-central-1'
+    },
 }

--- a/flask_helpers.py
+++ b/flask_helpers.py
@@ -1,0 +1,7 @@
+import flask
+import querylog
+
+@querylog.timed
+def render_template(filename, **kwargs):
+    """A copy of Flask's render_template that is timed."""
+    return flask.render_template(filename, **kwargs)

--- a/hedyweb.py
+++ b/hedyweb.py
@@ -1,10 +1,11 @@
 import collections
 import attr
 import glob
-import flask
 from os import path
 
-from flask import jsonify, render_template, abort, redirect
+from flask import abort
+from flask_helpers import render_template
+
 import courses
 from auth import current_user
 import utils

--- a/querylog.py
+++ b/querylog.py
@@ -227,4 +227,4 @@ def div_clip(x, y):
     return int(x // y) * y
 
 
-LOG_QUEUE = LogQueue(batch_window_s=300, do_print=True)
+LOG_QUEUE = LogQueue(batch_window_s=300)

--- a/querylog.py
+++ b/querylog.py
@@ -1,0 +1,230 @@
+import time
+import collections
+import functools
+import threading
+import logging
+import os
+import datetime
+import traceback
+
+
+class LogRecord:
+    """A log record."""
+    def __init__(self, **kwargs):
+        self.start_time = time.time()
+        self.attributes = kwargs
+        self.set(
+            start_time=dtfmt(self.start_time),
+            fault=0)
+
+        dyno = os.getenv('DYNO')
+        if dyno:
+            self.set(dyno=dyno)
+
+    def finish(self):
+        end_time = time.time()
+        duration = int((end_time - self.start_time) * 1000) # ms resolution is good enough
+        self.set(
+            end_time=dtfmt(end_time),
+            duration_ms=duration)
+
+        LOG_QUEUE.add(self)
+
+    def set(self, **kwargs):
+        self.attributes.update(kwargs)
+
+    def update(self, dict):
+        self.attributes.update(dict)
+
+    def timer(self, name):
+        return LogTimer(self, name)
+
+    def inc(self, name, amount=1):
+        if name in self.attributes:
+            self.attributes[name] = self.attributes[name] + amount
+        else:
+            self.attributes[name] = amount
+
+    def inc_timer(self, name, time_ms):
+        self.inc(name + '_ms', time_ms)
+        self.inc(name + '_cnt')
+
+    def record_exception(self, exc):
+        self.set(fault=1, error_message=str(exc))
+
+    def as_data(self):
+        return self.attributes
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type, value, tb):
+        if value:
+            self.record_exception(value)
+        self.finish()
+
+
+class NullRecord(LogRecord):
+    """A dummy log record that doesn't do anything.
+
+    Will be returned if we don't have a default record.
+    """
+    def __init__(self, **kwargs): pass
+    def finish(self): pass
+    def set(self, **kwargs): pass
+
+
+THREAD_LOCAL = threading.local()
+THREAD_LOCAL.current_log_record = NullRecord()
+
+def begin_global_log_record(**kwargs):
+    """Open a new global log record with the given attributes."""
+    THREAD_LOCAL.current_log_record = LogRecord(**kwargs)
+
+
+def finish_global_log_record(exc=None):
+    """Finish the global log record."""
+    record = THREAD_LOCAL.current_log_record
+    if exc:
+        record.record_exception(exc)
+    record.finish()
+    THREAD_LOCAL.current_log_record = NullRecord()
+
+
+def log_value(**kwargs):
+    """Log values into the currently globally active Log Record."""
+    THREAD_LOCAL.current_log_record.set(**kwargs)
+
+
+def log_time(name):
+    """Log a time into the currently globally active Log Record."""
+    return THREAD_LOCAL.current_log_record.timer(name)
+
+def log_counter(name, count=1):
+    """Increase the count of something in the currently globally active Log Record."""
+    return THREAD_LOCAL.current_log_record.inc(name, count)
+
+
+def timed(fn):
+    """Function decorator to make the given function timed into the currently active log record."""
+    @functools.wraps(fn)
+    def wrapped(*args, **kwargs):
+        with log_time(fn.__name__):
+            return fn(*args, **kwargs)
+
+    return wrapped
+
+
+def dtfmt(timestamp):
+    dt = datetime.datetime.utcfromtimestamp(timestamp)
+    return dt.isoformat() + 'Z'
+
+
+class LogTimer:
+    """A quick and dirty timer."""
+    def __init__(self, record, name):
+        self.record = record
+        self.name = name
+
+    def __enter__(self):
+        self.start = time.time()
+
+    def __exit__(self, type, value, tb):
+        delta = int((time.time() - self.start) * 1000) # ms resolution is good enough
+        self.record.inc_timer(self.name, delta)
+
+
+class LogQueue:
+    """A queue of records that still need to be written out.
+
+    For efficiency's sake, records are grouped into time windows of
+    'batch_window_s' seconds (say, 5 minutes). x'es below indicate
+    log record events:
+
+          300               600               900
+         |   x    x x      |             x   |
+       --+-----------------+-----------------+---------
+          ^                 ^                 ^
+        wake               wake              wake
+
+    Upon 'wake' events (every batch window seconds), a background thread
+    wakes up and collects all events from previous time windows.
+
+    We need to use a mutex since the dict we keep the queue in is not
+    thread-safe. We do as little work as possible every time we hold the mutex
+    to allow for maximum parallelism.
+    """
+    def __init__(self, batch_window_s, do_print=False):
+        self.records_queue = collections.defaultdict(list)
+        self.batch_window_s = batch_window_s
+        self.transmitter = None
+        self.do_print = do_print
+        self.mutex = threading.Lock()
+        self.thread = threading.Thread(target=self._write_thread, name='QueryLogWriter', daemon=True)
+        self.thread.start()
+
+    def add(self, record):
+        bucket = div_clip(time.time(), self.batch_window_s)
+        data = record.as_data()
+
+        if self.do_print:
+            print(data)
+
+        with self.mutex:
+            self.records_queue[bucket].append(data)
+
+    def set_transmitter(self, transmitter):
+        """Configure a function that will be called for every set of records.
+
+        The function looks like:
+
+            def transmitter(timestamp, records) -> Boolean:
+                ...
+        """
+        self.transmitter = transmitter
+
+    def _save_records(self, timestamp, records):
+        if self.transmitter:
+            return self.transmitter(timestamp, records)
+        else:
+            count = len(records)
+            logging.warn(f'No querylog transmitter configured, {count} records dropped')
+
+    def _write_thread(self):
+        """Background thread which will wake up every batch_window_s seconds to emit records from the queue."""
+        next_wake = div_clip(time.time(), self.batch_window_s) + self.batch_window_s
+        while True:
+            try:
+                # Wait for next wake time
+                time.sleep(max(0, next_wake - time.time()))
+
+                # Once woken, see what buckets we have left to push (all buckets
+                # with numbers lower than next_wake)
+                with self.mutex:
+                    keys = list(self.records_queue.keys())
+                keys.sort()
+                buckets_to_send = [k for k in keys if k < next_wake]
+
+                for bucket_ts in buckets_to_send:
+                    # Get the records out of the queue
+                    with self.mutex:
+                        bucket_records = self.records_queue[bucket_ts]
+
+                    # Try to send the records
+                    success = self._save_records(bucket_ts, bucket_records)
+
+                    # Only remove them from the queue if sending didn't fail
+                    if success != False:
+                        with self.mutex:
+                            del self.records_queue[bucket_ts]
+            except Exception as e:
+                traceback.print_exc(e)
+            next_wake += self.batch_window_s
+
+
+def div_clip(x, y):
+    """Return the highest value < x that's a multiple of y."""
+    return int(x // y) * y
+
+
+LOG_QUEUE = LogQueue(batch_window_s=300, do_print=True)

--- a/utils.py
+++ b/utils.py
@@ -184,6 +184,7 @@ def db_key (table, data, *remove):
 # Gets an item by index from the database. If not_primary is truthy, the search is done by a field that should be set as a secondary index.
 @querylog.timed
 def db_get (table, data, *not_primary):
+    querylog.log_counter('db_get:' + table)
     # If we're querying by something else than the primary key of the table, we assume that data contains only one field, that on which we want to search. We also require that field to have an index.
     if len (not_primary):
         field = list (data.keys ()) [0]
@@ -201,6 +202,7 @@ def db_get (table, data, *not_primary):
 # Gets an item by index from the database. If not_primary is truthy, the search is done by a field that should be set as a secondary index.
 @querylog.timed
 def db_get_many (table, data, *not_primary):
+    querylog.log_counter('db_get_many:' + table)
     if len (not_primary):
         field = list (data.keys ()) [0]
         # We use ScanIndexForward = False to get the latest items from the Programs table
@@ -216,6 +218,7 @@ def db_get_many (table, data, *not_primary):
 # Creates or updates an item by primary key.
 @querylog.timed
 def db_set (table, data):
+    querylog.log_counter('db_set:' + table)
     if db_get (table, data):
         result = db.update_item (TableName = db_prefix + '-' + table, Key = db_encode (db_key (table, data)), AttributeUpdates = db_encode (db_key (table, data, True), True))
     else:
@@ -225,11 +228,13 @@ def db_set (table, data):
 # Deletes an item by primary key.
 @querylog.timed
 def db_del (table, data):
+    querylog.log_counter('db_del:' + table)
     return db.delete_item (TableName = db_prefix + '-' + table, Key = db_encode (db_key (table, data)))
 
 # Deletes multiple items.
 @querylog.timed
 def db_del_many (table, data, *not_primary):
+    querylog.log_counter('db_del_many:' + table)
     # We define a recursive function in case the number of results is very large and cannot be returned with a single call to db_get_many.
     def batch ():
         to_delete = db_get_many (table, data, *not_primary)
@@ -243,6 +248,7 @@ def db_del_many (table, data, *not_primary):
 # Searches for items.
 @querylog.timed
 def db_scan (table):
+    querylog.log_counter('db_scan:' + table)
     result = db.scan (TableName = db_prefix + '-' + table)
     output = []
     querylog.log_counter('db_scan_items', len(result['Items']))
@@ -252,6 +258,7 @@ def db_scan (table):
 
 @querylog.timed
 def db_describe (table):
+    querylog.log_counter('db_describe:' + table)
     return db.describe_table (TableName = db_prefix + '-' + table)
 
 

--- a/utils.py
+++ b/utils.py
@@ -1,3 +1,4 @@
+import datetime
 import time
 from config import config
 import boto3
@@ -271,3 +272,9 @@ def slash_join(*args):
             ret.append('/')
         ret.append(arg.lstrip('/') if ret else arg)
     return ''.join(ret)
+
+
+def isoformat(timestamp):
+    """Turn a timestamp into an ISO formatted string."""
+    dt = datetime.datetime.utcfromtimestamp(timestamp)
+    return dt.isoformat() + 'Z'


### PR DESCRIPTION
This introduces structured request logging, with a way to log
counters, arbitrary values, and timers within each request.

Scopes are automatically opened and closed matching Flask requests,
by using `@app.before_request` and `@app.teardown_request`.

Currently annotates a number of functions such as `db_get()`,
`render_template()`, etc etc with `@querylog.timed` which automatically
records the time taken inside those functions, and how often they are
called. Some counters and values are recorded manually with
`log_counter` and `log_value`.

I'd recommend everyone log as many things as they can that may impact
performance or stability of the app, to help with ease of debugging
later on.

The mechanism to add a log sink are in place, but I'm not sure what
the current preferred log target is (I see something has been done
involving Papertrail but I'm not sure what that is or how that works),
and I investigated logging these to JSONBin but we may run into issues
there (it's not strictly optimized for that).

S3 is probably an easy and cheap log target, but I'm open to other
suggestions.