### PR TITLE
fix: translating to Hungarian doesn't work

### DIFF
--- a/static/js/translating.js
+++ b/static/js/translating.js
@@ -34,8 +34,14 @@ $(function() {
     const target = $(e.target);
     if (!target.hasClass('touched')) {
       target.addClass('touched');
+
+      // Change the 'data-name="xxx"' attribute into an actual 'name="xxx"' attribute
+      // so that the value is actually submitted via the form.
+      target.attr('name', target.data('name'));
+
       recordChangeToForm(target.closest('form'));
     }
+
     resizeArea(target);
   });
 

--- a/templates/translate-fromto.html
+++ b/templates/translate-fromto.html
@@ -54,7 +54,7 @@
             <tr class="border-b">
               <th style="max-width: 6em; overflow: hidden;">{{string.key}}</th>
               <td><pre style="max-width: 40em;">{{ string.original }}</pre></td>
-              <td><textarea name="c:{{string.encoded_path}}" rows="2" class="border border-green-600 p-2" style="width: 40em;">{{ string.translated }}</textarea></td>
+              <td><textarea data-name="c:{{string.encoded_path}}" rows="2" class="border border-green-600 p-2" style="width: 40em;">{{ string.translated }}</textarea></td>
             </tr>
           {% endif %}
         {% endfor %}

--- a/translating.py
+++ b/translating.py
@@ -100,15 +100,15 @@ def apply_change(data, path, value):
 
     index = int(key[2:])
     while len(container) < index + 1:
-      data.append({})
+      container.append({})
     container[index] = value
-    return container
+    return container[index]
   else:
     # Expecting to index into a dict
     if not isinstance(container, dict):
       container = apply_change(data, path[:-1], {})
     container[key] = value
-    return container
+    return container[key]
 
 
 def value_at(data, path):


### PR DESCRIPTION
Two mistakes:

- A bug in `apply_change` led to a 500 error
- All elements were transmitted (even the ones not entered), and so a
  lot of empty untranslated fields might be added at the end.