### PR TITLE
translate missing menu items to German

### DIFF
--- a/main/for-teachers-de.md
+++ b/main/for-teachers-de.md
@@ -1,4 +1,4 @@
-page_title: Für Lehrer — Hedy
+page_title: Für Lehrende — Hedy
 ---
 Schön, dass Sie Hedy in Ihr Klassenzimmer holen wollen! 
 Auf dieser Seite finden Sie alle Tipps & Tricks, damit Ihr Hedy-Unterricht so reibungslos wie möglich verläuft. 

--- a/main/menu.json
+++ b/main/menu.json
@@ -52,7 +52,7 @@
       "es": "Aprende más",
       "fr": "Learn more",
       "pt_br": "Learn more",
-      "de": "Learn more",
+      "de": "Mehr Infos",
       "zh": "了解更多",
       "el": "Μάθε περισσότερα"
     },
@@ -60,6 +60,7 @@
       "_": "for-teachers",
       "nl": "Voor leerkrachten",
       "en": "For teachers",
+      "de": "Für Lehrende",
       "zh": "教学资源"
     }
   ]


### PR DESCRIPTION
This translates missing, or rather English, menu items to German.