### PR TITLE
If the level is invalid, return 404 instead of throwing a 500

### DIFF
--- a/app.py
+++ b/app.py
@@ -434,7 +434,7 @@ def adventure_page(adventure_name, level):
 @app.route('/hedy/<level>', methods=['GET'], defaults={'step': 1})
 @app.route('/hedy/<level>/<step>', methods=['GET'])
 def index(level, step):
-    
+
 
     # Sublevel requested
     if re.match ('\d+-\d+', level):
@@ -442,7 +442,10 @@ def index(level, step):
         # If level has a dash, we keep it as a string
     # Normal level requested
     elif re.match ('\d', level):
-        g.level = level = int(level)
+        try:
+            g.level = level = int(level)
+        except:
+            return 'No such Hedy level!', 404
     else:
         return 'No such Hedy level!', 404
 


### PR DESCRIPTION
This fixes a weakening of the URL validation that was of my authorship while merging #412 

`/hedy/8foo` would throw a 500 error, now it will return a 404.