### PR TITLE
fix: return "Internal Server Error" with 500-code

### DIFF
--- a/app.py
+++ b/app.py
@@ -553,7 +553,7 @@ def error():
 def internal_error(exception):
     import traceback
     print(traceback.format_exc())
-    return "<h1>500 Internal Server Error</h1>"
+    return "<h1>500 Internal Server Error</h1>", 500
 
 @app.route('/index.html')
 @app.route('/')


### PR DESCRIPTION
The `@app.errorhandler()` is a normal view function, and must also
indicate the error code when returning a failure. Without an error
code, it would return a `200 SUCCESS` response, which is not
appropriate.

Make it explicitly return a `500` code instead.

Fixes #465.