### PR TITLE
Allow a proportion of 0% in the ab testing redirect

### DIFF
--- a/ab_proxying.py
+++ b/ab_proxying.py
@@ -68,7 +68,10 @@ def redirect_ab (request):
     user_identifier = current_user(request) ['username'] or str (session['session_id'])
 
     # This will send either % PROXY_TO_TEST_PROPORTION of the requests into redirect, or 50% if that variable is not specified.
-    redirect_proportion = int (os.getenv ('PROXY_TO_TEST_PROPORTION', '50'))
+    if os.getenv ('PROXY_TO_TEST_PROPORTION') == None:
+        redirect_proportion = 50
+    else:
+        redirect_proportion = int (os.getenv ('PROXY_TO_TEST_PROPORTION'))
     redirect_flag = (hash_user_or_session (user_identifier) % 100) < redirect_proportion
     return redirect_flag
 


### PR DESCRIPTION
Currently, if we pass a proportion of 0% to `PROXY_TO_TEST_PROPORTION`, we default to 50%. Besides this being tricky, it is also useful to be able to set the proportion to 0% quickly. This change allows for this.