### PR TITLE
Allow to share a program publicly

### DIFF
--- a/app.py
+++ b/app.py
@@ -369,7 +369,7 @@ def programs_page (request):
 
             date = round (date / 24)
 
-        programs.append ({'id': item ['id'], 'code': item ['code'], 'date': texts ['ago-1'] + ' ' + str (date) + ' ' + measure + ' ' + texts ['ago-2'], 'level': item ['level'], 'name': item ['name'], 'adventure_name': item.get ('adventure_name')})
+        programs.append ({'id': item ['id'], 'code': item ['code'], 'date': texts ['ago-1'] + ' ' + str (date) + ' ' + measure + ' ' + texts ['ago-2'], 'level': item ['level'], 'name': item ['name'], 'adventure_name': item.get ('adventure_name'), 'public': item.get ('public')})
 
     return render_template('programs.html', lang=requested_lang(), menu=render_main_menu('programs'), texts=texts, ui=ui, auth=TRANSLATIONS.data [requested_lang ()] ['Auth'], programs=programs, username=username, current_page='programs', from_user=from_user, adventures=adventures)
 
@@ -464,9 +464,10 @@ def index(level, step):
         result = db_get ('programs', {'id': step})
         if not result:
             return 'No such program', 404
-        # Allow only the owner of the program, the admin user and the teacher users to access the program
+        # If the program is not public, allow only the owner of the program, the admin user and the teacher users to access the program
         user = current_user (request)
-        if user ['username'] != result ['username'] and not is_admin (request) and not is_teacher (request):
+        public_program = 'public' in result and result ['public']
+        if not public_program and user ['username'] != result ['username'] and not is_admin (request) and not is_teacher (request):
             return 'No such program!', 404
         loaded_program = result ['code']
         loaded_program_name = result ['name']
@@ -767,6 +768,24 @@ def save_program (user):
     db_update('users', {'username': user ['username'], 'program_count': program_count + 1})
 
     return jsonify({'name': name})
+
+@app.route('/programs/share', methods=['POST'])
+@requires_login
+def share_unshare_program(user):
+    body = request.json
+    if not type_check (body, 'dict'):
+        return 'body must be an object', 400
+    if not object_check (body, 'id', 'str'):
+        return 'id must be a string', 400
+    if not object_check (body, 'public', 'bool'):
+        return 'public must be a string', 400
+
+    result = db_get ('programs', {'id': body ['id']})
+    if not result or result ['username'] != user ['username']:
+        return 'No such program!', 404
+
+    db_update ('programs', {'id': body ['id'], 'public': 1 if body ['public'] else None})
+    return jsonify({})
 
 @app.route('/translate/<source>/<target>')
 def translate_fromto(source, target):

--- a/coursedata/texts/en.yaml
+++ b/coursedata/texts/en.yaml
@@ -127,6 +127,7 @@ Auth:
     unsaved_changes: "You have an unsaved program. Do you want to leave without saving it?"
     save_success: "Success"
     save_success_detail: "Program saved successfully"
+    share_success_detail: "Program shared successfully"
     answer_question: "You can't run the program until you answer the question first"
 Programs:
     recent: "My recent programs"
@@ -139,5 +140,9 @@ Programs:
     open: "Open"
     delete: "Delete"
     delete_confirm: "Are you sure you want to delete the program?"
+    share: "Share"
+    share_confirm: "Are you sure you want to make the program public?"
+    unshare: "Unshare"
+    unshare_confirm: "Are you sure you want to make the program private?"
     no_programs: "You have no programs yet."
     write_first: "Write your first program!"

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -250,6 +250,27 @@ window.saveit = function saveit(level, lang, name, code, cb) {
   }
 }
 
+window.share_program = function share_program (id, Public, reload) {
+  $.ajax({
+    type: 'POST',
+    url: '/programs/share',
+    data: JSON.stringify({
+      id: id,
+      public: Public
+    }),
+    contentType: 'application/json',
+    dataType: 'json'
+  }).done(function(response) {
+    $ ('#okbox').show ();
+    $ ('#okbox .caption').html (window.auth.texts.save_success);
+    $ ('#okbox .details').html (window.auth.texts.share_success_detail);
+    if (reload) location.reload ();
+  }).fail(function(err) {
+    console.error(err);
+    error.show(ErrorMessages.Connection_error, JSON.stringify(err));
+  });
+}
+
 /**
  * Do a POST with the error to the server so we can log it
  */

--- a/templates/programs.html
+++ b/templates/programs.html
@@ -18,6 +18,11 @@
       <a href="{{localize_link ('/hedy/' + program.level|string + '/' + program.id)}}">{{ texts.open }}</a>
 
       <a href="#" onclick="if (confirm ('{{ texts.delete_confirm }}')) window.open ('/programs/delete/{{program.id}}', '_self')">{{ texts.delete }}</a>
+      {% if program.public %}
+        <a href="#" onclick="if (confirm ('{{ texts.unshare_confirm }}')) window.share_program ('{{program.id}}', false, true)">{{ texts.unshare}}</a>
+      {% else %}
+        <a href="#" onclick="if (confirm ('{{ texts.share_confirm }}')) window.share_program ('{{program.id}}', true, true)">{{ texts.share}}</a>
+      {% endif %}
       <pre>{{program.code | truncate (50) }}</pre>
     </li>
     <br>
@@ -34,5 +39,7 @@
 {% endblock %}
 {% block scripts %}
   <script src="{{static('/vendor/jquery.min.js')}}" type="text/javascript"></script>
+  <script src="{{static('/js/app.js')}}" type="text/javascript"></script>
+  <script src="{{static('/js/auth.js')}}" type="text/javascript"></script>
   <script>window.State = {lang: "{{ lang }}", level: "{{ level }}"}</script>
 {% endblock %}

--- a/website/auth.py
+++ b/website/auth.py
@@ -48,7 +48,7 @@ def is_admin (request):
 
 def is_teacher (request):
     user = current_user (request)
-    return bool (user ['is_teacher'])
+    return bool ('is_teacher' in user and user ['is_teacher'])
 
 # The translations are imported here because current_user above is used by hedyweb.py and we need to avoid circular dependencies
 import hedyweb


### PR DESCRIPTION
- Functionality for marking a program as public from the Programs page.
- Closes #452 

@Felienne this still doesn't include the green "Share program" button because I'd first like to discuss a few UI matters:
- If the user is not logged in, should we show this button? Should we show it disabled?
- If the user is logged in but the loaded program is from someone else, should we require the user to save the program as their own first and then show the share button? Or should we save+share the program?
- Same as the above for when trying to share a program that is not saved.
- What if the program is already shared? Do we still show the share button? Or do we show an unshare button.

Besides these design issues, the implementation of that button on the main page is non-trivial, because of all the ways in which a program can get there (default program from a level/adventure, loaded program, newly written program) combined with the not-logged vs logged in user. Before I go ahead and implement this, it'd be good to define the scope of this green button.

The existing implementation allows for sharing/unsharing from the Programs page.