### PR TITLE
Fix loading of program belonging to a level

### DIFF
--- a/static/js/tabs.js
+++ b/static/js/tabs.js
@@ -50,7 +50,7 @@ $(function() {
     });
 
     // If the loaded program (directly requested by link with id) matches the currently selected tab, use that, overriding the loaded program that came in the adventure or level.
-    if (window.State.loaded_program && window.State.adventure_name_onload === tabName) {
+    if (window.State.loaded_program && (window.State.adventure_name_onload || 'level') === tabName) {
       $ ('#program_name').val (window.State.loaded_program_name);
       window.editor.setValue (window.State.loaded_program);
     }


### PR DESCRIPTION
Fix loading of program belonging to a level that is not the latest program for that level.

- Fixes a bug that overrode the loaded program for a logged in user if 1) the program belonged to a level and not an adventure; 2) the program was not the latest saved program for that level. In this case, the latest program for the level saved by the user was loaded instead.
 - Closes #452
