### PR TITLE
Preparsing of newlines

### DIFF
--- a/app.py
+++ b/app.py
@@ -244,6 +244,9 @@ def parse():
     level = int(body ['level'])
     sublevel = body.get ('sublevel') or 0
 
+    code = re.sub(r'\n{2,}', '\n\n', code)
+    code += '\n';
+
     # Language should come principally from the request body,
     # but we'll fall back to browser default if it's missing for whatever
     # reason.


### PR DESCRIPTION
Recenty we noticed that a program with many newlines in a row is very hard to parse. Since we don't add any semantic value to multiple newlines in succession, we can simply condense them into two consecutive newlines.

We also add a newline at the end of each program, since this makes it easier to parse if there's no newline present.

This was almost too easy. My main concern is breaking existing programs, although all the tests are passing.