### PR TITLE
add security headers to response

### DIFF
--- a/app.py
+++ b/app.py
@@ -206,6 +206,16 @@ def after_request_log_status(response):
     querylog.log_value(http_code=response.status_code)
     return response
 
+@app.after_request
+def set_security_headers(response):
+    security_headers = {
+        'Strict-Transport-Security': 'max-age=31536000; includeSubDomains',
+        'X-Frame-Options': 'DENY',
+        'X-XSS-Protection': '1; mode=block',
+    }
+    response.headers.update(security_headers)
+    return response
+
 @app.teardown_request
 def teardown_request_finish_logging(exc):
     querylog.finish_global_log_record(exc)


### PR DESCRIPTION
We want some basic security headers, and instead of adding a new dependency on something like talisman, we decided the easiest update would be to add them directly to the response.

- The strict transport header will tell the browser that on every request after the first, it should auto-upgrade to https without needing to first connect to our server to receive an explicit redirect. The setting in this commit is for 1 year, and although we don't have any subdomains at the moment, there isn't any reason not to include subdomains.
- The X-Frame deny keeps other sites from spoofing ours by loading it inside an iframe, which is probably not very likely as an attack vector, but no reason not to implement this.
- The XSS-Protection isn't used by a lot of the more modern browsers, but gives us a bit of protection for the older browsers (https://caniuse.com/?search=xss-protection), and is a stopgap until we can decide on a solid Content Security Policy, which is the best-practice for addressing XSS these days.