### PR TITLE
fix: add caching on static content

### DIFF
--- a/app.py
+++ b/app.py
@@ -23,7 +23,7 @@ from utils import db_get, db_get_many, db_create, db_update, timems, type_check,
 import utils
 
 # app.py
-from flask import Flask, request, jsonify, session, abort, g, redirect, Response
+from flask import Flask, request, jsonify, session, abort, g, redirect, Response, make_response
 from flask_helpers import render_template
 from flask_compress import Compress
 
@@ -572,7 +572,9 @@ def space_eu(level, step):
 @app.route('/error_messages.js', methods=['GET'])
 def error():
     error_messages = TRANSLATIONS.get_translations(requested_lang(), "ClientErrorMessages")
-    return render_template("error_messages.js", error_messages=json.dumps(error_messages))
+    response = make_response(render_template("error_messages.js", error_messages=json.dumps(error_messages)))
+    response.cache_control.max_age = 60 * 60  # Seconds
+    return response
 
 
 @app.errorhandler(500)

--- a/app.py
+++ b/app.py
@@ -19,7 +19,7 @@ from flask_commonmark import Commonmark
 from werkzeug.urls import url_encode
 from config import config
 from website.auth import auth_templates, current_user, requires_login, is_admin, is_teacher
-from utils import db_get, db_get_many, db_create, db_update, timems, type_check, object_check, db_del, load_yaml, load_yaml_rt, dump_yaml_rt, version
+from utils import db_get, db_get_many, db_create, db_update, is_debug_mode, timems, type_check, object_check, db_del, load_yaml, load_yaml_rt, dump_yaml_rt, version
 import utils
 
 # app.py
@@ -573,7 +573,11 @@ def space_eu(level, step):
 def error():
     error_messages = TRANSLATIONS.get_translations(requested_lang(), "ClientErrorMessages")
     response = make_response(render_template("error_messages.js", error_messages=json.dumps(error_messages)))
-    response.cache_control.max_age = 60 * 60  # Seconds
+
+    if not is_debug_mode():
+        # Cache for longer when not devving
+        response.cache_control.max_age = 60 * 60  # Seconds
+
     return response
 
 

--- a/tools/download-programs
+++ b/tools/download-programs
@@ -57,4 +57,5 @@ export AWS_DEFAULT_REGION=eu-west-1
 export AWS_PROFILE=hedy-logs-viewer
 bucket=hedy-parse-logs
 
-aws s3 sync s3://${bucket}/${hedy_env}/${prefix} $dir
+set -x
+aws s3 sync s3://${bucket}/${hedy_env}${prefix} $dir

--- a/website/auth.py
+++ b/website/auth.py
@@ -4,7 +4,7 @@ import re
 import urllib
 from flask import request, make_response, jsonify, redirect
 from flask_helpers import render_template
-from utils import type_check, object_check, timems, times, db_get, db_create, db_update, db_del, db_del_many, db_scan, db_describe, db_get_many, extract_bcrypt_rounds, is_testing_request, valid_email
+from utils import type_check, object_check, timems, times, db_get, db_create, db_update, db_del, db_del_many, db_scan, db_describe, db_get_many, extract_bcrypt_rounds, is_testing_request, is_debug_mode, valid_email
 import datetime
 from functools import wraps
 from config import config
@@ -78,7 +78,9 @@ def routes (app, requested_lang):
     @app.route('/auth/texts', methods=['GET'])
     def auth_texts():
         response = make_response(jsonify(TRANSLATIONS.data [requested_lang ()] ['Auth']))
-        response.cache_control.max_age = 60 * 60  # Seconds
+        if not is_debug_mode():
+            # Cache for longer when not devving
+            response.cache_control.max_age = 60 * 60  # Seconds
         return response
 
     @app.route ('/auth/login', methods=['POST'])

--- a/website/auth.py
+++ b/website/auth.py
@@ -77,7 +77,9 @@ def routes (app, requested_lang):
 
     @app.route('/auth/texts', methods=['GET'])
     def auth_texts():
-        return jsonify (TRANSLATIONS.data [requested_lang ()] ['Auth'])
+        response = make_response(jsonify(TRANSLATIONS.data [requested_lang ()] ['Auth']))
+        response.cache_control.max_age = 60 * 60  # Seconds
+        return response
 
     @app.route ('/auth/login', methods=['POST'])
     def login ():


### PR DESCRIPTION
About 30% of the total request volume to the server is to retrieve
static error messages to use in the JavaScript (`/error_messages.js` and
`/auth/texts`). Because they are not cached, they are currently loaded
upon every page load (every time a user hits **Next level**).

They could *easily* be cached though, bringing down the total request
volume to the server by a lot.

Add a caching header to make the browser cache these responses for an
hour; we could think about routing them through the CDN as well,
but that's perhaps a bit much for now. Let's just see how this performs.