### PR TITLE
Fix program count for users

### DIFF
--- a/app.py
+++ b/app.py
@@ -786,11 +786,7 @@ def save_program (user):
         db_update('programs', stored_program)
     else:
         db_create('programs', stored_program)
-
-    program_count = 0
-    if 'program_count' in user:
-        program_count = user ['program_count']
-    db_update('users', {'username': user ['username'], 'program_count': program_count + 1})
+        db_update('users', {'username': user ['username'], 'program_count': len (programs) + 1})
 
     return jsonify({'name': name})
 


### PR DESCRIPTION
#497 introduced a bug where we add 1 to the program count of users even though they may be overwriting an existing program.

This PR fixes that. It also simplifies the logic by merely using the length of the programs already retrieved for the user.

If the count is wrong for a user, it should be fixed the next time the user creates a program.