### PR TITLE
Add validations to prevent 500s with malformed URLs

### DIFF
--- a/app.py
+++ b/app.py
@@ -525,7 +525,10 @@ def index(level, step):
 @app.route('/onlinemasters/<level>', methods=['GET'], defaults={'step': 1})
 @app.route('/onlinemasters/<level>/<step>', methods=['GET'])
 def onlinemasters(level, step):
-    g.level = level = int(level)
+    try:
+        g.level = level = int(level)
+    except:
+        return 'No such Hedy level!', 404
     g.lang = lang = requested_lang()
     g.prefix = '/onlinemasters'
 
@@ -548,7 +551,10 @@ def onlinemasters(level, step):
 @app.route('/space_eu/<level>', methods=['GET'], defaults={'step': 1})
 @app.route('/space_eu/<level>/<step>', methods=['GET'])
 def space_eu(level, step):
-    g.level = level = int(level)
+    try:
+        g.level = level = int(level)
+    except:
+        return 'No such Hedy level!', 404
     g.lang = requested_lang()
     g.prefix = '/space_eu'
 

--- a/app.py
+++ b/app.py
@@ -522,13 +522,10 @@ def index(level, step):
         adventure_name=adventure_name)
 
 @app.route('/onlinemasters', methods=['GET'], defaults={'level': 1, 'step': 1})
-@app.route('/onlinemasters/<level>', methods=['GET'], defaults={'step': 1})
-@app.route('/onlinemasters/<level>/<step>', methods=['GET'])
+@app.route('/onlinemasters/<int:level>', methods=['GET'], defaults={'step': 1})
+@app.route('/onlinemasters/<int:level>/<int:step>', methods=['GET'])
 def onlinemasters(level, step):
-    try:
-        g.level = level = int(level)
-    except:
-        return 'No such Hedy level!', 404
+    g.level = level = int(level)
     g.lang = lang = requested_lang()
     g.prefix = '/onlinemasters'
 
@@ -548,13 +545,10 @@ def onlinemasters(level, step):
         adventure_name='')
 
 @app.route('/space_eu', methods=['GET'], defaults={'level': 1, 'step': 1})
-@app.route('/space_eu/<level>', methods=['GET'], defaults={'step': 1})
-@app.route('/space_eu/<level>/<step>', methods=['GET'])
+@app.route('/space_eu/<int:level>', methods=['GET'], defaults={'step': 1})
+@app.route('/space_eu/<int:level>/<int:step>', methods=['GET'])
 def space_eu(level, step):
-    try:
-        g.level = level = int(level)
-    except:
-        return 'No such Hedy level!', 404
+    g.level = level = int(level)
     g.lang = requested_lang()
     g.prefix = '/space_eu'
 

--- a/website/querylog.py
+++ b/website/querylog.py
@@ -140,7 +140,9 @@ def finish_global_log_record(exc=None):
 
 def log_value(**kwargs):
     """Log values into the currently globally active Log Record."""
-    THREAD_LOCAL.current_log_record.set(**kwargs)
+    if hasattr(THREAD_LOCAL, 'current_log_record'):
+        # For some malformed URLs, the records are not initialized, so we check whether there's a current_log_record
+        THREAD_LOCAL.current_log_record.set(**kwargs)
 
 
 def log_time(name):


### PR DESCRIPTION
Currently, `/space_eu/1%3Flang=en` and `/hedy/1?lang=en?lang=en` trigger 500s. This code fixes both classes of malformed URLs by adding validations.