### PR TITLE
puts back a newline at the end of palette code

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -212,7 +212,7 @@ function tryPaletteCode(exampleCode) {
   var editor = ace.edit("editor");
 
   var MOVE_CURSOR_TO_END = 1;
-  editor.setValue(exampleCode, MOVE_CURSOR_TO_END);
+  editor.setValue(exampleCode + '\n', MOVE_CURSOR_TO_END);
   window.State.unsaved_changes = false;
 }
 


### PR DESCRIPTION
We removed this as a quickfix because we had issues in level 10 a while back, is fixed now!