### PR TITLE
fix(heroku): new `db_init` method not called on Heroku

### DIFF
--- a/app.py
+++ b/app.py
@@ -903,12 +903,21 @@ auth.routes (app, requested_lang)
 
 # *** START SERVER ***
 
-if __name__ == '__main__':
+def on_server_start():
+    """Called just before the server is started, both in developer mode and on Heroku.
+
+    Use this to initialize objects, dependencies and connections.
+    """
     db_init()
+
+
+if __name__ == '__main__':
     # Start the server on a developer machine. Flask is initialized in DEBUG mode, so it
     # hot-reloads files. We also flip our own internal "debug mode" flag to True, so our
     # own file loading routines also hot-reload.
     utils.set_debug_mode(True)
+
+    on_server_start()
 
     # Threaded option enables multiple instances for multiple user access support
     app.run(threaded=True, debug=True, port=config ['port'], host="0.0.0.0")

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -7,3 +7,8 @@ def worker_exit(server, worker):
     from website import querylog, jsonbin
     querylog.emergency_shutdown()
     jsonbin.emergency_shutdown()
+
+def post_fork(server, worker):
+    """When the worker has started."""
+    import app
+    app.on_server_start()


### PR DESCRIPTION
On Heroku, we don't use the `if __name__ == '__main__':` block to
initialize our application, but instead run the server through
`gunicorn`.

The new `db_init()` function introduced in #537, that is required to be
called at the start of the process, was not called when loaded via
gunicorn.

Add a new hook to properly call initialization routines in both
scenarios.