### PR TITLE
fix(logging): double exception in log handler

### DIFF
--- a/website/log_queue.py
+++ b/website/log_queue.py
@@ -145,7 +145,7 @@ class LogQueue:
                 # with numbers lower than next_wake)
                 self.transmit_now(next_wake)
             except Exception as e:
-                traceback.print_exc(e)
+                traceback.print_exc()
             next_wake += self.batch_window_s
 
 


### PR DESCRIPTION
`print_exc()` doesn't take arguments: it implicitly already prints
the most recent exception.

The fact that we called this function incorrectly meant an exception
was thrown during exception handling.