### PR TITLE
fix: user_ms and sys_ms are logged as lists

### DIFF
--- a/website/querylog.py
+++ b/website/querylog.py
@@ -36,8 +36,8 @@ class LogRecord:
         end_time = time.time()
         if not IS_WINDOWS:
             end_rusage = resource.getrusage(resource.RUSAGE_SELF)
-            user_ms = ms_from_fsec(end_rusage.ru_utime - self.start_rusage.ru_utime),
-            sys_ms = ms_from_fsec(end_rusage.ru_stime - self.start_rusage.ru_stime),
+            user_ms = ms_from_fsec(end_rusage.ru_utime - self.start_rusage.ru_utime)
+            sys_ms = ms_from_fsec(end_rusage.ru_stime - self.start_rusage.ru_stime)
         else:
             user_ms = None
             sys_ms = None


### PR DESCRIPTION
In the query log, the resource consumption entries are logged as
`user_ms: [15]` instead of `user_ms: 15` because of a trailing `,`
which makes the values tuples.