### PR TITLE
fix: script errors aren't reported properly in prod

### DIFF
--- a/app.py
+++ b/app.py
@@ -357,6 +357,7 @@ def report_client_exception():
         is_test=1 if os.getenv ('IS_TEST_ENV') else None
     )
 
+    # Return a 500 so the HTTP status codes will stand out in our monitoring/logging
     return 'logged', 500
 
 @app.route('/version', methods=['GET'])


### PR DESCRIPTION
Because `app.js` is loaded from the CDN in prod, if there's an error in
the script the browser hides the details of the error for security
reasons (different domain = you don't get to see the details).

Add a cross-origin header so the browser will treat the external
resources as safe.