### PR TITLE
fix: unbreak syntax highlighting

### DIFF
--- a/templates/code-page.html
+++ b/templates/code-page.html
@@ -90,10 +90,11 @@
     window.State.loaded_program = {{ loaded_program|tojson }};
     window.State.default_program_name = {{ (level_title + ' ' + level_nr)|tojson }};
   </script>
+  {# Important syntaxModeRules.js gets loaded first #}
+  <script src="{{static('/js/syntaxModesRules.js')}}" type="text/javascript"></script>
   <script src="{{static('/js/app.js')}}" type="text/javascript"></script>
   <script src="{{static('/js/auth.js')}}" type="text/javascript"></script>
   <script src="{{static('/js/tabs.js')}}" type="text/javascript"></script>
   <script src="{{static('/vendor/skulpt.min.js')}}" type="text/javascript"></script>
   <script src="{{static('/vendor/skulpt-stdlib.js')}}" type="text/javascript"></script>
-  <script src="{{static('/js/syntaxModesRules.js')}}" type="text/javascript"></script>
 {% endblock %}


### PR DESCRIPTION
Syntax highlighting was broken because JavaScript files were being
loaded in the wrong order.