### PR TITLE
fix: fix syntax highlighting and speech on share program page

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -551,6 +551,7 @@ function buildUrl(url, params) {
   }
 
   if (!window.speechSynthesis) { return; /* No point in even trying */ }
+  if (!window.State.lang) { return; /* Not on a code page */ }
 
   /**
    * Show the "speak" checkbox if we find that we have speech support for the

--- a/templates/view-program-page.html
+++ b/templates/view-program-page.html
@@ -15,6 +15,13 @@
   <script src="{{static('/vendor/skulpt.min.js')}}" type="text/javascript" crossorigin="anonymous"></script>
   <script src="{{static('/vendor/skulpt-stdlib.js')}}" type="text/javascript" crossorigin="anonymous"></script>
   <script src="/error_messages.js?lang={{ lang }}" type="text/javascript" crossorigin="anonymous"></script>
+  <script>
+    window.State = {};
+    window.State.lang = "{{ lang }}";
+    window.State.level = "{{ level }}";
+    window.State.sublevel = {{ sublevel or 0 }};
+    window.State.level_title = "{{ level_title }}";
+  </script>
   <script src="{{static('/js/syntaxModesRules.js')}}" type="text/javascript" crossorigin="anonymous"></script>
   <script src="{{static('/js/app.js')}}" type="text/javascript" crossorigin="anonymous"></script>
   <script src="{{static('/js/auth.js')}}" type="text/javascript" crossorigin="anonymous"></script>


### PR DESCRIPTION
`window.State.lang` could be `undefined` (in non-code page where
`app.js` is still loaded), probably `view-program-page`.

Make sure the vars are set but also write the code a bit more
defensively.