### PR TITLE
fix: level 3 syntax highlighting

### DIFF
--- a/static/js/syntaxModesRules.js
+++ b/static/js/syntaxModesRules.js
@@ -184,52 +184,39 @@ define('ace/mode/level3_highlight_rules', [], function(require, exports, module)
   var ExampleHighlightRules = function() {
 
     this.$rules = {
-
       "start": [{
-        token: "keyword",
         regex: "^print ",
+        token: "keyword",
         next: "print option"
       },{
-        token: "keyword",
         regex: " is ask ",
+        token: "keyword",
         next: "rest"
       },{
-        token: "keyword",
         regex: " is ",
+        token: "keyword",
         next: "rest"
       }],
 
       "print option": [{
-        token: "constant.character",
-        regex: "'",
-        next: "print rest"
+        regex: "('[^']*')(.*)",
+        token: ["constant.character", "text"],
+        next: "start",
       },{
-        defaultToken : "text"
+        regex: "\\w+",
+        token: "text",
+        next: "after print variable",
       }],
 
-      "print rest": [{
-        token: "keyword",
-        regex: " at random | at random$",
-      },{
-        token: "constant.character", // constant.character
-        regex: "'",
-        next: "rest"
-      },{
-        token: "text",
-        regex: "$",
-        next: "start"
-      },{
-        defaultToken : "constant.character"
-      }],
+      "rest": [{ regex: "$", next: "start" }],
 
-      "rest": [{
-        token: "text",
-        regex: "$",
-        next: "start"
-      },{
-        defaultToken : "text"
-      }]
+      "after print variable": [{
+        regex: "(\\s+at random)(.*)",
+        token: ["keyword", "text"],
+        next: "start",
+      }],
     };
+
     this.normalizeRules();
   };
 


### PR DESCRIPTION
The regexes in the tokenizer will only ever see one line at a time,
without the closing `\n`. As soon as all characters in a line have
been consumed, the tokenizer moves to the next line, remembering
the current state.

This means that consuming 0 characters at the end of line to move
back to the start state is not possible.

Instead, we take advantage of the ability of the tokenizer to capture
multiple groups (characters between `(...)` in the regex) and assign all
of them token classes at once by specifying them in arrays. This allows
us to finish regexes with `(.*)` to consume anything till the end of the
line (if present), so we know that we can move back to the `start` state
after having done so.