### PR TITLE
fix(highlight): remove invalid states

### DIFF
--- a/static/js/syntaxModesRules.js
+++ b/static/js/syntaxModesRules.js
@@ -419,7 +419,7 @@ function rule_printParen() {
   return recognize('start', {
     regex: '(print)(\\()',
     token: ['keyword', 'paren.lparen'],
-    next: 'expression'
+    next: 'start'
   });
 }
 
@@ -443,13 +443,13 @@ function rule_turtle() {
 
 
 /**
- * Add a 'print' rule with brackets
+ * Add an 'is input' rule with brackets
  */
 function rule_isInputParen() {
   return recognize('start', {
     regex: '(\\w+)( is input)(\\()',
     token: ['text', 'keyword', 'paren.lparen'],
-    next: 'expression'
+    next: 'start'
   });
 }
 


### PR DESCRIPTION
We recently had 500s, caused by this client error:

```
Uncaught Error: state doesn't exist
```

This is an error thrown by the Ace editor if the syntax
highlighting rules reference a `next` state that doesn't exist.

The state `expression` doesn't exist anymore, but was still referenced.
These days, we recognize most expressions simply from the `start` state.

Remove the invalid references to a state that doesn't exist anymore.