### PR TITLE
chore: client exceptions don't contain source page

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -358,6 +358,7 @@ function reportClientError(level, code, client_error) {
     data: JSON.stringify({
       level: level,
       code: code,
+      page: window.location.href,
       client_error: client_error,
     }),
     contentType: 'application/json',


### PR DESCRIPTION
Very relevant information on how to produce a client error
is missing: the page the error occurred on.

Add that in.