### PR TITLE
feat: "try example" button on examples

### DIFF
--- a/app.py
+++ b/app.py
@@ -705,17 +705,20 @@ def space_eu(level, step):
 
 
 
-@app.route('/error_messages.js', methods=['GET'])
-def error():
+@app.route('/client_messages.js', methods=['GET'])
+def client_messages():
     error_messages = TRANSLATIONS.get_translations(requested_lang(), "ClientErrorMessages")
-    response = make_response(render_template("error_messages.js", error_messages=json.dumps(error_messages)))
+    ui_messages = TRANSLATIONS.get_translations(requested_lang(), "ui")
+
+    response = make_response(render_template("client_messages.js",
+        error_messages=json.dumps(error_messages),
+        ui_messages=json.dumps(ui_messages)))
 
     if not is_debug_mode():
         # Cache for longer when not devving
         response.cache_control.max_age = 60 * 60  # Seconds
 
     return response
-
 
 @app.errorhandler(500)
 def internal_error(exception):

--- a/coursedata/adventures/en.yaml
+++ b/coursedata/adventures/en.yaml
@@ -1034,7 +1034,8 @@ adventures:
 
                     In level 1 we start our haunted house game by making up a scary story and ask the player what monster they'll see in the haunted house.
 
-                        ## Example Hedy code
+                    ## Example Hedy code
+
                     ```
                     print How did i get here?
                     print I remember my friend telling me to go into the old mansion...

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -12,11 +12,17 @@
   // read-only editors (for syntax highlighting)
   for (const preview of $('.turn-pre-into-ace pre').get()) {
     $(preview).addClass('text-lg rounded');
-    const editor = turnIntoAceEditor(preview, true)
+    const exampleEditor = turnIntoAceEditor(preview, true)
     // Fits to content size
-    editor.setOptions({ maxLines: Infinity });
+    exampleEditor.setOptions({ maxLines: Infinity });
     // Strip trailing newline, it renders better
-    editor.setValue(editor.getValue().replace(/\n+$/, ''), -1);
+    exampleEditor.setValue(exampleEditor.getValue().replace(/\n+$/, ''), -1);
+
+    // And add an overlay button to the editor
+    const buttonContainer = $('<div>').css({ position: 'absolute', top: 5, right: 5, width: 'auto' }).appendTo(preview);
+    $('<button>').attr('title', UiMessages.try_button).css({ fontFamily: 'sans-serif' }).addClass('green-btn').text('⇥').appendTo(buttonContainer).click(function() {
+      window.editor.setValue(exampleEditor.getValue() + '\n');
+    });
   }
 
   /**

--- a/templates/auth.html
+++ b/templates/auth.html
@@ -10,5 +10,5 @@
   <script src="{{static('/vendor/ace.js')}}" type="text/javascript" charset="utf-8" crossorigin="anonymous"></script>
   <script src="{{static('/js/app.js')}}" type="text/javascript" crossorigin="anonymous"></script>
   <script src="{{static('/js/auth.js')}}" type="text/javascript" crossorigin="anonymous"></script>
-  <script src="/error_messages.js?lang={{ lang }}" type="text/javascript" crossorigin="anonymous"></script>
+  <script src="/client_messages.js?lang={{ lang }}" type="text/javascript" crossorigin="anonymous"></script>
 {% endblock %}

--- a/templates/client_messages.js
+++ b/templates/client_messages.js
@@ -1,0 +1,2 @@
+var ErrorMessages = {{ error_messages|safe }};
+var UiMessages = {{ ui_messages|safe }};

--- a/templates/code-page.html
+++ b/templates/code-page.html
@@ -37,7 +37,7 @@
 
 {% block scripts %}
   <script src="{{static('/vendor/ace.js')}}" type="text/javascript" charset="utf-8" crossorigin="anonymous"></script>
-  <script src="/error_messages.js?lang={{ lang }}" type="text/javascript" crossorigin="anonymous"></script>
+  <script src="/client_messages.js?lang={{ lang }}" type="text/javascript" crossorigin="anonymous"></script>
   <script>
     window.State = {};
     window.State.lang = "{{ lang }}";
@@ -55,6 +55,7 @@
   </script>
   {# Important syntaxModeRules.js gets loaded first #}
   <script src="{{static('/js/syntaxModesRules.js')}}" type="text/javascript" crossorigin="anonymous"></script>
+  <script src="{{static('/js/examples.js')}}" type="text/javascript" crossorigin="anonymous"></script>
   <script src="{{static('/js/app.js')}}" type="text/javascript" crossorigin="anonymous"></script>
   <script src="{{static('/js/auth.js')}}" type="text/javascript" crossorigin="anonymous"></script>
   <script src="{{static('/js/tabs.js')}}" type="text/javascript" crossorigin="anonymous"></script>

--- a/templates/error_messages.js
+++ b/templates/error_messages.js
@@ -1,1 +1,0 @@
-var ErrorMessages = {{ error_messages|safe }};

--- a/templates/view-program-page.html
+++ b/templates/view-program-page.html
@@ -14,7 +14,7 @@
   <script src="{{static('/vendor/ace.js')}}" type="text/javascript" charset="utf-8" crossorigin="anonymous"></script>
   <script src="{{static('/vendor/skulpt.min.js')}}" type="text/javascript" crossorigin="anonymous"></script>
   <script src="{{static('/vendor/skulpt-stdlib.js')}}" type="text/javascript" crossorigin="anonymous"></script>
-  <script src="/error_messages.js?lang={{ lang }}" type="text/javascript" crossorigin="anonymous"></script>
+  <script src="/client_messages.js?lang={{ lang }}" type="text/javascript" crossorigin="anonymous"></script>
   <script>
     window.State = {};
     window.State.lang = "{{ lang }}";


### PR DESCRIPTION
For ever example we find in the content of tabs, add a button
to it to quickly copy the code into the editor.

Also in this commit: renamed `error_messages.js` to
`client_messages.js`, since sometimes we need UI translations in the
JavaScript as well, and it's a better name.

<img width="958" alt="image" src="https://user-images.githubusercontent.com/524162/130350770-fe169ceb-25bb-4374-ae67-13cbf5cda647.png">
