### PR TITLE
feat(tabs): remember selected tab upon refresh

### DIFF
--- a/static/js/tabs.js
+++ b/static/js/tabs.js
@@ -17,64 +17,78 @@
  * TARGET by the *absence* of the '.hidden' class.
  */
 $(function() {
+  function switchToTab(tabName) {
+    // Find the tab that leads to this selection, and its siblings
+    const tab = $('*[data-tab="' + tabName + '"]');
+    const allTabs = tab.siblings('*[data-tab]');
+
+    // Fidn the target associated with this selection, and its siblings
+    const target = $('*[data-tabtarget="' + tabName + '"]');
+    const allTargets = target.siblings('*[data-tabtarget]');
+
+    // Fix classes
+    allTabs.removeClass('tab-selected');
+    tab.addClass('tab-selected');
+
+    allTargets.addClass('hidden');
+    target.removeClass('hidden');
+
+    const adventures = {};
+    window.State.adventures.map (function (adventure) {
+      adventures [adventure.short_name] = adventure;
+    });
+
+    // If the loaded program (directly requested by link with id) matches the currently selected tab, use that, overriding the loaded program that came in the adventure or level.
+    if (window.State.loaded_program && (window.State.adventure_name_onload || 'level') === tabName) {
+      $ ('#program_name').val (window.State.loaded_program.name);
+      window.editor.setValue (window.State.loaded_program.code);
+    }
+    // If there's a loaded program for the adventure or level now selected, use it.
+    else if (adventures [tabName].loaded_program) {
+      $ ('#program_name').val (adventures [tabName].loaded_program.name);
+      window.editor.setValue (adventures [tabName].loaded_program.code);
+    }
+    // If there's no loaded program (either requested by id or associated to the adventure/level), load defaults.
+    else if (tabName === 'level') {
+      $ ('#program_name').val (window.State.default_program_name);
+      window.editor.setValue (window.State.default_program);
+    }
+    else {
+      $ ('#program_name').val (adventures [tabName].default_save_name + ' - ' + window.State.level_title + ' ' + window.State.level);
+      window.editor.setValue (adventures [tabName].start_code);
+    }
+
+    window.State.adventure_name = tabName === 'level' ? undefined : tabName;
+    window.editor.clearSelection();
+    // If user wants to override the unsaved program, reset unsaved_changes
+    window.State.unsaved_changes = false;
+  }
+
   $('*[data-tab]').click(function (e) {
     const tab = $(e.target);
-    const allTabs = tab.siblings('*[data-tab]');
-    const tabName = tab.data('tab').replace ('t-', '');
+    const tabName = tab.data('tab');
 
     e.preventDefault ();
 
-    // Everything is wrapped in a function so we can invoke it in the case that there are unsaved changes
-    var main = function () {
-      window.State.adventure_name = tabName === 'level' ? undefined : tabName;
-
-      const target = $('*[data-tabtarget="t-' + tabName + '"]');
-      const allTargets = target.siblings('*[data-tabtarget]');
-
-      allTabs.removeClass('tab-selected');
-      tab.addClass('tab-selected');
-
-      allTargets.addClass('hidden');
-      target.removeClass('hidden');
-
-      const adventures = {};
-      window.State.adventures.map (function (adventure) {
-        adventures [adventure.short_name] = adventure;
-      });
-
-      // If the loaded program (directly requested by link with id) matches the currently selected tab, use that, overriding the loaded program that came in the adventure or level.
-      if (window.State.loaded_program && (window.State.adventure_name_onload || 'level') === tabName) {
-        $ ('#program_name').val (window.State.loaded_program.name);
-        window.editor.setValue (window.State.loaded_program.code);
-      }
-      // If there's a loaded program for the adventure or level now selected, use it.
-      else if (adventures [tabName].loaded_program) {
-        $ ('#program_name').val (adventures [tabName].loaded_program.name);
-        window.editor.setValue (adventures [tabName].loaded_program.code);
-      }
-      // If there's no loaded program (either requested by id or associated to the adventure/level), load defaults.
-      else if (tabName === 'level') {
-        $ ('#program_name').val (window.State.default_program_name);
-        window.editor.setValue (window.State.default_program);
-      }
-      else {
-        $ ('#program_name').val (adventures [tabName].default_save_name + ' - ' + window.State.level_title + ' ' + window.State.level);
-        window.editor.setValue (adventures [tabName].start_code);
-      }
-
-      window.editor.clearSelection ();
-      // If user wants to override the unsaved program, reset unsaved_changes
-      window.State.unsaved_changes = false;
-    }
-
     // If there are unsaved changes, we warn the user before changing tabs.
-    if (window.State.unsaved_changes) window.modal.confirm (window.auth.texts.unsaved_changes, main);
-    else main ();
+    if (window.State.unsaved_changes) window.modal.confirm(window.auth.texts.unsaved_changes, () => switchToTab(tabName));
+    else switchToTab(tabName);
 
+    // Do a 'replaceState' to add a '#anchor' to the URL
+    const hashFragment = tabName !== 'level' ? tabName : '';
+    window.history?.replaceState(null, null, '#' + hashFragment);
   });
 
   // If we're opening an adventure from the beginning (either through a link to /hedy/adventures or through a saved program for an adventure), we click on the relevant tab.
   // We click on `level` to load a program associated with level, if any.
-  const adventureName = window.State && window.State.adventure_name;
-  $('*[data-tab="t-' + (adventureName || 'level') + '"]').click ();
+  if (window.State && window.State.adventure_name) {
+    switchToTab(adventureName);
+  }
+  else if (window.location.hash) {
+    // If we have an '#anchor' in the URL, switch to that tab
+    const hashFragment = window.location.hash.replace(/^#/, '');
+    if (hashFragment) {
+      switchToTab(hashFragment);
+    }
+  }
 });

--- a/templates/incl-adventure-tabs.html
+++ b/templates/incl-adventure-tabs.html
@@ -1,22 +1,22 @@
       {# TABS #}
       <div>
         <div class="flex cursor-pointer flex-end">
-        <a tabindex="0" href="#" data-tab="t-level" class="block text-black no-underline font-light tab tab-selected" tabindex="0">{{ level_title }} {{ level_nr }}</a>
+        <a tabindex="0" href="#" data-tab="level" class="block text-black no-underline font-light tab tab-selected" tabindex="0">{{ level_title }} {{ level_nr }}</a>
         {% for assignment in adventures %}
           {% if assignment.short_name != 'level' %}
-            <a tabindex="0" href="#" data-tab="t-{{assignment.short_name}}" class="text-black no-underline font-light tab" tabindex="0">{{ assignment.name }}</a>
+            <a tabindex="0" href="#" data-tab="{{assignment.short_name}}" class="text-black no-underline font-light tab" tabindex="0">{{ assignment.name }}</a>
           {% endif %}
         {% endfor %}
         </ul>
       </div>
       {# PANES #}
       <div style='width: 100%; min-height: 10em;' class="bg-white p-4 mb-8 shadow-md turn-pre-into-ace">
-        <div data-tabtarget="t-level">
+        <div data-tabtarget="level">
           {{intro_text|commonmark}}
         </div>
         {% for assignment in adventures %}
           {% if assignment.short_name != 'level' %}
-            <div data-tabtarget="t-{{assignment.short_name}}" class="hidden">
+            <div data-tabtarget="{{assignment.short_name}}" class="hidden">
               {% if assignment.image %}
                 <img class="float-right w-48" src="{{static('/images/' + assignment.image)}}">
               {% endif %}


### PR DESCRIPTION
Especially when testing, it's very annoying when a page refresh forgets
what tab you were on.

Use the browser `replaceState` API to change the current URL to include
the tab in a `#hash_fragment`, and automatically switch to that tab when
the page is loaded.

<img width="496" alt="image" src="https://user-images.githubusercontent.com/524162/130351813-4e1a5739-d91e-477b-9629-08061ec446fd.png">
