### PR TITLE
chore: remove duplicate dependency on Lark in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 Flask==1.1.4
-lark==0.11.3
-lark-parser==0.7.8
+lark-parser==0.11.3
 gunicorn==19.9.0
 flask-compress==1.4.0
 requests==2.23.0


### PR DESCRIPTION
Lark is published both to PyPI under the name `lark` as well as
`lark-parser`. They seem to be the same, so let's just depend
on the version that the docs say we should install.