### PR TITLE
Fix for `query` method in Dynamo

### DIFF
--- a/e2e_tests.py
+++ b/e2e_tests.py
@@ -449,6 +449,7 @@ def suite (username):
         ['unshare program', 'post', '/programs/share', {}, lambda state: {'id': state ['program'] ['id'], 'public': False}, 200],
         ['delete program', 'get', lambda state: '/programs/delete/' + state ['program'] ['id'], {}, {}, 302],
         ['retrieve programs after deleting saved program', 'get', '/programs_list', {}, {}, 200, retrieveProgramsBefore],
+        ['create program before destroying account', 'post', '/programs', {}, {'code': 'print Hello world', 'name': 'Program 1', 'level': 1}, 200],
         ['destroy account', 'post', '/auth/destroy', {}, {}, 200],
         ['get programs without being logged in', 'get', '/programs', {}, {}, 302],
         # Auth: profile (programming experience)

--- a/website/dynamo.py
+++ b/website/dynamo.py
@@ -172,9 +172,13 @@ class AwsDynamoStorage(TableStorage):
         return self._decode(result.get('Item', None))
 
     def query(self, table_name, key, reverse=False):
+        assert len(key.keys ()) == 1
+        key_field = list (key.keys ()) [0]
+        key_value = key [key_field]
         result = self.db.query(
             TableName=self.db_prefix + '-' + table_name,
-            Key = self._encode(key),
+            KeyConditionExpression = key_field + ' = :value',
+            ExpressionAttributeValues = {':value': {'S': key_value}},
             ScanIndexForward = not reverse)
         return list(map(self._decode, result.get('Items', [])))
 

--- a/website/dynamo.py
+++ b/website/dynamo.py
@@ -178,7 +178,7 @@ class AwsDynamoStorage(TableStorage):
         result = self.db.query(
             TableName=self.db_prefix + '-' + table_name,
             KeyConditionExpression = key_field + ' = :value',
-            ExpressionAttributeValues = {':value': {'S': key_value}},
+            ExpressionAttributeValues = {':value': self.SERIALIZER.serialize (key_value)},
             ScanIndexForward = not reverse)
         return list(map(self._decode, result.get('Items', [])))
 


### PR DESCRIPTION
While investigating #613 , it emerged that the `del_many` would throw an error when running on Dynamo (but not when running with the local DB) because of a call to `db.query`. Said call used the `Key` parameter which doesn't seem to be accepted by Dynamo itself.

This fixes `db.query` and, as a consequence, also `del_many`. It is indirectly tested by deleting a user with a program in the E2E tests.

I'm not sure whether the approach I used here is correct. It does work, but it may restrict the generic-ness of the method. @rix0rrr please let me know what you think.

Closes #613 