### PR TITLE
Fix admin view

### DIFF
--- a/e2e_tests.py
+++ b/e2e_tests.py
@@ -404,6 +404,8 @@ def suite (username):
         ['get session vars from main again', 'get', '/session_main', {}, {}, 200, checkMainSessionVarsAgain],
         # Main page
         ['get root', 'get', '/', {}, '', 200],
+        # Admin page
+        ['get admin', 'get', '/admin', {}, {}, 200],
         # Auth: signup
         invalidMap ('signup', 'post', '/auth/signup', ['', [], {}, {'username': 1}, {'username': 'user@me', 'password': 'foobar', 'email': 'a@a.com'}, {'username:': 'user: me', 'password': 'foobar', 'email': 'a@a.co'}, {'username': 't'}, {'username': '    t    '}, {'username': username}, {'username': username, 'password': 1}, {'username': username, 'password': 'foo'}, {'username': username, 'password': 'foobar'}, {'username': username, 'password': 'foobar', 'email': 'me@something'}, {'username': username, 'password': 'foobar', 'email': 'me@something.com', 'prog_experience': [2]}, {'username': username, 'password': 'foobar', 'email': 'me@something.com', 'prog_experience': 'foo'}, {'username': username, 'password': 'foobar', 'email': 'me@something.com', 'experience_languages': 'python'}]),
         ['valid signup', 'post', '/auth/signup', {}, {'username': username, 'password': 'foobar', 'email': username + '@e2e-testing.com'}, 200, successfulSignup],

--- a/website/auth.py
+++ b/website/auth.py
@@ -589,4 +589,4 @@ def auth_templates (page, lang, menu, request):
             user ['index'] = counter
             counter = counter + 1
 
-        return render_template ('admin.html', lang=lang, users=userdata, program_count=DATABASE.all_programs_count(), user_count=DATABASE.all_users_count())
+        return render_template ('admin.html', lang=lang, users=userdata, program_count=DATABASE.all_programs_count(), user_count=DATABASE.all_users_count(), auth=TRANSLATIONS.get_translations (lang, 'Auth'))

--- a/website/auth.py
+++ b/website/auth.py
@@ -561,7 +561,7 @@ def auth_templates (page, lang, menu, request):
     if page in ['signup', 'login', 'recover', 'reset']:
         return render_template (page + '.html',  lang=lang, auth=TRANSLATIONS.get_translations (lang, 'Auth'), menu=menu, username=current_user (request) ['username'], current_page='login')
     if page == 'admin':
-        if not is_admin (request):
+        if not is_testing_request (request) and not is_admin (request):
             return 'unauthorized', 403
 
         # After hitting 1k users, it'd be wise to add pagination.


### PR DESCRIPTION
Not sure how the admin stopped working. We have been requiring the `auth` tests in the template, but for a while we haven't passed them. Perhaps we were setting the `auth` variable as a global of some sort and somehow it managed to work all this time. A cursory check on the blame view shows that this wasn't broken the last time the line changed, but earlier.

In any case, we now pass the variable. I have also added a `GET /admin` to the E2E cycle - this would have uncovered the bug as soon as it emerged.

**How to test**: opening the admin should work instead of throwing a template error.