### PR TITLE
Fix typo causing program failure

### DIFF
--- a/coursedata/adventures/en.yaml
+++ b/coursedata/adventures/en.yaml
@@ -59,7 +59,7 @@ adventures:
                     It goes like this:
                     ```
                     animals is owl, hedgehog, armadillo
-                    print He now hears the sound of an animal at random
+                    print He now hears the sound of an animals at random
                     ```
 
                     ## What's next?


### PR DESCRIPTION
I'm getting an error message when running the randomness example from "Story" in Level 2. It says `name 'animal' is not defined`. This seems to be caused by the variable being called `animals` (plural) and being referenced as `animal` (singular). This PR fixes that.

**Sidenote:** I wasn't really sure whether the variable creation should be changed or the reference. The reference as it was looked good because it made the sourcecode read like proper English. But I went with changing the reference to make it match the source for Level 3.