### PR TITLE
Updates grammar for better error messages

### DIFF
--- a/coursedata/texts/nl.yaml
+++ b/coursedata/texts/nl.yaml
@@ -41,7 +41,7 @@ HedyErrorMessages:
     Has Blanks: "Let op! Jouw code is not niet compleet. Er staat nog een laag streepje in, daar moet jij de juiste code nog invullen."
     Parse: "De code die jij intypte is geen geldige Hedy code. Er zit een foutje op regel {location[0]}, op positie {location[1]}. Jij typte {character_found}, maar dat mag op die plek niet."
     Unquoted Text: "Let op! Als bij print en ask moet voor én achter de tekst een aanhalingsteken komen. Jij bent er ergens eentje vergeten."
-    VarUndefined: "Je probeerde de naam {name} te printen, maar die heb je niet ingesteld."
+    Var Undefined: "Je probeert de naam {name} te printen, maar die heb je niet ingesteld. Het kan ook zijn dat je het woord {name} wilde printen en aanhalingstekens vergeten bent."
     space: "een spatie"
     comma: "een komma"
     question mark: "een vraagteken"

--- a/grammars/level3-Additions.lark
+++ b/grammars/level3-Additions.lark
@@ -1,17 +1,17 @@
 command: print | ask | turtle | assign_list | ask_no_quotes| assign | print_no_quotes | invalid //catch all at the end
 
-//ask_no_quotes can conflict with assign (color is ask wat? -> color = 'ask wat?')
-// so it needs to go before
+// we need a separate rule for a var when used in a print argument
+// it parses the same, but should not be counted towards lookup table creation
+var_access : NAME
 
 //since ask allows for quotes, there is some duplication between ask and print
 //so maybe (_SPACE| list_access | quoted_text | var)* should be something like 'print_argument'?)
 
-//same holds for the unquoted arguments
-
-print: _PRINT _SPACE (_SPACE| list_access | quoted_text | var)*  -> print
+print: _PRINT _SPACE (_SPACE| list_access | quoted_text | var_access)*  -> print
 print_no_quotes: _PRINT _SPACE text -> print_nq
-ask: var _SPACE _IS _SPACE _ASK _SPACE (_SPACE| list_access | quoted_text | var)*
+ask: var _SPACE _IS _SPACE _ASK _SPACE (_SPACE| list_access | quoted_text | var_access)*
 ask_no_quotes: var _SPACE _IS _SPACE _ASK _SPACE (_SPACE| list_access | textwithoutspaces | punctuation)*  -> print_nq
+
 
 
 //anything can be parsed except for spaces, and a newlines and commas for list separators

--- a/grammars/level3-Additions.lark
+++ b/grammars/level3-Additions.lark
@@ -9,13 +9,13 @@ command: print | ask | turtle | assign_list | ask_no_quotes| assign | print_no_q
 //same holds for the unquoted arguments
 
 print: _PRINT _SPACE (_SPACE| list_access | quoted_text | var)*  -> print
-print_no_quotes: _PRINT _SPACE (_SPACE| list_access | textwithoutspaces | punctuation)*  -> print_nq
+print_no_quotes: _PRINT _SPACE text -> print_nq
 ask: var _SPACE _IS _SPACE _ASK _SPACE (_SPACE| list_access | quoted_text | var)*
 ask_no_quotes: var _SPACE _IS _SPACE _ASK _SPACE (_SPACE| list_access | textwithoutspaces | punctuation)*  -> print_nq
 
 
 //anything can be parsed except for spaces, and a newlines and commas for list separators
-textwithoutspaces: /([^\r\n,!?. *+-\/]+)/ -> text
+textwithoutspaces: /([^\r\n, *+-\/]+)/ -> text
 index : NUMBER //todo FH-June 21 : why does this need its own rule? can't it just be a token
 
 //anything can be parsed except for a newline and a comma for list separators

--- a/grammars/level6-Additions.lark
+++ b/grammars/level6-Additions.lark
@@ -1,4 +1,4 @@
-print: _PRINT _SPACE (quoted_text | list_access | var | sum) (_SPACE (quoted_text | list_access | var | sum))*
+print: _PRINT _SPACE (quoted_text | list_access | var_access | sum) (_SPACE (quoted_text | list_access | var_access | sum))*
 assign: var _SPACE _IS _SPACE sum | var _SPACE _IS _SPACE textwithoutspaces
 ?sum: product | sum _SPACE* _ADD _SPACE* product -> addition | sum _SPACE* _SUBTRACT _SPACE* product -> substraction
 ?product: atom | product _SPACE* _MULTIPLY _SPACE* atom -> multiplication | product _SPACE* _DIVIDE _SPACE* atom -> division

--- a/hedy.py
+++ b/hedy.py
@@ -183,8 +183,7 @@ class AllAssignmentCommands(Transformer):
     # additions Laura, to be checked for higher levels:
     def list_access_var(self, args):
         return args[0]
-    def var_access(self,args):
-        return args[0]
+
     def change_list_item(self, args):
         return args[0]
 

--- a/tests/tests_level_03.py
+++ b/tests/tests_level_03.py
@@ -30,12 +30,12 @@ class TestsLevel3(unittest.TestCase):
 
   def test_transpile_other(self):
     with self.assertRaises(Exception) as context:
-      result = hedy.transpile("abc felienne 123", 3)
+      result = hedy.transpile("abc felienne 123", self.level)
     self.assertEqual(str(context.exception), 'Invalid')
 
   def test_transpile_print_level_2(self):
     with self.assertRaises(Exception) as context:
-      result = hedy.transpile("print felienne 123", 3)
+      result = hedy.transpile("print felienne 123", self.level)
 
     self.assertEqual('Unquoted Text', context.exception.args[0])  # hier moet nog we een andere foutmelding komen!
 
@@ -45,7 +45,7 @@ class TestsLevel3(unittest.TestCase):
     code = textwrap.dedent("""\
     print 'hallo wereld!'""")
 
-    result = hedy.transpile(code, 3)
+    result = hedy.transpile(code, self.level)
 
     expected = textwrap.dedent("""\
     print('hallo wereld!')""")
@@ -55,7 +55,7 @@ class TestsLevel3(unittest.TestCase):
 
 
   def test_transpile_turtle_basic(self):
-    result = hedy.transpile("forward 50\nturn\nforward 100", 3)
+    result = hedy.transpile("forward 50\nturn\nforward 100", self.level)
     expected = textwrap.dedent("""\
     t.forward(50)
     t.right(90)
@@ -67,7 +67,7 @@ class TestsLevel3(unittest.TestCase):
     code = textwrap.dedent("""\
     afstand is ask 'hoe ver dan?'
     forward afstand""")
-    result = hedy.transpile(code, 3)
+    result = hedy.transpile(code, self.level)
     expected = textwrap.dedent("""\
     afstand = input('hoe ver dan?')
     t.forward(afstand)""")
@@ -79,7 +79,7 @@ class TestsLevel3(unittest.TestCase):
     naam is Hedy
     print 'ik heet ,'""")
 
-    result = hedy.transpile(code, 3)
+    result = hedy.transpile(code, self.level)
 
     expected = textwrap.dedent("""\
     naam = 'Hedy'
@@ -94,7 +94,7 @@ class TestsLevel3(unittest.TestCase):
     naam is Hedy
     print 'ik heet \\''""")
 
-    result = hedy.transpile(code, 3)
+    result = hedy.transpile(code, self.level)
 
     expected = textwrap.dedent("""\
     naam = 'Hedy'
@@ -108,7 +108,7 @@ class TestsLevel3(unittest.TestCase):
     voor_naam is Hedy
     print 'ik heet '""")
 
-    result = hedy.transpile(code, 3)
+    result = hedy.transpile(code, self.level)
 
     expected = textwrap.dedent("""\
     voor_naam = 'Hedy'
@@ -122,7 +122,7 @@ class TestsLevel3(unittest.TestCase):
     for is Hedy
     print 'ik heet ' for """)
 
-    result = hedy.transpile(code, 3)
+    result = hedy.transpile(code, self.level)
 
     expected = textwrap.dedent("""\
     _for = 'Hedy'
@@ -136,7 +136,7 @@ class TestsLevel3(unittest.TestCase):
     code = textwrap.dedent("""\
     print 'Cuál es tu color favorito?'""")
 
-    result = hedy.transpile(code, 3)
+    result = hedy.transpile(code, self.level)
 
     expected = textwrap.dedent("""\
     print('Cuál es tu color favorito?')""")
@@ -150,7 +150,7 @@ class TestsLevel3(unittest.TestCase):
     dieren is Hond, Kat, Kangoeroe
     print dieren at 1""")
 
-    result = hedy.transpile(code, 3)
+    result = hedy.transpile(code, self.level)
 
     expected = textwrap.dedent("""\
     dieren = ['Hond', 'Kat', 'Kangoeroe']
@@ -167,7 +167,7 @@ class TestsLevel3(unittest.TestCase):
     dieren is Hond, Kat, Kangoeroe
     print dieren at random""")
 
-    result = hedy.transpile(code, 3)
+    result = hedy.transpile(code, self.level)
 
     expected = textwrap.dedent("""\
     dieren = ['Hond', 'Kat', 'Kangoeroe']
@@ -181,7 +181,7 @@ class TestsLevel3(unittest.TestCase):
     code = textwrap.dedent("""\
     color is ask 'Cuál es tu color favorito?'""")
 
-    result = hedy.transpile(code, 3)
+    result = hedy.transpile(code, self.level)
 
     expected = textwrap.dedent("""\
     color = input('Cuál es tu color favorito?')""")
@@ -194,7 +194,7 @@ class TestsLevel3(unittest.TestCase):
     code = textwrap.dedent("""\
     print 'ik heet henk'""")
 
-    result = hedy.transpile(code, 3)
+    result = hedy.transpile(code, self.level)
 
     expected = textwrap.dedent("""\
     print('ik heet henk')""")
@@ -208,7 +208,7 @@ class TestsLevel3(unittest.TestCase):
     naam is Hedy
     print 'ik heet' naam""")
 
-    result = hedy.transpile(code, 3)
+    result = hedy.transpile(code, self.level)
 
     expected = textwrap.dedent("""\
     naam = 'Hedy'
@@ -223,7 +223,7 @@ class TestsLevel3(unittest.TestCase):
     kleur is ask 'wat is je lievelingskleur?'
     print 'jouw lievelingskleur is dus' kleur '!'""")
 
-    result = hedy.transpile(code, 3)
+    result = hedy.transpile(code, self.level)
 
     expected = textwrap.dedent("""\
     kleur = input('wat is je lievelingskleur?')
@@ -239,7 +239,7 @@ class TestsLevel3(unittest.TestCase):
     kleur is ask 'Wat is je lievelings' ding
     print 'Jouw favoriet is dus ' kleur""")
 
-    result = hedy.transpile(code, 3)
+    result = hedy.transpile(code, self.level)
 
     expected = textwrap.dedent("""\
     ding = 'kleur'
@@ -256,7 +256,7 @@ class TestsLevel3(unittest.TestCase):
     print 'Jouw favoriet is dus ' kleur""")
 
     with self.assertRaises(Exception) as context:
-      result = hedy.transpile(code, 3)
+      result = hedy.transpile(code, self.level)
 
     self.assertEqual('Unquoted Text', context.exception.args[0])  # hier moet nog we een andere foutmelding komen!
 
@@ -267,24 +267,25 @@ class TestsLevel3(unittest.TestCase):
       print hallo wereld'""")
 
     with self.assertRaises(Exception) as context:
-      result = hedy.transpile(code, 3)
+      result = hedy.transpile(code, self.level)
 
     self.assertEqual('Unquoted Text', context.exception.args[0])
 
 
   def test_transpile_missing_all_quotes(self):
-    # het probleem is dat dit wordt herkend als variabelen (natuurlijk)
-    # dus de oplossing is throwen bij herkennen var die niet in lookup staat
-    # met de varundefined dan ipv unquoted!
+    max_level = 5
 
     code = textwrap.dedent("""\
       print hallo wereld""")
+    
+    for level in range(self.level, max_level+1):
 
-    with self.assertRaises(Exception) as context:
-      result = hedy.transpile(code, 3)
+      with self.assertRaises(Exception) as context:
+        result = hedy.transpile(code, level)
 
-    self.assertEqual('Unquoted Text', context.exception.args[0])
+      self.assertEqual('Var Undefined', context.exception.args[0])
 
+      print(f'{self.test_name()} level {level}')
 
 
 
@@ -294,7 +295,7 @@ class TestsLevel3(unittest.TestCase):
       print welcome""")
 
     with self.assertRaises(Exception) as context:
-      result = hedy.transpile(code, 3)
+      result = hedy.transpile(code, self.level)
 
     self.assertEqual('Parse', context.exception.args[0])
 

--- a/tests/tests_level_03.py
+++ b/tests/tests_level_03.py
@@ -39,6 +39,7 @@ class TestsLevel3(unittest.TestCase):
 
     self.assertEqual('Unquoted Text', context.exception.args[0])  # hier moet nog we een andere foutmelding komen!
 
+
   def test_print(self):
 
     code = textwrap.dedent("""\
@@ -262,13 +263,30 @@ class TestsLevel3(unittest.TestCase):
 
 
   def test_transpile_missing_opening_quote(self):
-    code = textwrap.dedent("""
+    code = textwrap.dedent("""\
       print hallo wereld'""")
 
     with self.assertRaises(Exception) as context:
       result = hedy.transpile(code, 3)
 
-    self.assertEqual('Unquoted Text', context.exception.args[0])  # hier moet nog we een andere foutmelding komen!
+    self.assertEqual('Unquoted Text', context.exception.args[0])
+
+
+  def test_transpile_missing_all_quotes(self):
+    # het probleem is dat dit wordt herkend als variabelen (natuurlijk)
+    # dus de oplossing is throwen bij herkennen var die niet in lookup staat
+    # met de varundefined dan ipv unquoted!
+
+    code = textwrap.dedent("""\
+      print hallo wereld""")
+
+    with self.assertRaises(Exception) as context:
+      result = hedy.transpile(code, 3)
+
+    self.assertEqual('Unquoted Text', context.exception.args[0])
+
+
+
 
   def test_transpile_issue_375(self):
     code = textwrap.dedent("""
@@ -278,7 +296,7 @@ class TestsLevel3(unittest.TestCase):
     with self.assertRaises(Exception) as context:
       result = hedy.transpile(code, 3)
 
-    self.assertEqual('Parse', context.exception.args[0])  # hier moet nog we een andere foutmelding komen!
+    self.assertEqual('Parse', context.exception.args[0])
 
   def test_two_spaces_after_print(self):
 

--- a/tests/tests_level_04.py
+++ b/tests/tests_level_04.py
@@ -335,7 +335,7 @@ class TestsLevel4(unittest.TestCase):
     code = textwrap.dedent("""\
     kleur is geel
     if kleur is groen antwoord is ok else antwoord is stom
-    print ans""")
+    print antwoord""")
 
     for level in range(self.level, maxlevel+1):
       result = hedy.transpile(code, level)
@@ -346,7 +346,7 @@ class TestsLevel4(unittest.TestCase):
         antwoord = 'ok'
       else:
         antwoord = 'stom'
-      print(ans)""")
+      print(antwoord)""")
 
       self.assertEqual(expected, result.code)
       self.assertEqual(False, result.has_turtle)

--- a/tests/tests_level_06.py
+++ b/tests/tests_level_06.py
@@ -103,6 +103,19 @@ class TestsLevel6(unittest.TestCase):
     self.assertEqual(expected, result.code)
     self.assertEqual(False, result.has_turtle)
 
+  def test_addition_var(self):
+    code = textwrap.dedent("""\
+    var is 5
+    print var + 5""")
+
+    result = hedy.transpile(code, self.level)
+
+    expected = textwrap.dedent("""\
+    var = '5'
+    print(str(int(var) + int(5)))""")
+
+    self.assertEqual(expected, result.code)
+
   def test_simple_calculation_without_space(self):
     code = "nummer is 4+5"
     result = hedy.transpile(code, self.level)


### PR DESCRIPTION
Closes #698, also addresses #597 partially: in Dutch and up to level 5 only for now. For En and other langs we need to expand the error message.