### PR TITLE
fix: fixing 2 JavaScript errors in `tabs.js`

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -384,7 +384,8 @@ window.onerror = function reportClientException(message, source, line_number, co
       source: source,
       line_number: line_number,
       column_number: column_number,
-      error: error
+      error: error,
+      user_agent: navigator.userAgent,
     }),
     contentType: 'application/json',
     dataType: 'json'

--- a/static/js/tabs.js
+++ b/static/js/tabs.js
@@ -44,7 +44,7 @@ $(function() {
       window.editor.setValue (window.State.loaded_program.code);
     }
     // If there's a loaded program for the adventure or level now selected, use it.
-    else if (adventures [tabName].loaded_program) {
+    else if (adventures [tabName] && adventures[tabName].loaded_program) {
       $ ('#program_name').val (adventures [tabName].loaded_program.name);
       window.editor.setValue (adventures [tabName].loaded_program.code);
     }
@@ -76,7 +76,7 @@ $(function() {
 
     // Do a 'replaceState' to add a '#anchor' to the URL
     const hashFragment = tabName !== 'level' ? tabName : '';
-    window.history?.replaceState(null, null, '#' + hashFragment);
+    if (window.history) { window.history.replaceState(null, null, '#' + hashFragment); }
   });
 
   // If we're opening an adventure from the beginning (either through a link to /hedy/adventures or through a saved program for an adventure), we click on the relevant tab.

--- a/templates/code-page.html
+++ b/templates/code-page.html
@@ -55,7 +55,6 @@
   </script>
   {# Important syntaxModeRules.js gets loaded first #}
   <script src="{{static('/js/syntaxModesRules.js')}}" type="text/javascript" crossorigin="anonymous"></script>
-  <script src="{{static('/js/examples.js')}}" type="text/javascript" crossorigin="anonymous"></script>
   <script src="{{static('/js/app.js')}}" type="text/javascript" crossorigin="anonymous"></script>
   <script src="{{static('/js/auth.js')}}" type="text/javascript" crossorigin="anonymous"></script>
   <script src="{{static('/js/tabs.js')}}" type="text/javascript" crossorigin="anonymous"></script>


### PR DESCRIPTION
Fixing the following 2 errors from the log:

**Uncaught TypeError: Cannot read properties of undefined (reading 'loaded_program')**

This happens in:

```js
if (adventures[tabName].loaded_program)
```

If `adventures[tabName]` happens to be undefined.

**SyntaxError: Unexpected token '.'**

This happens on:

```js
window.history?.replaceState(...);
```

Likely the user's browser doesn't understand the `?.` syntax yet, using
an old browser: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining

To detect this in the future, log the userAgent.