### PR TITLE
fix: load_yaml_pickle test fails if a pickled file is on disk

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -27,7 +27,7 @@ class TestUtils(unittest.TestCase):
     n = 50
 
     # Pick a file with unicode in it so we're sure it gets handled properly
-    file = 'coursedata/adventures/hu.yaml'
+    file = os.path.join(os.path.dirname(__file__), '..', 'coursedata/adventures/hu.yaml')
 
     # Remove pickled version of this file if it exists, it may
     # influence the tests

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,7 @@
 import unittest
 import utils
 import bcrypt
+import os
 import time
 
 class TestUtils(unittest.TestCase):
@@ -17,19 +18,31 @@ class TestUtils(unittest.TestCase):
     salt = bcrypt.gensalt ().decode ('utf-8')
     self.assertEqual(12, utils.extract_bcrypt_rounds(salt))
 
-  # def test_load_yaml_speed(self):
-  #   #   n = 50
-  #   #   file = 'coursedata/adventures/hu.yaml'
-  #   #
-  #   #   start = time.time()
-  #   #   for _ in range(n):
-  #   #     original_data = utils.load_yaml_uncached(file)
-  #   #   original_seconds = time.time() - start
-  #   #
-  #   #   start = time.time()
-  #   #   for _ in range(n):
-  #   #     cached_data = utils.load_yaml_pickled(file)
-  #   #   cached_seconds = time.time() - start
-  #   #
-  #   #   self.assertEqual(original_data, cached_data)
-  #   #   print(f'YAML loading takes {original_seconds / n} seconds, unpickling takes {cached_seconds / n} ({original_seconds / cached_seconds}x faster)')
+  def test_load_yaml_equivalent(self):
+    """Test that when we load a YAML file uncached and cached, it produces the same data.
+
+    Also get a gauge for the speedup we get from loading a pickled file,
+    although we're not going to fail the test on the numbers we get from that.
+    """
+    n = 50
+
+    # Pick a file with unicode in it so we're sure it gets handled properly
+    file = 'coursedata/adventures/hu.yaml'
+
+    # Remove pickled version of this file if it exists, it may
+    # influence the tests
+    if os.path.isfile(f'{file}.pickle'):
+      os.unlink(f'{file}.pickle')
+
+    start = time.time()
+    for _ in range(n):
+      original_data = utils.load_yaml_uncached(file)
+    original_seconds = time.time() - start
+
+    start = time.time()
+    for _ in range(n):
+      cached_data = utils.load_yaml_pickled(file)
+    cached_seconds = time.time() - start
+
+    self.assertEqual(original_data, cached_data)
+    print(f'YAML loading takes {original_seconds / n} seconds, unpickling takes {cached_seconds / n} ({original_seconds / cached_seconds}x faster)')


### PR DESCRIPTION
The pickle test that loads `hu.yaml` compares it to loading
`hu.yaml.pickle`; if there was a `.pickle` file remaining on
disk, it may have different contents than the `.yaml` file.

This will not happen on the server since it gets a clean redeploy
every time, but it may happen on dev machines.