### PR TITLE
Ensure comparison is working on numbers

### DIFF
--- a/hedy.py
+++ b/hedy.py
@@ -858,17 +858,17 @@ class ConvertToPython_16(ConvertToPython_15):
         arg0 = process_variable(args[0], self.lookup)
         arg1 = process_variable(args[1], self.lookup)
         if len(args) == 2:
-            return f"str({arg0}) < str({arg1})"  # no and statements
+            return f"int({arg0}) < int({arg1})"  # no and statements
         else:
-            return f"str({arg0}) < str({arg1}) and {args[2]}"
+            return f"int({arg0}) < int({arg1}) and {args[2]}"
 
     def bigger(self, args):
         arg0 = process_variable(args[0], self.lookup)
         arg1 = process_variable(args[1], self.lookup)
         if len(args) == 2:
-            return f"str({arg0}) > str({arg1})"  # no and statements
+            return f"int({arg0}) > int({arg1})"  # no and statements
         else:
-            return f"str({arg0}) > str({arg1}) and {args[2]}"
+            return f"int({arg0}) > int({arg1}) and {args[2]}"
 
 class ConvertToPython_17(ConvertToPython_16):
     def while_loop(self, args):
@@ -933,17 +933,17 @@ class ConvertToPython_22(ConvertToPython_21):
         arg0 = process_variable(args[0], self.lookup)
         arg1 = process_variable(args[1], self.lookup)
         if len(args) == 2:
-            return f"str({arg0}) <= str({arg1})"  # no and statements
+            return f"int({arg0}) <= int({arg1})"  # no and statements
         else:
-            return f"str({arg0}) <= str({arg1}) and {args[2]}"
+            return f"int({arg0}) <= int({arg1}) and {args[2]}"
 
     def bigger_equal(self, args):
         arg0 = process_variable(args[0], self.lookup)
         arg1 = process_variable(args[1], self.lookup)
         if len(args) == 2:
-            return f"str({arg0}) >= str({arg1})"  # no and statements
+            return f"int({arg0}) >= int({arg1})"  # no and statements
         else:
-            return f"str({arg0}) >= str({arg1}) and {args[2]}"
+            return f"int({arg0}) >= int({arg1}) and {args[2]}"
 
 
 def merge_grammars(grammar_text_1, grammar_text_2):

--- a/tests/tests_level_16.py
+++ b/tests/tests_level_16.py
@@ -461,7 +461,7 @@ else:
         print('Dan ben je jonger dan ik!')""")
         expected = textwrap.dedent("""\
     leeftijd = input('Hoe oud ben jij?')
-    if str(leeftijd) < str('12'):
+    if int(leeftijd) < int('12'):
       print('Dan ben je jonger dan ik!')""")
 
         result = hedy.transpile(code, self.level)
@@ -475,7 +475,7 @@ else:
         print('Dan ben je ouder dan ik!')""")
         expected = textwrap.dedent("""\
     leeftijd = input('Hoe oud ben jij?')
-    if str(leeftijd) > str('12'):
+    if int(leeftijd) > int('12'):
       print('Dan ben je ouder dan ik!')""")
 
         result = hedy.transpile(code, self.level)
@@ -491,9 +491,9 @@ else:
         print('Dan ben je ouder dan ik!')""")
         expected = textwrap.dedent("""\
     leeftijd = input('Hoe oud ben jij?')
-    if str(leeftijd) < str('12'):
+    if int(leeftijd) < int('12'):
       print('Dan ben je jonger dan ik!')
-    elif str(leeftijd) > str('12'):
+    elif int(leeftijd) > int('12'):
       print('Dan ben je ouder dan ik!')""")
 
         result = hedy.transpile(code, self.level)

--- a/tests/tests_level_17.py
+++ b/tests/tests_level_17.py
@@ -460,7 +460,7 @@ else:
         print('Dan ben je jonger dan ik!')""")
         expected = textwrap.dedent("""\
     leeftijd = input('Hoe oud ben jij?')
-    if str(leeftijd) < str('12'):
+    if int(leeftijd) < int('12'):
       print('Dan ben je jonger dan ik!')""")
 
         result = hedy.transpile(code, self.level)
@@ -474,7 +474,7 @@ else:
         print('Dan ben je ouder dan ik!')""")
         expected = textwrap.dedent("""\
     leeftijd = input('Hoe oud ben jij?')
-    if str(leeftijd) > str('12'):
+    if int(leeftijd) > int('12'):
       print('Dan ben je ouder dan ik!')""")
 
         result = hedy.transpile(code, self.level)
@@ -490,9 +490,9 @@ else:
         print('Dan ben je ouder dan ik!')""")
         expected = textwrap.dedent("""\
     leeftijd = input('Hoe oud ben jij?')
-    if str(leeftijd) < str('12'):
+    if int(leeftijd) < int('12'):
       print('Dan ben je jonger dan ik!')
-    elif str(leeftijd) > str('12'):
+    elif int(leeftijd) > int('12'):
       print('Dan ben je ouder dan ik!')""")
 
         result = hedy.transpile(code, self.level)
@@ -528,7 +528,7 @@ else:
         expected = textwrap.dedent("""\
     tel = '1'
     # [' we gaan door totdat tel 3 is!']
-    while str(tel) < str('3'):
+    while int(tel) < int('3'):
       print('Dit is de '+str(tel)+'e keer')
       tel = int(tel) + int(1)
     print('We zijn klaar')""")

--- a/tests/tests_level_18.py
+++ b/tests/tests_level_18.py
@@ -461,7 +461,7 @@ else:
         print('Dan ben je jonger dan ik!')""")
         expected = textwrap.dedent("""\
     leeftijd = input('Hoe oud ben jij?')
-    if str(leeftijd) < str('12'):
+    if int(leeftijd) < int('12'):
       print('Dan ben je jonger dan ik!')""")
 
         result = hedy.transpile(code, self.level)
@@ -475,7 +475,7 @@ else:
         print('Dan ben je ouder dan ik!')""")
         expected = textwrap.dedent("""\
     leeftijd = input('Hoe oud ben jij?')
-    if str(leeftijd) > str('12'):
+    if int(leeftijd) > int('12'):
       print('Dan ben je ouder dan ik!')""")
 
         result = hedy.transpile(code, self.level)
@@ -491,9 +491,9 @@ else:
         print('Dan ben je ouder dan ik!')""")
         expected = textwrap.dedent("""\
     leeftijd = input('Hoe oud ben jij?')
-    if str(leeftijd) < str('12'):
+    if int(leeftijd) < int('12'):
       print('Dan ben je jonger dan ik!')
-    elif str(leeftijd) > str('12'):
+    elif int(leeftijd) > int('12'):
       print('Dan ben je ouder dan ik!')""")
 
         result = hedy.transpile(code, self.level)
@@ -529,7 +529,7 @@ else:
         expected = textwrap.dedent("""\
     tel = '1'
     # [' we gaan door totdat tel 3 is!']
-    while str(tel) < str('3'):
+    while int(tel) < int('3'):
       print('Dit is de '+str(tel)+'e keer')
       tel = int(tel) + int(1)
     print('We zijn klaar')""")

--- a/tests/tests_level_19.py
+++ b/tests/tests_level_19.py
@@ -458,7 +458,7 @@ else:
         print('Dan ben je jonger dan ik!')""")
         expected = textwrap.dedent("""\
     leeftijd = input('Hoe oud ben jij?')
-    if str(leeftijd) < str('12'):
+    if int(leeftijd) < int('12'):
       print('Dan ben je jonger dan ik!')""")
 
         result = hedy.transpile(code, self.level)
@@ -472,7 +472,7 @@ else:
         print('Dan ben je ouder dan ik!')""")
         expected = textwrap.dedent("""\
     leeftijd = input('Hoe oud ben jij?')
-    if str(leeftijd) > str('12'):
+    if int(leeftijd) > int('12'):
       print('Dan ben je ouder dan ik!')""")
 
         result = hedy.transpile(code, self.level)
@@ -488,9 +488,9 @@ else:
         print('Dan ben je ouder dan ik!')""")
         expected = textwrap.dedent("""\
     leeftijd = input('Hoe oud ben jij?')
-    if str(leeftijd) < str('12'):
+    if int(leeftijd) < int('12'):
       print('Dan ben je jonger dan ik!')
-    elif str(leeftijd) > str('12'):
+    elif int(leeftijd) > int('12'):
       print('Dan ben je ouder dan ik!')""")
 
         result = hedy.transpile(code, self.level)
@@ -526,7 +526,7 @@ else:
         expected = textwrap.dedent("""\
     tel = '1'
     # [' we gaan door totdat tel 3 is!']
-    while str(tel) < str('3'):
+    while int(tel) < int('3'):
       print('Dit is de '+str(tel)+'e keer')
       tel = int(tel) + int(1)
     print('We zijn klaar')""")

--- a/tests/tests_level_20.py
+++ b/tests/tests_level_20.py
@@ -459,7 +459,7 @@ else:
         print('Dan ben je jonger dan ik!')""")
         expected = textwrap.dedent("""\
     leeftijd = input('Hoe oud ben jij?')
-    if str(leeftijd) < str('12'):
+    if int(leeftijd) < int('12'):
       print('Dan ben je jonger dan ik!')""")
 
         result = hedy.transpile(code, self.level)
@@ -473,7 +473,7 @@ else:
         print('Dan ben je ouder dan ik!')""")
         expected = textwrap.dedent("""\
     leeftijd = input('Hoe oud ben jij?')
-    if str(leeftijd) > str('12'):
+    if int(leeftijd) > int('12'):
       print('Dan ben je ouder dan ik!')""")
 
         result = hedy.transpile(code, self.level)
@@ -489,9 +489,9 @@ else:
         print('Dan ben je ouder dan ik!')""")
         expected = textwrap.dedent("""\
     leeftijd = input('Hoe oud ben jij?')
-    if str(leeftijd) < str('12'):
+    if int(leeftijd) < int('12'):
       print('Dan ben je jonger dan ik!')
-    elif str(leeftijd) > str('12'):
+    elif int(leeftijd) > int('12'):
       print('Dan ben je ouder dan ik!')""")
 
         result = hedy.transpile(code, self.level)
@@ -527,7 +527,7 @@ else:
         expected = textwrap.dedent("""\
     tel = '1'
     # [' we gaan door totdat tel 3 is!']
-    while str(tel) < str('3'):
+    while int(tel) < int('3'):
       print('Dit is de '+str(tel)+'e keer')
       tel = int(tel) + int(1)
     print('We zijn klaar')""")

--- a/tests/tests_level_21.py
+++ b/tests/tests_level_21.py
@@ -459,7 +459,7 @@ else:
         print('Dan ben je jonger dan ik!')""")
         expected = textwrap.dedent("""\
     leeftijd = input('Hoe oud ben jij?')
-    if str(leeftijd) < str('12'):
+    if int(leeftijd) < int('12'):
       print('Dan ben je jonger dan ik!')""")
 
         result = hedy.transpile(code, self.level)
@@ -473,7 +473,7 @@ else:
         print('Dan ben je ouder dan ik!')""")
         expected = textwrap.dedent("""\
     leeftijd = input('Hoe oud ben jij?')
-    if str(leeftijd) > str('12'):
+    if int(leeftijd) > int('12'):
       print('Dan ben je ouder dan ik!')""")
 
         result = hedy.transpile(code, self.level)
@@ -489,9 +489,9 @@ else:
         print('Dan ben je ouder dan ik!')""")
         expected = textwrap.dedent("""\
     leeftijd = input('Hoe oud ben jij?')
-    if str(leeftijd) < str('12'):
+    if int(leeftijd) < int('12'):
       print('Dan ben je jonger dan ik!')
-    elif str(leeftijd) > str('12'):
+    elif int(leeftijd) > int('12'):
       print('Dan ben je ouder dan ik!')""")
 
         result = hedy.transpile(code, self.level)
@@ -527,7 +527,7 @@ else:
         expected = textwrap.dedent("""\
     tel = '1'
     # [' we gaan door totdat tel 3 is!']
-    while str(tel) < str('3'):
+    while int(tel) < int('3'):
       print('Dit is de '+str(tel)+'e keer')
       tel = int(tel) + int(1)
     print('We zijn klaar')""")

--- a/tests/tests_level_22.py
+++ b/tests/tests_level_22.py
@@ -459,7 +459,7 @@ else:
         print('Dan ben je jonger dan ik!')""")
         expected = textwrap.dedent("""\
     leeftijd = input('Hoe oud ben jij?')
-    if str(leeftijd) < str('12'):
+    if int(leeftijd) < int('12'):
       print('Dan ben je jonger dan ik!')""")
 
         result = hedy.transpile(code, self.level)
@@ -473,7 +473,7 @@ else:
         print('Dan ben je ouder dan ik!')""")
         expected = textwrap.dedent("""\
     leeftijd = input('Hoe oud ben jij?')
-    if str(leeftijd) > str('12'):
+    if int(leeftijd) > int('12'):
       print('Dan ben je ouder dan ik!')""")
 
         result = hedy.transpile(code, self.level)
@@ -489,9 +489,9 @@ else:
         print('Dan ben je ouder dan ik!')""")
         expected = textwrap.dedent("""\
     leeftijd = input('Hoe oud ben jij?')
-    if str(leeftijd) < str('12'):
+    if int(leeftijd) < int('12'):
       print('Dan ben je jonger dan ik!')
-    elif str(leeftijd) > str('12'):
+    elif int(leeftijd) > int('12'):
       print('Dan ben je ouder dan ik!')""")
 
         result = hedy.transpile(code, self.level)
@@ -527,7 +527,7 @@ else:
         expected = textwrap.dedent("""\
     tel = '1'
     # [' we gaan door totdat tel 3 is!']
-    while str(tel) < str('3'):
+    while int(tel) < int('3'):
       print('Dit is de '+str(tel)+'e keer')
       tel = int(tel) + int(1)
     print('We zijn klaar')""")
@@ -660,7 +660,7 @@ else:
         print('Dan ben je jonger dan ik!')""")
         expected = textwrap.dedent("""\
     leeftijd = input('Ik ben 12 jaar, hoe oud ben jij?')
-    if str(leeftijd) <= str('11'):
+    if int(leeftijd) <= int('11'):
       print('Dan ben je jonger dan ik!')""")
         result = hedy.transpile(code, self.level)
         self.assertEqual(expected, result.code)
@@ -673,7 +673,7 @@ else:
         print('Dan ben je jonger dan ik!')""")
         expected = textwrap.dedent("""\
     leeftijd = input('Ik ben 12 jaar, hoe oud ben jij?')
-    if str(leeftijd) >= str('11'):
+    if int(leeftijd) >= int('11'):
       print('Dan ben je jonger dan ik!')""")
         result = hedy.transpile(code, self.level)
         self.assertEqual(expected, result.code)
@@ -688,9 +688,9 @@ else:
         print('Dan ben je ouder dan ik!')""")
         expected = textwrap.dedent("""\
     leeftijd = input('Ik ben 12 jaar, hoe oud ben jij?')
-    if str(leeftijd) <= str('11'):
+    if int(leeftijd) <= int('11'):
       print('Dan ben je jonger dan ik!')
-    elif str(leeftijd) >= str('13'):
+    elif int(leeftijd) >= int('13'):
       print('Dan ben je ouder dan ik!')""")
         result = hedy.transpile(code, self.level)
         self.assertEqual(expected, result.code)


### PR DESCRIPTION
When we compare strings, python uses lexographic ordering and thus `'3' < '12'` returns false.

This PR fixes #788 