### PR TITLE
Do not reload translations every time in local development

### DIFF
--- a/hedyweb.py
+++ b/hedyweb.py
@@ -20,8 +20,7 @@ class Translations:
 
   @property
   def data(self):
-    # In debug mode, always reload all translations
-    if self._data is None or utils.is_debug_mode():
+    if self._data is None:
       translations = glob.glob('coursedata/texts/*.yaml')
       self._data = {}
       for trans_file in translations:


### PR DESCRIPTION
Lately I had been noticing that reloading the page during local development was taking ~5 seconds. After some inspection, I realized that in my (admittedly slow development machine), 3-4 seconds were spent in loading `client_messages.js`. This happens every time any page is reloaded.

The cause for this is that every time the file is requested, all the yamls are loaded from disk and re-processed. While this is very practical in itself, I feel it's not worth the ~3-4 seconds added to each refresh.

I am not 100% about this change, though, because it does require the developer to restart the development server to trigger the reloading of the app to update the translations - this is an inconvenience for someone already acquainted with Hedy development, and a gotcha for those just starting out.