### PR TITLE
Move all string literals in the parsers to level1.lark

### DIFF
--- a/grammars/level1.lark
+++ b/grammars/level1.lark
@@ -27,6 +27,7 @@ _TURN: "turn"
 
 //level 2
 _IS: "is"
+_AT: "at"
 random : "random" //random needs to appear in the tree for further processing so does not start with _ or is uppercase
 
 //level 4
@@ -34,7 +35,6 @@ _IN: "in"
 _IF: "if"
 _ELSE: "else"
 _AND: "and"
-_AT: "at"
 
 //level 5
 _REPEAT: "repeat"

--- a/grammars/level1.lark
+++ b/grammars/level1.lark
@@ -95,3 +95,6 @@ NAME: ID_START ID_CONTINUE*
 ID_START: /[\p{Lu}\p{Ll}\p{Lt}\p{Lm}\p{Lo}\p{Nl}_]+/
 ID_CONTINUE: ID_START | /[\p{Mn}\p{Mc}\p{Nd}\p{Pc}·]+/
 
+// Internal symbol added by the preprocess_blocks function to indicate the end of blocks
+// FIXME ensure that the user can't write this token
+_END_BLOCK: "end-block"

--- a/grammars/level11-Additions.lark
+++ b/grammars/level11-Additions.lark
@@ -5,4 +5,4 @@ command: print | ifs (elifs)* elses? | input | for_loop | assign_list | list_acc
 print: _PRINT _SPACE* _LEFT_BRACKET _SPACE* (quoted_text | list_access | var | sum) (_SPACE (quoted_text | list_access | var | sum))* _RIGHT_BRACKET
 input: var _SPACE _IS _SPACE _INPUT _LEFT_BRACKET  (quoted_text | list_access | var | sum) (_SPACE (quoted_text | list_access | var | sum))*  _RIGHT_BRACKET
 
-for_loop: _FOR _SPACE (NAME | var) _SPACE _IN _SPACE _RANGE _LEFT_BRACKET (NUMBER | var) (_COMMA _SPACE|_COMMA) (NUMBER | var) ((_COMMA _SPACE |_COMMA) (NUMBER | var))? _RIGHT_BRACKET _COLON _EOL (_SPACE command) (_EOL _SPACE command)* _EOL "end-block"
+for_loop: _FOR _SPACE (NAME | var) _SPACE _IN _SPACE _RANGE _LEFT_BRACKET (NUMBER | var) (_COMMA _SPACE|_COMMA) (NUMBER | var) ((_COMMA _SPACE |_COMMA) (NUMBER | var))? _RIGHT_BRACKET _COLON _EOL (_SPACE command) (_EOL _SPACE command)* _EOL _END_BLOCK

--- a/grammars/level14-Additions.lark
+++ b/grammars/level14-Additions.lark
@@ -1,7 +1,7 @@
 // Level 14 adds and and or
 
-ifs: _IF _SPACE (condition|andcondition|orcondition) _COLON _EOL (_SPACE command) (_EOL _SPACE command)* _EOL "end-block" //'if' cannot be used in Python, hence the name of the rule is 'ifs'
-elifs: _EOL (" ")* _ELIF _SPACE (condition|andcondition|orcondition) _COLON _EOL (_SPACE command) (_EOL _SPACE command)* _EOL "end-block"
+ifs: _IF _SPACE (condition|andcondition|orcondition) _COLON _EOL (_SPACE command) (_EOL _SPACE command)* _EOL _END_BLOCK //'if' cannot be used in Python, hence the name of the rule is 'ifs'
+elifs: _EOL (" ")* _ELIF _SPACE (condition|andcondition|orcondition) _COLON _EOL (_SPACE command) (_EOL _SPACE command)* _EOL _END_BLOCK
 condition: (equality_check|in_list_check)
 
 

--- a/grammars/level14-Additions.lark
+++ b/grammars/level14-Additions.lark
@@ -1,7 +1,7 @@
 // Level 14 adds and and or
 
 ifs: _IF _SPACE (condition|andcondition|orcondition) _COLON _EOL (_SPACE command) (_EOL _SPACE command)* _EOL _END_BLOCK //'if' cannot be used in Python, hence the name of the rule is 'ifs'
-elifs: _EOL (" ")* _ELIF _SPACE (condition|andcondition|orcondition) _COLON _EOL (_SPACE command) (_EOL _SPACE command)* _EOL _END_BLOCK
+elifs: _EOL _SPACE? _ELIF _SPACE (condition|andcondition|orcondition) _COLON _EOL (_SPACE command) (_EOL _SPACE command)* _EOL _END_BLOCK
 condition: (equality_check|in_list_check)
 
 

--- a/grammars/level17-Additions.lark
+++ b/grammars/level17-Additions.lark
@@ -2,4 +2,4 @@
 
 command: print | ifs (elifs)* elses? | input | for_loop | while_loop | assign_list | list_access_var | change_list_item| comment | assign
 
-while_loop: _WHILE _SPACE (condition|andcondition|orcondition) _COLON _EOL (_SPACE command) (_EOL _SPACE command)* _EOL "end-block"
+while_loop: _WHILE _SPACE (condition|andcondition|orcondition) _COLON _EOL (_SPACE command) (_EOL _SPACE command)* _EOL _END_BLOCK

--- a/grammars/level19-Additions.lark
+++ b/grammars/level19-Additions.lark
@@ -4,7 +4,7 @@ print: _PRINT _SPACE* _LEFT_BRACKET _SPACE* (quoted_text | list_access | var | s
 input: var _SPACE _IS _SPACE _INPUT _LEFT_BRACKET  (quoted_text | list_access | var | sum | length) (_SPACE (quoted_text | list_access | var | sum | length))*  _RIGHT_BRACKET
 assign: var _SPACE _IS _SPACE length | var _SPACE _IS _SPACE sum | var _SPACE _IS _SPACE textwithoutspaces | list_access _SPACE _IS _SPACE sum | list_access _SPACE _IS _SPACE textwithoutspaces
 equality_check: (length | textwithoutspaces | list_access) _SPACE _IS _SPACE (length | textwithoutspaces | list_access)
-for_loop: _FOR _SPACE (NAME | var) _SPACE _IN _SPACE _RANGE _LEFT_BRACKET (NUMBER | var | length)(_COMMA _SPACE|_COMMA) (NUMBER | var | length) _RIGHT_BRACKET _COLON _EOL (_SPACE command) (_EOL _SPACE command)* _EOL "end-block"
+for_loop: _FOR _SPACE (NAME | var) _SPACE _IN _SPACE _RANGE _LEFT_BRACKET (NUMBER | var | length)(_COMMA _SPACE|_COMMA) (NUMBER | var | length) _RIGHT_BRACKET _COLON _EOL (_SPACE command) (_EOL _SPACE command)* _EOL _END_BLOCK
 smaller: (textwithoutspaces | list_access | length) _SPACE _SMALLER _SPACE (textwithoutspaces | list_access | length)
 bigger: (textwithoutspaces | list_access | length) _SPACE _LARGER _SPACE (textwithoutspaces | list_access | length)
 length: _LENGTH _LEFT_BRACKET var _RIGHT_BRACKET

--- a/grammars/level2-Additions.lark
+++ b/grammars/level2-Additions.lark
@@ -19,7 +19,7 @@ index : DIGIT+
 punctuation : PUNCTUATION -> punctuation
 PUNCTUATION: _EXCLAMATION_MARK | _QUESTION_MARK | _PERIOD //uppercase places tokens in tree
 
-list_access: var " at " (index | random) -> list_access //todo: could be merged with list_access_var?
+list_access: var _SPACE _AT _SPACE (index | random) -> list_access //todo: could be merged with list_access_var?
 
 var: NAME -> var
 

--- a/grammars/level7-Additions.lark
+++ b/grammars/level7-Additions.lark
@@ -1,9 +1,9 @@
 program: _EOL* command (_SPACE)* (_EOL+ command (_SPACE)*)* _EOL* //lines may end on spaces and might be separated by many newlines
 command: print | repeat | ifs elses? | turtle | ask | assign_list | list_access_var | assign  //placing it here means print is will print 'is' and print is Felienne will print 'is Felienne'
 
-repeat: _REPEAT _SPACE (NUMBER | var) _SPACE _TIMES _EOL (_SPACE command) (_EOL _SPACE command)* _EOL "end-block"
+repeat: _REPEAT _SPACE (NUMBER | var) _SPACE _TIMES _EOL (_SPACE command) (_EOL _SPACE command)* _EOL _END_BLOCK
 
 // from level 7 on if is implemented slightly differently
-elses: _EOL (_SPACE)* _ELSE _EOL (_SPACE command) (_EOL _SPACE command)* _EOL "end-block"
+elses: _EOL (_SPACE)* _ELSE _EOL (_SPACE command) (_EOL _SPACE command)* _EOL _END_BLOCK
 //'if' cannot be used in Python, hence the name of the rule is 'ifs'
-ifs: _IF _SPACE condition _EOL (_SPACE command) (_EOL _SPACE command)* _EOL "end-block"
+ifs: _IF _SPACE condition _EOL (_SPACE command) (_EOL _SPACE command)* _EOL _END_BLOCK

--- a/grammars/level8-1-Additions.lark
+++ b/grammars/level8-1-Additions.lark
@@ -1,4 +1,4 @@
 command: print | ifs elses? | ask | for_loop | assign_list | list_access_var | assign
 
 //new for level 8-1, for loop and the end-blocks
-for_loop: _FOR _SPACE (NAME | var) _SPACE _IS _SPACE (NUMBER | var) _SPACE _TO _SPACE (NUMBER | var) _EOL (_SPACE command) (_EOL _SPACE command)* _EOL "end-block"
+for_loop: _FOR _SPACE (NAME | var) _SPACE _IS _SPACE (NUMBER | var) _SPACE _TO _SPACE (NUMBER | var) _EOL (_SPACE command) (_EOL _SPACE command)* _EOL _END_BLOCK

--- a/grammars/level8-Additions.lark
+++ b/grammars/level8-Additions.lark
@@ -1,7 +1,7 @@
 command: print | ifs elses? | ask | for_loop | assign_list | list_access_var | assign
 
 //new for level 8, for loop and the end-blocks
-for_loop: _FOR _SPACE (NAME | var) _SPACE _IN _SPACE _RANGE _SPACE (NUMBER | var) _SPACE _TO _SPACE (NUMBER | var) _EOL (_SPACE command) (_EOL _SPACE command)* _EOL "end-block"
+for_loop: _FOR _SPACE (NAME | var) _SPACE _IN _SPACE _RANGE _SPACE (NUMBER | var) _SPACE _TO _SPACE (NUMBER | var) _EOL (_SPACE command) (_EOL _SPACE command)* _EOL _END_BLOCK
 
-elses: _EOL (_SPACE)* _ELSE _EOL (_SPACE command) (_EOL _SPACE command)* _EOL "end-block"
-ifs: _IF _SPACE condition _EOL (_SPACE command) (_EOL _SPACE command)* _EOL "end-block" //'if' cannot be used in Python, hence the name of the rule is 'ifs'
+elses: _EOL (_SPACE)* _ELSE _EOL (_SPACE command) (_EOL _SPACE command)* _EOL _END_BLOCK
+ifs: _IF _SPACE condition _EOL (_SPACE command) (_EOL _SPACE command)* _EOL _END_BLOCK //'if' cannot be used in Python, hence the name of the rule is 'ifs'

--- a/grammars/level9-Additions.lark
+++ b/grammars/level9-Additions.lark
@@ -2,13 +2,13 @@
 
 command: print | ifs (elifs)* elses? | ask | for_loop | assign_list | list_access_var | assign
 
-elses: _EOL _SPACE* _ELSE _COLON _EOL (_SPACE command) (_EOL _SPACE command)* _EOL "end-block"
+elses: _EOL _SPACE* _ELSE _COLON _EOL (_SPACE command) (_EOL _SPACE command)* _EOL _END_BLOCK
 //TODO: after condition a space (or more) could also be ok? Python allows that
-ifs: _IF _SPACE condition _COLON _EOL (_SPACE command) (_EOL _SPACE command)* _EOL "end-block"//'if' cannot be used in Python, hence the name of the rule is 'ifs'
-elifs: _EOL _SPACE* _ELIF _SPACE condition _COLON _EOL (_SPACE command) (_EOL _SPACE command)* _EOL "end-block"
+ifs: _IF _SPACE condition _COLON _EOL (_SPACE command) (_EOL _SPACE command)* _EOL _END_BLOCK//'if' cannot be used in Python, hence the name of the rule is 'ifs'
+elifs: _EOL _SPACE* _ELIF _SPACE condition _COLON _EOL (_SPACE command) (_EOL _SPACE command)* _EOL _END_BLOCK
 
 //new for level 9
-for_loop: _FOR _SPACE (NAME | var) _SPACE _IN _SPACE _RANGE _SPACE (NUMBER | var) _SPACE _TO _SPACE (NUMBER | var) (_SPACE _STEP _SPACE (NUMBER | var))? _COLON _EOL (_SPACE command) (_EOL _SPACE command)* _EOL "end-block"
+for_loop: _FOR _SPACE (NAME | var) _SPACE _IN _SPACE _RANGE _SPACE (NUMBER | var) _SPACE _TO _SPACE (NUMBER | var) (_SPACE _STEP _SPACE (NUMBER | var))? _COLON _EOL (_SPACE command) (_EOL _SPACE command)* _EOL _END_BLOCK
 
 //anything can be parsed except for spaces (plus: a newline and a comma for list separators)
 //plus from level 6 on: calculation elements


### PR DESCRIPTION
This reduces the risk of a typo in the string contents, makes it easier to rename the symbols (eg translation) and centralizes token definitions a bit.

I also made the grammar more lenient with regards to multiple spaces where previously at most a single space was expected. This eliminates the existence of an error that is not existing in conventional programming languages either, thus avoiding the need for any program repair for them.