### PR TITLE
Allow multiple spaces inside lists

### DIFF
--- a/grammars/level12-Additions.lark
+++ b/grammars/level12-Additions.lark
@@ -6,7 +6,7 @@
 command: print | ifs (elifs)* elses? | input | for_loop | assign_list | list_access_var | change_list_item | assign
 
 assign: var _SPACE _IS _SPACE sum | var _SPACE _IS _SPACE textwithoutspaces | list_access _SPACE _IS _SPACE sum | list_access _SPACE _IS _SPACE textwithoutspaces
-assign_list: var _SPACE _IS _SPACE _LEFT_SQUARE_BRACKET quoted_text ((", "|",") quoted_text)+ _RIGHT_SQUARE_BRACKET
+assign_list: var _SPACE _IS _SPACE _LEFT_SQUARE_BRACKET quoted_text (_COMMA _SPACE? quoted_text)+ _RIGHT_SQUARE_BRACKET
 
 //new for level 12, assignment of list[i]
 change_list_item: var _LEFT_SQUARE_BRACKET (index | var) _RIGHT_SQUARE_BRACKET _SPACE _IS _SPACE (var | textwithoutspaces)

--- a/grammars/level4-Additions.lark
+++ b/grammars/level4-Additions.lark
@@ -2,7 +2,7 @@ program: _EOL* (command | invalid) (_SPACE)* (_EOL+ (command | invalid) (_SPACE)
 command: print | ifelse | ifs | ask | turtle | assign_list | list_access_var | assign | print_no_quotes
 //placing assign after print means print is will print 'is' and print is Felienne will print 'is Felienne'
 
-assign_list: var _SPACE _IS _SPACE textwithspaces (("," _SPACE |",") textwithspaces)+
+assign_list: var _SPACE _IS _SPACE textwithspaces (_COMMA _SPACE? textwithspaces)+
 assign: var _SPACE _IS _SPACE textwithspaces
 invalid: textwithoutspaces _SPACE textwithspaces
 

--- a/tests/tests_level_04.py
+++ b/tests/tests_level_04.py
@@ -140,6 +140,22 @@ class TestsLevel4(unittest.TestCase):
     self.assertEqual(False, result.has_turtle)
     self.assertIn(run_code(result), ['Hond', 'Kat', 'Kangoeroe'])
 
+  def test_list_multiple_spaces(self):
+    code = textwrap.dedent("""\
+    dieren is Hond,  Kat,       Kangoeroe
+    dier is dieren at random
+    print dier""")
+
+    result = hedy.transpile(code, self.level)
+
+    expected = textwrap.dedent("""\
+    dieren = ['Hond', 'Kat', 'Kangoeroe']
+    dier=random.choice(dieren)
+    print(f'{dier}')""")
+
+    self.assertEqual(expected, result.code)
+    self.assertEqual(False, result.has_turtle)
+
   def test_print_Spanish(self):
     code = textwrap.dedent("""\
     print 'Cuál es tu color favorito?'""")

--- a/tests/tests_level_12.py
+++ b/tests/tests_level_12.py
@@ -239,6 +239,19 @@ else:
     self.assertEqual(expected, result.code)
     self.assertEqual(False, result.has_turtle)
 
+  def test_list_multiple_spaces(self):
+    code = textwrap.dedent("""\
+    fruit is ['appel',  'banaan',    'kers']
+    print(fruit)""")
+    expected = textwrap.dedent("""\
+    fruit = ['appel', 'banaan', 'kers']
+    print(str(fruit))""")
+
+    result = hedy.transpile(code, self.level)
+
+    self.assertEqual(expected, result.code)
+    self.assertEqual(False, result.has_turtle)
+
   def test_random(self):
     code = textwrap.dedent("""\
     fruit is ['banaan', 'appel', 'kers']
@@ -294,7 +307,7 @@ else:
 
     self.assertEqual(expected, result.code)
     self.assertEqual(False, result.has_turtle)
-      
+
   def test_if_under_else_in_for(self):
     code = textwrap.dedent("""\
     for i in range(0, 10):


### PR DESCRIPTION
Split out of https://github.com/Felienne/hedy/pull/834.

Level 4 up to level 12 already allowed this, but from level 12 onwards only a single space was allowed previously.