### PR TITLE
Fix a mixup between original_level and working_level

### DIFF
--- a/coursedata/texts/cs.yaml
+++ b/coursedata/texts/cs.yaml
@@ -34,7 +34,7 @@ ClientErrorMessages:
     CheckInternet: Prosím zkontroluj své připojení k internetu.
     ServerError: Napsal*a jsi program, který jsme nečekali. Pokud potřebuješ pomoc, pošli nám email s číslem úrovně a svým kódem na hedy@felienne.com. Mezitím můžeš zkusit úkol vyřešit nějak jinak nebo se znova podívat na příklady. Díky!
 HedyErrorMessages:
-    Wrong Level: Toto je správný kód v Hedy, ale na špatné úrovni. Napsal jsi kód úrovně {original_level} na úrovni {working_level}.
+    Wrong Level: Toto je správný kód v Hedy, ale na špatné úrovni. Napsal jsi kód úrovně {working_level} na úrovni {original_level}.
     Incomplete: Jejda, zapomněl*a jsi kousek kódu! Na řádku {line_number} musíš ještě něco dopsat za {incomplete_command}.
     Invalid: '{invalid_command} není příkaz v Hedy na úrovni {level}. Nemyslel*a jsi spíš {guessed_command}?'
     Invalid Space: Jejda, řádek číslo {line_number} začíná mezerou! Mezery dokáží počítač pořádně zmást, mohl*a bys ji prosím vymazat?

--- a/coursedata/texts/de.yaml
+++ b/coursedata/texts/de.yaml
@@ -34,7 +34,7 @@ ClientErrorMessages:
     CheckInternet: "Have a look if your Internet connection is working properly?"
     ServerError: "You wrote a program we weren't expecting. If you want to help, send us an email with the level and your program at hedy@felienne.com. In the mean time, try something a little different and take another look at the examples. Thanks!"
 HedyErrorMessages:
-    Wrong Level: "Das war richtige Hedy-Sprache, aber nicht in der richtigen Stufe. Du hast Sprache aus Stufe {original_level} in Stufe {working_level} verwendet."
+    Wrong Level: "Das war richtige Hedy-Sprache, aber nicht in der richtigen Stufe. Du hast Sprache aus Stufe {working_level} in Stufe {original_level} verwendet."
     Incomplete: "Hoppla! Du hast ein Programm-Stück vergessen! In Zeile {line_number}, musst du nach {incomplete_command} noch Text eingeben."
     Invalid: "{invalid_command} ist kein Hedy-Stufe-{level}-Befehl. Meintest du {guessed_command}?"
     Invalid Space: "Hoppla! Du hast Zeile {line_number} mit einem Leerzeichen begonnen. Leerzeichen bringen Computer durcheinander. Kannst du es entfernen?"

--- a/coursedata/texts/el.yaml
+++ b/coursedata/texts/el.yaml
@@ -34,7 +34,7 @@ ClientErrorMessages:
     CheckInternet: "Have a look if your Internet connection is working properly?"
     ServerError: "You wrote a program we weren't expecting. If you want to help, send us an email with the level and your program at hedy@felienne.com. In the mean time, try something a little different and take another look at the examples. Thanks!"
 HedyErrorMessages:
-    Wrong Level: 'Αυτός ήταν σωστός κώδικας Hedy, αλλά όχι στο σωστό επίπεδο. Έγραψες κώδικα για το επίπεδο {original_level} στο επίπεδο {working_level}.'
+    Wrong Level: 'Αυτός ήταν σωστός κώδικας Hedy, αλλά όχι στο σωστό επίπεδο. Έγραψες κώδικα για το επίπεδο {working_level} στο επίπεδο {original_level}.'
     Incomplete: 'Ουπς! Ξέχασες ένα κομμάτι κώδικα! Στη γραμμή {line_number}, πρέπει να γράψεις κείμενο ύστερα από την {incomplete_command}.'
     Invalid: 'Η εντολή {invalid_command} δεν είναι μια εντολή του επιπέδου {level} της Hedy. Μήπως εννοούσες {guessed_command};'
     Invalid Space: 'Ουπς! Ξεκίνησες μια γραμμή με κενό στη γραμμή {line_number}. Τα κενά μπερδεύουν τους υπολογιστές, μπορείς να τα αφαιρέσεις;'

--- a/coursedata/texts/en.yaml
+++ b/coursedata/texts/en.yaml
@@ -35,7 +35,7 @@ ClientErrorMessages:
     CheckInternet: "Have a look if your Internet connection is working properly?"
     ServerError: "You wrote a program we weren't expecting. If you want to help, send us an email with the level and your program at hedy@felienne.com. In the mean time, try something a little different and take another look at the examples. Thanks!"
 HedyErrorMessages:
-    Wrong Level: "That was correct Hedy code, but not at the right level. You wrote code for level {original_level} at level {working_level}."
+    Wrong Level: "That was correct Hedy code, but not at the right level. You wrote code for level {working_level} at level {original_level}."
     Incomplete: "Oops! You forgot a bit of code! On line {line_number}, you need to enter text behind {incomplete_command}."
     Invalid: "{invalid_command} is not a Hedy level {level} command. Did you mean {guessed_command}?"
     Invalid Space: "Oops! You started a line with a space on line {line_number}. Spaces confuse computers, can you remove it?"

--- a/coursedata/texts/es.yaml
+++ b/coursedata/texts/es.yaml
@@ -34,7 +34,7 @@ ClientErrorMessages:
     CheckInternet: "Have a look if your Internet connection is working properly?"
     ServerError: "You wrote a program we weren't expecting. If you want to help, send us an email with the level and your program at hedy@felienne.com. In the mean time, try something a little different and take another look at the examples. Thanks!"
 HedyErrorMessages:
-    Wrong Level: "Ese código es correcto, pero no pertenece al nivel correcto. Has escrito código para el nivel {original_level} mientras trabajabas en el nivel {working_level}."
+    Wrong Level: "Ese código es correcto, pero no pertenece al nivel correcto. Has escrito código para el nivel {working_level} mientras trabajabas en el nivel {original_level}."
     Incomplete: "Oops! Has olvidado algo de código! En la línea {line_number}, debes agregar texto después de {incomplete_command}."
     Invalid: "{invalid_command} no es un comando de Hedy en nivel {level}. {guessed_command}?"
     Invalid Space: "Oops! Has comenzado una línea con un espacio en la línea {line_number}. Los espacios confunden a las computadoras, ¿podrías quitarlos?"

--- a/coursedata/texts/fr.yaml
+++ b/coursedata/texts/fr.yaml
@@ -34,7 +34,7 @@ ClientErrorMessages:
     CheckInternet: "Have a look if your Internet connection is working properly?"
     ServerError: "You wrote a program we weren't expecting. If you want to help, send us an email with the level and your program at hedy@felienne.com. In the mean time, try something a little different and take another look at the examples. Thanks!"
 HedyErrorMessages:
-    Wrong Level: "Ce code est du code Hedy valide, mais pas du bon niveau. Tu as saisis du code {original_level} au niveau {working_level}."
+    Wrong Level: "Ce code est du code Hedy valide, mais pas du bon niveau. Tu as saisis du code {working_level} au niveau {original_level}."
     Incomplete: "Oups ! Tu as oublié un morceau de code ! À la ligne {line_number}, tu dois écrire du texte après {incomplete_command}."
     Invalid: "{invalid_command} n’est pas une commande valide pour le niveau {level} de Hedy. Voulais-tu utiliser {guessed_command} ?"
     Invalid Space: "Oups ! Tu as commencé une ligne avec un espace à la ligne {line_number}. Ces espaces faussent tes programmes. Peux-tu le supprimer ?"

--- a/coursedata/texts/hu.yaml
+++ b/coursedata/texts/hu.yaml
@@ -37,7 +37,7 @@ ClientErrorMessages:
     CheckInternet: "Nézd meg, hogy az internetkapcsolat megfelelően működik -e?"
     ServerError: "Olyan programot írtál, amire nem számítottunk. Ha segíteni szeretnél, küldj nekünk egy e mailt a szinttel és a programmal a hedy@felienne.com címre. Időközben próbáld ki egy kicsit másképp, és nézd meg a példákat. Köszönjük!"
 HedyErrorMessages:
-    Wrong Level: "Ez helyes Hedy-kód volt, de nem a megfelelő szinten. A {original_level} szint kódját írtad {working_level} szinten."
+    Wrong Level: "Ez helyes Hedy-kód volt, de nem a megfelelő szinten. A {working_level} szint kódját írtad {original_level} szinten."
     Incomplete: "Hoppá! Elfelejtettél egy kis kódot! A(z) {line_number}. sorban, szöveget kell beírnod a {incomplete_command} mögé."
     Invalid: "{invalid_command} Nem Hedy szint {level} parancs. Erre gondoltál {guessed_command}?"
     Invalid Space: "Hoppá! Szóközzel kezdted a sort itt: {line_number}. sor. A szóközök összezavarják a számítógépet, el tudod távolítani?"

--- a/coursedata/texts/it.yaml
+++ b/coursedata/texts/it.yaml
@@ -34,7 +34,7 @@ ClientErrorMessages:
     CheckInternet: "Have a look if your Internet connection is working properly?"
     ServerError: "You wrote a program we weren't expecting. If you want to help, send us an email with the level and your program at hedy@felienne.com. In the mean time, try something a little different and take another look at the examples. Thanks!"
 HedyErrorMessages:
-    Wrong Level: "Questo è il codice Hedy corretto ma non al livello giusto. Hai scritto un codice per il livello {original_level} al livello {working_level}."
+    Wrong Level: "Questo è il codice Hedy corretto ma non al livello giusto. Hai scritto un codice per il livello {working_level} al livello {original_level}."
     Incomplete: "Ops! Hai dimenticato un pezzo di codice! Alla linea {line_number} devi mettere del codice dopo {incomplete_command}."
     Invalid: "{invalid_command} non è un commando Hedy per il livello {level}. Intendevi {guessed_command}?"
     Invalid Space: "Ops! Hai iniziato una linea con uno spazio alla linea {line_number}. Gli spazi confondono i computer, puoi rimuoverla?"

--- a/coursedata/texts/nl.yaml
+++ b/coursedata/texts/nl.yaml
@@ -35,7 +35,7 @@ ClientErrorMessages:
     CheckInternet: "Controleer even of je internetverbinding het nog doet?"
     ServerError: "Je hebt een programma geschreven dat we niet verwacht hadden. Als je wilt helpen, stuur ons dan een mailtje met het level en je programma op hedy@felienne.com. Probeer om verder te gaan je programma een beetje aan te passen en kijk nog eens goed naar de voorbeelden. Bedankt!"
 HedyErrorMessages:
-    Wrong Level: "Dat was goede code hoor, maar niet op het goede level. Je schreef code voor level {original_level} op level {working_level}."
+    Wrong Level: "Dat was goede code hoor, maar niet op het goede level. Je schreef code voor level {working_level} op level {original_level}."
     Incomplete: "Let op, je bent een stukje code vergeten. Op regel {line_number} moet er achter {incomplete_command} nog tekst komen."
     Invalid: "{invalid_command} is geen commando in Hedy level {level}. Bedoelde je {guessed_command}?"
     Invalid Space: "Oeps! Regel {line_number} begint met een spatie. Computers kunnen niet zo goed tegen spaties, kun je 'm weghalen?"

--- a/coursedata/texts/pt_br.yaml
+++ b/coursedata/texts/pt_br.yaml
@@ -34,7 +34,7 @@ ClientErrorMessages:
     CheckInternet: "Verifique se sua conexão com a Internet está funcionando corretamente."
     ServerError: "Você escreveu um programa que não estávamos esperando. Se você quiser ajudar, envie-nos um email com o nível e seu programa para hedy@felienne.com. Enquanto isso, tente algo um pouco diferente e dê uma outra olhada nos exemplos. Obrigado!"
 HedyErrorMessages:
-    Wrong Level: "Este era um código Hedy correto, mas não para o nível correto. Você escreveu para o nível {original_level} no nível {working_level}."
+    Wrong Level: "Este era um código Hedy correto, mas não para o nível correto. Você escreveu para o nível {working_level} no nível {original_level}."
     Incomplete: "Opa! Você esqueceu um pedaço do código! Na linha {line_number}, você precisa entrar com texto após {incomplete_command}."
     Invalid: "{invalid_command} não é um commando Hedy do nível {level}. Você quis dizer {guessed_command}?"
     Invalid Space: "Opa! Você começou uma linha com um espaço na linha {line_number}. Espaços confundem os computadores, você poderia removê-lo?"

--- a/coursedata/texts/pt_pt.yaml
+++ b/coursedata/texts/pt_pt.yaml
@@ -34,7 +34,7 @@ ClientErrorMessages:
     CheckInternet: "Verifica se a tua ligação de Internet está a funcionar correctamente?"
     ServerError: "Escreveste um programa que não estávamos à espera. Se queres ajudar, envia-nos um email com o nível e o teu programa para hedy@felienne.com. Entretanto, experimenta alguma coisa um pouco diferente e volta a olhar para os exemplos. Obrigado!"
 HedyErrorMessages:
-    Wrong Level: "Isso era código Hedy correcto, mas não no nível certo. Escreveste códio para o nível {original_level}, no nível {working_level}."
+    Wrong Level: "Isso era código Hedy correcto, mas não no nível certo. Escreveste códio para o nível {working_level}, no nível {original_level}."
     Incomplete: "Oops! Esqueceste-te de um pedaço de código! Na linha {line_number}, tens de introduzir texto a seguir de {incomplete_command}."
     Invalid: "{invalid_command} não é um comando Hedy do nível {level}. Será que querias dizer {guessed_command}?"
     Invalid Space: "Oops! Começaste uma linha com um espaço na linha {line_number}. Espaços confundem os computadores, podes apagá-lo?"

--- a/coursedata/texts/sw.yaml
+++ b/coursedata/texts/sw.yaml
@@ -34,7 +34,7 @@ ClientErrorMessages:
   CheckInternet: "Have a look if your Internet connection is working properly?"
   ServerError: "You wrote a program we weren't expecting. If you want to help, send us an email with the level and your program at hedy@felienne.com. In the mean time, try something a little different and take another look at the examples. Thanks!"
 HedyErrorMessages:
-  Wrong Level: "Ni sahihi, lakini sio jibu la kiwango hiki. Umeandika jibu la kiwango  {original_level} kwenye kiwango cha {working_level}."
+  Wrong Level: "Ni sahihi, lakini sio jibu la kiwango hiki. Umeandika jibu la kiwango  {working_level} kwenye kiwango cha {original_level}."
   Incomplete: "Oops! Umesahau kitu! Kwenye mstari wa {line_number}, unatakiwa kuandika nyuma ya {incomplete_command}."
   Invalid: "{invalid_command} hii sio sahihi kwa kiwango cha {level}. Ulimaanisha  {guessed_command}?"
   Invalid Space: "Oops! Ulianza mstari na nafasi(ujazo) katika mstari wa {line_number}. Nafasi huchanganya kompyuta, unaweza kuiondoa?"

--- a/coursedata/texts/zh.yaml
+++ b/coursedata/texts/zh.yaml
@@ -34,7 +34,7 @@ ClientErrorMessages:
     CheckInternet: "Have a look if your Internet connection is working properly?"
     ServerError: "You wrote a program we weren't expecting. If you want to help, send us an email with the level and your program at hedy@felienne.com. In the mean time, try something a little different and take another look at the examples. Thanks!"
 HedyErrorMessages:
-    Wrong Level: "这个 Hedy代码是正确的，但级别不对.你在第{working_level}级使用的是第{original_level}级的代码."
+    Wrong Level: "这个 Hedy代码是正确的，但级别不对.你在第{original_level}级使用的是第{working_level}级的代码."
     Incomplete: "糟糕! 你好像在第 {line_number}行忘写了一段代码!, 你需要在{incomplete_command}后面输入文字."
     Invalid: "{invalid_command} 不是一个第{level}级的 Hedy命令. 你编写的是{guessed_command}吗?"
     Invalid Space: "糟糕!你在第{line_number}行句首空了一格. 这个空格让计算机产生了困惑，你能不能删除这个空格?"

--- a/hedy.py
+++ b/hedy.py
@@ -1115,7 +1115,7 @@ def transpile(input_string, level, sub = 0):
                     # Parse at `level - 1` failed as well, just re-raise original error
                     raise E
                 # If the parse at `level - 1` succeeded, then a better error is "wrong level"
-                raise HedyException('Wrong Level', correct_code=result.code, original_level=new_level, working_level=level) from E
+                raise HedyException('Wrong Level', correct_code=result.code, working_level=new_level, original_level=level) from E
         raise E
 
 def repair(input_string):


### PR DESCRIPTION
`original_level` was used to indicate the level for which the code does work, while `working_level` was used for the current level.

Maybe `original_level` should be renamed to `current_level` or something like that to reduce confusion?