### PR TITLE
Allow empty programs in the grammar

### DIFF
--- a/app.py
+++ b/app.py
@@ -276,58 +276,53 @@ def parse():
 
     querylog.log_value(level=level, lang=lang, session_id=session_id(), username=username)
 
-    # Check if user sent code
-    if not code:
-        response["Error"] = "no code found, please send code."
-    # is so, parse
-    else:
-        try:
-            hedy_errors = TRANSLATIONS.get_translations(lang, 'HedyErrorMessages')
-            with querylog.log_time('transpile'):
-                transpile_result = hedy.transpile(code, level, sublevel)
-                python_code = transpile_result.code
-                has_turtle = transpile_result.has_turtle
+    try:
+        hedy_errors = TRANSLATIONS.get_translations(lang, 'HedyErrorMessages')
+        with querylog.log_time('transpile'):
+            transpile_result = hedy.transpile(code, level, sublevel)
+            python_code = transpile_result.code
+            has_turtle = transpile_result.has_turtle
 
-            response['has_turtle'] = has_turtle
-            if has_turtle:
-                response["Code"] = "# coding=utf8\nimport random\nimport time\nimport turtle\nt = turtle.Turtle()\nt.forward(0)\n" + python_code
-            else:
-                response["Code"] = "# coding=utf8\nimport random\n" + python_code
-        except hedy.HedyException as E:
-            traceback.print_exc()
-            # some 'errors' can be fixed, for these we throw an exception, but also
-            # return fixed code, so it can be ran
-            if E.args[0] == "Invalid Space":
-                error_template = hedy_errors[E.error_code]
-                response["Code"] = "# coding=utf8\n" + E.arguments['fixed_code']
-                response["Warning"] = error_template.format(**E.arguments)
-            elif E.args[0] == "Too Big":
-                error_template = hedy_errors[E.error_code]
-                response["Error"] = error_template.format(**E.arguments)
-            elif E.args[0] == "Parse":
-                error_template = hedy_errors[E.error_code]
-                # Localize the names of characters. If we can't do that, just show the original
-                # character.
-                if 'character_found' in E.arguments.keys():
-                    E.arguments['character_found'] = hedy_errors.get(E.arguments['character_found'], E.arguments['character_found'])
-                elif 'keyword_found' in E.arguments.keys():
-                    #if we find an invalid keyword, place it in the same location in the error message but without translating
-                    E.arguments['character_found'] = E.arguments['keyword_found']
+        response['has_turtle'] = has_turtle
+        if has_turtle:
+            response["Code"] = "# coding=utf8\nimport random\nimport time\nimport turtle\nt = turtle.Turtle()\nt.forward(0)\n" + python_code
+        else:
+            response["Code"] = "# coding=utf8\nimport random\n" + python_code
+    except hedy.HedyException as E:
+        traceback.print_exc()
+        # some 'errors' can be fixed, for these we throw an exception, but also
+        # return fixed code, so it can be ran
+        if E.args[0] == "Invalid Space":
+            error_template = hedy_errors[E.error_code]
+            response["Code"] = "# coding=utf8\n" + E.arguments['fixed_code']
+            response["Warning"] = error_template.format(**E.arguments)
+        elif E.args[0] == "Too Big":
+            error_template = hedy_errors[E.error_code]
+            response["Error"] = error_template.format(**E.arguments)
+        elif E.args[0] == "Parse":
+            error_template = hedy_errors[E.error_code]
+            # Localize the names of characters. If we can't do that, just show the original
+            # character.
+            if 'character_found' in E.arguments.keys():
+                E.arguments['character_found'] = hedy_errors.get(E.arguments['character_found'], E.arguments['character_found'])
+            elif 'keyword_found' in E.arguments.keys():
+                #if we find an invalid keyword, place it in the same location in the error message but without translating
+                E.arguments['character_found'] = E.arguments['keyword_found']
 
-                response["Error"] = error_template.format(**E.arguments)
-            elif E.args[0] == "Unquoted Text":
-                error_template = hedy_errors[E.error_code]
-                response["Error"] = error_template.format(**E.arguments)
-            elif E.args[0] == "Has Blanks":
-                error_template = hedy_errors[E.error_code]
-                response["Error"] = error_template.format(**E.arguments)
-            else:
-                error_template = hedy_errors[E.error_code]
-                response["Error"] = error_template.format(**E.arguments)
-        except Exception as E:
-            traceback.print_exc()
-            print(f"error transpiling {code}")
-            response["Error"] = str(E)
+            response["Error"] = error_template.format(**E.arguments)
+        elif E.args[0] == "Unquoted Text":
+            error_template = hedy_errors[E.error_code]
+            response["Error"] = error_template.format(**E.arguments)
+        elif E.args[0] == "Has Blanks":
+            error_template = hedy_errors[E.error_code]
+            response["Error"] = error_template.format(**E.arguments)
+        else:
+            error_template = hedy_errors[E.error_code]
+            response["Error"] = error_template.format(**E.arguments)
+    except Exception as E:
+        traceback.print_exc()
+        print(f"error transpiling {code}")
+        response["Error"] = str(E)
     querylog.log_value(server_error=response.get('Error'))
     parse_logger.log ({
         'session': session_id(),

--- a/coursedata/texts/en.yaml
+++ b/coursedata/texts/en.yaml
@@ -35,6 +35,7 @@ ClientErrorMessages:
     CheckInternet: "Have a look if your Internet connection is working properly?"
     ServerError: "You wrote a program we weren't expecting. If you want to help, send us an email with the level and your program at hedy@felienne.com. In the mean time, try something a little different and take another look at the examples. Thanks!"
 HedyErrorMessages:
+    Empty Program: No code found, please enter some code.
     Wrong Level: "That was correct Hedy code, but not at the right level. You wrote code for level {working_level} at level {original_level}."
     Incomplete: "Oops! You forgot a bit of code! On line {line_number}, you need to enter text behind {incomplete_command}."
     Invalid: "{invalid_command} is not a Hedy level {level} command. Did you mean {guessed_command}?"

--- a/coursedata/texts/nl.yaml
+++ b/coursedata/texts/nl.yaml
@@ -35,6 +35,7 @@ ClientErrorMessages:
     CheckInternet: "Controleer even of je internetverbinding het nog doet?"
     ServerError: "Je hebt een programma geschreven dat we niet verwacht hadden. Als je wilt helpen, stuur ons dan een mailtje met het level en je programma op hedy@felienne.com. Probeer om verder te gaan je programma een beetje aan te passen en kijk nog eens goed naar de voorbeelden. Bedankt!"
 HedyErrorMessages:
+    Empty Program: "Er was geen code gevonden. Typ graag wat code in."
     Wrong Level: "Dat was goede code hoor, maar niet op het goede level. Je schreef code voor level {working_level} op level {original_level}."
     Incomplete: "Let op, je bent een stukje code vergeten. Op regel {line_number} moet er achter {incomplete_command} nog tekst komen."
     Invalid: "{invalid_command} is geen commando in Hedy level {level}. Bedoelde je {guessed_command}?"

--- a/grammars/level1.lark
+++ b/grammars/level1.lark
@@ -68,7 +68,7 @@ _WHILE: "while"
 _LENGTH: "length"
 
 start: program
-program: _EOL* command (_SPACE)* (_EOL+ command (_SPACE)*)* _EOL* //lines may end on spaces and might be separated by many newlines
+program: _EOL* (command (_SPACE)* _EOL+)* (command (_SPACE)*)? //lines may end on spaces and might be separated by many newlines
 command: print | ask | echo | turtle | invalid_space | invalid
 
 print: _PRINT (_SPACE text)?

--- a/hedy.py
+++ b/hedy.py
@@ -378,6 +378,10 @@ class IsValid(Filter):
     # all rules are valid except for the "Invalid" production rule
     # this function is used to generate more informative error messages
     # tree is transformed to a node of [Bool, args, command number]
+    def program(self, args):
+        if len(args) == 0:
+            return False, "empty program", 1
+        return super().program(args)
 
     def invalid_space(self, args):
         # return space to indicate that line starts in a space
@@ -1317,6 +1321,8 @@ def transpile_inner(input_string, level, sub=0):
         elif args == 'print without quotes':
             # grammar rule is ignostic of line number so we can't easily return that here
             raise HedyException('Unquoted Text', level=level)
+        elif args == 'empty program':
+            raise HedyException('Empty Program')
         else:
             invalid_command = args
             closest = closest_command(invalid_command, commands_per_level[level])

--- a/tests/tests_level_01.py
+++ b/tests/tests_level_01.py
@@ -290,7 +290,6 @@ class TestsLevel1(unittest.TestCase):
     self.assertEqual(False, result.has_turtle)
 
   def test_two_spaces_after_print(self):
-
     code = "print        hallo!"
 
     result = hedy.transpile(code, self.level)
@@ -300,3 +299,11 @@ class TestsLevel1(unittest.TestCase):
 
     self.assertEqual(expected, result.code)
     self.assertEqual(False, result.has_turtle)
+
+  def test_newlines_only(self):
+    code = textwrap.dedent("""\
+
+    """)
+    with self.assertRaises(Exception) as context:
+      result = hedy.transpile(code, self.level)
+    self.assertEqual('Empty Program', str(context.exception))


### PR DESCRIPTION
The empty program check is now moved to IsValid and will handle programs consisting entirely of newlines without crashing.

Programs consisting entirely of spaces do still give a parse error, but unlike newline only programs previously they don't crash Hedy.

Fixes https://github.com/Felienne/hedy/issues/833