### PR TITLE
Stop long running programs in client-side JS

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -402,7 +402,9 @@ function runPythonProgram(code, hasTurtle, cb) {
     read: builtinRead,
     inputfun: inputFromInlineModal,
     inputfunTakesPrompt: true,
-    __future__: Sk.python3
+    __future__: Sk.python3,
+    // Give up after three seconds of execution, there might be an infinite loop.
+    execLimit: 3000
   });
 
   return Sk.misceval.asyncToPromise(function () {
@@ -414,6 +416,7 @@ function runPythonProgram(code, hasTurtle, cb) {
     // Extract error message from error
     console.log(err);
     const errorMessage = errorMessageFromSkulptError(err) || JSON.stringify(err);
+    if (errorMessage === 'Program exceeded run time limit.') window.modal.alert ('Your program takes too long to run.');
     throw new Error(errorMessage);
   });
 

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -415,8 +415,12 @@ function runPythonProgram(code, hasTurtle, cb) {
   }).catch(function(err) {
     // Extract error message from error
     console.log(err);
-    const errorMessage = errorMessageFromSkulptError(err) || JSON.stringify(err);
-    if (errorMessage === 'Program exceeded run time limit.') window.modal.alert ('Your program takes too long to run.');
+    var errorMessage = errorMessageFromSkulptError(err) || JSON.stringify(err);
+    if (errorMessage === 'Program exceeded run time limit.') {
+      // TODO: internationalize this text.
+      errorMessage = 'Your program takes too long to run.';
+      window.modal.alert (errorMessage);
+    }
     throw new Error(errorMessage);
   });
 


### PR DESCRIPTION
- Closes #560
- Stops Python program execution in the client after 3 seconds
- Prints a modal

**How to test**:
- Go to http://localhost:5000/hedy/17
- Run this code:
```
a is True
while a is True:
    b is 1
```
- See that a modal appears after three seconds and that code execution is indeed interrupted.

@Felienne suggestions to the shown text are welcome! Once we agree on the text, I can add the text entry to the yamls.