### PR TITLE
Show 404 page when requesting a level that does not exist

### DIFF
--- a/app.py
+++ b/app.py
@@ -766,6 +766,8 @@ def index(level, step):
 
     adventures = load_adventures_per_level(requested_lang(), level)
     level_defaults_for_lang = LEVEL_DEFAULTS[requested_lang()]
+    if level not in level_defaults_for_lang.levels:
+        return utils.page_404 (TRANSLATIONS, render_main_menu('hedy'), current_user(request) ['username'], requested_lang (), TRANSLATIONS.get_translations (requested_lang (), 'ui').get ('no_such_level'))
     defaults = level_defaults_for_lang.get_defaults_for_level(level)
     max_level = level_defaults_for_lang.max_level()
 


### PR DESCRIPTION
- Closes #993 

**How to test**:
- Go to http://localhost:5000/hedy/29
- See that the app shows a 404 page with the error "No such Hedy level!".
- Note that the app doesn't crash anymore when that page is requested.