### PR TITLE
chore: log query string in querylog

### DIFF
--- a/app.py
+++ b/app.py
@@ -233,7 +233,8 @@ if utils.is_heroku() and not os.getenv('HEROKU_RELEASE_CREATED_AT'):
 
 @app.before_request
 def before_request_begin_logging():
-    querylog.begin_global_log_record(path=request.path, method=request.method)
+    path = (request.path + '?' + request.query_string) if request.query_string else request.path
+    querylog.begin_global_log_record(path=path, method=request.method)
 
 # A context processor injects variables in the context that are available to all templates.
 @app.context_processor

--- a/app.py
+++ b/app.py
@@ -233,7 +233,7 @@ if utils.is_heroku() and not os.getenv('HEROKU_RELEASE_CREATED_AT'):
 
 @app.before_request
 def before_request_begin_logging():
-    path = (request.path + '?' + request.query_string) if request.query_string else request.path
+    path = (str(request.path) + '?' + str(request.query_string)) if request.query_string else str(request.path)
     querylog.begin_global_log_record(path=path, method=request.method)
 
 # A context processor injects variables in the context that are available to all templates.

--- a/tools/download-logs
+++ b/tools/download-logs
@@ -26,4 +26,8 @@ sed -e '$a\' $cache_dir/* > $finalfile
 
 echo "Now run a command like:"
 echo ""
+echo "Page loads that take a long time:"
 echo "   cat $finalfile | recs grep '{{duration_ms}} > 1000' | tee _lastquery.jsonl | recs totable -k start_time,duration_ms,method,path,'!_ms\$!' | less -S"
+echo ""
+echo "Count of failures:"
+echo "   cat $finalfile | recs grep '{{http_code}} ne 200' | tee _lastquery.jsonl | recs collate -k http_code,method,path -a count | recs sort -k count=-n | recs totable | less -S"


### PR DESCRIPTION
We used to be only logging the path in the query log (`/hedy/8`),
but the language is pretty relevant and that is passed in the query
string (`/hedy/8?lang=fr`).

Log the query string as well if passed.

Also add an example query to the download script so I don't have to
look up how to do this every time :).
