### PR TITLE
Ignore empty lines

### DIFF
--- a/hedy.py
+++ b/hedy.py
@@ -1536,6 +1536,10 @@ def preprocess_blocks(code, level):
         if indent_size == None and leading_spaces > 0:
             indent_size = leading_spaces
 
+        # ignore whitespace-only lines
+        if leading_spaces == len(line):
+            continue
+
         #calculate nuber of indents if possible
         if indent_size != None:
             if (leading_spaces % indent_size) != 0:

--- a/tests/test_level_08.py
+++ b/tests/test_level_08.py
@@ -116,6 +116,28 @@ class TestsLevel8(HedyTester):
 
     self.assertEqual(expected, result.code)
 
+  def test_empty_line_with_whitespace(self):
+    code = textwrap.dedent("""\
+    repeat 3 times
+      food is ask 'What do you want?'
+      if food is 'pizza'
+        print 'nice!'
+         
+      else
+        print 'pizza is better'""")
+
+    result = hedy.transpile(code, self.level)
+
+    expected = textwrap.dedent("""\
+    for i in range(int(3)):
+      food = input('What do you want?')
+      if str(food) == str('pizza'):
+        print(f'nice!')
+      else:
+        print(f'pizza is better')""")
+
+    self.assertEqual(expected, result.code)
+
 
 
 


### PR DESCRIPTION
This PR changes `preprocess_blocks` to ignore empty lines (with or without whitespace). 

**Description**

Ignores whitespace-only lines accepting more programs as valid.

**Fix for**

Fixes #1197

**How to test**

* Go to level 8
* Paste this code taken from #1197 (make sure to preserve the whitespace in line 4):

```
food is ask 'What do you want?'
if food is 'pizza'
    print 'nice!'
    
else
    print 'pizza is better'
```

* Check that no error is raised and an ask modal is displayed
