### PR TITLE
Adding tests for parsing dutch keyword

### DIFF
--- a/tests/test_level_01.py
+++ b/tests/test_level_01.py
@@ -87,6 +87,18 @@ class TestsLevel1(HedyTester):
 
     self.assertEqual(expected, result.code)
     self.assertEqual(False, result.has_turtle)
+  def test_print_dutch(self):
+    result = hedy.transpile("drukaf Hallo welkom bij Hedy!", self.level, lang="nl")
+    expected = "print('Hallo welkom bij Hedy!')"
+    self.assertEqual(expected, result.code)
+    self.assertEqual(False, result.has_turtle)
+    self.assertEqual('Hallo welkom bij Hedy!', HedyTester.run_code(result))
+  def test_print_dutch_error(self):
+    code = textwrap.dedent("""print Hallo welkom bij Hedy!""")
+
+    with self.assertRaises(hedy.exceptions.ParseException) as context:
+      result = hedy.transpile(code, self.level, lang="nl")
+    self.assertEqual('Parse', context.exception.error_code)
 
   # ask tests
   def test_ask(self):

--- a/tests/test_level_09.py
+++ b/tests/test_level_09.py
@@ -39,4 +39,17 @@ class TestsLevel9(HedyTester):
       print(f'{shark} shark')""")
 
     self.assertEqual(expected, result.code)
+  def test_for_list_dutch(self):
+    code = textwrap.dedent("""\
+    dieren is hond, kat, papegaai
+    voor dier in dieren
+      drukaf dier""")
 
+    result = hedy.transpile(code, self.level, lang="nl")
+
+    expected = textwrap.dedent("""\
+    dieren = ['hond', 'kat', 'papegaai']
+    for dier in dieren:
+      print(f'{dier}')""")
+
+    self.assertEqual(expected, result.code)


### PR DESCRIPTION
We have added some tests for the parsing of Dutch keywords. Two tests for the print keyword and one for a for-loop (just a safety-check to see if that also works). Parsing other keywords in Dutch should also be right "by construction".

This should resolve issue #1212 

