### PR TITLE
fix number of next level in Vooruitblik bij level 9

### DIFF
--- a/coursedata/adventures/nl.yaml
+++ b/coursedata/adventures/nl.yaml
@@ -25,7 +25,7 @@ adventures:
                     ```
                     ask De hoofdpersoon van dit verhaal is
                     print De hoofdpersoon gaat nu in het bos lopen
-                    echo Hij is wel een beetje bang, die 
+                    echo Hij is wel een beetje bang, die
                     print Overal hoort hij gekke geluiden
                     print Hij is bang dat dit een spookbos is
                     ```
@@ -122,18 +122,18 @@ adventures:
                     ```
 
                 start_code: "repeat 5 times print 'Help!'"
-            7: 
+            7:
                 story_text: |
                     ## Verhaal
                     In level 7 kun je je verhaal écht interactief maken! In dit level is het `if` commando namelijk veranderd, waardoor je meerdere regels kan printen na een `if`.
                     Zo kun je de lezer van je verhaal een keuze laten maken. Na de keuze gaat het verhaal verder op basis van die keuze. Kijk maar naar het voorbeeld.
-                    
+
                     ## Voorbeeld Hedy code
                     ```
                     hoofdpersoon is ask 'Hoe heet de hoofdpersoon in dit verhaal?'
                     print hoofdpersoon ' loopt door het bos'
                     print hoofdpersoon ' hoort plotseling een geluid!'
-                    dapper is ask 'Gaat 'hoofdpersoon ' op het geluid af?' 
+                    dapper is ask 'Gaat 'hoofdpersoon ' op het geluid af?'
                     if dapper is ja
                         print 'Dapper stapt ' hoofdpersoon ' op het geluid af'
                         print _
@@ -143,7 +143,7 @@ adventures:
                     ```
                     In dit voorbeeld zie je hoe je twee verschillende verhalen kunt maken; eentje waarbij je op het geluid afgaat en eentje waarbij je je verstopt. Vul zelf lege plekken in! Wat gebeurt er verder?
                 start_code: ""
-                
+
             8:
                 story_text: |
                     ## Verhaal
@@ -280,8 +280,8 @@ adventures:
             7:
                 story_text: |
                     ## Zing een liedje!
-                    In level 7 kun je meerdere regels herhalen, wat heel fijn is in liedjes! 
-                    
+                    In level 7 kun je meerdere regels herhalen, wat heel fijn is in liedjes!
+
                     ## Cowboy Billie Boem
                     ```
                     repeat 3 times
@@ -296,7 +296,7 @@ adventures:
                         print 'en nu mag je zelf bedenken wat voor beest dat is geweest!'
                     ```
                 start_code: ""
-                    
+
             9:
                 story_text: |
                     ## Zing een liedje!
@@ -777,7 +777,7 @@ adventures:
                     ```
                     print wat kies jij?
                     ask kies uit steen, schaar of papier
-                    echo dus jouw keuze was: 
+                    echo dus jouw keuze was:
                     ```
                 start_code: "print Welkom bij jouw eigen steen schaar papier!"
             2:
@@ -974,33 +974,33 @@ adventures:
             1:
                 story_text: |
                     ## Hedy de Waarzegger
-                    Heb je ooit op de kermis jouw toekomst laten voorspellen door een waarzegger? Of heb je ooit met magische biljartbal gespeeld? 
-                    Dan weet je waarschijnlijk dat zij niet echt de toekomst kunnen voorspellen, maar dat maakt de voorspelling niet minder leuk! 
-                    
-                    Ook Hedy kunnen we omtoveren in een waarzeggersmachine! In level 1 beginnen we makkelijk, met het voorstellen van Hedy de Waarzegger en het herhalen van de antwoorden van de speler met echo. 
-                    Kijk maar naar het voorbeeld: 
-                    
+                    Heb je ooit op de kermis jouw toekomst laten voorspellen door een waarzegger? Of heb je ooit met magische biljartbal gespeeld?
+                    Dan weet je waarschijnlijk dat zij niet echt de toekomst kunnen voorspellen, maar dat maakt de voorspelling niet minder leuk!
+
+                    Ook Hedy kunnen we omtoveren in een waarzeggersmachine! In level 1 beginnen we makkelijk, met het voorstellen van Hedy de Waarzegger en het herhalen van de antwoorden van de speler met echo.
+                    Kijk maar naar het voorbeeld:
+
                     ## Voorbeeld Hedy code
                     ```
                     print Hoi, ik ben Hedy de waarzegger!
                     ask Wie ben jij?
                     print Ik voorspel... Ik voorspel...
-                    echo Jouw naam is 
+                    echo Jouw naam is
                     ```
-                    
+
                     ## Uitdaging
-                    Hedy kan nu voorspellen hoe jij heet, maar kun jij ervoor zorgen dat Hedy meer voorspellingen over je kan maken? 
-                    
-                    Zoals je merkt, is Hedy nog niet echt een goede waarzegger. Ze voorspelt alleen wat je haar vertelt! 
-                    Neem een kijkje in level 2 om te leren om echte voorspellingen te doen! 
+                    Hedy kan nu voorspellen hoe jij heet, maar kun jij ervoor zorgen dat Hedy meer voorspellingen over je kan maken?
+
+                    Zoals je merkt, is Hedy nog niet echt een goede waarzegger. Ze voorspelt alleen wat je haar vertelt!
+                    Neem een kijkje in level 2 om te leren om echte voorspellingen te doen!
                 start_code: ""
             2:
-                story_text: | 
+                story_text: |
                     ## Hedy de Waarzegger
-                    In level 1 heb je een begin gemaakt aan de waarzegger, maar echt voorspellingen waren er nog niet. 
-                    In level 2 kun je een variabele gebruiken en het `at random` commando om Hedy antwoorden te laten kiezen op je vraag. 
-                    Kijk maar naar dit voorbeeld: 
-                    
+                    In level 1 heb je een begin gemaakt aan de waarzegger, maar echt voorspellingen waren er nog niet.
+                    In level 2 kun je een variabele gebruiken en het `at random` commando om Hedy antwoorden te laten kiezen op je vraag.
+                    Kijk maar naar dit voorbeeld:
+
                     ## Voorbeeld Hedy code
                     ```
                     print Hoi Ik ben Hedy de Waarzegger
@@ -1010,15 +1010,15 @@ adventures:
                     print Mijn glazen bol zegt...
                     print antwoorden at random
                     ```
-                    
+
                     ## Uitdaging
                     Er zijn nu maar 3 antwoordopties waar Hedy uit kan kiezen, kun jij er meer toevoegen? Bijvoorbeeld: zeker weten, geen idee of probeer het nog eens!
                 start_code: ""
             3:
-                story_text: | 
+                story_text: |
                     ## Hedy de Waarzegger
                     In level 3 kun je oefenen met de aanhalingstekens. Probeer dezelfde code te maken als in level 2, maar let op dat je de aanhalingstekens op de goede plek plaatst!
-                    
+
                     ## Voorbeeld Hedy code
                     ```
                     print 'Hoi ik ben Hedy de Waarzegger!'
@@ -1029,13 +1029,13 @@ adventures:
                     print antwoorden at random
                     ```
                 start_code: ""
-            4: 
+            4:
                 story_text: |
                     ## Hedy de Waarzegger
-                    In level 4 leer je hoe je er (stiekem) voor kunt zorgen dat Hedy altijd goede voorspellingen voor jou heeft. 
+                    In level 4 leer je hoe je er (stiekem) voor kunt zorgen dat Hedy altijd goede voorspellingen voor jou heeft.
                     Door `if` en `else` te gebruiken kun je er namelijk voor zorgen dat jij de leuke voorspellingen krijgt, en de anderen niet!
-                    Kijk naar het voorbeeld om te zien hoe het moet: 
-                    
+                    Kijk naar het voorbeeld om te zien hoe het moet:
+
                     ## Voorbeeld Hedy code
                     ```
                     print 'Hoi ik ben Hedy de Waarzegger'
@@ -1043,11 +1043,11 @@ adventures:
                     naam is ask 'Wie ben jij?'
                     if naam is Hedy print 'Hoera, je wint!' else print 'Helaas, iemand anders wint'
                     ```
-                    
-                    Verander Hedy in je eigen naam en jij zult altijd de loterij winnen! Natuurlijk is dit wel een beetje verdacht voor andere spelers... 
-                    Om dat op te lossen kun je ervoor zorgen dat Hedy wel steeds iets anders zegt, maar bij jou altijd een goed antwoord en bij de anderen een slechte. 
-                    Kijk maar naar dit voorbeeld: 
-                    
+
+                    Verander Hedy in je eigen naam en jij zult altijd de loterij winnen! Natuurlijk is dit wel een beetje verdacht voor andere spelers...
+                    Om dat op te lossen kun je ervoor zorgen dat Hedy wel steeds iets anders zegt, maar bij jou altijd een goed antwoord en bij de anderen een slechte.
+                    Kijk maar naar dit voorbeeld:
+
                     ## Voorbeeld Hedy code
                     ```
                     print 'Hoi ik ben Hedy de Waarzegger'
@@ -1057,10 +1057,10 @@ adventures:
                     slechtantwoord is Helaas!, Geen prijs voor jou, Probeer het nog eens
                     if naam is Hedy print goedantwoord at random else print slechtantwoord at random
                     ```
-                    
+
                     ##Uitdaging
                     Op deze manier kun je nog veel meer programma's schrijven! Je zou bijvoorbeeld kunnen voorspellen welke club de Eredivisie wint.
-                    Of je zou de toverspiegel uit Sneeuwwitje kunnen laten voorspellen dat jij de mooiste van het land bent (en de rest natuurlijk niet!). 
+                    Of je zou de toverspiegel uit Sneeuwwitje kunnen laten voorspellen dat jij de mooiste van het land bent (en de rest natuurlijk niet!).
                     Of er zijn nog heel veel meer opties, laat je fantasie de vrije loop en wees creatief!
                 start_code: ""
             5:
@@ -1102,7 +1102,7 @@ adventures:
                 story_text: |
                     ## Hedy de Waarzegger
                     In level 6 kun je het `repeat` commando gebruiken om meerdere voorspellingen te doen. Kijk maar naar het voorbeeld:
-                    
+
                     ## Voorbeeld Hedy code
                     ```
                     print 'Ik ben Hedy de waarzegger'
@@ -1111,26 +1111,26 @@ adventures:
                     antwoorden is ja, nee, misschien
                     repeat 3 times print 'Mijn glazen bol zegt... ' antwoorden at random
                     ```
-                   
+
                     ## Uitdaging
-                    Zoals je ziet worden de vragen niet geprint in dit voorbeeld. Dat komt omdat de variabele 'vraag' 3x veranderd wordt. 
-                    Elke keer als een speler een nieuw antwoord geeft, wordt de variabele namelijk overschreven, waardoor het vorige antwoord verloren gaat. 
-                    Dit betekent dat je dus niet alle vragen kunt printen op deze manier. 
-                   
-                    Als je 3 verschillende variabelen gebruikt, in plaats van eentje (bijvoorbeeld vraag1, vraag2 en vraag3), kun je dit probleem oplossen en de vragen wel printen. 
-                    Dit betekent wel dat je het repeat commando alleen bij de antwoorden kunt gebruiken en alle vragen apart moet stellen. 
+                    Zoals je ziet worden de vragen niet geprint in dit voorbeeld. Dat komt omdat de variabele 'vraag' 3x veranderd wordt.
+                    Elke keer als een speler een nieuw antwoord geeft, wordt de variabele namelijk overschreven, waardoor het vorige antwoord verloren gaat.
+                    Dit betekent dat je dus niet alle vragen kunt printen op deze manier.
+
+                    Als je 3 verschillende variabelen gebruikt, in plaats van eentje (bijvoorbeeld vraag1, vraag2 en vraag3), kun je dit probleem oplossen en de vragen wel printen.
+                    Dit betekent wel dat je het repeat commando alleen bij de antwoorden kunt gebruiken en alle vragen apart moet stellen.
                     Lukt het jou dit te maken?
-                   
+
                     In level 7 verandert de opmaak van het repeat-commando, waardoor dit probleem verdwijnt!
                 start_code: ""
-            7: 
+            7:
                  story_text: |
                      ## Hedy de waarzegger
-                     Weet je nog dat je in Level 5 een waarzegger hebt gemaakt die drie vragen tegelijk kon stellen? 
-                     Het enige probleem dat we tegenkwamen is dat Hedy toen eerst de drie vragen printte en daarna pas de drie antwoorden. 
-                     In Level 7 is dat probleem opgelost en kan Hedy na een vraag meteen een antwoord printen, omdat je nu niet maar één regel code kunt herhalen met repeat, maar een heel stuk van je code! 
+                     Weet je nog dat je in Level 5 een waarzegger hebt gemaakt die drie vragen tegelijk kon stellen?
+                     Het enige probleem dat we tegenkwamen is dat Hedy toen eerst de drie vragen printte en daarna pas de drie antwoorden.
+                     In Level 7 is dat probleem opgelost en kan Hedy na een vraag meteen een antwoord printen, omdat je nu niet maar één regel code kunt herhalen met repeat, maar een heel stuk van je code!
                      Kijk maar:
-                     
+
                      ## Voorbeeld Hedy code
                      ```
                      print 'Ik ben Hedy de waarzegger!'
@@ -1193,26 +1193,26 @@ adventures:
             1:
                 story_text: |
                     ## Restaurant level 1
-                    Je kunt met Hedy ook een virtueel restaurant bouwen en de bestellingen van je klanten opnemen! 
-                    
+                    Je kunt met Hedy ook een virtueel restaurant bouwen en de bestellingen van je klanten opnemen!
+
                     ## Voorbeeld Hedy Code
                     ```
                     print Welkom bij McHedy!
                     ask Wat wilt u bestellen?
-                    echo Dus u wilt graag 
+                    echo Dus u wilt graag
                     print Bedankt voor uw bestelling!
                     ```
-                    
+
                     ## Uitdaging
-                    Kun jij het restaurant verder uitbreiden door meer regels code toe te voegen? Je zou bijvoorbeeld kunnen vragen of je klant ook iets wil drinken, vertellen hoe duur het is, of de klant eet smakelijk wensen! 
-                    
+                    Kun jij het restaurant verder uitbreiden door meer regels code toe te voegen? Je zou bijvoorbeeld kunnen vragen of je klant ook iets wil drinken, vertellen hoe duur het is, of de klant eet smakelijk wensen!
+
                 start_code: "print Welkom bij McHedy!"
-                
+
             2:
                 story_text: |
                     ## Restaurant level 2
-                    In level 2 kun je variabelen gebruiken om je restaurant interactiever te maken! Kijk maar naar het voorbeeld. 
-                    
+                    In level 2 kun je variabelen gebruiken om je restaurant interactiever te maken! Kijk maar naar het voorbeeld.
+
                     ## Voorbeeld Hedy Code
                     ```
                     print Welkom bij McHedy!
@@ -1222,10 +1222,10 @@ adventures:
                     print U heeft eten met saus en drinken besteld.
                     print Bedankt voor uw bestelling!
                     ```
-                  
+
                     ## Random restaurant
                     In level 2 kun je ook het commando `at random` gebruiken om Hedy voor jou te laten kiezen. Hierdoor kun je ook een grappig random restaurant bouwen, waarbij je Hedy laat kiezen wat jij te eten krijgt!
-                    
+
                     ## Voorbeeld Hedy Code Random Restaurant
                     ```
                     gerechten is patat, pizza, spruitjes
@@ -1239,20 +1239,20 @@ adventures:
                     print Dat wordt dan prijzen at random
                     print Eet smakelijk!
                     ```
-                    
+
                     ## Uitdaging
                     Kun jij de restaurants nog leuker maken?
                 start_code: ""
             3:
-                story_text: |    
+                story_text: |
                     ## Restaurant level 3
                     Lukt het jou om in level 3 aanhalingstekens toe te voegen aan je restaurant van level 2?
                 start_code: ""
             4:
                 story_text: |
                     ## Restaurant level 4
-                    In level 4 kun je het nieuwe `if` commando gebruiken om verschillende reacties te geven op antwoorden van de klanten. Zo kun je bijvoorbeeld vragen of de klant saus wil bij de frietjes, terwijl dat een rare vraag zou zijn als de klant pizza bestelt. 
-                    
+                    In level 4 kun je het nieuwe `if` commando gebruiken om verschillende reacties te geven op antwoorden van de klanten. Zo kun je bijvoorbeeld vragen of de klant saus wil bij de frietjes, terwijl dat een rare vraag zou zijn als de klant pizza bestelt.
+
                     ## Voorbeeld Hedy Code
                     ```
                     print 'Welkom bij McHedy'
@@ -1262,8 +1262,8 @@ adventures:
                     print eten
                     ```
                     ## Prijslijst toevoegen
-                    Je kunt het `if` commando ook goed gebruiken om een prijslijst te maken.  
-                    
+                    Je kunt het `if` commando ook goed gebruiken om een prijslijst te maken.
+
                     ## Voorbeeld Hedy Code
                     print 'Welkom bij McHedy'
                     prijs is 0
@@ -1271,7 +1271,7 @@ adventures:
                     if eten is friet prijs is 3
                     if eten is pizza prijs is 4
                     print 'Dat wordt dan ' prijs ' euro, alstublieft.'
-                    
+
                 start_code: ""
             5:
                 story_text: |
@@ -1334,7 +1334,7 @@ adventures:
                 story_text: |
                     ## Restaurant level 6
                     In level 6 kun je het `repeat` commando gebruiken om van meerdere klanten de bestelling op te nemen.
-                    
+
                     ## Voorbeeld Hedy Code
                     ```
                     print 'Welkom bij restaurant Hedy'
@@ -1342,15 +1342,15 @@ adventures:
                     repeat mensen times eten is ask 'Wat wilt u bestellen?'
                     print 'Bedankt voor uw bestelling!'
                     ```
-                    In level 5 kun je zoals je ziet wel aan meerdere mensen vragen wat ze willen eten, maar het printen van al die bestellingen lukt nog niet. 
-                    In level 7 wordt dit probleem opgelost, want daar kun je meerdere regels code printen. 
+                    In level 5 kun je zoals je ziet wel aan meerdere mensen vragen wat ze willen eten, maar het printen van al die bestellingen lukt nog niet.
+                    In level 7 wordt dit probleem opgelost, want daar kun je meerdere regels code printen.
                 start_code: ""
-            7: 
-                story_text: | 
+            7:
+                story_text: |
                     ## Restaurant level 7
-                    In level 7 kun je meerdere regels code herhalen, wat betekent dat je meerdere mensen kunt vragen wat ze willen eten en drinken en dat ook nog kunt printen. 
+                    In level 7 kun je meerdere regels code herhalen, wat betekent dat je meerdere mensen kunt vragen wat ze willen eten en drinken en dat ook nog kunt printen.
                     Kijk maar naar het voorbeeld!
-                    
+
                     ## Voorbeeld Hedy code
                     ```
                     print 'Welkom bij McHedy!'
@@ -1364,11 +1364,11 @@ adventures:
                     prijs is 4 * mensen
                     print 'Dat wordt dan ' prijs ' euro!'
                     ```
-                                       
+
                     ## Toevoegingen met `if`
-                    Je kunt natuurlijk ook zorgen dat er vervolgvragen komen. 
+                    Je kunt natuurlijk ook zorgen dat er vervolgvragen komen.
                     Als men bijvoorbeeld een patatje bestelt, kun je vragen welke saus ze daarbij willen. Of je kunt vragen of ze cola light willen of normale cola.
-                    En zo kun je vast zelf nog veel meer vragen bedenken! 
+                    En zo kun je vast zelf nog veel meer vragen bedenken!
                     ```
                     print 'Welkom bij McHedy!'
                     print 'U kunt hier uw bestelling doorgeven'
@@ -1383,11 +1383,11 @@ adventures:
                         print drinken light
                     print 'Bedankt voor uw bestelling!'
                     ```
-                    
+
                     ## Uitdaging prijzen
                     De prijs is nu altijd 4 euro per persoon, kun jij nog een andere manier bedenken om de prijs te berekenen?
                     Bijvoorbeeld:
-                    
+
                     ```
                     prijs is 0
                     if eten is patat
@@ -1395,8 +1395,8 @@ adventures:
                     if drinken is cola
                         prijs is prijs + 1
                     ```
-                start_code: "print 'Welkom bij McHedy!' "    
-                
+                start_code: "print 'Welkom bij McHedy!' "
+
             8:
                 story_text: |
                     ## Restaurant
@@ -1500,12 +1500,12 @@ adventures:
         default_save_name: "Spookhuis"
         levels:
             1:
-                story_text: |            
+                story_text: |
                     ## Spookhuis
-                    in dit avontuur leer je een echte spookhuis game maken, waarbij de spelers moeten ontsnappen uit jouw spookhuis door je juiste deur te kiezen. 
+                    in dit avontuur leer je een echte spookhuis game maken, waarbij de spelers moeten ontsnappen uit jouw spookhuis door je juiste deur te kiezen.
                     Als je de goede deur kiest overleef je het, maar anders...
-                    In level 1 beginnen we ons spookhuisspel door een spannend verhaal te verzinnen en de speler te vragen welk monster ze tegenkomen in het spookhuis. 
-          
+                    In level 1 beginnen we ons spookhuisspel door een spannend verhaal te verzinnen en de speler te vragen welk monster ze tegenkomen in het spookhuis.
+
                     ## Voorbeeld Hedy code
                     ```
                     print Hoe ben ik hier terechtgekomen?
@@ -1518,7 +1518,7 @@ adventures:
                     print Ik moet maken dat ik wegkom!
                     print Er staan drie deuren voor me, maar welke moet ik kiezen?
                     ask Welke deur kies ik?
-                    echo Ik kies deur 
+                    echo Ik kies deur
                     print ...?
                     ```
                     ## Challenge
@@ -1527,8 +1527,8 @@ adventures:
             2:
                 story_text: |
                     ## Spookhuis
-                    In level 1 heb je een spannende intro bedacht voor je spookhuis, maar een echt spel is het nog niet: Het loopt namelijk altijd hetzelfde af. 
-                    In level twee kun je je verhaal interactiever maken door verschillende eindes te bedenken: soms wordt je opgepeuzeld door een verschikkelijk monster en soms ontsnap je! 
+                    In level 1 heb je een spannende intro bedacht voor je spookhuis, maar een echt spel is het nog niet: Het loopt namelijk altijd hetzelfde af.
+                    In level twee kun je je verhaal interactiever maken door verschillende eindes te bedenken: soms wordt je opgepeuzeld door een verschikkelijk monster en soms ontsnap je!
                     Hedy kiest random of je overleeft of niet...
 
                     ## Voorbeeld Hedy Code
@@ -1542,27 +1542,27 @@ adventures:
                     print monsters at random
                     ```
                     ## Uitdaging
-                    Dit verhaal is kort maar krachtig. Kun jij het verhaal opleuken tot een echte spannende game? 
+                    Dit verhaal is kort maar krachtig. Kun jij het verhaal opleuken tot een echte spannende game?
                     Daarbij zijn er nu maar 3 mogelijke opties voor wat er achter de deur zit, kun jij meer monsters toevoegen aan die lijst?
-                    
+
                     ## Verander het spel in een tv prijzenshow!
-                    Tot slot willen we je graag uitdagen om dit spel om te bouwen tot een prijzenshow zoals op tv! 
-                    In prijzenshows kiest de kandidaat een deur of een koffertje en vindt daarin een grote prijs (of niets natuurlijk...). 
+                    Tot slot willen we je graag uitdagen om dit spel om te bouwen tot een prijzenshow zoals op tv!
+                    In prijzenshows kiest de kandidaat een deur of een koffertje en vindt daarin een grote prijs (of niets natuurlijk...).
                     Kun jij een prijzenshow bouwen?
-                   
+
 
                 start_code: "print Ontsnap uit het spookhuis!"
             3:
                 story_text: |
                     ## Spookhuis
-                    In level 3 heb je geleerd hoe je aanhalingstekens moet gebruiken. 
+                    In level 3 heb je geleerd hoe je aanhalingstekens moet gebruiken.
                     Kun jij je spookhuis ook in level 3 aan de praat krijgen?
                 start_code: "print 'Ontsnap uit het spookhuis!'"
             4:
                 story_text: |
                     ## Spookhuis
-                    Tot nu toe werd er in je spookhuisspel wel altijd aan de speler gevraagd welke deur geopend moest worden, maar zoals je misschien al gemerkt hebt, maakte het niet uit wat voor antwoord de speler gaf. 
-                    De speler kon netjes een deur kiezen, maar als de speler een compleet random antwoord gaf, zoals 'pannenkoek!', dan zou de speler het spel nog steeds kunnen winnen (ook al is er niet eens een deur gekozen!). 
+                    Tot nu toe werd er in je spookhuisspel wel altijd aan de speler gevraagd welke deur geopend moest worden, maar zoals je misschien al gemerkt hebt, maakte het niet uit wat voor antwoord de speler gaf.
+                    De speler kon netjes een deur kiezen, maar als de speler een compleet random antwoord gaf, zoals 'pannenkoek!', dan zou de speler het spel nog steeds kunnen winnen (ook al is er niet eens een deur gekozen!).
                     In level 4 kun je alleen winnen als je dezelfde deur kiest als Hedy heeft gekozen en maakt het dus echt uit welk antwoord je invult!
 
                     ## voorbeeld Hedy code
@@ -1574,7 +1574,7 @@ adventures:
                     gekozendeur is ask 'Welke deur kies je?'
                     print 'Jij kiest deur...' gekozendeur
                     goededeur is deuren at random
-                    if gekozendeur is goededeur print 'Hoera! Je ontsnapt!' 
+                    if gekozendeur is goededeur print 'Hoera! Je ontsnapt!'
                     else print 'Oh nee! Je wordt opgepeuzeld door een...' monsters at random
                     ```
                 start_code: "print 'Ontsnap uit het spookhuis!'"
@@ -1756,49 +1756,49 @@ adventures:
             1:
                 story_text: |
                     ## Vooruitblik
-                    Gefeliciteerd! Je bent aan het einde gekomen van het eerste level van Hedy. Hopelijk heb je al wat mooie codes kunnen maken, maar er is in Hedy nog veel meer te ontdekken. 
-                    
-                    In level 1 ben je er misschien tegenaan gelopen dat Hedy in het `echo` commando maar één ding kan onthouden. 
-                    In het restaurantavontuur kon je bijvoorbeeld alleen herhalen wat de klant wilde eten, of alleen wat hij wilde drinken. Kijk maar: 
-                    
+                    Gefeliciteerd! Je bent aan het einde gekomen van het eerste level van Hedy. Hopelijk heb je al wat mooie codes kunnen maken, maar er is in Hedy nog veel meer te ontdekken.
+
+                    In level 1 ben je er misschien tegenaan gelopen dat Hedy in het `echo` commando maar één ding kan onthouden.
+                    In het restaurantavontuur kon je bijvoorbeeld alleen herhalen wat de klant wilde eten, of alleen wat hij wilde drinken. Kijk maar:
+
                     ```
                     print Welkom bij restaurant Hedy
                     ask wat wilt u eten?
-                    echo Dus dit wilt u eten 
+                    echo Dus dit wilt u eten
                     ask wat wilt u drinken
-                    echo Dus dit wilt u drinken 
+                    echo Dus dit wilt u drinken
                     ```
                     Als de speler hamburger en cola invult, kun je nog niet zeggen `dus u wilt een hamburger en cola`, maar je moet daar twee lossen zinnen van maken.
                     Daarnaast echoot Hedy alleen woorden aan het einde van de zin. Dus je kunt in level 1 niet zeggen 'Je hamburger komt eraan!'
-                    
-                    Dat verandert in level 2. In level 2 leer je namelijk werken met variabelen waardoor je Hedy heel veel verschillende stukjes informatie kunt laten onthouden en ze overal in de zin te printen. 
-                    Daarnaast leer je in level 2 werken met het `at random` commando, waardoor je echte spelletjes kunt gaan maken. 
-                    Neem snel een kijkje! 
-                    
+
+                    Dat verandert in level 2. In level 2 leer je namelijk werken met variabelen waardoor je Hedy heel veel verschillende stukjes informatie kunt laten onthouden en ze overal in de zin te printen.
+                    Daarnaast leer je in level 2 werken met het `at random` commando, waardoor je echte spelletjes kunt gaan maken.
+                    Neem snel een kijkje!
+
                 start_code: "print Op naar het volgende level!"
             2:
                 story_text: |
                     ## Vooruitblik
-                    In level 2 heb je veel geoefend met variabelen, maar misschien heb je ook wel eens gezien dat dat nog niet altijd perfect werkt. 
-                    
-                    Probeer deze code maar eens uit: 
+                    In level 2 heb je veel geoefend met variabelen, maar misschien heb je ook wel eens gezien dat dat nog niet altijd perfect werkt.
+
+                    Probeer deze code maar eens uit:
                     ```
                     naam is Sophie
                     print Mijn naam is naam
                     ```
                     Je wilde natuurlijk printen `Mijn naam is Sophie` maar Hedy print `Mijn Sophie is Sophie`.
-                    
-                    In level 3 wordt dit probleem opgelost door aanhalingstekens te gebruiken, kijk maar eens in level 3. 
-                 
+
+                    In level 3 wordt dit probleem opgelost door aanhalingstekens te gebruiken, kijk maar eens in level 3.
+
                 start_code: "print Op naar het volgende level!"
             3:
                 story_text: |
-                    
+
                     ## Vooruitblik
-                    In level 2 en 3 heb al codes leren maken met `at random` waardoor je programma's elke keer anders waren als je ze afspeelde. 
-                    Toch waren de codes niet echt interactief, je hebt er als speler namelijk geen invloed op. 
-                
-                    In level 4 leer je het `if` commando waarmee je kunt zorgen voor 2 verschillende reacties in je code. 
+                    In level 2 en 3 heb al codes leren maken met `at random` waardoor je programma's elke keer anders waren als je ze afspeelde.
+                    Toch waren de codes niet echt interactief, je hebt er als speler namelijk geen invloed op.
+
+                    In level 4 leer je het `if` commando waarmee je kunt zorgen voor 2 verschillende reacties in je code.
                     Zo kun je bijvoorbeeld je computer beveiligen met een wachtwoord. Neem maar een kijkje in level 4!
                 start_code: "print 'Op naar het volgende level!'"
             4:
@@ -1838,11 +1838,11 @@ adventures:
                     Want nu moest je wel een hoop knippen en plakken in sommige programma's.
 
                     In level 7 wordt dat mogelijk gemaakt door stukjes code bij elkaar een groepje te maken, door ze te beginnen met een aantal spaties. Zo'n groepje regels kun je dan in één keer herhalen met repeat.
-                    
+
                     ```
                     repeat 5 times print 'vanaf level 7 kun je meerdere regels code in een keer herhalen!'
                     ```
-                    
+
                 start_code: "print 'Op naar het volgende level!'"
             8:
                 story_text: |
@@ -1864,7 +1864,7 @@ adventures:
             9:
                 story_text: |
                     ## Vooruitblik
-                    Je bent alweer aan het einde van level 9, knap hoor! Je staat op het punt om door te gaan naar level 8. In de hogere levels gaan we steeds een beetje meer toewerken naar de programmeertaal Python.
+                    Je bent alweer aan het einde van level 9, knap hoor! Je staat op het punt om door te gaan naar level 10. In de hogere levels gaan we steeds een beetje meer toewerken naar de programmeertaal Python.
                     In Python bestaat het commando `repeat` echter niet, dus gaan we dat vervangen door 'echte' programmeertaal!
                     Ben je benieuwd hoe dat eruit ziet? Ga dan snel naar level 10.
                 start_code: "print 'Op naar het volgende level!'"


### PR DESCRIPTION
Provide a general summary of your changes in the Title of the PR

**Description**

Dutch text for Vooruitblik at level 9 says level 8 is next, instead of 10.
This PR (accidentally) also removes superfluous spaces. I can separate those changes if desired. The only content change is in line 1867
