### PR TITLE
#930 Block should start with 4 spaces instead of None

### DIFF
--- a/coursedata/texts/nl.yaml
+++ b/coursedata/texts/nl.yaml
@@ -48,7 +48,7 @@ HedyErrorMessages:
     Invalid: "{invalid_command} is geen commando in Hedy level {level}. Bedoelde je {guessed_command}?"
     Invalid Space: "Oeps! Regel {line_number} begint met een spatie. Computers kunnen niet zo goed tegen spaties, kun je 'm weghalen?"
     Has Blanks: "Let op! Jouw code is nog niet compleet. Er staat nog een laag streepje in, daar moet jij de juiste code nog invullen."
-    Unexpected Outdentation: "Je hebt te weinig spaties voor regel {line_number} gebruikt. Er staan {leading_spaces} spaties, maar dat is te weinig. Begin een blok steeds met {indent_size} spaties dan de regel ervoor."
+    No Indentation: "Je hebt te weinig spaties voor regel {line_number} gebruikt. Er staan {leading_spaces} spaties, maar dat is te weinig. Begin een blok steeds met {indent_size} meer spaties dan de regel ervoor."
     Unexpected Indentation: "Je hebt te veel spaties voor regel {line_number} gebruikt. Er staan {leading_spaces} spaties, maar dat is te veel. Begin een blok steeds met {indent_size} spaties."
     Parse: "De code die jij intypte is geen geldige Hedy code. Er zit een foutje op regel {location[0]}, op positie {location[1]}. Jij typte {character_found}, maar dat mag op die plek niet."
     Unquoted Text: "Let op! Bij print en ask moet voor én achter de tekst een aanhalingsteken komen. Jij bent er ergens eentje vergeten."

--- a/hedy.py
+++ b/hedy.py
@@ -1516,16 +1516,19 @@ def preprocess_blocks(code, level):
     lines = code.split("\n")
     current_number_of_indents = 0
     previous_number_of_indents = 0
-    indent_size = None # we don't fix indent size but the first encounter sets it
+    indent_size = 4 # set at 4 for now
+    indent_size_adapted = False
     line_number = 0
     next_line_needs_indentation = False
     for line in lines:
         leading_spaces = find_indent_length(line)
 
         line_number += 1
-        #first encounter sets indent size for this program
-        if indent_size == None and leading_spaces > 0:
+
+        # first encounter sets indent size for this program
+        if indent_size_adapted == False and leading_spaces > 0:
             indent_size = leading_spaces
+            indent_size_adapted = True
 
         #calculate nuber of indents if possible
         if indent_size != None:
@@ -1544,7 +1547,7 @@ def preprocess_blocks(code, level):
 
         if next_line_needs_indentation and current_number_of_indents <= previous_number_of_indents:
             raise hedy.exceptions.NoIndentationException(line_number=line_number, leading_spaces=leading_spaces,
-                                                         indent_size=4)
+                                                         indent_size=indent_size)
 
         if needs_indentation(line):
             next_line_needs_indentation = True

--- a/hedy.py
+++ b/hedy.py
@@ -1544,7 +1544,7 @@ def preprocess_blocks(code, level):
 
         if next_line_needs_indentation and current_number_of_indents <= previous_number_of_indents:
             raise hedy.exceptions.NoIndentationException(line_number=line_number, leading_spaces=leading_spaces,
-                                                         indent_size=indent_size)
+                                                         indent_size=4)
 
         if needs_indentation(line):
             next_line_needs_indentation = True


### PR DESCRIPTION
**Fix:** Whenever you start a block with 0 spaces, part the error message that occurs in level 7 is: "You used too few spaces in line 2. You used 0 spaces, which is not enough. Start every new block with None spaces more than the line before". 'None'  is changed to '4' to make the sentence grammatically correct. This is also the indent size you learn in level 7. 
 
**Small discussion:** It is still possible to start a block with more than 0 spaces, but different than 4. For example: whenever you start a block with 3 spaces, every block should start with exactly 3 spaces. There are two changes possible:
1. The text at the top of level 7 should be changed to "start every block with the same number of spaces"
2. The error message should be changed to "Oops! You used 3 spaces instead of 4".