### PR TITLE
chore: remove unnecessary `lang` parameters

### DIFF
--- a/app.py
+++ b/app.py
@@ -221,11 +221,21 @@ parse_logger = jsonbin.MultiParseLogger(
     jsonbin.S3ParseLogger.from_env_vars())
 querylog.LOG_QUEUE.set_transmitter(aws_helpers.s3_querylog_transmitter_from_env())
 
-# Check that requested language is supported, otherwise return 404
 @app.before_request
-def check_language():
-    if requested_lang() not in ALL_LANGUAGES.keys():
-        return "Language " + requested_lang() + " not supported", 404
+def setup_language():
+    # Determine the user's requested language code.
+    #
+    # If not in the request parameters, use the browser's accept-languages
+    # header to do language negotiation.
+    lang = request.args.get('lang')
+    if not lang:
+        lang = request.accept_languages.best_match(ALL_LANGUAGES.keys(), 'en')
+
+    g.lang = lang
+
+    # Check that requested language is supported, otherwise return 404
+    if g.lang not in ALL_LANGUAGES.keys():
+        return "Language " + g.lang + " not supported", 404
 
 if utils.is_heroku() and not os.getenv('HEROKU_RELEASE_CREATED_AT'):
     logging.warning('Cannot determine release; enable Dyno metadata by running "heroku labs:enable runtime-dyno-metadata -a <APP_NAME>"')
@@ -295,7 +305,7 @@ def parse():
     # Language should come principally from the request body,
     # but we'll fall back to browser default if it's missing for whatever
     # reason.
-    lang = body.get('lang', requested_lang())
+    lang = body.get('lang', g.lang)
 
     # true if kid enabled the read aloud option
     read_aloud = body.get('read_aloud', False)
@@ -449,9 +459,9 @@ def programs_page(request):
         if from_user not in students:
             return "unauthorized", 403
 
-    texts=TRANSLATIONS.get_translations(requested_lang(), 'Programs')
-    ui=TRANSLATIONS.get_translations(requested_lang(), 'ui')
-    adventures = load_adventure_for_language(requested_lang())
+    texts=TRANSLATIONS.get_translations(g.lang, 'Programs')
+    ui=TRANSLATIONS.get_translations(g.lang, 'ui')
+    adventures = load_adventure_for_language(g.lang)
 
     result = DATABASE.programs_for_user(from_user or username)
     programs =[]
@@ -470,14 +480,13 @@ def programs_page(request):
 
         programs.append({'id': item['id'], 'code': item['code'], 'date': texts['ago-1'] + ' ' + str(date) + ' ' + measure + ' ' + texts['ago-2'], 'level': item['level'], 'name': item['name'], 'adventure_name': item.get('adventure_name'), 'public': item.get('public')})
 
-    return render_template('programs.html', lang=requested_lang(), menu=render_main_menu('programs'), texts=texts, ui=ui, auth=TRANSLATIONS.get_translations(requested_lang(), 'Auth'), programs=programs, current_page='programs', from_user=from_user, adventures=adventures)
+    return render_template('programs.html', menu=render_main_menu('programs'), texts=texts, ui=ui, auth=TRANSLATIONS.get_translations(g.lang, 'Auth'), programs=programs, current_page='programs', from_user=from_user, adventures=adventures)
 
 @app.route('/quiz/start/<int:level>', methods=['GET'])
 def get_quiz_start(level):
     if not config.get('quiz-enabled') and g.lang != 'nl':
-        return utils.page_404 (TRANSLATIONS, render_main_menu('adventures'), current_user()['username'], requested_lang (), 'Hedy quiz disabled!')
+        return utils.page_404 (TRANSLATIONS, render_main_menu('adventures'), current_user()['username'], g.lang, 'Hedy quiz disabled!')
     else:
-        g.lang = lang = requested_lang()
         g.prefix = '/hedy'
 
         # A unique identifier to record the answers under
@@ -488,8 +497,7 @@ def get_quiz_start(level):
         session['correct_answer'] = 0
 
         return render_template('startquiz.html', level=level, next_assignment=1, menu=render_main_menu('adventures'),
-                               lang=lang,
-                               auth=TRANSLATIONS.get_translations(requested_lang(), 'Auth'))
+                               auth=TRANSLATIONS.get_translations(g.lang, 'Auth'))
 
 # Quiz mode
 # Fill in the filename as source
@@ -497,7 +505,7 @@ def get_quiz_start(level):
 @app.route('/quiz/quiz_questions/<int:level_source>/<int:question_nr>/<int:attempt>', methods=['GET'])
 def get_quiz(level_source, question_nr, attempt):
     if not config.get('quiz-enabled') and g.lang != 'nl':
-        return utils.page_404 (TRANSLATIONS, render_main_menu('adventures'), current_user()['username'], requested_lang (), 'Hedy quiz disabled!')
+        return utils.page_404 (TRANSLATIONS, render_main_menu('adventures'), current_user()['username'], g.lang, 'Hedy quiz disabled!')
 
     # If we don't have an attempt ID yet, redirect to the start page
     if not session.get('quiz-attempt-id'):
@@ -509,7 +517,6 @@ def get_quiz(level_source, question_nr, attempt):
         return 'No quiz yaml file found for this level', 404
 
     # set globals
-    g.lang = lang = requested_lang()
     g.prefix = '/hedy'
 
     questionStatus = 'start' if attempt == 1 else 'false'
@@ -532,15 +539,15 @@ def get_quiz(level_source, question_nr, attempt):
                            correct=session.get('correct_answer'),
                            attempt = attempt,
                            is_last_attempt=attempt == quiz.MAX_ATTEMPTS,
-                           menu=render_main_menu('adventures'), lang=lang,
-                           auth=TRANSLATIONS.get_translations(requested_lang(), 'Auth'))
+                           menu=render_main_menu('adventures'),
+                           auth=TRANSLATIONS.get_translations(g.lang, 'Auth'))
 
 
 @app.route('/quiz/finished/<int:level>', methods=['GET'])
 def quiz_finished(level):
     """Results page at the end of the quiz."""
     if not config.get('quiz-enabled') and g.lang != 'nl':
-        return utils.page_404 (TRANSLATIONS, render_main_menu('adventures'), current_user() ['username'], requested_lang (), 'Hedy quiz disabled!')
+        return utils.page_404 (TRANSLATIONS, render_main_menu('adventures'), current_user() ['username'], g.lang, 'Hedy quiz disabled!')
 
     # Reading the yaml file
     quiz_data = quiz.quiz_data_file_for(level)
@@ -548,15 +555,14 @@ def quiz_finished(level):
         return 'No quiz yaml file found for this level', 404
 
     # set globals
-    g.lang = lang = requested_lang()
     g.prefix = '/hedy'
 
     return render_template('endquiz.html', correct=session.get('correct_answer', 0),
                            total_score=session.get('total_score', 0),
-                           menu=render_main_menu('adventures'), lang=lang,
+                           menu=render_main_menu('adventures'),
                            quiz=quiz_data, level=int(level) + 1, questions=quiz_data['questions'],
                            next_assignment=1,
-                           auth=TRANSLATIONS.get_translations (requested_lang(), 'Auth'))
+                           auth=TRANSLATIONS.get_translations (g.lang, 'Auth'))
 
 
 @app.route('/quiz/submit_answer/<int:level_source>/<int:question_nr>/<int:attempt>', methods=["POST"])
@@ -644,16 +650,16 @@ def quiz_feedback(level_source, question_nr):
                            answer_was_correct=answer_was_correct,
                            index_option=index_option,
                            correct_option=correct_option,
-                           menu=render_main_menu('adventures'), lang=lang,
-                           auth=TRANSLATIONS.data[requested_lang()]['Auth'])
+                           menu=render_main_menu('adventures'),
+                           auth=TRANSLATIONS.data[g.lang]['Auth'])
 
 
 # Adventure mode
 @app.route('/hedy/adventures', methods=['GET'])
 def adventures_list():
-    adventures = load_adventure_for_language(requested_lang())
+    adventures = load_adventure_for_language(g.lang)
     menu = render_main_menu('adventures')
-    return render_template('adventures.html', lang=lang, adventures=adventures, menu=menu, auth=TRANSLATIONS.get_translations(requested_lang(), 'Auth'))
+    return render_template('adventures.html', adventures=adventures, menu=menu, auth=TRANSLATIONS.get_translations(g.lang, 'Auth'))
 
 @app.route('/hedy/adventures/<adventure_name>', methods=['GET'], defaults={'level': 1})
 @app.route('/hedy/adventures/<adventure_name>/<level>', methods=['GET'])
@@ -661,11 +667,11 @@ def adventure_page(adventure_name, level):
 
     user = current_user()
     level = int(level)
-    adventures = load_adventure_for_language(requested_lang())
+    adventures = load_adventure_for_language(g.lang)
 
     # If requested adventure does not exist, return 404
     if not adventure_name in adventures:
-        return utils.page_404 (TRANSLATIONS, render_main_menu('adventures'), current_user()['username'], requested_lang (), TRANSLATIONS.get_translations (requested_lang (), 'ui').get ('no_such_adventure'))
+        return utils.page_404 (TRANSLATIONS, render_main_menu('adventures'), current_user()['username'], g.lang, TRANSLATIONS.get_translations (g.lang, 'ui').get ('no_such_adventure'))
 
     adventure = adventures[adventure_name]
 
@@ -691,19 +697,17 @@ def adventure_page(adventure_name, level):
 
     # If requested level is not in adventure, return 404
     if not level in adventure['levels']:
-        return utils.page_404 (TRANSLATIONS, render_main_menu('adventures'), current_user()['username'], requested_lang (), TRANSLATIONS.get_translations (requested_lang (), 'ui').get ('no_such_adventure_level'))
+        return utils.page_404 (TRANSLATIONS, render_main_menu('adventures'), current_user()['username'], g.lang, TRANSLATIONS.get_translations (g.lang, 'ui').get ('no_such_adventure_level'))
 
-    adventures_for_level = load_adventures_per_level(requested_lang(), level)
-    level_defaults_for_lang = LEVEL_DEFAULTS[requested_lang()]
+    adventures_for_level = load_adventures_per_level(g.lang, level)
+    level_defaults_for_lang = LEVEL_DEFAULTS[g.lang]
     defaults = level_defaults_for_lang.get_defaults_for_level(level)
     max_level = level_defaults_for_lang.max_level()
 
     g.prefix = '/hedy'
     return hedyweb.render_code_editor_with_tabs(
-        request=request,
         level_defaults=defaults,
         max_level=max_level,
-        lang=requested_lang(),
         level_number=level,
         menu=render_main_menu('hedy'),
         translations=TRANSLATIONS,
@@ -726,11 +730,10 @@ def index(level, step):
         try:
             g.level = level = int(level)
         except:
-            return utils.page_404 (TRANSLATIONS, render_main_menu('hedy'), current_user()['username'], requested_lang (), TRANSLATIONS.get_translations (requested_lang (), 'ui').get ('no_such_level'))
+            return utils.page_404 (TRANSLATIONS, render_main_menu('hedy'), current_user()['username'], g.lang, TRANSLATIONS.get_translations (g.lang, 'ui').get ('no_such_level'))
     else:
-        return utils.page_404 (TRANSLATIONS, render_main_menu('hedy'), current_user()['username'], requested_lang (), TRANSLATIONS.get_translations (requested_lang (), 'ui').get ('no_such_level'))
+        return utils.page_404 (TRANSLATIONS, render_main_menu('hedy'), current_user()['username'], g.lang, TRANSLATIONS.get_translations (g.lang, 'ui').get ('no_such_level'))
 
-    g.lang = requested_lang()
     g.prefix = '/hedy'
 
     loaded_program = ''
@@ -740,26 +743,24 @@ def index(level, step):
     if step and isinstance(step, str) and len(step) > 2:
         result = DATABASE.program_by_id(step)
         if not result:
-            return utils.page_404 (TRANSLATIONS, render_main_menu('hedy'), current_user()['username'], requested_lang (), TRANSLATIONS.get_translations (requested_lang (), 'ui').get ('no_such_program'))
+            return utils.page_404 (TRANSLATIONS, render_main_menu('hedy'), current_user()['username'], g.lang, TRANSLATIONS.get_translations (g.lang, 'ui').get ('no_such_program'))
         # If the program is not public, allow only the owner of the program, the admin user and the teacher users to access the program
         user = current_user()
         public_program = 'public' in result and result['public']
         if not public_program and user['username'] != result['username'] and not is_admin(user) and not is_teacher(user):
-            return utils.page_404 (TRANSLATIONS, render_main_menu('hedy'), current_user()['username'], requested_lang (), TRANSLATIONS.get_translations (requested_lang (), 'ui').get ('no_such_program'))
+            return utils.page_404 (TRANSLATIONS, render_main_menu('hedy'), current_user()['username'], g.lang, TRANSLATIONS.get_translations (g.lang, 'ui').get ('no_such_program'))
         loaded_program = {'code': result['code'], 'name': result['name'], 'adventure_name': result.get('adventure_name')}
         if 'adventure_name' in result:
             adventure_name = result['adventure_name']
 
-    adventures = load_adventures_per_level(requested_lang(), level)
-    level_defaults_for_lang = LEVEL_DEFAULTS[requested_lang()]
+    adventures = load_adventures_per_level(g.lang, level)
+    level_defaults_for_lang = LEVEL_DEFAULTS[g.lang]
     if level not in level_defaults_for_lang.levels:
-        return utils.page_404 (TRANSLATIONS, render_main_menu('hedy'), current_user()['username'], requested_lang (), TRANSLATIONS.get_translations (requested_lang (), 'ui').get ('no_such_level'))
+        return utils.page_404 (TRANSLATIONS, render_main_menu('hedy'), current_user()['username'], g.lang, TRANSLATIONS.get_translations (g.lang, 'ui').get ('no_such_level'))
     defaults = level_defaults_for_lang.get_defaults_for_level(level)
     max_level = level_defaults_for_lang.max_level()
 
     return hedyweb.render_code_editor_with_tabs(
-        request=request,
-        lang=g.lang,
         level_defaults=defaults,
         max_level=max_level,
         level_number=level,
@@ -772,20 +773,19 @@ def index(level, step):
 
 @app.route('/hedy/<id>/view', methods=['GET'])
 def view_program(id):
-    g.lang = requested_lang()
     g.prefix = '/hedy'
 
     user = current_user()
 
     result = DATABASE.program_by_id(id)
     if not result:
-        return utils.page_404 (TRANSLATIONS, render_main_menu('hedy'), user['username'], requested_lang (), TRANSLATIONS.get_translations (requested_lang (), 'ui').get ('no_such_program'))
+        return utils.page_404 (TRANSLATIONS, render_main_menu('hedy'), user['username'], g.lang, TRANSLATIONS.get_translations (g.lang, 'ui').get ('no_such_program'))
 
+    # If we asked for a specific language, use that, otherwise use the language
+    # of the program's author.
     # Default to the language of the program's author(but still respect)
     # the switch if given.
-    lang = request.args.get("lang")
-    if not lang:
-        lang = result['lang']
+    g.lang = request.args.get('lang', result['lang'])
 
     arguments_dict = {}
     arguments_dict['program_id'] = id
@@ -797,7 +797,6 @@ def view_program(id):
 
     # Everything below this line has nothing to do with this page and it's silly
     # that every page needs to put in so much effort to re-set it
-    arguments_dict['lang'] = lang
     arguments_dict['menu'] = render_main_menu('view')
     arguments_dict['auth'] = TRANSLATIONS.get_translations(lang, 'Auth')
     arguments_dict['username'] = user.get('username', None)
@@ -811,9 +810,9 @@ def view_program(id):
 
 @app.route('/client_messages.js', methods=['GET'])
 def client_messages():
-    error_messages = TRANSLATIONS.get_translations(requested_lang(), "ClientErrorMessages")
-    ui_messages = TRANSLATIONS.get_translations(requested_lang(), "ui")
-    auth_messages = TRANSLATIONS.get_translations(requested_lang(), "Auth")
+    error_messages = TRANSLATIONS.get_translations(g.lang, "ClientErrorMessages")
+    ui_messages = TRANSLATIONS.get_translations(g.lang, "ui")
+    auth_messages = TRANSLATIONS.get_translations(g.lang, "Auth")
 
     response = make_response(render_template("client_messages.js",
         error_messages=json.dumps(error_messages),
@@ -828,13 +827,13 @@ def client_messages():
 
 @app.errorhandler(404)
 def not_found(exception):
-    return utils.page_404 (TRANSLATIONS, render_main_menu('adventures'), current_user()['username'], requested_lang (), TRANSLATIONS.get_translations (requested_lang (), 'ui').get ('page_not_found'))
+    return utils.page_404 (TRANSLATIONS, render_main_menu('adventures'), current_user()['username'], g.lang, TRANSLATIONS.get_translations (g.lang, 'ui').get ('page_not_found'))
 
 @app.errorhandler(500)
 def internal_error(exception):
     import traceback
     print(traceback.format_exc())
-    return utils.page_500 (TRANSLATIONS, render_main_menu('hedy'), current_user()['username'], requested_lang ())
+    return utils.page_500 (TRANSLATIONS, render_main_menu('hedy'), current_user()['username'], g.lang)
 
 @app.route('/index.html')
 @app.route('/')
@@ -846,18 +845,14 @@ def main_page(page):
     if page == 'favicon.ico':
         abort(404)
 
-    lang = requested_lang()
-    effective_lang = lang
-
     if page in['signup', 'login', 'my-profile', 'recover', 'reset', 'admin']:
-        return auth_templates(page, lang, render_main_menu(page), request)
+        return auth_templates(page, g.lang, render_main_menu(page), request)
 
     if page == 'programs':
         return programs_page(request)
 
     # Default to English if requested language is not available
-    if not path.isfile(f'main/{page}-{effective_lang}.md'):
-        effective_lang = 'en'
+    effective_lang = g.lang if path.isfile(f'main/{page}-{g.lang}.md') else 'en'
 
     try:
         with open(f'main/{page}-{effective_lang}.md', 'r', encoding='utf-8') as f:
@@ -874,13 +869,13 @@ def main_page(page):
             welcome_teacher = session.get('welcome-teacher') or False
             session['welcome-teacher'] = False
             teacher_classes =[] if not current_user()['username'] else DATABASE.get_teacher_classes(current_user()['username'], True)
-            return render_template('for-teachers.html', sections=split_teacher_docs(contents), lang=lang, menu=menu,
-                                   auth=TRANSLATIONS.get_translations(lang, 'Auth'), teacher_classes=teacher_classes,
+            return render_template('for-teachers.html', sections=split_teacher_docs(contents), menu=menu,
+                                   auth=TRANSLATIONS.get_translations(g.lang, 'Auth'), teacher_classes=teacher_classes,
                                    welcome_teacher=welcome_teacher, **front_matter)
         else:
             return "unauthorized", 403
 
-    return render_template('main-page.html', mkd=markdown, lang=lang, menu=menu, auth=TRANSLATIONS.get_translations(lang, 'Auth'), **front_matter)
+    return render_template('main-page.html', mkd=markdown, menu=menu, auth=TRANSLATIONS.get_translations(g.lang, 'Auth'), **front_matter)
 
 
 def session_id():
@@ -892,20 +887,9 @@ def session_id():
             session['session_id'] = uuid.uuid4().hex
     return session['session_id']
 
-def requested_lang():
-    """Return the user's requested language code.
-
-    If not in the request parameters, use the browser's accept-languages
-    header to do language negotiation.
-    """
-    lang = request.args.get("lang")
-    if lang: return lang
-
-    return request.accept_languages.best_match(ALL_LANGUAGES.keys(), 'en')
-
 @app.template_global()
 def current_language():
-    return make_lang_obj(requested_lang())
+    return make_lang_obj(g.lang)
 
 @app.template_filter()
 def nl2br(x):
@@ -929,17 +913,17 @@ def hedy_link(level_nr, assignment_nr, subpage=None, lang=None):
     if subpage and subpage != 'code':
         parts.append('/' + subpage)
     parts.append('?')
-    parts.append('lang=' +(lang if lang else requested_lang()))
+    parts.append('lang=' +(lang if lang else g.lang))
     return ''.join(parts)
 
 @app.template_global()
 def other_languages():
-    cl = requested_lang()
+    cl = g.lang
     return[make_lang_obj(l) for l in ALL_LANGUAGES.keys() if l != cl]
 
 @app.template_global()
 def localize_link(url):
-    lang = requested_lang()
+    lang = g.lang
     if not lang:
         return url
     if '?' in url:
@@ -1000,7 +984,7 @@ def split_teacher_docs(contents):
 def render_main_menu(current_page):
     """Render a list of(caption, href, selected, color) from the main menu."""
     return[dict(
-        caption=item.get(requested_lang(), item.get('en', '???')),
+        caption=item.get(g.lang, item.get('en', '???')),
         href='/' + item['_'],
         selected=(current_page == item['_']),
         accent_color=item.get('accent_color', 'white'),
@@ -1058,7 +1042,7 @@ def save_program(user):
         'id': program_id,
         'session': session_id(),
         'date': timems(),
-        'lang': requested_lang(),
+        'lang': g.lang,
         'version': version(),
         'level': body['level'],
         'code': body['code'],
@@ -1150,13 +1134,13 @@ def update_yaml():
 @app.route('/invite/<code>', methods=['GET'])
 def teacher_invitation(code):
     user = current_user()
-    lang = requested_lang()
+    lang = g.lang
 
     if os.getenv('TEACHER_INVITE_CODE') != code:
         return utils.page_404(TRANSLATIONS, render_main_menu('invite'), user['username'], lang,
-                              TRANSLATIONS.get_translations(requested_lang(), 'ui').get('invalid_teacher_invitation_code'))
+                              TRANSLATIONS.get_translations(g.lang, 'ui').get('invalid_teacher_invitation_code'))
     if not user['username']:
-        return render_template('teacher-invitation.html', lang=lang, auth=TRANSLATIONS.get_translations(lang, 'Auth'),
+        return render_template('teacher-invitation.html', auth=TRANSLATIONS.get_translations(lang, 'Auth'),
                                menu=render_main_menu('invite'))
 
     update_is_teacher(user)
@@ -1168,12 +1152,12 @@ def teacher_invitation(code):
 # *** AUTH ***
 
 from website import auth
-auth.routes(app, DATABASE, requested_lang)
+auth.routes(app, DATABASE)
 
 # *** TEACHER BACKEND
 
 from website import teacher
-teacher.routes(app, DATABASE, requested_lang)
+teacher.routes(app, DATABASE)
 
 # *** START SERVER ***
 

--- a/hedyweb.py
+++ b/hedyweb.py
@@ -4,11 +4,11 @@ import attr
 import glob
 from os import path
 
-from flask import abort, session
+from flask import g
 from flask_helpers import render_template
 
 import hedy_content
-from website.auth import current_user, is_teacher 
+from website.auth import current_user, is_teacher
 import re
 import utils
 from config import config
@@ -31,18 +31,17 @@ class Translations:
     return d
 
 
-def render_code_editor_with_tabs(request, level_defaults, lang, max_level, level_number, menu, translations, version, loaded_program, adventures, adventure_name):
+def render_code_editor_with_tabs(level_defaults, max_level, level_number, menu, translations, version, loaded_program, adventures, adventure_name):
   user = current_user()
 
   if not level_defaults:
-    return utils.page_404 (translations, menu, user['username'], lang, translations.get_translations (lang, 'ui').get ('no_such_level'))
+    return utils.page_404 (translations, menu, user['username'], g.lang, translations.get_translations (g.lang, 'ui').get ('no_such_level'))
 
 
   arguments_dict = {}
 
   # Meta stuff
   arguments_dict['level_nr'] = str(level_number)
-  arguments_dict['lang'] = lang
   arguments_dict['level'] = level_number
   arguments_dict['prev_level'] = int(level_number) - 1 if int(level_number) > 1 else None
   arguments_dict['next_level'] = int(level_number) + 1 if int(level_number) < max_level else None
@@ -50,7 +49,7 @@ def render_code_editor_with_tabs(request, level_defaults, lang, max_level, level
   arguments_dict['latest'] = version
   arguments_dict['selected_page'] = 'code'
   arguments_dict['page_title'] = f'Level {level_number} – Hedy'
-  arguments_dict['auth'] = translations.get_translations (lang, 'Auth')
+  arguments_dict['auth'] = translations.get_translations (g.lang, 'Auth')
   arguments_dict['username'] = user['username']
   arguments_dict['is_teacher'] = is_teacher(user)
   arguments_dict['loaded_program'] = loaded_program
@@ -58,7 +57,7 @@ def render_code_editor_with_tabs(request, level_defaults, lang, max_level, level
   arguments_dict['adventure_name'] = adventure_name
 
   # Translations
-  arguments_dict.update(**translations.get_translations(lang, 'ui'))
+  arguments_dict.update(**translations.get_translations(g.lang, 'ui'))
 
   # Merge level defaults into adventures so it is rendered as the first tab
   arguments_dict.update(**attr.asdict(level_defaults))

--- a/main/start-cs.md
+++ b/main/start-cs.md
@@ -6,7 +6,7 @@ page_title: Vítej v Hedy!
     <h2 class="font-sans font-light text-white text-shadow-md tracking-wide my-1">Stupňovitý programovací jazyk</h2>
   </div>
   <div class="flex-none">
-    <a class="green-btn text-white px-8 py-4" href="/hedy?lang=en">Vyzkoušej to</a>
+    <a class="green-btn text-white px-8 py-4" href="/hedy?lang=cs">Vyzkoušej to</a>
   </div>
 </div>
 

--- a/main/start-de.md
+++ b/main/start-de.md
@@ -6,26 +6,26 @@ page_title: Willkommen bei Hedy!
     <h2 class="font-sans font-light text-white text-shadow-md tracking-wide my-1">Eine graduelle Programmiersprache</h2>
   </div>
   <div class="flex-none">
-    <a href="/hedy?lang=en"><button class="green-btn text-white px-8 py-4">Probier es aus</button></a>
+    <a href="/hedy?lang=de"><button class="green-btn text-white px-8 py-4">Probier es aus</button></a>
   </div>
 </div>
 
 ## Was ist eine graduelle Programmiersprache?
 
-Programmieren lernen kann schwer sein. 
-Nicht, dass Programmieren selbst *schwer* wäre! 
+Programmieren lernen kann schwer sein.
+Nicht, dass Programmieren selbst *schwer* wäre!
 Aber es gibt eine Menge Regeln, die du dir einprägen musst, genau wie beim Erlernen der deutschen Sprache.
 Genauso musst du viel üben, um Programmieren zu lernen.
 
-Du kannst diese Sätze mit Leichtigkeit lesen. 
-Aber weißt du noch, als du lesen gelernt hast? 
+Du kannst diese Sätze mit Leichtigkeit lesen.
+Aber weißt du noch, als du lesen gelernt hast?
 Damals hast du für jeden Buchstaben etwas Zeit gebraucht!
 Das gilt auch für das Programmieren, es mag am Anfang schwer sein, aber es wird einfacher!
 
-Das Schöne an Hedy ist, dass Hedy *graduell* ist. 
+Das Schöne an Hedy ist, dass Hedy *graduell* ist.
 Das bedeutet, dass du nicht alle Regeln auf einmal lernen musst.
 Die ersten paar Level haben nicht so viele Regeln, so dass du dich bequem an das Programmieren gewöhnen kannst.
-In jedem Level kommen neue Regeln hinzu, wodurch die Anzahl der Befehle, die du kennst, steigt. 
+In jedem Level kommen neue Regeln hinzu, wodurch die Anzahl der Befehle, die du kennst, steigt.
 Befehle sind Anweisungen für einen Computer.
 
 ## Warum ist Hedy graduell?
@@ -37,21 +37,21 @@ Dieses Video ist derzeit nur auf Englisch verfügbar.
 </center>
 
 ## Für wen ist Hedy?
-Hedy ist für alle Kinder gedacht, die programmieren lernen wollen! 
+Hedy ist für alle Kinder gedacht, die programmieren lernen wollen!
 Du solltest schon gut lesen können.
 
 ## Brauche ich Programmiererfahrung?
-Nein, das ist nicht erforderlich. 
+Nein, das ist nicht erforderlich.
 Wenn du jedoch mit Scratch oder Python programmiert hast, werden dir einige Befehle bekannt vorkommen.
 
 ## Ist Hedy kostenlos?
-Ja! Die Universität Leiden erlaubt uns, es gratis zur Verfügung zu stellen. 
-Hedy ist außerdem 'Open Source'. 
-Das bedeutet, dass jeder, der programmieren kann, uns helfen kann, Hedy besser zu machen. 
+Ja! Die Universität Leiden erlaubt uns, es gratis zur Verfügung zu stellen.
+Hedy ist außerdem 'Open Source'.
+Das bedeutet, dass jeder, der programmieren kann, uns helfen kann, Hedy besser zu machen.
 Du kannst den Code auf [GitHub](https://github.com/Felienne/hedy) finden.
 Wenn dir Hedy gefällt, würden wir uns über eine [Spende](https://www.steunleiden.nl/project/hedy?locale=en) freuen!
 
 ## Muss ich etwas installieren?
-Nein. Hedy funktioniert im Browser, also in dem Programm, mit dem du diese Seite ansiehst. 
-Wahrscheinlich Chrome oder Edge oder FireFox. 
+Nein. Hedy funktioniert im Browser, also in dem Programm, mit dem du diese Seite ansiehst.
+Wahrscheinlich Chrome oder Edge oder FireFox.
 Hedy funktioniert auch auf dem Handy oder Tablet.

--- a/main/start-el.md
+++ b/main/start-el.md
@@ -6,7 +6,7 @@
     <h2 class="font-sans font-light text-white text-shadow-md tracking-wide my-1">Μια βαθμιαία γλώσσα προγραμματισμού</h2>
   </div>
   <div class="flex-none">
-    <a href="/hedy?lang=en"><button class="green-btn text-white px-8 py-4">Δοκίμασέ τη</button></a>
+    <a href="/hedy?lang=el"><button class="green-btn text-white px-8 py-4">Δοκίμασέ τη</button></a>
   </div>
 </div>
 

--- a/main/start-id.md
+++ b/main/start-id.md
@@ -6,7 +6,7 @@ page_title: Selamat datang di Hedy!
     <h2 class="font-sans font-light text-white text-shadow-md tracking-wide my-1">Sebuah bahasa pemrograman bertahap</h2>
   </div>
   <div class="flex-none">
-    <a href="/hedy?lang=en"><button class="green-btn text-white px-8 py-4">Coba</button></a>
+    <a href="/hedy?lang=id"><button class="green-btn text-white px-8 py-4">Coba</button></a>
   </div>
 </div>
 

--- a/main/start-sw.md
+++ b/main/start-sw.md
@@ -6,7 +6,7 @@ page_title: Welcome to Hedy!
     <h2 class="font-sans font-light text-white text-shadow-md tracking-wide my-1">A gradual programming language</h2>
   </div>
   <div class="flex-none">
-    <a href="/hedy?lang=en"><button class="green-btn text-white px-8 py-4">Jaribu</button></a>
+    <a href="/hedy?lang=sw"><button class="green-btn text-white px-8 py-4">Jaribu</button></a>
   </div>
 </div>
 

--- a/main/start-zh.md
+++ b/main/start-zh.md
@@ -6,7 +6,7 @@ page_title: 欢迎来到 Hedy (海迪)！
     <h2 class="font-sans font-light text-white text-shadow-md tracking-wide my-1">A gradual programming language</h2>
   </div>
   <div class="flex-none">
-    <a href="/hedy?lang=en"><button class="green-btn text-white px-8 py-4">Try it</button></a>
+    <a href="/hedy?lang=zh"><button class="green-btn text-white px-8 py-4">Try it</button></a>
   </div>
 </div>
 

--- a/templates/auth.html
+++ b/templates/auth.html
@@ -9,7 +9,7 @@
   <script src="{{static('/vendor/ace.js')}}" type="text/javascript" charset="utf-8" crossorigin="anonymous"></script>
   <script src="{{static('/vendor/ext-whitespace.js')}}" type="text/javascript" charset="utf-8" crossorigin="anonymous"></script>
   <script src="{{static('/vendor/ext-rtl.js')}}" type="text/javascript" charset="utf-8" crossorigin="anonymous"></script>
-  <script src="/client_messages.js?lang={{ lang }}" type="text/javascript" crossorigin="anonymous"></script>
-  <script>window.State = {lang: "{{ lang }}", level: "{{ level }}"}</script>
+  <script src="/client_messages.js?lang={{ g.lang }}" type="text/javascript" crossorigin="anonymous"></script>
+  <script>window.State = {lang: "{{ g.lang }}", level: "{{ level }}"}</script>
   <script src="{{static('/js/appbundle.js')}}" type="text/javascript" crossorigin="anonymous"></script>
 {% endblock %}

--- a/templates/code-page.html
+++ b/templates/code-page.html
@@ -44,10 +44,10 @@
   <script src="{{static('/vendor/ace.js')}}" type="text/javascript" charset="utf-8" crossorigin="anonymous"></script>
   <script src="{{static('/vendor/ext-whitespace.js')}}" type="text/javascript" charset="utf-8" crossorigin="anonymous"></script>
   <script src="{{static('/vendor/ext-rtl.js')}}" type="text/javascript" charset="utf-8" crossorigin="anonymous"></script>
-  <script src="/client_messages.js?lang={{ lang }}" type="text/javascript" crossorigin="anonymous"></script>
+  <script src="/client_messages.js?lang={{ g.lang }}" type="text/javascript" crossorigin="anonymous"></script>
   <script>
     window.State = {};
-    window.State.lang = "{{ lang }}";
+    window.State.lang = "{{ g.lang }}";
     window.State.level = "{{ level }}";
     window.State.level_title = "{{ level_title }}";
     window.State.adventure_name = "{{ adventure_name }}";

--- a/templates/incl-editor-and-output.html
+++ b/templates/incl-editor-and-output.html
@@ -83,7 +83,7 @@
     <div class="order-2 lg:order-4">
       <br>
       <div class="flex justify-between">
-        <button id="runit" class="green-btn" onclick="hedyApp.runit({{ level }}, '{{ lang }}')">{{run_code_button}}</button>
+        <button id="runit" class="green-btn" onclick="hedyApp.runit({{ level }}, '{{ g.lang }}')">{{run_code_button}}</button>
         {% if show_edit_button %}
         <a href="/hedy/{{level}}/{{program_id}}" class="btn blue-btn">{{edit_code_button}}</a>
         {% endif %}

--- a/templates/level-page.html
+++ b/templates/level-page.html
@@ -9,8 +9,8 @@
   </div>
   <div class="w-full flex items-center justify-end ml-auto mr-4">
     <input id="program_name" type="text" class="border border-green-400 rounded p-2 px-3 w-1/2 h-4/5" value="{{ (loaded_program or {}).name or (level_title + ' ' + level_nr)}}">
-    <input type="submit" class="green-btn mx-2" value="{{ save_code_button }}" onclick="hedyApp.saveit({{ level }}, '{{ lang }}', $ ('#program_name').val (), hedyApp.get_trimmed_code());">
-    <input type="submit" class="green-btn mx-2" value="{{ share_code_button }}" onclick="hedyApp.share_program({{ level }}, '{{ lang }}', true, true);">
+    <input type="submit" class="green-btn mx-2" value="{{ save_code_button }}" onclick="hedyApp.saveit({{ level }}, '{{ g.lang }}', $ ('#program_name').val (), hedyApp.get_trimmed_code());">
+    <input type="submit" class="green-btn mx-2" value="{{ share_code_button }}" onclick="hedyApp.share_program({{ level }}, '{{ g.lang }}', true, true);">
   </div>
 </div>
 

--- a/templates/login.html
+++ b/templates/login.html
@@ -19,9 +19,9 @@
     <div id="error" class="flex-0 mt-8 mb-8 bg-red-100 border-t-4 border-red-500 rounded-b text-red-900 px-4 py-3 shadow-md" role="alert" style="display: none;"></div>
     <div id="success" class="flex-0 mt-8 mb-8 bg-green-100 border-t-4 border-green-500 rounded-b text-green-900 px-4 py-3 shadow-md" role="alert" style="display: none;"></div>
   </form>
-  <form id="create-account" class="py-2" onsubmit="event.preventDefault (); window.location.href = '/signup{% if lang and lang != "en" %}?lang={{lang}}{% endif %}'">
+  <form id="create-account" class="py-2" onsubmit="event.preventDefault (); window.location.href = '/signup{% if g.lang and g.lang != "en" %}?lang={{g.lang}}{% endif %}'">
     {{auth.no_account}}&nbsp;&nbsp;<button type="submit" class="green-btn">{{auth.create_account}}</button>
   </form>
-  <form class="py-2" onsubmit="event.preventDefault (); window.location.href = '/recover{% if lang and lang != "en" %}?lang={{lang}}{% endif %}'"><button type="submit" class="btn">{{auth.forgot_password}}</button></form>
+  <form class="py-2" onsubmit="event.preventDefault (); window.location.href = '/recover{% if g.lang and g.lang != "en" %}?lang={{g.lang}}{% endif %}'"><button type="submit" class="btn">{{auth.forgot_password}}</button></form>
 </div>
 {% endblock %}

--- a/templates/programs.html
+++ b/templates/programs.html
@@ -34,10 +34,10 @@
         <a href="{{localize_link ('/hedy/' + program.level|string + '/' + program.id)}}"><button class="green-btn">{{ texts.open }}</button></a>
         <button class="red-btn" onclick="hedyApp.modal.confirm ('{{ texts.delete_confirm }}', function () {window.open ('/programs/delete/{{program.id}}', '_self')})">{{ texts.delete }}</button>
           {% if program.public %}
-            <button class="blue-btn" onclick="hedyApp.modal.confirm ('{{ texts.unshare_confirm }}', function () {hedyApp.share_program ({{program.level}}, '{{ lang }}', '{{program.id}}', false, true)})">{{ texts.unshare}}</button>
+            <button class="blue-btn" onclick="hedyApp.modal.confirm ('{{ texts.unshare_confirm }}', function () {hedyApp.share_program ({{program.level}}, '{{ g.lang }}', '{{program.id}}', false, true)})">{{ texts.unshare}}</button>
             <button class="blue-btn" onclick="hedyApp.copy_to_clipboard(hedyApp.viewProgramLink('{{program.id}}'))">{{ texts.copy_link_to_share }}</button>
           {% else %}
-              <button class="blue-btn" onclick="hedyApp.modal.confirm ('{{ texts.share_confirm }}', function () {hedyApp.share_program ({{program.level}}, '{{lang}}', '{{program.id}}', true, true)})">{{ texts.share}}</button>
+              <button class="blue-btn" onclick="hedyApp.modal.confirm ('{{ texts.share_confirm }}', function () {hedyApp.share_program ({{program.level}}, '{{g.lang}}', '{{program.id}}', true, true)})">{{ texts.share}}</button>
           {% endif %}
     </div>
     <br>
@@ -53,7 +53,7 @@
 </div>
 {% endblock %}
 {% block scripts %}
-  <script src="/client_messages.js?lang={{ lang }}" type="text/javascript" crossorigin="anonymous"></script>
+  <script src="/client_messages.js?lang={{ g.lang }}" type="text/javascript" crossorigin="anonymous"></script>
   <script src="{{static('/js/appbundle.js')}}" type="text/javascript" crossorigin="anonymous"></script>
-  <script>window.State = {lang: "{{ lang }}", level: "{{ level }}"}</script>
+  <script>window.State = {lang: "{{ g.lang }}", level: "{{ level }}"}</script>
 {% endblock %}

--- a/templates/view-program-page.html
+++ b/templates/view-program-page.html
@@ -10,7 +10,7 @@
 {% endblock %}
 
 {% block scripts %}
-  <script src="/client_messages.js?lang={{ lang }}" type="text/javascript" crossorigin="anonymous"></script>
+  <script src="/client_messages.js?lang={{ g.lang }}" type="text/javascript" crossorigin="anonymous"></script>
   <script src="{{static('/vendor/jquery.min.js')}}" type="text/javascript" crossorigin="anonymous"></script>
   <script src="{{static('/vendor/ace.js')}}" type="text/javascript" charset="utf-8" crossorigin="anonymous"></script>
   <script src="{{static('/vendor/ext-whitespace.js')}}" type="text/javascript" charset="utf-8" crossorigin="anonymous"></script>
@@ -19,7 +19,7 @@
   <script src="{{static('/vendor/skulpt-stdlib.js')}}" type="text/javascript" crossorigin="anonymous"></script>
   <script>
     window.State = {};
-    window.State.lang = "{{ lang }}";
+    window.State.lang = "{{ g.lang }}";
     window.State.level = "{{ level }}";
     window.State.level_title = "{{ level_title }}";
   </script>

--- a/website/auth.py
+++ b/website/auth.py
@@ -113,7 +113,7 @@ def requires_login(f):
     return inner
 
 # Note: translations are used only for texts that will be seen by a GUI user.
-def routes(app, database, requested_lang):
+def routes(app, database):
     global DATABASE
     DATABASE = database
 
@@ -601,9 +601,9 @@ def send_email_template(template, email, link):
 
 def auth_templates(page, lang, menu, request):
     if page == 'my-profile':
-        return render_template('profile.html', lang=lang, auth=TRANSLATIONS.get_translations(lang, 'Auth'), menu=menu, current_page='my-profile')
+        return render_template('profile.html', auth=TRANSLATIONS.get_translations(lang, 'Auth'), menu=menu, current_page='my-profile')
     if page in['signup', 'login', 'recover', 'reset']:
-        return render_template(page + '.html',  lang=lang, auth=TRANSLATIONS.get_translations(lang, 'Auth'), menu=menu, is_teacher=False, current_page='login')
+        return render_template(page + '.html',  auth=TRANSLATIONS.get_translations(lang, 'Auth'), menu=menu, is_teacher=False, current_page='login')
     if page == 'admin':
         if not is_testing_request(request) and not is_admin(current_user()):
             return 'unauthorized', 403
@@ -628,4 +628,4 @@ def auth_templates(page, lang, menu, request):
             user['index'] = counter
             counter = counter + 1
 
-        return render_template('admin.html', lang=lang, users=userdata, program_count=DATABASE.all_programs_count(), user_count=DATABASE.all_users_count(), auth=TRANSLATIONS.get_translations(lang, 'Auth'))
+        return render_template('admin.html', users=userdata, program_count=DATABASE.all_programs_count(), user_count=DATABASE.all_users_count(), auth=TRANSLATIONS.get_translations(lang, 'Auth'))

--- a/website/teacher.py
+++ b/website/teacher.py
@@ -1,7 +1,7 @@
 from website.auth import requires_login, is_teacher, current_user
 import utils
 import uuid
-from flask import request, jsonify, redirect
+from flask import g, request, jsonify, redirect
 from flask_helpers import render_template
 import os
 import hedyweb
@@ -9,7 +9,7 @@ TRANSLATIONS = hedyweb.Translations ()
 from config import config
 cookie_name     = config ['session'] ['cookie_name']
 
-def routes (app, database, requested_lang):
+def routes (app, database):
     global DATABASE
     DATABASE = database
 
@@ -29,7 +29,7 @@ def routes (app, database, requested_lang):
             return 'Only teachers can retrieve classes', 403
         Class = DATABASE.get_class (class_id)
         if not Class or Class ['teacher'] != user ['username']:
-            return utils.page_404 (TRANSLATIONS, render_main_menu('my-profile'), current_user()['username'], requested_lang(), TRANSLATIONS.get_translations(requested_lang(), 'ui').get('no_such_class'))
+            return utils.page_404 (TRANSLATIONS, render_main_menu('my-profile'), current_user()['username'], g.lang, TRANSLATIONS.get_translations(g.lang, 'ui').get('no_such_class'))
         students = []
         for student_username in Class.get ('students', []):
             student = DATABASE.user_by_username (student_username)
@@ -45,7 +45,7 @@ def routes (app, database, requested_lang):
 
         if utils.is_testing_request (request):
             return jsonify ({'students': students, 'link': Class ['link'], 'name': Class ['name'], 'id': Class ['id']})
-        return render_template ('class-overview.html', lang=requested_lang (), auth=TRANSLATIONS.get_translations (requested_lang (), 'Auth'), menu=render_main_menu('my-profile'), current_page='my-profile', class_info={'students': students, 'link': os.getenv ('BASE_URL') + '/hedy/l/' + Class ['link'], 'name': Class ['name'], 'id': Class ['id']})
+        return render_template ('class-overview.html', auth=TRANSLATIONS.get_translations (g.lang, 'Auth'), menu=render_main_menu('my-profile'), current_page='my-profile', class_info={'students': students, 'link': os.getenv ('BASE_URL') + '/hedy/l/' + Class ['link'], 'name': Class ['name'], 'id': Class ['id']})
 
     @app.route('/class', methods=['POST'])
     @requires_login
@@ -108,22 +108,21 @@ def routes (app, database, requested_lang):
     def prejoin_class (class_id, link):
         Class = DATABASE.get_class (class_id)
         if not Class or Class ['link'] != link:
-            return utils.page_404 (TRANSLATIONS, render_main_menu('my-profile'), current_user()['username'], requested_lang(), TRANSLATIONS.get_translations(requested_lang(), 'ui').get('invalid_class_link'))
+            return utils.page_404 (TRANSLATIONS, render_main_menu('my-profile'), current_user()['username'], g.lang, TRANSLATIONS.get_translations(g.lang, 'ui').get('invalid_class_link'))
         user = {}
         if request.cookies.get (cookie_name):
             token = DATABASE.get_token(request.cookies.get (cookie_name))
             if token:
                 if token ['username'] in Class.get ('students', []):
-                    return render_template ('class-already-joined.html', lang=requested_lang (), auth=TRANSLATIONS.get_translations (requested_lang (), 'Auth'), menu=render_main_menu('my-profile'), current_page='my-profile', class_info={'name': Class ['name']})
+                    return render_template ('class-already-joined.html', auth=TRANSLATIONS.get_translations (g.lang, 'Auth'), menu=render_main_menu('my-profile'), current_page='my-profile', class_info={'name': Class ['name']})
                 user = DATABASE.user_by_username(token ['username'])
 
         return render_template ('class-prejoin.html',
-            lang=requested_lang (),
-            auth=TRANSLATIONS.get_translations (requested_lang (), 'Auth'),
+            auth=TRANSLATIONS.get_translations (g.lang, 'Auth'),
             menu=render_main_menu('my-profile'),
             current_page='my-profile',
             class_info={
-                'link': os.getenv ('BASE_URL') + '/class/' + Class ['id'] + '/join/' + Class ['link'] + '?lang=' + requested_lang (),
+                'link': os.getenv ('BASE_URL') + '/class/' + Class ['id'] + '/join/' + Class ['link'] + '?lang=' + g.lang,
                 'name': Class ['name'],
             })
 
@@ -132,7 +131,7 @@ def routes (app, database, requested_lang):
     def join_class (user, class_id, link):
         Class = DATABASE.get_class (class_id)
         if not Class or Class ['link'] != link:
-            return utils.page_404 (TRANSLATIONS, render_main_menu('my-profile'), current_user()['username'], requested_lang(), TRANSLATIONS.get_translations(requested_lang(), 'ui').get('invalid_class_link'))
+            return utils.page_404 (TRANSLATIONS, render_main_menu('my-profile'), current_user()['username'], g.lang, TRANSLATIONS.get_translations(g.lang, 'ui').get('invalid_class_link'))
 
         DATABASE.add_student_to_class (Class ['id'], user ['username'])
 
@@ -154,5 +153,5 @@ def routes (app, database, requested_lang):
     def resolve_class_link (link_id):
         Class = DATABASE.resolve_class_link (link_id)
         if not Class:
-            return utils.page_404 (TRANSLATIONS, render_main_menu('my-profile'), current_user()['username'], requested_lang(), TRANSLATIONS.get_translations(requested_lang(), 'ui').get('invalid_class_link'))
+            return utils.page_404 (TRANSLATIONS, render_main_menu('my-profile'), current_user()['username'], g.lang, TRANSLATIONS.get_translations(g.lang, 'ui').get('invalid_class_link'))
         return redirect(request.url.replace('/hedy/l/' + link_id, '/class/' + Class ['id'] + '/prejoin/' + link_id), code=302)


### PR DESCRIPTION
The "language" parameter should just be a global, automatically
available in every request and template. No need to set and pass
it in every Python handler and every call to `render_template()`
anymore.

Relates to #1179.
