### PR TITLE
Radio button size changes in Q6 quiz level 7

### DIFF
--- a/templates/quiz_question.html
+++ b/templates/quiz_question.html
@@ -47,16 +47,19 @@
                     {% for column in row %}
                         <div class="flex flex-col">
                             {% if question.correct_answer == chosen_option %}
-                                <div class="p-1 border-blue-600 border-4 rounded-lg shadow-lg radio-block"
+                                <div class="p-1 border-blue-600 border-4 rounded-lg shadow-lg radio-block flex flex-row"
                                      id="{{ question_options[counter.value].char_index }}">
-                                    <label class="inline-flex items-center"><p
+                                    <label class="inline-flex items-center">
+                                    <div class="flex-1 flex-col justify-center items-center">
+                                          <p
                                             class="text-4xl font-bold ml-6 mr-6 font-slab">
                                         {{ question_options[counter.value].char_index }}</p>
-                                        <input
+                                                          <input
                                                 type="radio"
                                                 name="radio_option"
                                                 value="{{ question_nr }}-{{ question_options[counter.value].char_index }}"
                                                 class="class form-radio h-12 w-12">
+                                        </div>
                                         <span>
 
                                         {% if not question_options[counter.value].option_text or question_options[counter.value].option_text == 'None' %}
@@ -67,16 +70,21 @@
                                     </label>
                                 </div>
                             {% elif question_options[counter.value].char_index == chosen_option %}
-                                <div class="p-1 border-blue-600 border-4 rounded-lg shadow-lg" radio-block
+                                <div class="p-1 border-blue-600 border-4 rounded-lg shadow-lg radio-block flex flex-row"
                                      id="answer-disabled-{{ question_options[counter.value].char_index }}">
                                     <label class="inline-flex items-center"><p
                                             class="text-4xl font-bold ml-6 mr-6 font-slab">
-                                        {{ question_options[counter.value].char_index }}</p></p>
-                                        <input
+                                        <div class="flex-1 flex-col justify-center items-center">
+                                            <p class="text-4xl font-bold ml-6 mr-6 font-slab">
+                                                 {{ question_options[counter.value].char_index }}</p>
+                                         <input
                                                 type="radio"
                                                 name="radio_option"
                                                 value="{{ question_nr }}-{{ question_options[counter.value].char_index }}"
                                                 class="class form-radio h-12 w-12" disabled="disabled">
+
+
+                                            </div>
                                         <span>
                                         {% if not question_options[counter.value].option_text or question_options[counter.value].option_text == 'None' %}
                                             <code class="ml-6 text-xl">{{ question_options[counter.value].code | nl2br  }}</code>
@@ -87,16 +95,19 @@
                                     </label>
                                 </div>
                             {% else %}
-                                <div class="p-1 border-blue-600 border-4 rounded-lg shadow-lg radio-block"
+                                <div class="p-1 border-blue-600 border-4 rounded-lg shadow-lg radio-block flex flex-row"
                                      id={{ question_options[counter.value].char_index }}>
-                                    <label class="inline-flex items-center"><p
-                                            class="text-4xl font-bold ml-6 mr-6 font-slab">
+                                    <label class="inline-flex items-center">
+                                         <div class="flex-1 flex-col justify-center items-center">
+                                              <p class="text-4xl font-bold ml-6 mr-6 font-slab">
                                         {{ question_options[counter.value].char_index }}</p>
                                         <input
                                                 type="radio"
                                                 name="radio_option"
                                                 value="{{ question_nr }}-{{ question_options[counter.value].char_index }}"
                                                 class="class form-radio h-12 w-12">
+
+                                           </div>
                                         <span>
                                                 {% if not question_options[counter.value].option_text or question_options[counter.value].option_text == 'None' %}
                                                     <code class="ml-6 text-xl">{{ question_options[counter.value].code | nl2br }}</code>
@@ -104,6 +115,7 @@
                                                     <p class="ml-6 text-xl font-bold"> {{ question_options[counter.value].option_text | nl2br }}</p>
                                                 {% endif %}
                                             </span>
+
                                     </label>
                                 </div>
                             {% endif %}


### PR DESCRIPTION
The radio button is moved under the option symbol. This makes more space for the option text and eliminates an problem where the radiobutton resizes

**Description**

The radio button  has been swapped with the option symbol. The tailwind CSS is adjusted with flex-col and justify-center, items-center tags.

**Fix for**

Radio button size changes in Q6 quiz level 7 #1075


**How to test**
![image](https://user-images.githubusercontent.com/86956321/141788445-070c6d5e-a064-4e44-a47f-8eaa0adc3153.png)
 
 Is changed to this, with radiobuttons moved to underneath the option symbol.
![image](https://user-images.githubusercontent.com/86956321/141788409-f5dd1e2c-4ff6-4cdf-8bf1-47f39fd9d141.png)



