### PR TITLE
Fix for issue #1252: Added a flag for local keywords

### DIFF
--- a/app.py
+++ b/app.py
@@ -324,7 +324,7 @@ def parse():
         with querylog.log_time('transpile'):
 
             try:
-                transpile_result = hedy.transpile(code, level)
+                transpile_result = hedy.transpile(code, level, lang)
             except hedy.exceptions.FtfyException as ex:
                 # The code was fixed with a warning
                 response['Warning'] = translate_error(ex.error_code, hedy_errors, ex.arguments)

--- a/hedy.py
+++ b/hedy.py
@@ -18,6 +18,9 @@ HEDY_MAX_LEVEL = 16
 MAX_LINES = 100
 LEVEL_STARTING_INDENTATION = 8
 
+# Boolean variables to allow code which is under construction to not be executed
+local_keywords_enabled = False # If this is True, only the keywords in the specified language can be used for now
+
 #dictionary to store transpilers
 TRANSPILER_LOOKUP = {}
 
@@ -1485,9 +1488,16 @@ def get_full_grammar_for_level(level):
 
 def get_keywords_for_language(language):
     script_dir = path.abspath(path.dirname(__file__))
-    filename = "keywords-" + str(language) + ".lark"
-    with open(path.join(script_dir, "grammars", filename), "r", encoding="utf-8") as file:
-        grammar_text = file.read()
+    try: 
+        if not local_keywords_enabled: 
+            raise FileNotFoundError("Local keywords are not enabled")
+        filename = "keywords-" + str(language) + ".lark"
+        with open(path.join(script_dir, "grammars", filename), "r", encoding="utf-8") as file:
+            grammar_text = file.read()
+    except FileNotFoundError: 
+        filename = "keywords-en.lark"
+        with open(path.join(script_dir, "grammars", filename), "r", encoding="utf-8") as file:
+            grammar_text = file.read()
     return grammar_text
 
 PARSER_CACHE = {}

--- a/tests/test_level_01.py
+++ b/tests/test_level_01.py
@@ -1,7 +1,7 @@
 import hedy
 import textwrap
 from Tester import HedyTester
-
+from hedy import local_keywords_enabled
 
 
 class TestsLevel1(HedyTester):
@@ -89,18 +89,19 @@ class TestsLevel1(HedyTester):
 
     self.assertEqual(expected, result.code)
     self.assertEqual(False, result.has_turtle)
-  def test_print_dutch(self):
-    result = hedy.transpile("drukaf Hallo welkom bij Hedy!", self.level, lang="nl")
-    expected = "print('Hallo welkom bij Hedy!')"
-    self.assertEqual(expected, result.code)
-    self.assertEqual(False, result.has_turtle)
-    self.assertEqual('Hallo welkom bij Hedy!', HedyTester.run_code(result))
-  def test_print_dutch_error(self):
-    code = textwrap.dedent("""print Hallo welkom bij Hedy!""")
+  if local_keywords_enabled:
+    def test_print_dutch(self):
+      result = hedy.transpile("drukaf Hallo welkom bij Hedy!", self.level, lang="nl")
+      expected = "print('Hallo welkom bij Hedy!')"
+      self.assertEqual(expected, result.code)
+      self.assertEqual(False, result.has_turtle)
+      self.assertEqual('Hallo welkom bij Hedy!', HedyTester.run_code(result))
+    def test_print_dutch_error(self):
+      code = textwrap.dedent("""print Hallo welkom bij Hedy!""")
 
-    with self.assertRaises(hedy.exceptions.ParseException) as context:
-      result = hedy.transpile(code, self.level, lang="nl")
-    self.assertEqual('Parse', context.exception.error_code)
+      with self.assertRaises(hedy.exceptions.ParseException) as context:
+        result = hedy.transpile(code, self.level, lang="nl")
+      self.assertEqual('Parse', context.exception.error_code)
 
   # ask tests
   def test_ask(self):

--- a/tests/test_level_10.py
+++ b/tests/test_level_10.py
@@ -1,7 +1,7 @@
 import hedy
 import textwrap
 from test_level_01 import HedyTester
-
+from hedy import local_keywords_enabled
 class TestsLevel10(HedyTester):
   level = 10
   
@@ -39,17 +39,18 @@ class TestsLevel10(HedyTester):
       print(f'{shark} shark')""")
 
     self.assertEqual(expected, result.code)
-  def test_for_list_dutch(self):
-    code = textwrap.dedent("""\
-    dieren is hond, kat, papegaai
-    voor dier in dieren
-      drukaf dier""")
+  if local_keywords_enabled: 
+    def test_for_list_dutch(self):
+      code = textwrap.dedent("""\
+      dieren is hond, kat, papegaai
+      voor dier in dieren
+        drukaf dier""")
 
-    result = hedy.transpile(code, self.level, lang="nl")
+      result = hedy.transpile(code, self.level, lang="nl")
 
-    expected = textwrap.dedent("""\
-    dieren = ['hond', 'kat', 'papegaai']
-    for dier in dieren:
-      print(f'{dier}')""")
+      expected = textwrap.dedent("""\
+      dieren = ['hond', 'kat', 'papegaai']
+      for dier in dieren:
+        print(f'{dier}')""")
 
-    self.assertEqual(expected, result.code)
+      self.assertEqual(expected, result.code)


### PR DESCRIPTION
Added a flag for local keywords and Fixes issue #1252. Also made sure, language is passed as an argument when hedy.transpile() is called in app.py. This makes it possible in the future, possible to use translation of keywords. 

Same as PR #1253 

