### PR TITLE
chore: in-memory database returns object references

### DIFF
--- a/website/dynamo.py
+++ b/website/dynamo.py
@@ -1,5 +1,6 @@
 import functools
 import boto3
+import copy
 import numbers
 from abc import ABCMeta
 import os
@@ -341,7 +342,7 @@ class MemoryStorage(TableStorage):
         if reverse:
             filtered.reverse()
 
-        return filtered
+        return copy.copy(filtered)
 
     # NOTE: on purpose not @synchronized here
     def query_index(self, table_name, index_name, key, reverse=False):
@@ -352,9 +353,9 @@ class MemoryStorage(TableStorage):
         records = self.tables.setdefault(table_name, [])
         index = self._find_index(records, key)
         if index is None:
-            records.append(data)
+            records.append(copy.copy(data))
         else:
-            records[index] = data
+            records[index] = copy.copy(data)
         self._flush()
 
     @lock.synchronized
@@ -418,7 +419,7 @@ class MemoryStorage(TableStorage):
 
     @lock.synchronized
     def scan(self, table_name):
-        return self.tables.get(table_name, [])
+        return copy.copy(self.tables.get(table_name, []))
 
     def _find_index(self, records, key):
         for i, v in enumerate(records):


### PR DESCRIPTION
Right now the in-memory database returns references to
objects that are stored in it, allowing you to corrupt the
contents out-of-band.

Instead, it should be handing out copies of those objects.
