### PR TITLE
Translation structure level 1 setup

### DIFF
--- a/grammars/keywords-en.lark
+++ b/grammars/keywords-en.lark
@@ -18,7 +18,6 @@ _FROM: "from"
 _AT: "at"
 random : "random" //random needs to appear in the tree for further processing so does not start with _ or is uppercase
 
-
 //level 4
 _IN: "in"
 _IF: "if"

--- a/hedy.py
+++ b/hedy.py
@@ -20,7 +20,7 @@ MAX_LINES = 100
 LEVEL_STARTING_INDENTATION = 8
 
 # Boolean variables to allow code which is under construction to not be executed
-local_keywords_enabled = True # If this is True, only the keywords in the specified language can be used for now
+local_keywords_enabled = False # If this is True, only the keywords in the specified language can be used for now
 
 #dictionary to store transpilers
 TRANSPILER_LOOKUP = {}

--- a/hedy.py
+++ b/hedy.py
@@ -20,7 +20,7 @@ MAX_LINES = 100
 LEVEL_STARTING_INDENTATION = 8
 
 # Boolean variables to allow code which is under construction to not be executed
-local_keywords_enabled = False # If this is True, only the keywords in the specified language can be used for now
+local_keywords_enabled = True # If this is True, only the keywords in the specified language can be used for now
 
 #dictionary to store transpilers
 TRANSPILER_LOOKUP = {}
@@ -1889,6 +1889,97 @@ def execute(input_string, level):
     if python.has_turtle:
         raise exceptions.HedyException("hedy.execute doesn't support turtle")
     exec(python.code)
+
+
+def keywords_to_dict(to_lang="nl"):
+    """"Return a dictionary of keywords from language of choice. Key is english value is lang of choice"""
+    keywords = {}
+    keywords_from = get_keywords_for_language("en").replace("\n\n", "\n").splitlines()
+
+    keywords_to = get_keywords_for_language(to_lang).replace("\n\n", "\n").splitlines()
+    keywords_from_withoutlvl = []
+    for line in keywords_from:
+        if line[0] != '/':
+            keywords_from_withoutlvl.append(line)
+
+    for line in range(len(keywords_from_withoutlvl)):
+        if keywords_from[line][0] != '/':
+            keywords[(keywords_from[line].split('"'))[1]] = keywords_to[line].split('"')[1]
+
+    return keywords
+
+
+def translate_keywords(input_string, from_lang="nl", to_lang="nl", level=1):
+    """"Return code with keywords translated to language of choice in level of choice"""
+    parser = get_parser(level, from_lang)
+
+    punctuation_symbols = ['!', '?', '.']
+
+    keywordDict = keywords_to_dict(to_lang)
+    program_root = parser.parse(input_string + '\n').children[0]
+    abstract_syntaxtree = ExtractAST().transform(program_root)
+    translator = TRANSPILER_LOOKUP[level]
+    abstract_syntaxtree = translator(keywordDict, punctuation_symbols).transform(program_root)
+
+    return abstract_syntaxtree
+
+
+def hedy_translator(level):
+    def decorator(c):
+        TRANSPILER_LOOKUP[level] = c
+        c.level = level
+        return c
+
+    return decorator
+
+
+@hedy_translator(level=1)
+class ConvertToLang1(Transformer):
+
+    def __init__(self, keywords, punctuation_symbols):
+        self.keywords = keywords
+        self.punctuation_symbols = punctuation_symbols
+        __class__.level = 1
+
+    def command(self, args):
+        return args[0]
+
+    def program(self, args):
+        return '\n'.join([str(c) for c in args])
+
+    def text(self, args):
+        return ''.join([str(c) for c in args])
+
+    def invalid_space(self, args):
+        return " " + ''.join([str(c) for c in args])
+
+    def print(self, args):
+        return self.keywords["print"] + " " + "".join([str(c) for c in args])
+
+    def echo(self, args):
+        all_args = self.keywords["echo"]
+        if args:
+            all_args += " "
+        return all_args + "".join([str(c) for c in args])
+
+    def ask(self, args):
+        return self.keywords["ask"] + " " + "".join([str(c) for c in args])
+
+    def turn(self, args):
+        return self.keywords["turn"] + " " + "".join([str(c) for c in args])
+
+    def forward(self, args):
+        return self.keywords["forward"] + " " + "".join([str(c) for c in args])
+
+    def random(self, args):
+        return self.keywords["random"] + "".join([str(c) for c in args])
+
+    def invalid(self, args):
+        return ' '.join([str(c) for c in args])
+
+    def __default__(self, data, children, meta):
+        return Tree(data, children, meta)
+
 
 # f = open('output.py', 'w+')
 # f.write(python)

--- a/hedy.py
+++ b/hedy.py
@@ -20,7 +20,7 @@ MAX_LINES = 100
 LEVEL_STARTING_INDENTATION = 8
 
 # Boolean variables to allow code which is under construction to not be executed
-local_keywords_enabled = True # If this is True, only the keywords in the specified language can be used for now
+local_keywords_enabled = False # If this is True, only the keywords in the specified language can be used for now
 
 #dictionary to store transpilers
 TRANSPILER_LOOKUP = {}
@@ -1889,97 +1889,6 @@ def execute(input_string, level):
     if python.has_turtle:
         raise exceptions.HedyException("hedy.execute doesn't support turtle")
     exec(python.code)
-
-
-def keywords_to_dict(to_lang="nl"):
-    """"Return a dictionary of keywords from language of choice. Key is english value is lang of choice"""
-    keywords = {}
-    keywords_from = get_keywords_for_language("en").replace("\n\n", "\n").splitlines()
-
-    keywords_to = get_keywords_for_language(to_lang).replace("\n\n", "\n").splitlines()
-    keywords_from_withoutlvl = []
-    for line in keywords_from:
-        if line[0] != '/':
-            keywords_from_withoutlvl.append(line)
-
-    for line in range(len(keywords_from_withoutlvl)):
-        if keywords_from[line][0] != '/':
-            keywords[(keywords_from[line].split('"'))[1]] = keywords_to[line].split('"')[1]
-
-    return keywords
-
-
-def translate_keywords(input_string, from_lang="nl", to_lang="nl", level=1):
-    """"Return code with keywords translated to language of choice in level of choice"""
-    parser = get_parser(level, from_lang)
-
-    punctuation_symbols = ['!', '?', '.']
-
-    keywordDict = keywords_to_dict(to_lang)
-    program_root = parser.parse(input_string + '\n').children[0]
-    abstract_syntaxtree = ExtractAST().transform(program_root)
-    translator = TRANSPILER_LOOKUP[level]
-    abstract_syntaxtree = translator(keywordDict, punctuation_symbols).transform(program_root)
-
-    return abstract_syntaxtree
-
-
-def hedy_translator(level):
-    def decorator(c):
-        TRANSPILER_LOOKUP[level] = c
-        c.level = level
-        return c
-
-    return decorator
-
-
-@hedy_translator(level=1)
-class ConvertToLang1(Transformer):
-
-    def __init__(self, keywords, punctuation_symbols):
-        self.keywords = keywords
-        self.punctuation_symbols = punctuation_symbols
-        __class__.level = 1
-
-    def command(self, args):
-        return args[0]
-
-    def program(self, args):
-        return '\n'.join([str(c) for c in args])
-
-    def text(self, args):
-        return ''.join([str(c) for c in args])
-
-    def invalid_space(self, args):
-        return " " + ''.join([str(c) for c in args])
-
-    def print(self, args):
-        return self.keywords["print"] + " " + "".join([str(c) for c in args])
-
-    def echo(self, args):
-        all_args = self.keywords["echo"]
-        if args:
-            all_args += " "
-        return all_args + "".join([str(c) for c in args])
-
-    def ask(self, args):
-        return self.keywords["ask"] + " " + "".join([str(c) for c in args])
-
-    def turn(self, args):
-        return self.keywords["turn"] + " " + "".join([str(c) for c in args])
-
-    def forward(self, args):
-        return self.keywords["forward"] + " " + "".join([str(c) for c in args])
-
-    def random(self, args):
-        return self.keywords["random"] + "".join([str(c) for c in args])
-
-    def invalid(self, args):
-        return ' '.join([str(c) for c in args])
-
-    def __default__(self, data, children, meta):
-        return Tree(data, children, meta)
-
 
 # f = open('output.py', 'w+')
 # f.write(python)

--- a/hedy.py
+++ b/hedy.py
@@ -20,7 +20,7 @@ MAX_LINES = 100
 LEVEL_STARTING_INDENTATION = 8
 
 # Boolean variables to allow code which is under construction to not be executed
-local_keywords_enabled = False # If this is True, only the keywords in the specified language can be used for now
+local_keywords_enabled = True # If this is True, only the keywords in the specified language can be used for now
 
 #dictionary to store transpilers
 TRANSPILER_LOOKUP = {}

--- a/hedy_translation.py
+++ b/hedy_translation.py
@@ -16,9 +16,13 @@ def keywords_to_dict(to_lang="nl"):
         if line[0] != '/':
             keywords_from_withoutlvl.append(line)
 
+    keywords_to_withoutlvl = []
+    for line in keywords_to:
+        if line[0] != '/':
+            keywords_to_withoutlvl.append(line)
+
     for line in range(len(keywords_from_withoutlvl)):
-        if keywords_from[line][0] != '/':
-            keywords[(keywords_from[line].split('"'))[1]] = keywords_to[line].split('"')[1]
+        keywords[(keywords_from_withoutlvl[line].split('"'))[1]] = keywords_to_withoutlvl[line].split('"')[1]
 
     return keywords
 
@@ -93,3 +97,6 @@ class ConvertToLang1(Transformer):
 
     def __default__(self, data, children, meta):
         return Tree(data, children, meta)
+
+code = translate_keywords('print Hallo welkom bij Hedy\nask hoe heet je\necho','en','nl', level=1)
+translate_keywords(code,'nl','en', level=1)

--- a/hedy_translation.py
+++ b/hedy_translation.py
@@ -97,6 +97,3 @@ class ConvertToLang1(Transformer):
 
     def __default__(self, data, children, meta):
         return Tree(data, children, meta)
-
-code = translate_keywords('print Hallo welkom bij Hedy\nask hoe heet je\necho','en','nl', level=1)
-translate_keywords(code,'nl','en', level=1)

--- a/hedy_translation.py
+++ b/hedy_translation.py
@@ -1,0 +1,95 @@
+from lark import Transformer, Tree
+from hedy import get_keywords_for_language, ExtractAST, get_parser
+
+
+TRANSPILER_LOOKUP = {}
+
+
+def keywords_to_dict(to_lang="nl"):
+    """"Return a dictionary of keywords from language of choice. Key is english value is lang of choice"""
+    keywords = {}
+    keywords_from = get_keywords_for_language("en").replace("\n\n", "\n").splitlines()
+
+    keywords_to = get_keywords_for_language(to_lang).replace("\n\n", "\n").splitlines()
+    keywords_from_withoutlvl = []
+    for line in keywords_from:
+        if line[0] != '/':
+            keywords_from_withoutlvl.append(line)
+
+    for line in range(len(keywords_from_withoutlvl)):
+        if keywords_from[line][0] != '/':
+            keywords[(keywords_from[line].split('"'))[1]] = keywords_to[line].split('"')[1]
+
+    return keywords
+
+
+def translate_keywords(input_string, from_lang="nl", to_lang="nl", level=1):
+    """"Return code with keywords translated to language of choice in level of choice"""
+    parser = get_parser(level, from_lang)
+
+    punctuation_symbols = ['!', '?', '.']
+
+    keywordDict = keywords_to_dict(to_lang)
+    program_root = parser.parse(input_string + '\n').children[0]
+    abstract_syntaxtree = ExtractAST().transform(program_root)
+    translator = TRANSPILER_LOOKUP[level]
+    abstract_syntaxtree = translator(keywordDict, punctuation_symbols).transform(program_root)
+
+    return abstract_syntaxtree
+
+
+def hedy_translator(level):
+    def decorating(c):
+        TRANSPILER_LOOKUP[level] = c
+        c.level = level
+        return c
+
+    return decorating
+
+
+@hedy_translator(level=1)
+class ConvertToLang1(Transformer):
+
+    def __init__(self, keywords, punctuation_symbols):
+        self.keywords = keywords
+        self.punctuation_symbols = punctuation_symbols
+        __class__.level = 1
+
+    def command(self, args):
+        return args[0]
+
+    def program(self, args):
+        return '\n'.join([str(c) for c in args])
+
+    def text(self, args):
+        return ''.join([str(c) for c in args])
+
+    def invalid_space(self, args):
+        return " " + ''.join([str(c) for c in args])
+
+    def print(self, args):
+        return self.keywords["print"] + " " + "".join([str(c) for c in args])
+
+    def echo(self, args):
+        all_args = self.keywords["echo"]
+        if args:
+            all_args += " "
+        return all_args + "".join([str(c) for c in args])
+
+    def ask(self, args):
+        return self.keywords["ask"] + " " + "".join([str(c) for c in args])
+
+    def turn(self, args):
+        return self.keywords["turn"] + " " + "".join([str(c) for c in args])
+
+    def forward(self, args):
+        return self.keywords["forward"] + " " + "".join([str(c) for c in args])
+
+    def random(self, args):
+        return self.keywords["random"] + "".join([str(c) for c in args])
+
+    def invalid(self, args):
+        return ' '.join([str(c) for c in args])
+
+    def __default__(self, data, children, meta):
+        return Tree(data, children, meta)

--- a/tests/test_level_01.py
+++ b/tests/test_level_01.py
@@ -91,13 +91,13 @@ class TestsLevel1(HedyTester):
     self.assertEqual(False, result.has_turtle)
   if local_keywords_enabled:
     def test_print_dutch(self):
-      result = hedy.transpile("drukaf Hallo welkom bij Hedy!", self.level, lang="nl")
+      result = hedy.transpile("print Hallo welkom bij Hedy!", self.level, lang="nl")
       expected = "print('Hallo welkom bij Hedy!')"
       self.assertEqual(expected, result.code)
       self.assertEqual(False, result.has_turtle)
       self.assertEqual('Hallo welkom bij Hedy!', HedyTester.run_code(result))
-    def test_print_dutch_error(self):
-      code = textwrap.dedent("""print Hallo welkom bij Hedy!""")
+    def test_ask_dutch_error(self):
+      code = textwrap.dedent("""ask Heb je er zin?""")
 
       with self.assertRaises(hedy.exceptions.ParseException) as context:
         result = hedy.transpile(code, self.level, lang="nl")

--- a/tests/test_level_10.py
+++ b/tests/test_level_10.py
@@ -44,7 +44,7 @@ class TestsLevel10(HedyTester):
       code = textwrap.dedent("""\
       dieren is hond, kat, papegaai
       voor dier in dieren
-        drukaf dier""")
+        print dier""")
 
       result = hedy.transpile(code, self.level, lang="nl")
 

--- a/tests/test_translation_level_01.py
+++ b/tests/test_translation_level_01.py
@@ -19,9 +19,10 @@ class TestsTranslationLevel1(HedyTester):
 
     @check_local_lang_bool
     def test_print(self):
-        result = hedy_translation.translate_keywords(f"{self.keywords_from['print']} Hallo welkom bij Hedy!", "en", "nl",
-                                         self.level)
-        expected = f"{self.keywords_to['print']} Hallo welkom bij Hedy!"
+        code = 'print Hallo welkom bij Hedy!'
+
+        result = hedy_translation.translate_keywords(code, from_lang="en", to_lang="nl", level=self.level)
+        expected = 'vraag Hallo welkom bij Hedy!'
 
         self.assertEqual(result, expected)
 
@@ -38,6 +39,8 @@ class TestsTranslationLevel1(HedyTester):
     def test_print_kewords(self):
         result = hedy_translation.translate_keywords(f"{self.keywords_from['print']} print ask echo", "en", "nl", self.level)
         expected = f"{self.keywords_to['print']} print ask echo"
+
+        self.assertEqual(result, expected)
 
     @check_local_lang_bool
     def test_ask(self):

--- a/tests/test_translation_level_01.py
+++ b/tests/test_translation_level_01.py
@@ -9,7 +9,15 @@ def check_local_lang_bool(func):
             return
 
         return func(self)
+
     return inner
+
+
+    # tests should be ordered as follows:
+    # * Translation from English to Dutch
+    # * Translation from Dutch to English
+    # * Translation to several languages
+    # * Error handling
 
 
 class TestsTranslationLevel1(HedyTester):
@@ -18,109 +26,163 @@ class TestsTranslationLevel1(HedyTester):
     keywords_to = hedy_translation.keywords_to_dict('nl')
 
     @check_local_lang_bool
-    def test_print(self):
+    def test_print_english_dutch(self):
         code = 'print Hallo welkom bij Hedy!'
 
         result = hedy_translation.translate_keywords(code, from_lang="en", to_lang="nl", level=self.level)
-        expected = 'vraag Hallo welkom bij Hedy!'
+        expected = 'print Hallo welkom bij Hedy!'
 
         self.assertEqual(result, expected)
 
     @check_local_lang_bool
-    def test_print_multiple_lines(self):
-        result = hedy_translation.translate_keywords(
-            f"{self.keywords_from['print']} Hallo welkom bij Hedy!\n{self.keywords_from['print']} veel plezier", "en",
-            "nl", self.level)
-        expected = f"{self.keywords_to['print']} Hallo welkom bij Hedy!\n{self.keywords_to['print']} veel plezier"
+    def test_ask_english_dutch(self):
+        code = "ask Hallo welkom bij Hedy!"
+
+        result = hedy_translation.translate_keywords(code, from_lang="en", to_lang="nl", level=self.level)
+        expected = "vraag Hallo welkom bij Hedy!"
 
         self.assertEqual(result, expected)
 
     @check_local_lang_bool
-    def test_print_kewords(self):
-        result = hedy_translation.translate_keywords(f"{self.keywords_from['print']} print ask echo", "en", "nl", self.level)
-        expected = f"{self.keywords_to['print']} print ask echo"
+    def test_echo_english_dutch(self):
+        code = "ask Hallo welkom bij Hedy!\necho"
+
+        result = hedy_translation.translate_keywords(code, from_lang="en", to_lang="nl", level=self.level)
+        expected = "vraag Hallo welkom bij Hedy!\nherhaal"
 
         self.assertEqual(result, expected)
 
     @check_local_lang_bool
-    def test_ask(self):
-        result = hedy_translation.translate_keywords(f"{self.keywords_from['ask']} Hallo welkom bij Hedy!", "en", "nl", self.level)
-        expected = f"{self.keywords_to['ask']} Hallo welkom bij Hedy!"
+    def test_ask_echo_english_dutch(self):
+        code = 'print Hallo welkom bij Hedy\nvraag hoe heet je\nherhaal'
+
+        result = hedy_translation.translate_keywords(code, from_lang="nl", to_lang="en", level=self.level)
+        expected = 'print Hallo welkom bij Hedy\nask hoe heet je\necho'
 
         self.assertEqual(result, expected)
 
     @check_local_lang_bool
-    def test_ask_multiple_lines(self):
-        result = hedy_translation.translate_keywords(
-            f"{self.keywords_from['ask']} Hallo welkom bij Hedy!\n{self.keywords_from['ask']} veel plezier", "en", "nl",
-            self.level)
-        expected = f"{self.keywords_to['ask']} Hallo welkom bij Hedy!\n{self.keywords_to['ask']} veel plezier"
+    def test_print_kewords_english_dutch(self):
+        code = "print print ask echo"
+
+        result = hedy_translation.translate_keywords(code, from_lang="en", to_lang="nl", level=self.level)
+        expected = "print print ask echo"
+
+        self.assertEqual(result, expected)
+
+
+    @check_local_lang_bool
+    def test_forward_english_dutch(self):
+        code = "forward 50"
+
+        result = hedy_translation.translate_keywords(code, from_lang="en", to_lang="nl", level=self.level)
+        expected = "vooruit 50"
 
         self.assertEqual(result, expected)
 
     @check_local_lang_bool
-    def test_ask_kewords(self):
-        result = hedy_translation.translate_keywords(f"{self.keywords_from['ask']} print ask echo", "en", "nl", self.level)
-        expected = f"{self.keywords_to['ask']} print ask echo"
+    def test_turn_english_dutch(self):
+        code = "turn 50"
+
+        result = hedy_translation.translate_keywords(code, from_lang="en", to_lang="nl", level=self.level)
+        expected = "draai 50"
+
+        self.assertEqual(result, expected)
+
+
+
+    @check_local_lang_bool
+    def test_print_dutch_english(self):
+        code = 'print Hallo welkom bij Hedy!'
+
+        result = hedy_translation.translate_keywords(code, from_lang="nl", to_lang="en", level=self.level)
+        expected = 'print Hallo welkom bij Hedy!'
+
+        self.assertEqual(result, expected)
+
+
+    @check_local_lang_bool
+    def test_ask_dutch_english(self):
+        code = "vraag Hallo welkom bij Hedy!\nvraag veel plezier"
+
+        result = hedy_translation.translate_keywords(code, from_lang="nl", to_lang="en", level=self.level)
+        expected = "ask Hallo welkom bij Hedy!\nask veel plezier"
 
         self.assertEqual(result, expected)
 
     @check_local_lang_bool
-    def test_echo(self):
-        result = hedy_translation.translate_keywords(
-            f"{self.keywords_from['ask']} Hallo welkom bij Hedy!\n{self.keywords_from['echo']}", "en", "nl", self.level)
-        expected = f"{self.keywords_to['ask']} Hallo welkom bij Hedy!\n{self.keywords_to['echo']}"
+    def test_echo_dutch_english(self):
+        code = "vraag stel je vraag\nherhaal tekst"
+
+        result = hedy_translation.translate_keywords(code, from_lang="nl", to_lang="en", level=self.level)
+        expected = "ask stel je vraag\necho tekst"
 
         self.assertEqual(result, expected)
 
     @check_local_lang_bool
-    def test_echo_text(self):
-        result = hedy_translation.translate_keywords(
-            f"{self.keywords_from['ask']} stel je vraag\n{self.keywords_from['echo']} tekst", "en", "nl", self.level)
-        expected = f"{self.keywords_to['ask']} stel je vraag\n{self.keywords_to['echo']} tekst"
+    def test_ask_echo_dutch_english(self):
+        code = 'vraag Hallo welkom bij Hedy!\nherhaal hoi'
+
+        result = hedy_translation.translate_keywords(code, from_lang="nl", to_lang="en", level=self.level)
+        expected = 'ask Hallo welkom bij Hedy!\necho hoi'
 
         self.assertEqual(result, expected)
 
     @check_local_lang_bool
-    def test_forward(self):
-        result = hedy_translation.translate_keywords(f"{self.keywords_from['forward']} 50", "en", "nl", self.level)
-        expected = f"{self.keywords_to['forward']} 50"
+    def test_ask_kewords_dutch_english(self):
+        code = "vraag print ask echo"
+
+        result = hedy_translation.translate_keywords(code, from_lang="nl", to_lang="en", level=self.level)
+        expected = "ask print ask echo"
 
         self.assertEqual(result, expected)
 
     @check_local_lang_bool
-    def test_turn(self):
-        result = hedy_translation.translate_keywords(f"{self.keywords_from['turn']} left", "en", "nl", self.level)
-        expected = f"{self.keywords_to['turn']} left"
+    def test_turn_dutch_english(self):
+        code = "draai left"
+
+        result = hedy_translation.translate_keywords(code, from_lang="nl", to_lang="en", level=self.level)
+        expected = "turn left"
 
         self.assertEqual(result, expected)
+
+
 
     @check_local_lang_bool
-    def test_turn_value(self):
-        result = hedy_translation.translate_keywords(f"{self.keywords_from['turn']} 50", "en", "nl", self.level)
-        expected = f"{self.keywords_to['turn']} 50"
+    def test_translate_back(self):
+        code = 'print Hallo welkom bij Hedy\nask hoe heet je\necho'
 
-        self.assertEqual(result, expected)
+        result = hedy_translation.translate_keywords(code, from_lang="en", to_lang="nl", level=self.level)
+        result = hedy_translation.translate_keywords(result, from_lang="nl", to_lang="en", level=self.level)
+
+        self.assertEqual(code, result)
+
+
 
     @check_local_lang_bool
     def test_invalid(self):
-        result = hedy_translation.translate_keywords(f"hallo", "en", "nl", self.level)
-        expected = f"hallo"
+        code = "hallo"
+
+        result = hedy_translation.translate_keywords(code, from_lang="en", to_lang="nl", level=self.level)
+        expected = "hallo"
 
         self.assertEqual(result, expected)
 
     # No translation because of the invalid space error
     @check_local_lang_bool
     def test_invalid_space(self):
-        result = hedy_translation.translate_keywords(f" {self.keywords_from['print']} Hedy", "en", "nl", self.level)
-        expected = f" {self.keywords_from['print']} Hedy"
+        code = " ask Hedy"
+
+        result = hedy_translation.translate_keywords(code, from_lang="en", to_lang="nl", level=self.level)
+        expected = " ask Hedy"
 
         self.assertEqual(result, expected)
 
     @check_local_lang_bool
     def no_argument_ask(self):
-        result = hedy_translation.translate_keywords(f"{self.keywords_to['ask']}", "en", "nl", self.level)
-        expected = f"{self.keywords_to['ask']}"
+        code = "ask"
+
+        result = hedy_translation.translate_keywords(code, from_lang="en", to_lang="nl", level=self.level)
+        expected = "ask"
 
         self.assertEqual(result, expected)
-

--- a/tests/test_translation_level_01.py
+++ b/tests/test_translation_level_01.py
@@ -1,0 +1,122 @@
+import hedy
+import textwrap
+from test_level_01 import HedyTester
+
+
+def check_local_lang_bool(func):
+    def inner(self):
+        if not hedy.local_keywords_enabled:
+            return
+
+        return func(self)
+    return inner
+
+class TestsTranslationLevel1(HedyTester):
+    level = 1
+    keywords_from = hedy.keywords_to_dict('en')
+    keywords_to = hedy.keywords_to_dict('nl')
+
+    @check_local_lang_bool
+    def test_print(self):
+        result = hedy.translate_keywords(f"{self.keywords_from['print']} Hallo welkom bij Hedy!", "en", "nl",
+                                         self.level)
+        expected = f"{self.keywords_to['print']} Hallo welkom bij Hedy!"
+
+        self.assertEqual(result, expected)
+
+    @check_local_lang_bool
+    def test_print_multiple_lines(self):
+        result = hedy.translate_keywords(
+            f"{self.keywords_from['print']} Hallo welkom bij Hedy!\n{self.keywords_from['print']} veel plezier", "en",
+            "nl", self.level)
+        expected = f"{self.keywords_to['print']} Hallo welkom bij Hedy!\n{self.keywords_to['print']} veel plezier"
+
+        self.assertEqual(result, expected)
+
+    @check_local_lang_bool
+    def test_print_kewords(self):
+        result = hedy.translate_keywords(f"{self.keywords_from['print']} print ask echo", "en", "nl", self.level)
+        expected = f"{self.keywords_to['print']} print ask echo"
+
+    @check_local_lang_bool
+    def test_ask(self):
+        result = hedy.translate_keywords(f"{self.keywords_from['ask']} Hallo welkom bij Hedy!", "en", "nl", self.level)
+        expected = f"{self.keywords_to['ask']} Hallo welkom bij Hedy!"
+
+        self.assertEqual(result, expected)
+
+    @check_local_lang_bool
+    def test_ask_multiple_lines(self):
+        result = hedy.translate_keywords(
+            f"{self.keywords_from['ask']} Hallo welkom bij Hedy!\n{self.keywords_from['ask']} veel plezier", "en", "nl",
+            self.level)
+        expected = f"{self.keywords_to['ask']} Hallo welkom bij Hedy!\n{self.keywords_to['ask']} veel plezier"
+
+        self.assertEqual(result, expected)
+
+    @check_local_lang_bool
+    def test_ask_kewords(self):
+        result = hedy.translate_keywords(f"{self.keywords_from['ask']} print ask echo", "en", "nl", self.level)
+        expected = f"{self.keywords_to['ask']} print ask echo"
+
+        self.assertEqual(result, expected)
+
+    @check_local_lang_bool
+    def test_echo(self):
+        result = hedy.translate_keywords(
+            f"{self.keywords_from['ask']} Hallo welkom bij Hedy!\n{self.keywords_from['echo']}", "en", "nl", self.level)
+        expected = f"{self.keywords_to['ask']} Hallo welkom bij Hedy!\n{self.keywords_to['echo']}"
+
+        self.assertEqual(result, expected)
+
+    @check_local_lang_bool
+    def test_echo_text(self):
+        result = hedy.translate_keywords(
+            f"{self.keywords_from['ask']} stel je vraag\n{self.keywords_from['echo']} tekst", "en", "nl", self.level)
+        expected = f"{self.keywords_to['ask']} stel je vraag\n{self.keywords_to['echo']} tekst"
+
+        self.assertEqual(result, expected)
+
+    @check_local_lang_bool
+    def test_forward(self):
+        result = hedy.translate_keywords(f"{self.keywords_from['forward']} 50", "en", "nl", self.level)
+        expected = f"{self.keywords_to['forward']} 50"
+
+        self.assertEqual(result, expected)
+
+    @check_local_lang_bool
+    def test_turn(self):
+        result = hedy.translate_keywords(f"{self.keywords_from['turn']} left", "en", "nl", self.level)
+        expected = f"{self.keywords_to['turn']} left"
+
+        self.assertEqual(result, expected)
+
+    @check_local_lang_bool
+    def test_turn_value(self):
+        result = hedy.translate_keywords(f"{self.keywords_from['turn']} 50", "en", "nl", self.level)
+        expected = f"{self.keywords_to['turn']} 50"
+
+        self.assertEqual(result, expected)
+
+    @check_local_lang_bool
+    def test_invalid(self):
+        result = hedy.translate_keywords(f"hallo", "en", "nl", self.level)
+        expected = f"hallo"
+
+        self.assertEqual(result, expected)
+
+    # No translation because of the invalid space error
+    @check_local_lang_bool
+    def test_invalid_space(self):
+        result = hedy.translate_keywords(f" {self.keywords_from['print']} Hedy", "en", "nl", self.level)
+        expected = f" {self.keywords_from['print']} Hedy"
+
+        self.assertEqual(result, expected)
+
+    @check_local_lang_bool
+    def no_argument_ask(self):
+        result = hedy.translate_keywords(f"{self.keywords_to['ask']}", "en", "nl", self.level)
+        expected = f"{self.keywords_to['ask']}"
+
+        self.assertEqual(result, expected)
+

--- a/tests/test_translation_level_01.py
+++ b/tests/test_translation_level_01.py
@@ -54,10 +54,10 @@ class TestsTranslationLevel1(HedyTester):
 
     @check_local_lang_bool
     def test_ask_echo_english_dutch(self):
-        code = 'print Hallo welkom bij Hedy\nvraag hoe heet je\nherhaal'
+        code = 'print Hallo welkom bij Hedy\'\'\nvraag hoe heet je\nherhaal'
 
         result = hedy_translation.translate_keywords(code, from_lang="nl", to_lang="en", level=self.level)
-        expected = 'print Hallo welkom bij Hedy\nask hoe heet je\necho'
+        expected = 'print Hallo welkom bij Hedy\'\'\nask hoe heet je\necho'
 
         self.assertEqual(result, expected)
 

--- a/tests/test_translation_level_01.py
+++ b/tests/test_translation_level_01.py
@@ -1,6 +1,6 @@
 import hedy
-import textwrap
 from test_level_01 import HedyTester
+import hedy_translation
 
 
 def check_local_lang_bool(func):
@@ -11,14 +11,15 @@ def check_local_lang_bool(func):
         return func(self)
     return inner
 
+
 class TestsTranslationLevel1(HedyTester):
     level = 1
-    keywords_from = hedy.keywords_to_dict('en')
-    keywords_to = hedy.keywords_to_dict('nl')
+    keywords_from = hedy_translation.keywords_to_dict('en')
+    keywords_to = hedy_translation.keywords_to_dict('nl')
 
     @check_local_lang_bool
     def test_print(self):
-        result = hedy.translate_keywords(f"{self.keywords_from['print']} Hallo welkom bij Hedy!", "en", "nl",
+        result = hedy_translation.translate_keywords(f"{self.keywords_from['print']} Hallo welkom bij Hedy!", "en", "nl",
                                          self.level)
         expected = f"{self.keywords_to['print']} Hallo welkom bij Hedy!"
 
@@ -26,7 +27,7 @@ class TestsTranslationLevel1(HedyTester):
 
     @check_local_lang_bool
     def test_print_multiple_lines(self):
-        result = hedy.translate_keywords(
+        result = hedy_translation.translate_keywords(
             f"{self.keywords_from['print']} Hallo welkom bij Hedy!\n{self.keywords_from['print']} veel plezier", "en",
             "nl", self.level)
         expected = f"{self.keywords_to['print']} Hallo welkom bij Hedy!\n{self.keywords_to['print']} veel plezier"
@@ -35,19 +36,19 @@ class TestsTranslationLevel1(HedyTester):
 
     @check_local_lang_bool
     def test_print_kewords(self):
-        result = hedy.translate_keywords(f"{self.keywords_from['print']} print ask echo", "en", "nl", self.level)
+        result = hedy_translation.translate_keywords(f"{self.keywords_from['print']} print ask echo", "en", "nl", self.level)
         expected = f"{self.keywords_to['print']} print ask echo"
 
     @check_local_lang_bool
     def test_ask(self):
-        result = hedy.translate_keywords(f"{self.keywords_from['ask']} Hallo welkom bij Hedy!", "en", "nl", self.level)
+        result = hedy_translation.translate_keywords(f"{self.keywords_from['ask']} Hallo welkom bij Hedy!", "en", "nl", self.level)
         expected = f"{self.keywords_to['ask']} Hallo welkom bij Hedy!"
 
         self.assertEqual(result, expected)
 
     @check_local_lang_bool
     def test_ask_multiple_lines(self):
-        result = hedy.translate_keywords(
+        result = hedy_translation.translate_keywords(
             f"{self.keywords_from['ask']} Hallo welkom bij Hedy!\n{self.keywords_from['ask']} veel plezier", "en", "nl",
             self.level)
         expected = f"{self.keywords_to['ask']} Hallo welkom bij Hedy!\n{self.keywords_to['ask']} veel plezier"
@@ -56,14 +57,14 @@ class TestsTranslationLevel1(HedyTester):
 
     @check_local_lang_bool
     def test_ask_kewords(self):
-        result = hedy.translate_keywords(f"{self.keywords_from['ask']} print ask echo", "en", "nl", self.level)
+        result = hedy_translation.translate_keywords(f"{self.keywords_from['ask']} print ask echo", "en", "nl", self.level)
         expected = f"{self.keywords_to['ask']} print ask echo"
 
         self.assertEqual(result, expected)
 
     @check_local_lang_bool
     def test_echo(self):
-        result = hedy.translate_keywords(
+        result = hedy_translation.translate_keywords(
             f"{self.keywords_from['ask']} Hallo welkom bij Hedy!\n{self.keywords_from['echo']}", "en", "nl", self.level)
         expected = f"{self.keywords_to['ask']} Hallo welkom bij Hedy!\n{self.keywords_to['echo']}"
 
@@ -71,7 +72,7 @@ class TestsTranslationLevel1(HedyTester):
 
     @check_local_lang_bool
     def test_echo_text(self):
-        result = hedy.translate_keywords(
+        result = hedy_translation.translate_keywords(
             f"{self.keywords_from['ask']} stel je vraag\n{self.keywords_from['echo']} tekst", "en", "nl", self.level)
         expected = f"{self.keywords_to['ask']} stel je vraag\n{self.keywords_to['echo']} tekst"
 
@@ -79,28 +80,28 @@ class TestsTranslationLevel1(HedyTester):
 
     @check_local_lang_bool
     def test_forward(self):
-        result = hedy.translate_keywords(f"{self.keywords_from['forward']} 50", "en", "nl", self.level)
+        result = hedy_translation.translate_keywords(f"{self.keywords_from['forward']} 50", "en", "nl", self.level)
         expected = f"{self.keywords_to['forward']} 50"
 
         self.assertEqual(result, expected)
 
     @check_local_lang_bool
     def test_turn(self):
-        result = hedy.translate_keywords(f"{self.keywords_from['turn']} left", "en", "nl", self.level)
+        result = hedy_translation.translate_keywords(f"{self.keywords_from['turn']} left", "en", "nl", self.level)
         expected = f"{self.keywords_to['turn']} left"
 
         self.assertEqual(result, expected)
 
     @check_local_lang_bool
     def test_turn_value(self):
-        result = hedy.translate_keywords(f"{self.keywords_from['turn']} 50", "en", "nl", self.level)
+        result = hedy_translation.translate_keywords(f"{self.keywords_from['turn']} 50", "en", "nl", self.level)
         expected = f"{self.keywords_to['turn']} 50"
 
         self.assertEqual(result, expected)
 
     @check_local_lang_bool
     def test_invalid(self):
-        result = hedy.translate_keywords(f"hallo", "en", "nl", self.level)
+        result = hedy_translation.translate_keywords(f"hallo", "en", "nl", self.level)
         expected = f"hallo"
 
         self.assertEqual(result, expected)
@@ -108,14 +109,14 @@ class TestsTranslationLevel1(HedyTester):
     # No translation because of the invalid space error
     @check_local_lang_bool
     def test_invalid_space(self):
-        result = hedy.translate_keywords(f" {self.keywords_from['print']} Hedy", "en", "nl", self.level)
+        result = hedy_translation.translate_keywords(f" {self.keywords_from['print']} Hedy", "en", "nl", self.level)
         expected = f" {self.keywords_from['print']} Hedy"
 
         self.assertEqual(result, expected)
 
     @check_local_lang_bool
     def no_argument_ask(self):
-        result = hedy.translate_keywords(f"{self.keywords_to['ask']}", "en", "nl", self.level)
+        result = hedy_translation.translate_keywords(f"{self.keywords_to['ask']}", "en", "nl", self.level)
         expected = f"{self.keywords_to['ask']}"
 
         self.assertEqual(result, expected)


### PR DESCRIPTION
Added structure for translation of level 1 to Hedy.py, issue #1338 .

Adds a way to translate code from one language to another with a transformer.
Works if the keyword lark file is available for the chosen language and if the "local_keywords_enabled" is set to True.
Adds a "keywords_to_dict" helper function to make a dictionary out of a Lark file.
Does not currently do anything on the Hedy site, only when tests are run.
Adds a test file for the translation of level 1.
Removed one empty line from "keywords-en.lark".

Tests can later be added to the "test_level_01" file, but have but separated initially for ease of use.
Same for the Transformers, which could be put in a new python file.

It is maybe too much for a single pull request bit it seemed better to me if the main functionalities were present with a testing structure

**How to test**

Tests are available in the new test_translation_level_01 file, otherwise the "translate_keywords" function can be run.

