### PR TITLE
Set level to 1 by default when run from command line

### DIFF
--- a/runhedy.py
+++ b/runhedy.py
@@ -26,8 +26,11 @@ def main():
                 try:
                     level = int(args[2])
                     if level > 8:
-                        print("Level has been set to 8, because the value specified was to high")
+                        print("Level has been set to 8, because the value specified was too high")
                         level = 8
+                    elif level <= 0:
+                        print("Level has been set to 1, because the value specified was too low")
+                        level = 1
                 except ValueError:
                     print("Level argument is not an integer, skipping argument.")
 
@@ -41,8 +44,14 @@ def main():
             if len(parts) >= 2:
                 level = int(parts[1])
                 if level > 8:
-                    print("Level has been set to 8, because the value specified was to high")
+                    print("Level has been set to 8, because the value specified was too high")
                     level = 8
+                elif level <= 0:
+                    print("Level has been set to 1, because the value specified was too low")
+                    level = 1
+
+    if level == 0:
+        level = 1 # Set level to 1 if not provided through other means
 
     program = '\n'.join([line
         for line in lines


### PR DESCRIPTION
The purpose of this PR is to fix #1341.

The current code base first tries to read the level from the command line. If no level was provided on the command line, we try to find a `#LEVEL <level>` in the source file. If none of these approaches render a level, the level will be left at `0`. 

This PR ensures that in that situation, the level will be set to `1`.

As part of this work, I also took the liberty of ensuring that you cannot explicitly set a non-positive level.