### PR TITLE
Change ask command to have the grammar as print after level 6 #1351

### DIFF
--- a/grammars/level2-Additions.lark
+++ b/grammars/level2-Additions.lark
@@ -1,6 +1,7 @@
 command: print | ask | turtle | assign | sleep | invalid_space | ask_dep_2 | echo_dep_2 | comment | invalid
 
-print: _PRINT (_SPACE (_SPACE | textwithoutspaces | punctuation)*)?
+print: _PRINT (_SPACE _print_argument)?
+_print_argument: (_SPACE | textwithoutspaces | punctuation)*
 ask: var _SPACE _IS _SPACE _ASK (_SPACE + (_SPACE | text_ask | punctuation)*)?
 
 //level 1 deprecated commands, for now manually added for better errors

--- a/grammars/level3-Additions.lark
+++ b/grammars/level3-Additions.lark
@@ -1,6 +1,6 @@
 command: print | ask | turtle | assign | assign_list | add | remove | sleep | invalid_space | ask_dep_2 | echo_dep_2 | comment | invalid
 
-print: _PRINT (_SPACE (_SPACE| list_access | textwithoutspaces | punctuation)*)?
+_print_argument: (_SPACE | list_access | textwithoutspaces | punctuation)*
 
 assign_list: var _SPACE _IS _SPACE text_list ((_COMMA _SPACE|_COMMA) text_list)+
 text_list: /([^\r\n,]+)/ -> text // list elements may contain punctionationm but not commas or course, these are separators

--- a/grammars/level4-Additions.lark
+++ b/grammars/level4-Additions.lark
@@ -7,7 +7,7 @@ var_access : NAME
 print: _PRINT (_SPACE _print_argument)? -> print
 print_no_quotes: _PRINT _SPACE text -> print_nq
 ask: var _SPACE _IS _SPACE _ASK (_SPACE _print_argument)?
-ask_no_quotes: var _SPACE _IS _SPACE _ASK _SPACE (_SPACE| list_access | textwithoutspaces | punctuation)*  -> print_nq
+ask_no_quotes: var _SPACE _IS _SPACE _ASK _SPACE text  -> print_nq
 
 _print_argument: (_SPACE | list_access | quoted_text | var_access)*
 

--- a/grammars/level6-Additions.lark
+++ b/grammars/level6-Additions.lark
@@ -1,4 +1,4 @@
-print: _PRINT (_SPACE (quoted_text | list_access | var_access | sum) (_SPACE (quoted_text | list_access | var_access | sum))*)?
+_print_argument: (_SPACE | quoted_text | list_access | var_access | sum)*
 assign: var _SPACE _IS _SPACE sum | var _SPACE _IS _SPACE textwithoutspaces
 ?sum: product | sum _SPACE* _ADD _SPACE* product -> addition | sum _SPACE* _SUBTRACT _SPACE* product -> subtraction
 ?product: atom | product _SPACE* _MULTIPLY _SPACE* atom -> multiplication | product _SPACE* _DIVIDE _SPACE* atom -> division

--- a/tests/test_level_04.py
+++ b/tests/test_level_04.py
@@ -92,7 +92,7 @@ class TestsLevel4(HedyTester):
     code = textwrap.dedent("""\
     color is ask 'Cuál es tu color favorito?'""")
     expected = textwrap.dedent("""\
-    color = input('Cuál es tu color favorito?')""")
+    color = input(f'Cuál es tu color favorito?')""")
     self.multi_level_tester(
       max_level=10,
       code=code,
@@ -113,11 +113,11 @@ class TestsLevel4(HedyTester):
   def test_ask_with_list_var(self):
     code = textwrap.dedent("""\
     colors is orange, blue, green
-    favorite is ask 'Is your fav color' colors at random""")
+    favorite is ask 'Is your fav color ' colors at random""")
 
     expected = textwrap.dedent("""\
     colors = ['orange', 'blue', 'green']
-    favorite = input('Is your fav color'+random.choice(colors))""")
+    favorite = input(f'Is your fav color {random.choice(colors)}')""")
 
     self.multi_level_tester(
         max_level=10,
@@ -142,11 +142,11 @@ class TestsLevel4(HedyTester):
   def test_ask_with_string_var(self):
     code = textwrap.dedent("""\
     color is orange
-    favorite is ask 'Is your fav color' color""")
+    favorite is ask 'Is your fav color ' color""")
 
     expected = textwrap.dedent("""\
     color = 'orange'
-    favorite = input('Is your fav color'+color)""")
+    favorite = input(f'Is your fav color {color}')""")
 
     self.multi_level_tester(
         max_level=10,
@@ -162,7 +162,7 @@ class TestsLevel4(HedyTester):
 
     expected = textwrap.dedent("""\
     number = '10'
-    favorite = input('Is your fav number'+number)""")
+    favorite = input(f'Is your fav number{number}')""")
 
     self.multi_level_tester(
         max_level=10,
@@ -224,7 +224,7 @@ class TestsLevel4(HedyTester):
     print colors at random""")
 
     expected = textwrap.dedent("""\
-    color = input('what is your favorite color? ')
+    color = input(f'what is your favorite color? ')
     colors = ['green', 'red', 'blue']
     colors.append(color)
     print(f'{random.choice(colors)}')""")
@@ -244,7 +244,7 @@ class TestsLevel4(HedyTester):
 
     expected = textwrap.dedent("""\
     colors = ['green', 'red', 'blue']
-    color = input('what color to remove?')
+    color = input(f'what color to remove?')
     try:
         colors.remove(color)
     except:
@@ -323,7 +323,7 @@ class TestsLevel4(HedyTester):
     result = hedy.transpile(code, self.level)
 
     expected = textwrap.dedent("""\
-    kleur = input('wat is je lievelingskleur?')
+    kleur = input(f'wat is je lievelingskleur?')
     print(f'jouw lievelingskleur is dus{kleur}!')""")
 
     self.assertEqual(expected, result.code)
@@ -332,14 +332,14 @@ class TestsLevel4(HedyTester):
 
     code = textwrap.dedent("""
     ding is kleur
-    kleur is ask 'Wat is je lievelings' ding
+    kleur is ask 'Wat is je lievelings ' ding
     print 'Jouw favoriet is dus ' kleur""")
 
     result = hedy.transpile(code, self.level)
 
     expected = textwrap.dedent("""\
     ding = 'kleur'
-    kleur = input('Wat is je lievelings'+ding)
+    kleur = input(f'Wat is je lievelings {ding}')
     print(f'Jouw favoriet is dus {kleur}')""")
 
     self.assertEqual(expected, result.code)
@@ -350,7 +350,7 @@ class TestsLevel4(HedyTester):
     afstand is ask 'hoe ver dan?'
     forward afstand""")
     expected = textwrap.dedent("""\
-    afstand = input('hoe ver dan?')
+    afstand = input(f'hoe ver dan?')
     t.forward(afstand)
     time.sleep(0.1)""")
     self.multi_level_tester(

--- a/tests/test_level_05.py
+++ b/tests/test_level_05.py
@@ -114,7 +114,7 @@ class TestsLevel5(HedyTester):
     result = hedy.transpile(code, self.level)
 
     expected = textwrap.dedent("""\
-    kleur = input('wat is je lievelingskleur?')
+    kleur = input(f'wat is je lievelingskleur?')
     print(f'jouw lievelingskleur is dus{kleur}!')""")
 
     self.assertEqual(expected, result.code)
@@ -146,7 +146,7 @@ class TestsLevel5(HedyTester):
     result = hedy.transpile(code, self.level)
 
     expected = textwrap.dedent("""\
-    kleur = input('Wat is je lievelingskleur?')
+    kleur = input(f'Wat is je lievelingskleur?')
     if kleur == 'groen':
       print(f'mooi!')
     else:

--- a/tests/test_level_06.py
+++ b/tests/test_level_06.py
@@ -41,7 +41,7 @@ class TestsLevel6(HedyTester):
     result = hedy.transpile(code, self.level)
 
     expected = textwrap.dedent("""\
-    antwoord = input('wat is je lievelingskleur?')""")
+    antwoord = input(f'wat is je lievelingskleur?')""")
 
     self.assertEqual(expected, result.code)
     self.assertEqual(False, result.has_turtle)

--- a/tests/test_level_08.py
+++ b/tests/test_level_08.py
@@ -134,7 +134,7 @@ class TestsLevel8(HedyTester):
     result = hedy.transpile(code, self.level)
 
     expected = textwrap.dedent("""\
-    antwoord = input('Hoeveel is 10 plus 10?')
+    antwoord = input(f'Hoeveel is 10 plus 10?')
     if str(antwoord) == str('20'):
       print(f'Goedzo!')
       print(f'Het antwoord was inderdaad {antwoord}')

--- a/tests/test_level_09.py
+++ b/tests/test_level_09.py
@@ -74,7 +74,7 @@ class TestsLevel9(HedyTester):
     print(f'kassabon')
     prijs = '0'
     for i in range(int(7)):
-      ingredient = input('wat wil je kopen?')
+      ingredient = input(f'wat wil je kopen?')
       if str(ingredient) == str('appel'):
         prijs = int(prijs) + int(1)
     print(f'Dat is in totaal {prijs} euro.')""")
@@ -130,7 +130,7 @@ class TestsLevel9(HedyTester):
 
     expected = textwrap.dedent("""\
     for i in range(int(3)):
-      food = input('What do you want?')
+      food = input(f'What do you want?')
       if str(food) == str('pizza'):
         print(f'nice!')
       else:

--- a/tests/test_level_11.py
+++ b/tests/test_level_11.py
@@ -30,7 +30,7 @@ class TestsLevel11(HedyTester):
         print 'Het antwoord moest zijn ' antwoord""")
 
     expected = textwrap.dedent("""\
-    antwoord = input('Hoeveel is 10 plus 10?')
+    antwoord = input(f'Hoeveel is 10 plus 10?')
     if str(antwoord) == str('20'):
       print(f'Goedzo!')
       print(f'Het antwoord was inderdaad {antwoord}')
@@ -145,7 +145,7 @@ class TestsLevel11(HedyTester):
     expected = textwrap.dedent("""\
     step = 1 if int(0) < int(10) else -1
     for i in range(int(0), int(10) + step, step):
-      antwoord = input('Wat is 5*5')
+      antwoord = input(f'Wat is 5*5')
       if str(antwoord) == str('24'):
         print(f'Dat is fout!')
       else:
@@ -171,7 +171,7 @@ class TestsLevel11(HedyTester):
     expected = textwrap.dedent("""\
       step = 1 if int(0) < int(10) else -1
       for i in range(int(0), int(10) + step, step):
-        antwoord = input('Wat is 5*5')
+        antwoord = input(f'Wat is 5*5')
         if str(antwoord) == str('24'):
           print(f'fout')
       print(f'klaar met for loop')""")

--- a/tests/test_level_12.py
+++ b/tests/test_level_12.py
@@ -61,7 +61,7 @@ class TestsLevel12(HedyTester):
     sparen is prijs - gespaard
     print 'hallo' sparen""")
     expected = textwrap.dedent("""\
-    prijs = input('hoeveel?')
+    prijs = input(f'hoeveel?')
     try:
       prijs = int(prijs)
     except ValueError:
@@ -88,7 +88,7 @@ class TestsLevel12(HedyTester):
 
     expected = textwrap.dedent("""\
       colors = ['orange', 'blue', 'green']
-      favorite = input('Is your fav color'+colors[1-1])
+      favorite = input(f'Is your fav color{colors[1-1]}')
       try:
         favorite = int(favorite)
       except ValueError:
@@ -112,7 +112,7 @@ class TestsLevel12(HedyTester):
 
     expected = textwrap.dedent("""\
       color = 'orange'
-      favorite = input('Is your fav color'+color)
+      favorite = input(f'Is your fav color{color}')
       try:
         favorite = int(favorite)
       except ValueError:
@@ -137,7 +137,7 @@ class TestsLevel12(HedyTester):
 
     expected = textwrap.dedent(f"""\
       number = {number}
-      favorite = input('Is your fav number'+number)
+      favorite = input(f'Is your fav number{{number}}')
       try:
         favorite = int(favorite)
       except ValueError:
@@ -549,7 +549,7 @@ class TestsLevel12(HedyTester):
         print 'Het antwoord moest zijn ' antwoord""")
 
     expected = textwrap.dedent("""\
-    antwoord = input('Hoeveel is 10 plus 10?')
+    antwoord = input(f'Hoeveel is 10 plus 10?')
     try:
       antwoord = int(antwoord)
     except ValueError:
@@ -579,7 +579,7 @@ class TestsLevel12(HedyTester):
     print colors at random""")
 
     expected = textwrap.dedent("""\
-    color = input('what is your favorite color? ')
+    color = input(f'what is your favorite color? ')
     try:
       color = int(color)
     except ValueError:
@@ -606,7 +606,7 @@ class TestsLevel12(HedyTester):
 
     expected = textwrap.dedent("""\
     colors = ['green', 'red', 'blue']
-    color = input('what color to remove?')
+    color = input(f'what color to remove?')
     try:
       color = int(color)
     except ValueError:

--- a/tests/test_level_13.py
+++ b/tests/test_level_13.py
@@ -13,7 +13,7 @@ class TestsLevel13(HedyTester):
       if naam is 'Felienne' and leeftijd is 37
           print 'hallo jij!'""")
     expected = textwrap.dedent("""\
-      naam = input('hoe heet jij?')
+      naam = input(f'hoe heet jij?')
       try:
         naam = int(naam)
       except ValueError:
@@ -21,7 +21,7 @@ class TestsLevel13(HedyTester):
           naam = float(naam)
         except ValueError:
           pass
-      leeftijd = input('hoe oud ben jij?')
+      leeftijd = input(f'hoe oud ben jij?')
       try:
         leeftijd = int(leeftijd)
       except ValueError:

--- a/tests/test_level_14.py
+++ b/tests/test_level_14.py
@@ -13,7 +13,7 @@ class TestsLevel14(HedyTester):
       if leeftijd {comparison} 12
           print 'Dan ben je jonger dan ik!'""")
     expected = textwrap.dedent(f"""\
-      leeftijd = input('Hoe oud ben jij?')
+      leeftijd = input(f'Hoe oud ben jij?')
       try:
         leeftijd = int(leeftijd)
       except ValueError:
@@ -41,7 +41,7 @@ class TestsLevel14(HedyTester):
       else
           print 'Dan ben je ouder dan ik!'""")
     expected = textwrap.dedent(f"""\
-      leeftijd = input('Hoe oud ben jij?')
+      leeftijd = input(f'Hoe oud ben jij?')
       try:
         leeftijd = int(leeftijd)
       except ValueError:
@@ -69,7 +69,7 @@ class TestsLevel14(HedyTester):
     if leeftijd{comparison}12
       print 'Dan ben je jonger dan ik!'""")
     expected = textwrap.dedent(f"""\
-    leeftijd = input('Hoe oud ben jij?')
+    leeftijd = input(f'Hoe oud ben jij?')
     try:
       leeftijd = int(leeftijd)
     except ValueError:

--- a/tests/test_level_15.py
+++ b/tests/test_level_15.py
@@ -14,7 +14,7 @@ class TestsLevel15(HedyTester):
     expected = textwrap.dedent("""\
     antwoord = 0
     while str(antwoord).zfill(100)!=str(25).zfill(100):
-      antwoord = input(\'Wat is 5 keer 5?\')
+      antwoord = input(f'Wat is 5 keer 5?')
       try:
         antwoord = int(antwoord)
       except ValueError:
@@ -41,7 +41,7 @@ class TestsLevel15(HedyTester):
     expected = textwrap.dedent("""\
     getal = 0
     while str(getal).zfill(100)<str(100000).zfill(100):
-      getal = input('HOGER!!!!!')
+      getal = input(f'HOGER!!!!!')
       try:
         getal = int(getal)
       except ValueError:

--- a/tests/test_level_16.py
+++ b/tests/test_level_16.py
@@ -105,7 +105,7 @@ class TestsLevel16(HedyTester):
 
         expected = textwrap.dedent("""\
         colors = ['orange', 'blue', 'green']
-        favorite = input('Is your fav color'+colors[1-1])
+        favorite = input(f'Is your fav color{colors[1-1]}')
         try:
           favorite = int(favorite)
         except ValueError:
@@ -129,7 +129,7 @@ class TestsLevel16(HedyTester):
 
         expected = textwrap.dedent("""\
         colors = ['orange', 'blue', 'green']
-        favorite = input('Is your fav color'+colors)
+        favorite = input(f'Is your fav color{colors}')
         try:
           favorite = int(favorite)
         except ValueError:
@@ -154,7 +154,7 @@ class TestsLevel16(HedyTester):
         print colors[random]""")
 
         expected = textwrap.dedent("""\
-        color = input('what is your favorite color? ')
+        color = input(f'what is your favorite color? ')
         try:
           color = int(color)
         except ValueError:
@@ -182,7 +182,7 @@ class TestsLevel16(HedyTester):
 
         expected = textwrap.dedent("""\
         colors = ['green', 'red', 'blue']
-        color = input('what color to remove?')
+        color = input(f'what color to remove?')
         try:
           color = int(color)
         except ValueError:

--- a/tests/test_level_17.py
+++ b/tests/test_level_17.py
@@ -31,7 +31,7 @@ class TestsLevel17(HedyTester):
         print 'Het antwoord moest zijn ' antwoord""")
 
     expected = textwrap.dedent("""\
-    antwoord = input('Hoeveel is 10 plus 10?')
+    antwoord = input(f'Hoeveel is 10 plus 10?')
     try:
       antwoord = int(antwoord)
     except ValueError:
@@ -166,7 +166,7 @@ class TestsLevel17(HedyTester):
     expected = textwrap.dedent("""\
     step = 1 if int(0) < int(10) else -1
     for i in range(int(0), int(10) + step, step):
-      antwoord = input('Wat is 5*5')
+      antwoord = input(f'Wat is 5*5')
       try:
         antwoord = int(antwoord)
       except ValueError:
@@ -269,7 +269,7 @@ class TestsLevel17(HedyTester):
       if leeftijd {comparison} 12:
           print 'Dan ben je jonger dan ik!'""")
     expected = textwrap.dedent(f"""\
-      leeftijd = input('Hoe oud ben jij?')
+      leeftijd = input(f'Hoe oud ben jij?')
       try:
         leeftijd = int(leeftijd)
       except ValueError:

--- a/tests/test_level_18.py
+++ b/tests/test_level_18.py
@@ -40,7 +40,7 @@ class TestsLevel18(HedyTester):
         leeftijd is input('Hoe oud ben jij?')
         print(leeftijd)""")
         expected = textwrap.dedent("""\
-        leeftijd = input('Hoe oud ben jij?')
+        leeftijd = input(f'Hoe oud ben jij?')
         try:
           leeftijd = int(leeftijd)
         except ValueError:
@@ -108,7 +108,7 @@ class TestsLevel18(HedyTester):
           print('Het antwoord moest zijn', antwoord)""")
 
       expected = textwrap.dedent("""\
-      antwoord = input('Hoeveel is 10 plus 10?')
+      antwoord = input(f'Hoeveel is 10 plus 10?')
       try:
         antwoord = int(antwoord)
       except ValueError:
@@ -179,7 +179,7 @@ class TestsLevel18(HedyTester):
 
       expected = textwrap.dedent("""\
       color = ['green', 'blue']
-      choice = input('Is your favorite color one of: '+color)
+      choice = input(f'Is your favorite color one of: {color}')
       try:
         choice = int(choice)
       except ValueError:


### PR DESCRIPTION
Provide a general summary of your changes in the Title of the PR

**Description**

- Change ask command to have the grammar as print after level 6
- Refactor ask command to use f-strings in transpiler
- Fix python concatenation error of ask argument at level 12

**Fix for**

#1351

**How to test**

- Review the changes in the grammar
- At level 12, the following snippet should not cause python error:
```
a is 10
answer is ask 'is your number ' a
```

**Checklist**

If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [ ] Links to an existing issue or discussion (if not, create an issue first)
- [ ] Describes changes clear in the format above (present tense, no subject)
- [ ] Has a "how to test" section
- [ ] Only one thing is done in this pull request (specifically please try to refrain from mixing textual changes to the yamls from code changes)

