### PR TITLE
Localizing translate characters

### DIFF
--- a/hedy.py
+++ b/hedy.py
@@ -12,6 +12,7 @@ import hashlib
 import re
 from dataclasses import dataclass, field
 import exceptions
+import hedy_translation
 
 import yaml
 import program_repair
@@ -1658,40 +1659,42 @@ def transpile(input_string, level, lang="en"):
     transpile_result = transpile_inner(input_string, level, lang)
     return transpile_result
 
-def translate_characters(s):
+def translate_characters(s, lang):
 # this method is used to make it more clear to kids what is meant in error messages
 # for example ' ' is hard to read, space is easier
 # this could (should?) be localized so we can call a ' "Hoge komma" for example (Felienne, dd Feb 25, 2021)
     if s == ' ':
-        return 'space'
+        word = 'space'
     elif s == ',':
-        return 'comma'
+        word = 'comma'
     elif s == '?':
-        return 'question mark'
+        word = 'question mark'
     elif s == '\n':
-        return 'newline'
+        word = 'newline'
     elif s == '.':
-        return 'period'
+        word = 'period'
     elif s == '!':
-        return 'exclamation mark'
+        word = 'exclamation mark'
     elif s == '*':
-        return 'star'
+        word = 'star'
     elif s == "'":
-        return 'single quotes'
+        word = 'single quotes'
     elif s == '"':
-        return 'double quotes'
+        word = 'double quotes'
     elif s == '/':
-        return 'slash'
+        word = 'slash'
     elif s == '-':
-        return 'dash'
+        word = 'dash'
     elif s >= 'a' and s <= 'z' or s >= 'A' and s <= 'Z':
         return s
-    else:
-        return s
+    try:
+        return hedy_translation.translate_character_localized(word, lang)
+    except Exception:
+        return s 
 
 
-def beautify_parse_error(character_found):
-    character_found = translate_characters(character_found)
+def beautify_parse_error(character_found, lang):
+    character_found = translate_characters(character_found, lang)
     return character_found
 
 def find_indent_length(line):
@@ -1826,7 +1829,7 @@ def parse_input(input_string, level, lang):
         try:
             location = e.line, e.column
             characters_expected = str(e.allowed) #not yet in use, could be used in the future (when our parser rules are better organize, now it says ANON*__12 etc way too often!)
-            character_found = beautify_parse_error(e.char)
+            character_found = beautify_parse_error(e.char, lang)
             # print(e.args[0])
             # print(location, character_found, characters_expected)
             raise exceptions.ParseException(level=level, location=location, found=character_found) from e

--- a/hedy.py
+++ b/hedy.py
@@ -1663,32 +1663,8 @@ def translate_characters(s, lang):
 # this method is used to make it more clear to kids what is meant in error messages
 # for example ' ' is hard to read, space is easier
 # this could (should?) be localized so we can call a ' "Hoge komma" for example (Felienne, dd Feb 25, 2021)
-    if s == ' ':
-        word = 'space'
-    elif s == ',':
-        word = 'comma'
-    elif s == '?':
-        word = 'question mark'
-    elif s == '\n':
-        word = 'newline'
-    elif s == '.':
-        word = 'period'
-    elif s == '!':
-        word = 'exclamation mark'
-    elif s == '*':
-        word = 'star'
-    elif s == "'":
-        word = 'single quotes'
-    elif s == '"':
-        word = 'double quotes'
-    elif s == '/':
-        word = 'slash'
-    elif s == '-':
-        word = 'dash'
-    elif s >= 'a' and s <= 'z' or s >= 'A' and s <= 'Z':
-        return s
     try:
-        return hedy_translation.translate_character_localized(word, lang)
+        return hedy_translation.translate_character_localized(s, lang)
     except Exception:
         return s 
 

--- a/hedy_translation.py
+++ b/hedy_translation.py
@@ -18,14 +18,18 @@ def translate_character_localized(character, lang):
     """Returns a word for a given character, which can be used for error messages. 
        The word depends on the given language. 
     """
-    path_characters = "../coursedata/texts"
+    dict_character_word = {' ': 'space', ',': 'comma', '?': 'question mark',
+                           '\n': 'newline', '.': 'period', '!': 'exclamation mark',
+                           '*': 'star', "'": 'single quotes', '"': 'double quotes', 
+                           '/': 'slash', '-': 'dash'}
+    path_characters = "./coursedata/texts"
     
     if hedy.local_keywords_enabled:
         try:
-            return get_character(character, path_characters, lang)
+            return get_character(dict_character_word[character], path_characters, lang)
         except Exception:
             pass        
-    return get_character(character, path_characters, "en")
+    return get_character(dict_character_word[character], path_characters, "en")
 
 def keywords_to_dict(to_lang="nl"):
     """"Return a dictionary of keywords from language of choice. Key is english value is lang of choice"""

--- a/hedy_translation.py
+++ b/hedy_translation.py
@@ -18,7 +18,7 @@ def translate_character_localized(character, lang):
     """Returns a word for a given character, which can be used for error messages. 
        The word depends on the given language. 
     """
-    path_characters = "./coursedata/texts"
+    path_characters = "../coursedata/texts"
     
     if hedy.local_keywords_enabled:
         try:

--- a/hedy_translation.py
+++ b/hedy_translation.py
@@ -22,7 +22,7 @@ def translate_character_localized(character, lang):
                            '\n': 'newline', '.': 'period', '!': 'exclamation mark',
                            '*': 'star', "'": 'single quotes', '"': 'double quotes', 
                            '/': 'slash', '-': 'dash'}
-    path_characters = "./coursedata/texts"
+    path_characters = "../coursedata/texts"
     
     if hedy.local_keywords_enabled:
         try:

--- a/hedy_translation.py
+++ b/hedy_translation.py
@@ -1,9 +1,31 @@
 from lark import Transformer, Tree
 import hedy
+import os 
+import yaml 
 
 
 TRANSPILER_LOOKUP = {}
 
+def get_character(character, path_characters, lang):
+    yaml_filesname_with_path = os.path.join(path_characters, lang + '.yaml')
+            
+    with open(yaml_filesname_with_path, 'r') as stream:
+        yaml_dict = yaml.safe_load(stream)
+            
+    return yaml_dict['HedyErrorMessages'][character]
+    
+def translate_character_localized(character, lang):
+    """Returns a word for a given character, which can be used for error messages. 
+       The word depends on the given language. 
+    """
+    path_characters = "./coursedata/texts"
+    
+    if hedy.local_keywords_enabled:
+        try:
+            return get_character(character, path_characters, lang)
+        except Exception:
+            pass        
+    return get_character(character, path_characters, "en")
 
 def keywords_to_dict(to_lang="nl"):
     """"Return a dictionary of keywords from language of choice. Key is english value is lang of choice"""

--- a/tests/test_translation_level_01.py
+++ b/tests/test_translation_level_01.py
@@ -26,6 +26,15 @@ class TestsTranslationLevel1(HedyTester):
     keywords_to = hedy_translation.keywords_to_dict('nl')
 
     @check_local_lang_bool
+    def test_character_translation_dutch(self):
+        word = 'period'
+        
+        result = hedy_translation.translate_character_localized(word, 'nl')
+        expected = 'een punt'
+        
+        self.assertEqual(result, expected)
+
+    @check_local_lang_bool
     def test_print_english_dutch(self):
         code = 'print Hallo welkom bij Hedy!'
 

--- a/tests/test_translation_level_01.py
+++ b/tests/test_translation_level_01.py
@@ -27,7 +27,7 @@ class TestsTranslationLevel1(HedyTester):
 
     @check_local_lang_bool
     def test_character_translation_dutch(self):
-        word = 'period'
+        word = '.'
         
         result = hedy_translation.translate_character_localized(word, 'nl')
         expected = 'een punt'


### PR DESCRIPTION
**Description**
With this PR the function 'translate_characters' is localized, which means that instead of the following error message: 
<img width="208" alt="translate_characters" src="https://user-images.githubusercontent.com/36051227/143601144-a06d835d-7f86-4d6f-bc07-9d33d0cb35d7.PNG">

The programmer will recieve this error message: 
<img width="207" alt="translate_characters2" src="https://user-images.githubusercontent.com/36051227/143601145-4c8cbe2f-ff70-4ec4-9c56-1b047951dd9d.PNG">

Fixes issue #1302 
