### PR TITLE
[UI] Show submitted program status on program-view page

### DIFF
--- a/app.py
+++ b/app.py
@@ -554,20 +554,24 @@ def programs_page(request):
     programs =[]
     now = timems()
     for item in result:
-        program_age = now - item['date']
-        if program_age < 1000 * 60 * 60:
-            measure = texts['minutes']
-            date = round(program_age /(1000 * 60))
-        elif program_age < 1000 * 60 * 60 * 24:
-            measure = texts['hours']
-            date = round(program_age /(1000 * 60 * 60))
-        else:
-            measure = texts['days']
-            date = round(program_age /(1000 * 60 * 60 * 24))
-
+        date, measure = get_user_formatted_timestamp(texts, now, item['date'])
         programs.append({'id': item['id'], 'code': item['code'], 'date': texts['ago-1'] + ' ' + str(date) + ' ' + measure + ' ' + texts['ago-2'], 'level': item['level'], 'name': item['name'], 'adventure_name': item.get('adventure_name'), 'submitted': item.get('submitted'), 'public': item.get('public')})
 
     return render_template('programs.html', texts=texts, ui=ui, auth=TRANSLATIONS.get_translations(g.lang, 'Auth'), programs=programs, current_page='programs', from_user=from_user, adventures=adventures)
+
+
+def get_user_formatted_timestamp(texts, now, date):
+    program_age = now - date
+    if program_age < 1000 * 60 * 60:
+        measure = texts['minutes']
+        date = round(program_age /(1000 * 60))
+    elif program_age < 1000 * 60 * 60 * 24:
+        measure = texts['hours']
+        date = round(program_age /(1000 * 60 * 60))
+    else:
+        measure = texts['days']
+        date = round(program_age /(1000 * 60 * 60 * 24))
+    return date, measure
 
 @app.route('/quiz/start/<int:level>', methods=['GET'])
 def get_quiz_start(level):
@@ -857,20 +861,11 @@ def view_program(id):
     arguments_dict['loaded_program'] = result
     arguments_dict['editor_readonly'] = True
 
-    if ("submitted" in result and result['submitted']):
+    if "submitted" in result and result['submitted']:
         arguments_dict['show_edit_button'] = False
         texts = TRANSLATIONS.get_translations(g.lang, 'Programs')
         now = timems()
-        program_age = now - result['date']
-        if program_age < 1000 * 60 * 60:
-            measure = texts['minutes']
-            date = round(program_age / (1000 * 60))
-        elif program_age < 1000 * 60 * 60 * 24:
-            measure = texts['hours']
-            date = round(program_age / (1000 * 60 * 60))
-        else:
-            measure = texts['days']
-            date = round(program_age / (1000 * 60 * 60 * 24))
+        date, measure = get_user_formatted_timestamp(texts, now, result['date'])
         arguments_dict['submitted_header'] = texts['submitted_header']
         arguments_dict['last_edited'] = texts['last_edited']
         arguments_dict['program_timestamp'] = texts['ago-1'] + ' ' + str(date) + ' ' + measure + ' ' + texts['ago-2']

--- a/app.py
+++ b/app.py
@@ -865,10 +865,9 @@ def view_program(id):
         arguments_dict['show_edit_button'] = False
         texts = TRANSLATIONS.get_translations(g.lang, 'Programs')
         now = timems()
-        date, measure = get_user_formatted_timestamp(texts, now, result['date'])
         arguments_dict['submitted_header'] = texts['submitted_header']
         arguments_dict['last_edited'] = texts['last_edited']
-        arguments_dict['program_timestamp'] = texts['ago-1'] + ' ' + str(date) + ' ' + measure + ' ' + texts['ago-2']
+        arguments_dict['program_timestamp'] = datetime.datetime.fromtimestamp(result['date']/1000.0).strftime('%d-%m-%Y, %H:%M:%S')
     else:
         arguments_dict['show_edit_button'] = True
 

--- a/app.py
+++ b/app.py
@@ -859,6 +859,21 @@ def view_program(id):
 
     if ("submitted" in result and result['submitted']):
         arguments_dict['show_edit_button'] = False
+        texts = TRANSLATIONS.get_translations(g.lang, 'Programs')
+        now = timems()
+        program_age = now - result['date']
+        if program_age < 1000 * 60 * 60:
+            measure = texts['minutes']
+            date = round(program_age / (1000 * 60))
+        elif program_age < 1000 * 60 * 60 * 24:
+            measure = texts['hours']
+            date = round(program_age / (1000 * 60 * 60))
+        else:
+            measure = texts['days']
+            date = round(program_age / (1000 * 60 * 60 * 24))
+        arguments_dict['submitted_header'] = texts['submitted_header']
+        arguments_dict['last_edited'] = texts['last_edited']
+        arguments_dict['program_timestamp'] = texts['ago-1'] + ' ' + str(date) + ' ' + measure + ' ' + texts['ago-2']
     else:
         arguments_dict['show_edit_button'] = True
 
@@ -949,7 +964,6 @@ def main_page(page):
             return utils.page_403 (TRANSLATIONS, current_user()['username'], g.lang, TRANSLATIONS.get_translations (g.lang, 'ui').get ('not_teacher'))
 
     return render_template('main-page.html', mkd=markdown, auth=TRANSLATIONS.get_translations(g.lang, 'Auth'), **front_matter)
-
 
 def session_id():
     """Returns or sets the current session ID."""

--- a/coursedata/texts/en.yaml
+++ b/coursedata/texts/en.yaml
@@ -248,6 +248,7 @@ Programs:
     level: "Level"
     title: "Title"
     created: "When created"
+    last_edited: "Last edited"
     minutes: "minutes"
     hours: "hours"
     days: "days"

--- a/coursedata/texts/nl.yaml
+++ b/coursedata/texts/nl.yaml
@@ -248,6 +248,7 @@ Programs:
     level: "Level"
     title: "Titel"
     created: "Wanneer gemaakt"
+    last_edited: "Laatst bewerkt"
     minutes: "minuten"
     hours: "uur"
     days: "dagen"

--- a/templates/programs.html
+++ b/templates/programs.html
@@ -16,7 +16,7 @@
             <tr class="text-left">
                 <th class="w-1/4 text-blue-600">{{ texts.title }}</th>
                 <th class="w-1/4 text-blue-600">{{ texts.level }}</th>
-                <th class="w-1/4 text-blue-600">{{ texts.created }}</th>
+                <th class="w-1/4 text-blue-600">{{ texts.last_edited }}</th>
             </tr>
         </thead>
         <tbody>

--- a/templates/view-program-page.html
+++ b/templates/view-program-page.html
@@ -5,7 +5,7 @@
   {% if loaded_program.submitted %}
       <div class="text-center">
         <h2>{{submitted_header}}</h2>
-        <h3>{{last_edited}}: {{ program_timestamp }}</h3>
+        <h3>{{last_edited}}: {{program_timestamp}}</h3>
       </div>
   {% endif %}
   <h1>{{loaded_program.name}}</h1>

--- a/templates/view-program-page.html
+++ b/templates/view-program-page.html
@@ -1,7 +1,13 @@
 {% extends "layout.html" %}
 {% block body %}
 <div style="height: 30px;"></div>
-<div tabindex="0" class="flex-grow p-8">
+<div tabindex="0" class="flex-grow px-8">
+  {% if loaded_program.submitted %}
+      <div class="text-center">
+        <h2>{{submitted_header}}</h2>
+        <h3>{{last_edited}}: {{ program_timestamp }}</h3>
+      </div>
+  {% endif %}
   <h1>{{loaded_program.name}}</h1>
   <div>{{by}} <strong>{{loaded_program.username}}</strong></div>
   {% include "incl-editor-and-output.html" %}


### PR DESCRIPTION
**Description**
Currently students are able to submit programs and through that process "freezing" the program. However, when sharing the program the program-view page was identical for submitted and non-submitted programs. Giving the teacher no information if the shared program was indeed submitted by the student and therefore not altered later on. In this PR we return additional information on the program-view page if the program is submitted. Returning an additional header with the notification of looking at a submitted program as well as the last-edited timestamp.

**Fix for**
No specific issue, just a forgotten feature of #1374 

**How to test**
View a submitted and a non-submitted program through a shared link and notice the UI difference.

**Checklist**

If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [ ] Links to an existing issue or discussion (if not, create an issue first)
- [ ] Describes changes clear in the format above (present tense, no subject)
- [ ] Has a "how to test" section
- [ ] Only one thing is done in this pull request (specifically please try to refrain from mixing textual changes to the yamls from code changes)

