### PR TITLE
More information to InvalidInfo

### DIFF
--- a/hedy.py
+++ b/hedy.py
@@ -639,6 +639,8 @@ def are_all_arguments_true(args):
 # this class contains code shared between IsValid and IsComplete, which are quite similar
 # because both filter out some types of 'wrong' nodes
 # TODO: this could also use a default lark rule like AllAssignmentCommands does now
+
+# TODO: maybe this could use meta (with v_args) instead of both inheritors?
 class Filter(Transformer):
     def __default__(self, args, children, meta):
         return are_all_arguments_true(children)

--- a/program_repair.py
+++ b/program_repair.py
@@ -1,38 +1,23 @@
-def calc_index(input_string, line, column):
-    """"returns the index of char at (line, column) from input_string"""
-    # calc_index('print \'hello\'\nprint ,', 2, 7)
-    #                                    ^
-    # will return index 20 such that input_string[20] points to the same char at line 2 column 7
-    # lark starts counting line and column from 1
-    current_line = 1
-    current_index = column - 1
+def insert(input_string, line, column, new_string):
+    """"insert new_string at (line, column)"""
+    rows = input_string.splitlines()
+    rows[line] = rows[line][:column + 1] + new_string + rows[line][column + 1:]
 
-    for char in input_string:
-        if current_line == line:
-            break
-            
-        if char == '\n':
-            current_line += 1
-
-        current_index += 1
-
-    return current_index
+    return '\n'.join(rows)
 
 
-def insert(input_string, index, new_string):
-    """"insert new_string at input_string[index]"""
-    return input_string[:index + 1] + new_string + input_string[index + 1:]
+def delete(input_string, line, column, length):
+    """"delete length chars starting at (line, column)"""
+    rows = input_string.splitlines()
+    rows[line] = rows[line][:column] + rows[line][column + length:]
+
+    return '\n'.join(rows)
 
 
-def delete(input_string, index, length):
-    """"delete length chars from input_string[index]"""
-    return input_string[:index + 1] + input_string[index + 1 + length:]
-
-
-def replace(input_string, index, length, new_string):
-    """"replace at input_string[index] length chars with new_string"""
-    result = delete(input_string, index, length)
-    result = insert(result, index, new_string)
+def replace(input_string, line, column, length, new_string):
+    """"replace at (line, column) length chars with new_string"""
+    result = delete(input_string, line, column, length)
+    result = insert(result, line, column, new_string)
 
     return result
 

--- a/tests/test_level_04.py
+++ b/tests/test_level_04.py
@@ -364,7 +364,7 @@ class TestsLevel4(HedyTester):
     # self.assertEqual('name', context.exception.arguments['name'])
 
   def test_issue_375(self):
-    code = textwrap.dedent("""
+    code = textwrap.dedent("""\
       is Foobar
       print welcome""")
 


### PR DESCRIPTION
**Description**
Adds line and column to the dataclass `InvalidInfo` for invalid nodes. They are not being used yet in this PR, but they will be crucial for [program_repair.py](https://github.com/Felienne/hedy/blob/main/program_repair.py).
Also removes the unnecessary conversion from (line, column) to an index in [program_repair.py](https://github.com/Felienne/hedy/blob/main/program_repair.py) (from #1339).

**Fix for**
Progress for #1225.

**How to test**
`invalid_info` in `is_program_valid` has attributes `line` and `column`, you can view it in debug mode or print it to the terminal (Lark starts counting at 1).

