### PR TITLE
Translation levels 6 and 7

### DIFF
--- a/hedy_translation.py
+++ b/hedy_translation.py
@@ -34,14 +34,6 @@ def translate_keywords(input_string, from_lang="en", to_lang="nl", level=1):
     return abstract_syntaxtree
 
 
-def indent(s):
-    newIndent = ""
-    for line in s:
-        lines = line.split('\n')
-        newIndent += ''.join(['\n    ' + l for l in lines])
-    return newIndent
-
-
 def hedy_translator(level):
     def decorating(c):
         TRANSPILER_LOOKUP[level] = c
@@ -222,35 +214,4 @@ class ConvertToLang6(ConvertToLang5):
 class ConvertToLang7(ConvertToLang6):
     def repeat(self, args):
         return self.keywords["repeat"] + " " + args[0] + " " + self.keywords["times"] + " " + args[1]
-
-
-@hedy_translator(level=8)
-class ConvertToLang8(ConvertToLang7):
-    def repeat(self, args):
-        return self.keywords["repeat"] + " " + args[0] + " " + self.keywords["times"] + indent(args[1:])
-
-    def ifs(self, args):
-        return self.keywords["if"] + " " + args[0] + indent(args[1:])
-
-    def elses(self, args):
-        return self.keywords["else"] + indent(args[0:])
-
-    def end_block(self, args):
-        return args
-
-
-@hedy_translator(level=9)
-class ConvertToLang9(ConvertToLang8):
-    def command(self, args):
-        return '\n'.join([str(c) for c in args])
-
-
-@hedy_translator(level=10)
-class ConvertToLang10(ConvertToLang9):
-    def repeat_list(self, args):
-        return self.keywords["for"] + " " + args[0] + " " + self.keywords["in"] + " " + args[1] + indent(args[2:])
-
-
-code = " print hoi hallo"
-result = translate_keywords(code, from_lang="en", to_lang="nl", level=1)
 

--- a/hedy_translation.py
+++ b/hedy_translation.py
@@ -23,10 +23,11 @@ def translate_keywords(input_string, from_lang="en", to_lang="nl", level=1):
 
     punctuation_symbols = ['!', '?', '.']
 
-    input_string = hedy.preprocess_blocks(input_string, level)
+    if level > 7:
+        input_string = hedy.preprocess_blocks(input_string, level)
     keywordDict = keywords_to_dict(to_lang)
     program_root = parser.parse(input_string + '\n').children[0]
-    abstract_syntaxtree = hedy.ExtractAST().transform(program_root)
+    hedy.ExtractAST().transform(program_root)
     translator = TRANSPILER_LOOKUP[level]
     abstract_syntaxtree = translator(keywordDict, punctuation_symbols).transform(program_root)
 
@@ -250,8 +251,6 @@ class ConvertToLang10(ConvertToLang9):
         return self.keywords["for"] + " " + args[0] + " " + self.keywords["in"] + " " + args[1] + indent(args[2:])
 
 
-code = "animals is cat, dog\n" \
-       "for animal in animals\n" \
-       "   print animal"
-result = translate_keywords(code, from_lang="en", to_lang="nl", level=10)
+code = " print hoi hallo"
+result = translate_keywords(code, from_lang="en", to_lang="nl", level=1)
 

--- a/hedy_translation.py
+++ b/hedy_translation.py
@@ -1,7 +1,7 @@
 from lark import Transformer, Tree
 import hedy
-import yaml 
-import os 
+import yaml
+import os
 
 TRANSPILER_LOOKUP = {}
 
@@ -10,11 +10,12 @@ def keywords_to_dict(to_lang="nl"):
     """"Return a dictionary of keywords from language of choice. Key is english value is lang of choice"""
     keywords_path = './coursedata/keywords/'
     yaml_filesname_with_path = os.path.join(keywords_path, to_lang + '.yaml')
-    
+
     with open(yaml_filesname_with_path, 'r') as stream:
-      command_combinations = yaml.safe_load(stream)
+        command_combinations = yaml.safe_load(stream)
 
     return command_combinations
+
 
 def translate_keywords(input_string, from_lang="en", to_lang="nl", level=1):
     """"Return code with keywords translated to language of choice in level of choice"""
@@ -22,6 +23,7 @@ def translate_keywords(input_string, from_lang="en", to_lang="nl", level=1):
 
     punctuation_symbols = ['!', '?', '.']
 
+    input_string = hedy.preprocess_blocks(input_string, level)
     keywordDict = keywords_to_dict(to_lang)
     program_root = parser.parse(input_string + '\n').children[0]
     abstract_syntaxtree = hedy.ExtractAST().transform(program_root)
@@ -29,6 +31,14 @@ def translate_keywords(input_string, from_lang="en", to_lang="nl", level=1):
     abstract_syntaxtree = translator(keywordDict, punctuation_symbols).transform(program_root)
 
     return abstract_syntaxtree
+
+
+def indent(s):
+    newIndent = ""
+    for line in s:
+        lines = line.split('\n')
+        newIndent += ''.join(['\n    ' + l for l in lines])
+    return newIndent
 
 
 def hedy_translator(level):
@@ -49,7 +59,7 @@ class ConvertToLang1(Transformer):
         __class__.level = 1
 
     def command(self, args):
-        return args[0]
+        return ''.join([str(c) for c in args])
 
     def program(self, args):
         return '\n'.join([str(c) for c in args])
@@ -127,7 +137,8 @@ class ConvertToLang2(ConvertToLang1):
         var = args[0]
         all_parameters = [hedy.process_characters_needing_escape(a) for a in args]
 
-        return all_parameters[0] + " " + self.keywords["is"] + " " + self.keywords["ask"] + " " + ''.join(all_parameters[1:])
+        return all_parameters[0] + " " + self.keywords["is"] + " " + self.keywords["ask"] + " " + ''.join(
+            all_parameters[1:])
 
     def ask_dep_2(self, args):
         return self.keywords["ask"] + " " + ''.join([str(c) for c in args])
@@ -155,7 +166,7 @@ class ConvertToLang3(ConvertToLang2):
 
 @hedy_translator(level=4)
 class ConvertToLang4(ConvertToLang3):
-    
+
     def print(self, args):
         i = 0
         #    self.check_args_type_allowed(args, 'print', self.level)
@@ -189,3 +200,58 @@ class ConvertToLang5(ConvertToLang4):
 
     def in_list_check(self, args):
         return args[0] + " " + self.keywords["in"] + " " + ''.join([str(c) for c in args[1:]]) + " "
+
+
+@hedy_translator(level=6)
+class ConvertToLang6(ConvertToLang5):
+    def addition(self, args):
+        return args[0] + " + " + args[1]
+
+    def substraction(self, args):
+        return args[0] + " - " + args[1]
+
+    def multiplication(self, args):
+        return args[0] + " * " + args[1]
+
+    def division(self, args):
+        return args[0] + " / " + args[1]
+
+
+@hedy_translator(level=7)
+class ConvertToLang7(ConvertToLang6):
+    def repeat(self, args):
+        return self.keywords["repeat"] + " " + args[0] + " " + self.keywords["times"] + " " + args[1]
+
+
+@hedy_translator(level=8)
+class ConvertToLang8(ConvertToLang7):
+    def repeat(self, args):
+        return self.keywords["repeat"] + " " + args[0] + " " + self.keywords["times"] + indent(args[1:])
+
+    def ifs(self, args):
+        return self.keywords["if"] + " " + args[0] + indent(args[1:])
+
+    def elses(self, args):
+        return self.keywords["else"] + indent(args[0:])
+
+    def end_block(self, args):
+        return args
+
+
+@hedy_translator(level=9)
+class ConvertToLang9(ConvertToLang8):
+    def command(self, args):
+        return '\n'.join([str(c) for c in args])
+
+
+@hedy_translator(level=10)
+class ConvertToLang10(ConvertToLang9):
+    def repeat_list(self, args):
+        return self.keywords["for"] + " " + args[0] + " " + self.keywords["in"] + " " + args[1] + indent(args[2:])
+
+
+code = "animals is cat, dog\n" \
+       "for animal in animals\n" \
+       "   print animal"
+result = translate_keywords(code, from_lang="en", to_lang="nl", level=10)
+

--- a/tests/test_translation_level_06.py
+++ b/tests/test_translation_level_06.py
@@ -1,0 +1,52 @@
+import hedy
+from test_level_01 import HedyTester
+import hedy_translation
+from test_translating import check_local_lang_bool
+
+# tests should be ordered as follows:
+# * Translation from English to Dutch
+# * Translation from Dutch to English
+# * Translation to several languages
+# * Error handling
+
+
+class TestsTranslationLevel6(HedyTester):
+    level = 6
+    keywords_from = hedy_translation.keywords_to_dict('en')
+    keywords_to = hedy_translation.keywords_to_dict('nl')
+
+    @check_local_lang_bool
+    def test_multiplication(self):
+        code = "vermenigvuldiging is 3 * 8"
+
+        result = hedy_translation.translate_keywords(code, from_lang="en", to_lang="nl", level=self.level)
+        expected = "vermenigvuldiging is 3 * 8"
+
+        self.assertEqual(result, expected)
+
+    @check_local_lang_bool
+    def test_addition(self):
+        code = "print 'Hallo welkom bij Hedy' 5 + 7"
+
+        result = hedy_translation.translate_keywords(code, from_lang="en", to_lang="nl", level=self.level)
+        expected = "print 'Hallo welkom bij Hedy' 5 + 7"
+
+        self.assertEqual(result, expected)
+
+    @check_local_lang_bool
+    def test_division_dutch_english(self):
+        code = "angle is 360 / angles"
+
+        result = hedy_translation.translate_keywords(code, from_lang="nl", to_lang="en", level=self.level)
+        expected = "angle is 360 / angles"
+
+        self.assertEqual(result, expected)
+
+    @check_local_lang_bool
+    def test_translate_back(self):
+        code ="print 13 / 4"
+
+        result = hedy_translation.translate_keywords(code, from_lang="en", to_lang="nl", level=self.level)
+        result = hedy_translation.translate_keywords(result, from_lang="nl", to_lang="en", level=self.level)
+
+        self.assertEqual(code, result)

--- a/tests/test_translation_level_06.py
+++ b/tests/test_translation_level_06.py
@@ -44,7 +44,7 @@ class TestsTranslationLevel6(HedyTester):
 
     @check_local_lang_bool
     def test_translate_back(self):
-        code ="print 13 / 4"
+        code ="breuk is 13 / 4"
 
         result = hedy_translation.translate_keywords(code, from_lang="en", to_lang="nl", level=self.level)
         result = hedy_translation.translate_keywords(result, from_lang="nl", to_lang="en", level=self.level)

--- a/tests/test_translation_level_07.py
+++ b/tests/test_translation_level_07.py
@@ -1,0 +1,62 @@
+import hedy
+from test_level_01 import HedyTester
+import hedy_translation
+from test_translating import check_local_lang_bool
+
+
+# tests should be ordered as follows:
+# * Translation from English to Dutch
+# * Translation from Dutch to English
+# * Translation to several languages
+# * Error handling
+
+
+class TestsTranslationLevel7(HedyTester):
+    level = 7
+    keywords_from = hedy_translation.keywords_to_dict('en')
+    keywords_to = hedy_translation.keywords_to_dict('nl')
+
+    @check_local_lang_bool
+    def test_repeat_english_dutch(self):
+        code = "repeat 3 times print 'Hedy is fun!'"
+
+        result = hedy_translation.translate_keywords(code, from_lang="en", to_lang="nl", level=self.level)
+        expected = "herhaal 3 keer print 'Hedy is fun!'"
+
+        self.assertEqual(result, expected)
+
+    @check_local_lang_bool
+    def test_repeat2_english_dutch(self):
+        code = "repeat 2 times print name"
+
+        result = hedy_translation.translate_keywords(code, from_lang="en", to_lang="nl", level=self.level)
+        expected = "herhaal 2 keer print name"
+
+        self.assertEqual(result, expected)
+
+    @check_local_lang_bool
+    def test_repeat_dutch_english(self):
+        code = "herhaal 3 keer print 'Hedy is fun!'"
+
+        result = hedy_translation.translate_keywords(code, from_lang="nl", to_lang="en", level=self.level)
+        expected = "repeat 3 times print 'Hedy is fun!'"
+
+        self.assertEqual(result, expected)
+
+    @check_local_lang_bool
+    def test_repeat2_dutch_english(self):
+        code = "herhaal 2 keer print ask"
+
+        result = hedy_translation.translate_keywords(code, from_lang="nl", to_lang="en", level=self.level)
+        expected = "repeat 2 times print ask"
+
+        self.assertEqual(result, expected)
+
+    @check_local_lang_bool
+    def test_translate_back(self):
+        code = "repeat 4 times print 'Welcome to Hedy'"
+
+        result = hedy_translation.translate_keywords(code, from_lang="en", to_lang="nl", level=self.level)
+        result = hedy_translation.translate_keywords(result, from_lang="nl", to_lang="en", level=self.level)
+
+        self.assertEqual(code, result)


### PR DESCRIPTION
Added level 6 and 7 into the translation structure.

-Adds level 6 and 7 to the translation structure.
-Adds tests for translation of levels 6 and 7.
-Adds support for the operators available in level 6.
-Adds support for the 'repeat' and 'times' keywords


Tests available by running the tests
