### PR TITLE
Compact size of the quiz, bij resizing the font and removing padding …

### DIFF
--- a/static/css/quiz-css.css
+++ b/static/css/quiz-css.css
@@ -20,6 +20,7 @@
 
 .button-bar {
     display: flex;
+    padding: 1rem;
     background-color: #c6f6d5 !important;
     justify-content: space-between !important;
 
@@ -46,20 +47,20 @@ input:disabled{
 }
 
 #A, #D, #answer-disabled-A, #answer-disabled-D{
-    padding: 1.5rem;
+    padding: 0.5rem;
     background-color: #bee3f8;
     flex-direction: row;
     flex-grow: 1;
-    margin: 1rem;
+    margin: 0.5rem;
 }
 
 #B, #C, #answer-disabled-B, #answer-disabled-C {
-    padding: 1.5rem;
+    padding: 0.5rem;
     background-color: #c6f6d5;
     border-color: #2d9068;
     flex-direction: row;
     flex-grow: 1;
-    margin: 1rem;
+    margin: 0.5rem;
 }
 
 .flex-col{
@@ -67,3 +68,12 @@ input:disabled{
     width: 100%
 }
 
+.tw-border-3 {
+    border-width: 3px;
+}
+
+.size-input{
+    width: 2rem;
+    height: 2rem;
+    margin-left: 0.75rem;
+}

--- a/templates/quiz.html
+++ b/templates/quiz.html
@@ -2,19 +2,15 @@
     <link rel="stylesheet" href="{{static('/css/generated.css')}}">
     <link rel="stylesheet" href="{{static('/css/additional.css')}}">
     <link rel="stylesheet" href="{{ static('/css/quiz-css.css') }}">
-    <div class="px-6 bg-blue-200 border-b-8 border-blue-600" >
+    <div class="px-6 bg-blue-200" >
         <div class="flex justify-around bg-blue-200">
-            <div class="font-slab text-white text-4xl font-bold rounded-full flex items-center justify-self-start bg-blue-600 p-4 m-8"> {{ ui.level_title }} {{ level_source }} </div>
             {% if questionStatus == 'false' %}
-                 <div class="font-slab text-white text-4xl font-bold rounded-full flex items-center justify-self-end bg-red-600 p-4 m-8">{{ ui.incorrect }}</div>
+                 <div class="font-slab text-white text-2xl font-bold rounded-full flex items-center justify-self-end bg-red-600 p-2 m-2">{{ ui.incorrect }}</div>
             {% elif questionStatus== 'start'%}
-                 <div class="font-slab text-white text-4xl font-bold rounded-full flex items-center justify-self-end bg-blue-600 p-4 m-8"> {{ ui.question }} {{ question_nr }}</div>
+                 <div class="font-slab text-white text-2xl font-bold rounded-full flex items-center justify-self-end bg-blue-600 p-2 m-2"> {{ ui.question }} {{ question_nr }}</div>
             {% else %}
-                <div class="font-slab text-white text-4xl font-bold rounded-full flex items-center justify-self-end bg-green-600 p-4 m-8">{{ ui.correct }}</div>
+                <div class="font-slab text-white text-2xl font-bold rounded-full flex items-center justify-self-end bg-green-600 p-2 m-2">{{ ui.correct }}</div>
             {% endif %}
-
-            <div class="font-slab italic text-white text-xl font-normal rounded-full flex items-center justify-self-end bg-blue-600 p-4 m-8"> {{ ui.correct }}
-                {{ ui.from_number_of_questions }} {{ questions|length }} {{ ui.answered_correctly }}</div>
         </div>
     </div>
 {% block question %}{% endblock %}

--- a/templates/quiz_question.html
+++ b/templates/quiz_question.html
@@ -31,7 +31,7 @@
             {{ question.question_text }}
         </p>
         {% if question.code and question.code!= "..." %}
-            <pre><code class="ml-6 text-xl">{{ question.code }}</code></pre>
+            <pre><code class="ml-6 text-l">{{ question.code }}</code></pre>
         {% endif %}
         {% if wrong_answer_hint %}
             <div class="text-red-900 text-2xl text-center flex flex-row justify-center font-slab font-semibold">
@@ -61,9 +61,9 @@
                                         </div>
 
                                         {% if not question_options[counter.value].option_text or question_options[counter.value].option_text == 'None' %}
-                                            <code class="ml-3 text-xl">{{ question_options[counter.value].code|nl2br }}</code>
+                                            <code class="ml-3 text-l">{{ question_options[counter.value].code|nl2br }}</code>
                                         {% elif not question_options[counter.value].code or question_options[counter.value].code == 'None'  %}
-                                            <p class="ml-3 text-xl font-bold"> {{ question_options[counter.value].option_text|nl2br }}</p>
+                                            <p class="ml-3 text-l font-bold"> {{ question_options[counter.value].option_text|nl2br }}</p>
                                         {% endif %}
                                     </label>
                                 </div>
@@ -84,9 +84,9 @@
 
                                             </div>
                                         {% if not question_options[counter.value].option_text or question_options[counter.value].option_text == 'None' %}
-                                            <code class="ml-3 text-xl">{{ question_options[counter.value].code | nl2br  }}</code>
+                                            <code class="ml-3 text-l">{{ question_options[counter.value].code | nl2br  }}</code>
                                         {% elif not question_options[counter.value].code or question_options[counter.value].code == 'None'   %}
-                                            <p class="ml-3 text-xl font-bold"> {{ question_options[counter.value].option_text | nl2br }}</p>
+                                            <p class="ml-3 text-l font-bold"> {{ question_options[counter.value].option_text | nl2br }}</p>
                                         {% endif %}
                                     </label>
                                 </div>
@@ -105,9 +105,9 @@
 
                                            </div>
                                                 {% if not question_options[counter.value].option_text or question_options[counter.value].option_text == 'None' %}
-                                                    <code class="ml-3 text-xl">{{ question_options[counter.value].code | nl2br }}</code>
+                                                    <code class="ml-3 text-l">{{ question_options[counter.value].code | nl2br }}</code>
                                                 {% elif not question_options[counter.value].code or question_options[counter.value].code == 'None'  %}
-                                                    <p class="ml-3 text-xl font-bold"> {{ question_options[counter.value].option_text | nl2br }}</p>
+                                                    <p class="ml-3 text-l font-bold"> {{ question_options[counter.value].option_text | nl2br }}</p>
                                                 {% endif %}
                                     </label>
                                 </div>

--- a/templates/quiz_question.html
+++ b/templates/quiz_question.html
@@ -39,75 +39,75 @@
             </div>
         {% endif %}
         <form action="{{ url_for('submit_answer', level_source=level_source, question_nr=question_nr, attempt=attempt, lang=lang) }}" method="POST">
-            <div class="grid gap-1 rounded-t-xl">
+            <div>
                 {% set counter = namespace(value=0) %}
                 {% for row in question.mp_choice_options|batch(2) %}
                     <div class="flex flex-row">
                     {% for column in row %}
                         <div class="flex flex-col">
                             {% if question.correct_answer == chosen_option %}
-                                <div class="p-1 border-blue-600 border-4 rounded-lg shadow-lg radio-block flex flex-row"
+                                <div class="p-1 border-blue-600 tw-border-3 rounded-lg shadow-lg radio-block flex flex-row"
                                      id="{{ question_options[counter.value].char_index }}">
                                     <label class="inline-flex items-center">
                                     <div class="flex-1 flex-col justify-center items-center">
                                           <p
-                                            class="text-4xl font-bold ml-6 mr-6 font-slab">
+                                            class="text-3xl font-bold ml-3 mr-3 font-slab">
                                         {{ question_options[counter.value].char_index }}</p>
                                                           <input
                                                 type="radio"
                                                 name="radio_option"
                                                 value="{{ question_nr }}-{{ question_options[counter.value].char_index }}"
-                                                class="class form-radio h-12 w-12">
+                                                class="class form-radio size-input">
                                         </div>
 
                                         {% if not question_options[counter.value].option_text or question_options[counter.value].option_text == 'None' %}
-                                            <code class="ml-6 text-xl">{{ question_options[counter.value].code|nl2br }}</code>
+                                            <code class="ml-3 text-xl">{{ question_options[counter.value].code|nl2br }}</code>
                                         {% elif not question_options[counter.value].code or question_options[counter.value].code == 'None'  %}
-                                            <p class="ml-6 text-xl font-bold"> {{ question_options[counter.value].option_text|nl2br }}</p>
+                                            <p class="ml-3 text-xl font-bold"> {{ question_options[counter.value].option_text|nl2br }}</p>
                                         {% endif %}
                                     </label>
                                 </div>
                             {% elif question_options[counter.value].char_index == chosen_option %}
-                                <div class="p-1 border-blue-600 border-4 rounded-lg shadow-lg radio-block flex flex-row"
+                                <div class="p-1 border-blue-600 tw-border-3 rounded-lg shadow-lg radio-block flex flex-row"
                                      id="answer-disabled-{{ question_options[counter.value].char_index }}">
                                     <label class="inline-flex items-center"><p
-                                            class="text-4xl font-bold ml-6 mr-6 font-slab">
+                                            class="text-3xl font-bold ml-3 mr-3 font-slab">
                                         <div class="flex-1 flex-col justify-center items-center">
-                                            <p class="text-4xl font-bold ml-6 mr-6 font-slab">
+                                            <p class="text-3xl font-bold ml-3 mr-3 font-slab">
                                                  {{ question_options[counter.value].char_index }}</p>
                                          <input
                                                 type="radio"
                                                 name="radio_option"
                                                 value="{{ question_nr }}-{{ question_options[counter.value].char_index }}"
-                                                class="class form-radio h-12 w-12" disabled="disabled">
+                                                class="class form-radio size-input" disabled="disabled">
 
 
                                             </div>
                                         {% if not question_options[counter.value].option_text or question_options[counter.value].option_text == 'None' %}
-                                            <code class="ml-6 text-xl">{{ question_options[counter.value].code | nl2br  }}</code>
+                                            <code class="ml-3 text-xl">{{ question_options[counter.value].code | nl2br  }}</code>
                                         {% elif not question_options[counter.value].code or question_options[counter.value].code == 'None'   %}
-                                            <p class="ml-6 text-xl font-bold"> {{ question_options[counter.value].option_text | nl2br }}</p>
+                                            <p class="ml-3 text-xl font-bold"> {{ question_options[counter.value].option_text | nl2br }}</p>
                                         {% endif %}
                                     </label>
                                 </div>
                             {% else %}
-                                <div class="p-1 border-blue-600 border-4 rounded-lg shadow-lg radio-block flex flex-row"
+                                <div class="p-1 border-blue-600 tw-border-3 rounded-lg shadow-lg radio-block flex flex-row"
                                      id={{ question_options[counter.value].char_index }}>
                                     <label class="inline-flex items-center">
                                          <div class="flex-1 flex-col justify-center items-center">
-                                              <p class="text-4xl font-bold ml-6 mr-6 font-slab">
+                                              <p class="text-3xl font-bold ml-3 mr-3 font-slab">
                                         {{ question_options[counter.value].char_index }}</p>
                                         <input
                                                 type="radio"
                                                 name="radio_option"
                                                 value="{{ question_nr }}-{{ question_options[counter.value].char_index }}"
-                                                class="class form-radio h-12 w-12">
+                                                class="class form-radio size-input">
 
                                            </div>
                                                 {% if not question_options[counter.value].option_text or question_options[counter.value].option_text == 'None' %}
-                                                    <code class="ml-6 text-xl">{{ question_options[counter.value].code | nl2br }}</code>
+                                                    <code class="ml-3 text-xl">{{ question_options[counter.value].code | nl2br }}</code>
                                                 {% elif not question_options[counter.value].code or question_options[counter.value].code == 'None'  %}
-                                                    <p class="ml-6 text-xl font-bold"> {{ question_options[counter.value].option_text | nl2br }}</p>
+                                                    <p class="ml-3 text-xl font-bold"> {{ question_options[counter.value].option_text | nl2br }}</p>
                                                 {% endif %}
                                     </label>
                                 </div>
@@ -118,7 +118,7 @@
                        </div>
                 {% endfor %}
                 </div>
-                <div class="p-10 button-bar border-t-8 border-green-600">
+                <div class="p-10 button-bar">
                     <div class="invisible" id="hidden-hint"> {{ question.hint }}</div>
                     <div>
                         <button type="button" onclick="changeHint()"


### PR DESCRIPTION
…and margin. Bars are much smaller with less info.

**Description**

The padding,  and margin are with 33% reduced. The fontsize is one size smaller from XL -> L . 
The input radio button is reduced. The top and bottom bars don't have a border anymore and are much smaller. Level and number of questions correct is removed.
This design will serve as an intermediate form before te whole quiz UI will be changed.

**Fix for**

The design was too wide and big.

**How to test**

![originalquiz1](https://user-images.githubusercontent.com/86956321/144843856-38e50f8c-f016-4152-8975-69c9f49f9932.PNG)
The current UI of the quiz.

![compactsizeofquiz2](https://user-images.githubusercontent.com/86956321/144843883-4eadb2c1-2267-492d-9100-3b5501f3ae8f.PNG)

The new UI of the quiz. 