### PR TITLE
Repair for UnexpectedCharacters exceptions

### DIFF
--- a/exceptions.py
+++ b/exceptions.py
@@ -53,13 +53,16 @@ class InvalidSpaceException(FtfyException):
             fixed_result=fixed_result)
 
 class ParseException(HedyException):
-    def __init__(self, level, location, found):
+    def __init__(self, level, location, found, fixed_code):
         super().__init__('Parse',
             level=level,
             location=location,
             found=found,
             # 'character_found' for backwards compatibility
             character_found=found)
+
+        #TODO (FH, 8 dec 21) many exceptions now support fixed code maybe we should move it to hedyexception?
+        self.fixed_code = fixed_code
 
 class UndefinedVarException(HedyException):
     def __init__(self, name):

--- a/exceptions.py
+++ b/exceptions.py
@@ -53,7 +53,7 @@ class InvalidSpaceException(FtfyException):
             fixed_result=fixed_result)
 
 class ParseException(HedyException):
-    def __init__(self, level, location, found, fixed_code):
+    def __init__(self, level, location, found, fixed_code=None):
         super().__init__('Parse',
             level=level,
             location=location,

--- a/hedy.py
+++ b/hedy.py
@@ -1822,6 +1822,7 @@ def parse_input(input_string, level, lang):
             character_found = beautify_parse_error(e.char)
             # print(e.args[0])
             # print(location, character_found, characters_expected)
+            fixed_code = program_repair.remove_unexpected_char(input_string, location[0], location[1])
             raise exceptions.ParseException(level=level, location=location, found=character_found) from e
         except UnexpectedEOF:
             # this one can't be beautified (for now), so give up :)

--- a/hedy.py
+++ b/hedy.py
@@ -1823,7 +1823,7 @@ def parse_input(input_string, level, lang):
             # print(e.args[0])
             # print(location, character_found, characters_expected)
             fixed_code = program_repair.remove_unexpected_char(input_string, location[0], location[1])
-            raise exceptions.ParseException(level=level, location=location, found=character_found) from e
+            raise exceptions.ParseException(level=level, location=location, found=character_found, fixed_code=fixed_code) from e
         except UnexpectedEOF:
             # this one can't be beautified (for now), so give up :)
             raise e

--- a/program_repair.py
+++ b/program_repair.py
@@ -25,3 +25,7 @@ def replace(input_string, line, column, length, new_string):
 def remove_leading_spaces(input_string):
     # the only repair we can do now is remove leading spaces, more can be added!
     return '\n'.join([x.lstrip() for x in input_string.split('\n')])
+
+
+def remove_unexpected_char(input_string, line, column):
+    return delete(input_string, line - 1, column - 1, 1)

--- a/tests/test_level_04.py
+++ b/tests/test_level_04.py
@@ -367,6 +367,15 @@ class TestsLevel4(HedyTester):
       expected=expected
     )
 
+  def test_repair(self):
+    code = "print ,'Hello'"
+    with self.assertRaises(hedy.exceptions.ParseException) as context:
+      result = hedy.transpile(code, self.level)
+
+    self.assertEqual("print 'Hello'", context.exception.fixed_code)
+
+
+
   #assorti
   def test_detect_accented_chars(self):
     self.assertEqual(True, hedy.hash_needed('éyyy'))


### PR DESCRIPTION
**Description**

Repairs `UnexpectedCharacters` exceptions by removing that character.

**Fix for**

Progress for #1225, point 3.

**How to test**

For example, on level 4 or higher run the following Hedy code:
`print ,'Hello'`

`fixed_code` will have the `,` removed,  remaining `print 'Hello'`. It is still possible that other errors arise after the repair.

