### PR TITLE
Repairs for too many/few indentations exception

### DIFF
--- a/exceptions.py
+++ b/exceptions.py
@@ -161,18 +161,20 @@ class CodePlaceholdersPresentException(HedyException):
         super().__init__('Has Blanks')
 
 class NoIndentationException(HedyException):
-    def __init__(self, line_number, leading_spaces, indent_size):
+    def __init__(self, line_number, leading_spaces, indent_size, fixed_code=None):
         super().__init__('No Indentation',
             line_number=line_number,
             leading_spaces=leading_spaces,
             indent_size=indent_size)
+        self.fixed_code = fixed_code
 
 class IndentationException(HedyException):
-    def __init__(self, line_number, leading_spaces, indent_size):
+    def __init__(self, line_number, leading_spaces, indent_size, fixed_code=None):
         super().__init__('Unexpected Indentation',
             line_number=line_number,
             leading_spaces=leading_spaces,
             indent_size=indent_size)
+        self.fixed_code = fixed_code
 
 class UnsupportedFloatException(HedyException):
     def __init__(self, value):

--- a/hedy.py
+++ b/hedy.py
@@ -1762,19 +1762,22 @@ def preprocess_blocks(code, level):
             if (leading_spaces % indent_size) != 0:
                 # there is inconsistent indentation, not sure if that is too much or too little!
                 if leading_spaces < current_number_of_indents * indent_size:
+                    fixed_code = program_repair.fix_indent(code, line_number, leading_spaces, indent_size)
                     raise hedy.exceptions.NoIndentationException(line_number=line_number, leading_spaces=leading_spaces,
-                                                                 indent_size=indent_size)
+                                                                 indent_size=indent_size, fixed_code=fixed_code)
                 else:
+                    fixed_code = program_repair.fix_indent(code, line_number, leading_spaces, indent_size)
                     raise hedy.exceptions.IndentationException(line_number=line_number, leading_spaces=leading_spaces,
-                                                                 indent_size=indent_size)
+                                                                 indent_size=indent_size, fixed_code=fixed_code)
 
             current_number_of_indents = leading_spaces // indent_size
             if current_number_of_indents > 1 and level == hedy.LEVEL_STARTING_INDENTATION:
                 raise hedy.exceptions.LockedLanguageFeatureException(concept="nested blocks")
 
         if next_line_needs_indentation and current_number_of_indents <= previous_number_of_indents:
+            fixed_code = program_repair.fix_indent(code, line_number, leading_spaces, indent_size)
             raise hedy.exceptions.NoIndentationException(line_number=line_number, leading_spaces=leading_spaces,
-                                                         indent_size=indent_size)
+                                                         indent_size=indent_size, fixed_code=fixed_code)
 
         if needs_indentation(line):
             next_line_needs_indentation = True
@@ -1782,8 +1785,9 @@ def preprocess_blocks(code, level):
             next_line_needs_indentation = False
 
         if current_number_of_indents - previous_number_of_indents > 1:
+            fixed_code = program_repair.fix_indent(code, line_number, leading_spaces, indent_size)
             raise hedy.exceptions.IndentationException(line_number=line_number, leading_spaces=leading_spaces,
-                                            indent_size=indent_size)
+                                            indent_size=indent_size, fixed_code=fixed_code)
 
 
 

--- a/program_repair.py
+++ b/program_repair.py
@@ -1,7 +1,7 @@
 def insert(input_string, line, column, new_string):
     """"insert new_string at (line, column)"""
     rows = input_string.splitlines()
-    rows[line] = rows[line][:column + 1] + new_string + rows[line][column + 1:]
+    rows[line] = rows[line][:column] + new_string + rows[line][column:]
 
     return '\n'.join(rows)
 
@@ -29,3 +29,12 @@ def remove_leading_spaces(input_string):
 
 def remove_unexpected_char(input_string, line, column):
     return delete(input_string, line - 1, column - 1, 1)
+
+
+def fix_indent(input_string, line, leading_spaces, indent_size):
+    if leading_spaces < indent_size:
+        # not enough spaces, add spaces
+        return insert(input_string, line - 1, 0, ' ' * (indent_size - leading_spaces))
+    else:
+        # too many spaces, remove spaces
+        return delete(input_string, line - 1, 0, leading_spaces - indent_size)

--- a/tests/Tester.py
+++ b/tests/Tester.py
@@ -80,13 +80,14 @@ class HedyTester(unittest.TestCase):
   def single_level_tester(self, code, level=None, exception=None, expected=None, extra_check_function=None, output=None):
     if level is None: # no level set (from the multi-tester)? grap current level from class
       level = self.level
-    if extra_check_function is None: # most programs have no turtle so make that the default
-      extra_check_function = self.is_not_turtle()
     if exception is not None:
       with self.assertRaises(exception) as context:
         result = hedy.transpile(code, level)
       if extra_check_function is not None:
         self.assertTrue(extra_check_function(context))
+
+    if extra_check_function is None: # most programs have no turtle so make that the default
+      extra_check_function = self.is_not_turtle()
 
     if expected is not None:
       result = hedy.transpile(code, level)
@@ -94,7 +95,6 @@ class HedyTester(unittest.TestCase):
       self.assertTrue(self.validate_Python_code(result))
       if output is not None:
         self.assertEqual(output, HedyTester.run_code(result))
-      if extra_check_function is not None:
         self.assertTrue(extra_check_function(result))
 
   @staticmethod

--- a/tests/Tester.py
+++ b/tests/Tester.py
@@ -85,6 +85,9 @@ class HedyTester(unittest.TestCase):
     if exception is not None:
       with self.assertRaises(exception) as context:
         result = hedy.transpile(code, level)
+      if extra_check_function is not None:
+        self.assertTrue(extra_check_function(context))
+
     if expected is not None:
       result = hedy.transpile(code, level)
       self.assertEqual(expected, result.code)

--- a/tests/test_level_01.py
+++ b/tests/test_level_01.py
@@ -169,8 +169,7 @@ class TestsLevel1(HedyTester):
     self.multi_level_tester(
       max_level=self.max_turtle_level,
       code=code,
-      exception=hedy.exceptions.InvalidArgumentTypeException,
-      extra_check_function=self.is_turtle()
+      exception=hedy.exceptions.InvalidArgumentTypeException
     )
 
   def test_multiple_forward_without_arguments(self):

--- a/tests/test_level_02.py
+++ b/tests/test_level_02.py
@@ -332,6 +332,8 @@ class TestsLevel2(HedyTester):
     with self.assertRaises(hedy.exceptions.WrongLevelException) as context:
       hedy.transpile(code, self.level)
     self.assertEqual('Wrong Level', context.exception.error_code)
+
+
   def test_ask_without_argument(self):
     self.multi_level_tester(
       max_level=17,

--- a/tests/test_level_08.py
+++ b/tests/test_level_08.py
@@ -241,27 +241,31 @@ class TestsLevel8(HedyTester):
     repeat 5 times
          print('repair')
       print('me')""")
-    expected = textwrap.dedent("""\
+
+    fixed_code = textwrap.dedent("""\
     repeat 5 times
          print('repair')
          print('me')""")
 
-    with self.assertRaises(hedy.exceptions.NoIndentationException) as context:
-      result = hedy.transpile(code, self.level)
+    self.multi_level_tester(
+      code=code,
+      exception=hedy.exceptions.NoIndentationException,
+      extra_check_function=(lambda x: x.exception.fixed_code == fixed_code)
+    )
 
-    self.assertEqual(expected, context.exception.fixed_code)
 
   def test_repair_too_many_indents(self):
     code = textwrap.dedent("""\
     repeat 5 times
       print('repair')
          print('me')""")
-    expected = textwrap.dedent("""\
+    fixed_code = textwrap.dedent("""\
     repeat 5 times
       print('repair')
       print('me')""")
 
-    with self.assertRaises(hedy.exceptions.IndentationException) as context:
-      result = hedy.transpile(code, self.level)
-
-    self.assertEqual(expected, context.exception.fixed_code)
+    self.multi_level_tester(
+      code=code,
+      exception=hedy.exceptions.NoIndentationException,
+      extra_check_function=(lambda x: x.exception.fixed_code == fixed_code)
+    )

--- a/tests/test_level_08.py
+++ b/tests/test_level_08.py
@@ -266,6 +266,6 @@ class TestsLevel8(HedyTester):
 
     self.multi_level_tester(
       code=code,
-      exception=hedy.exceptions.NoIndentationException,
+      exception=hedy.exceptions.IndentationException,
       extra_check_function=(lambda x: x.exception.fixed_code == fixed_code)
     )

--- a/tests/test_level_08.py
+++ b/tests/test_level_08.py
@@ -236,4 +236,32 @@ class TestsLevel8(HedyTester):
       code=code,
       exception=hedy.exceptions.NoIndentationException)
 
+  def test_repair_too_few_indents(self):
+    code = textwrap.dedent("""\
+    repeat 5 times
+         print('repair')
+      print('me')""")
+    expected = textwrap.dedent("""\
+    repeat 5 times
+         print('repair')
+         print('me')""")
 
+    with self.assertRaises(hedy.exceptions.NoIndentationException) as context:
+      result = hedy.transpile(code, self.level)
+
+    self.assertEqual(expected, context.exception.fixed_code)
+
+  def test_repair_too_many_indents(self):
+    code = textwrap.dedent("""\
+    repeat 5 times
+      print('repair')
+         print('me')""")
+    expected = textwrap.dedent("""\
+    repeat 5 times
+      print('repair')
+      print('me')""")
+
+    with self.assertRaises(hedy.exceptions.IndentationException) as context:
+      result = hedy.transpile(code, self.level)
+
+    self.assertEqual(expected, context.exception.fixed_code)


### PR DESCRIPTION
**Description**

For the indentation exceptions (`IndentationException` and `NoIndentationException`), the necessary information to repair the errors were already available in Hedy. With those information, `leading_spaces` and `indent_size`, the error can easily be fixed with some simple math.
`fix_indent` first checks whether the error line has more or less indentations than the intended amount, then deletes or inserts accordingly.

**Fix for**

Progress for #1225.

**How to test**

I added 2 tests for these repairs in level 8:
`test_repair_too_few_indents` tests if the correct amount of indentations are added.
`test_repair_too_many_indents` tests if the correct amount of indentations are deleted.