### PR TITLE
Use a proper regex string in the index route

### DIFF
--- a/app.py
+++ b/app.py
@@ -848,7 +848,7 @@ def no_quiz_data_error():
 @app.route('/hedy/<level>', methods=['GET'], defaults={'step': 1})
 @app.route('/hedy/<level>/<step>', methods=['GET'])
 def index(level, step):
-    if re.match('\d', level):
+    if re.match('\\d', level):
         try:
             g.level = level = int(level)
         except:


### PR DESCRIPTION
Previously python would first try to interpret the \d as an escape sequence and throw "DeprecationWarning: invalid escape sequence \d" upon noticing that \d is not a valid escape sequence. By escaping the \, the regex engine will get a proper \d literal without python throwing a warning.