### PR TITLE
Fix bug with string literals support in != comparisons #1550

### DIFF
--- a/hedy.py
+++ b/hedy.py
@@ -919,6 +919,8 @@ def process_variable_for_fstring_padded(name, lookup):
         return f"str({hash_var(name)}).zfill(100)"
     elif is_float(name):
         return f"str({name}).zfill(100)"
+    elif is_quoted(name):
+        return f"{name}.zfill(100)"
     else:
         return f"'{name}'.zfill(100)"
 

--- a/tests/test_level_14.py
+++ b/tests/test_level_14.py
@@ -96,6 +96,20 @@ class TestsLevel14(HedyTester):
       exception=hedy.exceptions.InvalidArgumentTypeException
     )
 
+  def test_not_equal_string_literal(self):
+    code = textwrap.dedent(f"""\
+      if 'quoted' != 'string'
+        sleep 0""")
+    expected = textwrap.dedent(f"""\
+      if 'quoted'.zfill(100)!='string'.zfill(100):
+        time.sleep(0)""")
+
+    self.multi_level_tester(
+      code=code,
+      max_level=16,
+      expected=expected
+    )
+
   def test_not_equal_with_string(self):
     code = textwrap.dedent(f"""\
       a is 'text'

--- a/tests/test_level_17.py
+++ b/tests/test_level_17.py
@@ -285,3 +285,17 @@ class TestsLevel17(HedyTester):
       code=code,
       exception=hedy.exceptions.InvalidArgumentTypeException
     )
+
+  def test_not_equal_string_literal(self):
+    code = textwrap.dedent(f"""\
+      if 'quoted' != 'string':
+        sleep 0""")
+    expected = textwrap.dedent(f"""\
+      if 'quoted'.zfill(100)!='string'.zfill(100):
+        time.sleep(0)""")
+
+    self.multi_level_tester(
+      code=code,
+      expected=expected
+    )
+


### PR DESCRIPTION
Fix bug with string literals support in != comparisons

**Fix for**

Fixes #1550

**How to test**

- Tests are added to cover the bug

**Checklist**

If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [ ] Links to an existing issue or discussion (if not, create an issue first)
- [ ] Describes changes clear in the format above (present tense, no subject)
- [ ] Has a "how to test" section
- [ ] Only one thing is done in this pull request (specifically please try to refrain from mixing textual changes to the yamls from code changes)

