### PR TITLE
Hashes variable inside turn command

### DIFF
--- a/hedy.py
+++ b/hedy.py
@@ -881,7 +881,6 @@ class ConvertToPython_1(Transformer):
             return "t.right(90)"  # no arguments defaults to a right turn
 
         arg = args[0]
-
         if is_variable(arg, self.lookup) or arg.isnumeric():
             return f"t.right({arg})"
         elif arg == 'left':

--- a/hedy.py
+++ b/hedy.py
@@ -881,6 +881,7 @@ class ConvertToPython_1(Transformer):
             return "t.right(90)"  # no arguments defaults to a right turn
 
         arg = args[0]
+
         if is_variable(arg, self.lookup) or arg.isnumeric():
             return f"t.right({arg})"
         elif arg == 'left':
@@ -1004,7 +1005,7 @@ class ConvertToPython_2(ConvertToPython_1):
         if len(args) == 0:
             return "t.right(90)"
 
-        arg = args[0]
+        arg = hash_var(args[0])
         if is_variable(arg, self.lookup) or arg.isnumeric():
             return f"t.right({arg})"
 

--- a/tests/test_level_02.py
+++ b/tests/test_level_02.py
@@ -198,6 +198,20 @@ class TestsLevel2(HedyTester):
       exception=hedy.exceptions.InvalidArgumentTypeException
     )
 
+  def test_turn_with_non_ascii_var(self):
+    code = textwrap.dedent("""\
+      ángulo is 90
+      turn ángulo""")
+    expected = textwrap.dedent("""\
+      vefd88f42b64136f16e8f305dd375a921 = '90'
+      t.right(vefd88f42b64136f16e8f305dd375a921)""")
+    self.multi_level_tester(
+      max_level=self.max_turtle_level,
+      code=code,
+      expected=expected,
+      extra_check_function=self.is_turtle()
+    )
+
   @parameterized.expand(['left', 'right'])
   def test_one_turn_with_literal_string_gives_type_error(self, arg):
     code = f"turn {arg}"


### PR DESCRIPTION
**Description**

Hashes variables used in the `turn` command

**Fix for**

This:

**How to test**

This code now works at level 2:

```
ángulo is 90
girar ángulo
```




