### PR TITLE
[BUG FIX] Correctly translated subtitles to English for main page

### DIFF
--- a/coursedata/pages/start/en.yaml
+++ b/coursedata/pages/start/en.yaml
@@ -14,22 +14,22 @@ sections:
       The nice thing about Hedy is that Hedy is *gradual*. That means that you do not have to learn all rules at once.
       The first few levels do not have that many rules, so you can get used to programming comfortably.
       In every level we add new rules, increasing the number of commands that you know. Commands are instructions for a computer.
-  - title: "Waarom is Hedy gradueel?"
+  - title: "Why is Hedy gradual?"
     text: |
       In this video Felienne, the creator of Hedy, explains why Hedy is gradual.
 
       <iframe width="560" height="315" class="mx-auto mt-4" src="https://www.youtube.com/embed/EdqT313rM40" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-  - title: "Voor wie is Hedy bedoeld?"
+  - title: "Who is Hedy for?"
     text: |
       Hedy is meant for all kids that want to learn programming! You do need to be able to read English with ease.
-  - title: "Moet ik al iets kennen of weten?"
+  - title: "Do I need programming experience?"
     text: |
       No, that is not needed. However, if you have programmed with Scratch or Python, some commands will look familiar to you.
-  - title: "Is Hedy gratis?"
+  - title: "Is Hedy free?"
     text: |
       Yes! Leiden University allows us to share it for free. Hedy is also 'Open source', which means that everyone who can program can help us make Hedy better.
       You can find the code on [GitHub](https://github.com/Felienne/hedy).
       If you like Hedy and want to contribute, we do accept (and are very grateful for) [donations](https://www.steunleiden.nl/project/hedy)!
-  - title: "Moet ik iets installeren?"
+  - title: "Do I need to install anything?"
     text: |
       No. Hedy works in the browser, which is the program you are using to look at this page. Probably Chrome or Edge or FireFox. Hedy also works on your phone or tablet.


### PR DESCRIPTION
**Description**
In this PR we correctly translate the titles for the main page in English.

**Fix for**
This PR fixed #1568.

**How to test**
Run and navigate to the main page. Notice that the titles and subtitles are now correctly displayed in English.


**Checklist**

If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [ ] Links to an existing issue or discussion (if not, create an issue first)
- [ ] Describes changes clear in the format above (present tense, no subject)
- [ ] Has a "how to test" section
- [ ] Only one thing is done in this pull request (specifically please try to refrain from mixing textual changes to the yamls from code changes)

