### PR TITLE
Split assigment rules from level 6 on

### DIFF
--- a/grammars/level12-Additions.lark
+++ b/grammars/level12-Additions.lark
@@ -1,7 +1,12 @@
 //assigning a string now must be done with quotes
 
-assign: var _SPACE (_IS|_EQUALS) _SPACE sum | var _SPACE (_IS|_EQUALS) _SPACE text_in_quotes
-assign_list: var _SPACE (_IS|_EQUALS) _SPACE (text_in_quotes|NUMBER) ((_COMMA _SPACE|_COMMA) (text_in_quotes|NUMBER))+
+//assign: var _SPACE (_IS|_EQUALS) _SPACE sum | var _SPACE (_IS|_EQUALS) _SPACE text_in_quotes
+assign_is: var _SPACE _IS _SPACE sum | var _SPACE _IS _SPACE text_in_quotes
+assign_equals: var _SPACE _EQUALS _SPACE sum | var _SPACE _EQUALS _SPACE text_in_quotes
+
+//assign_list: var _SPACE (_IS|_EQUALS) _SPACE (text_in_quotes|NUMBER) ((_COMMA _SPACE|_COMMA) (text_in_quotes|NUMBER))+
+assign_list_is: var _SPACE _IS _SPACE (text_in_quotes|NUMBER) ((_COMMA _SPACE|_COMMA) (text_in_quotes|NUMBER))+
+assign_list_equals: var _SPACE _EQUALS _SPACE (text_in_quotes|NUMBER) ((_COMMA _SPACE|_COMMA) (text_in_quotes|NUMBER))+
 
 ?atom: NUMBER | var //unsupported numbers are gone, we can now allow floats with NUMBER
 

--- a/grammars/level12-Additions.lark
+++ b/grammars/level12-Additions.lark
@@ -1,10 +1,7 @@
 //assigning a string now must be done with quotes
-
-//assign: var _SPACE (_IS|_EQUALS) _SPACE sum | var _SPACE (_IS|_EQUALS) _SPACE text_in_quotes
 assign_is: var _SPACE _IS _SPACE sum | var _SPACE _IS _SPACE text_in_quotes
 assign_equals: var _SPACE _EQUALS _SPACE sum | var _SPACE _EQUALS _SPACE text_in_quotes
 
-//assign_list: var _SPACE (_IS|_EQUALS) _SPACE (text_in_quotes|NUMBER) ((_COMMA _SPACE|_COMMA) (text_in_quotes|NUMBER))+
 assign_list_is: var _SPACE _IS _SPACE (text_in_quotes|NUMBER) ((_COMMA _SPACE|_COMMA) (text_in_quotes|NUMBER))+
 assign_list_equals: var _SPACE _EQUALS _SPACE (text_in_quotes|NUMBER) ((_COMMA _SPACE|_COMMA) (text_in_quotes|NUMBER))+
 

--- a/grammars/level16-Additions.lark
+++ b/grammars/level16-Additions.lark
@@ -6,4 +6,5 @@
 ?atom: NUMBER | var | list_access | error_unsupported_number
 list_access: var _LEFT_SQUARE_BRACKET (INT | random | var) _RIGHT_SQUARE_BRACKET
 change_list_item: var _LEFT_SQUARE_BRACKET (INT | var) _RIGHT_SQUARE_BRACKET _SPACE _EQUALS _SPACE (var | textwithoutspaces)
-assign_list: var _SPACE (_IS|_EQUALS) _SPACE _LEFT_SQUARE_BRACKET (quoted_text | INT) (_COMMA _SPACE? (quoted_text | INT))+ _RIGHT_SQUARE_BRACKET
+assign_list_is: var _SPACE _IS _SPACE _LEFT_SQUARE_BRACKET (quoted_text | INT) (_COMMA _SPACE? (quoted_text | INT))+ _RIGHT_SQUARE_BRACKET
+assign_list_equals: var _SPACE _EQUALS _SPACE _LEFT_SQUARE_BRACKET (quoted_text | INT) (_COMMA _SPACE? (quoted_text | INT))+ _RIGHT_SQUARE_BRACKET

--- a/grammars/level6-Additions.lark
+++ b/grammars/level6-Additions.lark
@@ -1,15 +1,24 @@
 _print_argument: (_SPACE | quoted_text | list_access | var_access | sum)*
 
+//splitting  these commands into two rules, one for equals and one for is so they can be properly handled in the translator
+command:+= ask_is | ask_equals | list_access_var_equals | list_access_var_is | assign_is | assign_equals | assign_list_is | assign_list_equals -= ask | list_access | assign | assign_list
 
 _IS_OR_EQUALS: (_IS|_EQUALS)
 
-ask: var _SPACE (_IS|_EQUALS) _SPACE _ASK (_SPACE _print_argument)?
+ask_is: var _SPACE _IS _SPACE _ASK (_SPACE _print_argument)?
+ask_equals: var _SPACE _EQUALS _SPACE _ASK (_SPACE _print_argument)?
+
 equality_check: textwithoutspaces _SPACE _IS_OR_EQUALS _SPACE textwithoutspaces //TODO FH nov 2021: not super pretty that this is textwithoutquotes for both a var and also a textual constant, level 11 handles this nicer now, could be done here too
 
-list_access_var: var _SPACE (_IS|_EQUALS) _SPACE var _SPACE _AT _SPACE (INT | random)
-assign_list: var _SPACE (_IS|_EQUALS) _SPACE textwithspaces (_COMMA _SPACE? textwithspaces)+
+list_access_var_is: var _SPACE _IS _SPACE var _SPACE _AT _SPACE (INT | random)
+list_access_var_equals: var _SPACE _EQUALS _SPACE var _SPACE _AT _SPACE (INT | random)
 
-assign: var _SPACE (_IS|_EQUALS) _SPACE sum | var _SPACE (_IS|_EQUALS) _SPACE textwithoutspaces
+assign_list_is: var _SPACE _IS _SPACE textwithspaces (_COMMA _SPACE? textwithspaces)+
+assign_list_equals: var _SPACE _EQUALS _SPACE textwithspaces (_COMMA _SPACE? textwithspaces)+
+
+assign_is: var _SPACE _IS _SPACE sum | var _SPACE _IS _SPACE textwithoutspaces
+assign_equals: var _SPACE _EQUALS _SPACE sum | var _SPACE _EQUALS _SPACE textwithoutspaces
+
 ?sum: product | sum _SPACE* _ADD _SPACE* product -> addition | sum _SPACE* _SUBTRACT _SPACE* product -> subtraction
 ?product: atom | product _SPACE* _MULTIPLY _SPACE* atom -> multiplication | product _SPACE* _DIVIDE _SPACE* atom -> division
 ?atom: INT | var_access | error_unsupported_number //TODO: means we cannot assign strings with spaces? would we want that?

--- a/hedy.py
+++ b/hedy.py
@@ -344,6 +344,12 @@ class LookupEntryCollector(visitors.Visitor):
         # in level 1 there is no variable name on the left side of the ask command
         if self.level > 1:
             self.add_to_lookup(tree.children[0].children[0], tree)
+    
+    def ask_is(self, tree):
+        self.ask(tree)
+    
+    def ask_equals(self, tree):
+        self.ask(tree)
 
     def input(self, tree):
         var_name = tree.children[0].children[0]
@@ -352,10 +358,22 @@ class LookupEntryCollector(visitors.Visitor):
     def assign(self, tree):
         var_name = tree.children[0].children[0]
         self.add_to_lookup(var_name, tree.children[1])
+    
+    def assign_is(self, tree):
+        return self.assign(tree)
+    
+    def assign_equals(self, tree):
+        return self.assign(tree)
 
     def assign_list(self, tree):
         var_name = tree.children[0].children[0]
         self.add_to_lookup(var_name, tree)
+    
+    def assign_list_is(self, tree):
+        return self.assign_list(tree)
+
+    def assign_list_equals(self, tree):
+        return self.assign_list(tree)
 
     # list access is added to the lookup table not because it must be escaped
     # for example we print(dieren[1]) not print('dieren[1]')
@@ -370,6 +388,12 @@ class LookupEntryCollector(visitors.Visitor):
 
     def list_access_var(self, tree):
         self.add_to_lookup(tree.children[0].children[0], tree)
+
+    def list_access_var_is(self, tree):
+        return self.list_access_var(tree)
+
+    def list_access_var_equals(self, tree):
+        return self.list_access_var(tree)
 
     def change_list_item(self, tree):
         self.add_to_lookup(tree.children[0].children[0], tree, True)
@@ -413,6 +437,12 @@ class TypeValidator(Transformer):
             self.save_type_to_lookup(tree.children[0].children[0], HedyType.any)
         self.validate_args_type_allowed(tree.children[1:], Command.ask)
         return self.to_typed_tree(tree, HedyType.any)
+    
+    def ask_is(self, tree):
+        self.ask(tree)
+    
+    def ask_equals(self, tree):
+        self.ask(tree)
 
     def input(self, tree):
         self.validate_args_type_allowed(tree.children[1:], Command.ask)
@@ -435,10 +465,22 @@ class TypeValidator(Transformer):
         self.save_type_to_lookup(tree.children[0].children[0], type_)
         return self.to_typed_tree(tree, HedyType.none)
 
+    def assign_is(self, tree):
+        return self.assign(tree)
+    
+    def assign_equals(self, tree):
+        return self.assign(tree)
+    
     def assign_list(self, tree):
         self.save_type_to_lookup(tree.children[0].children[0], HedyType.list)
         return self.to_typed_tree(tree, HedyType.list)
 
+    def assign_list_is(self, tree):
+        return self.assign_list(tree)
+
+    def assign_list_equals(self, tree):
+        return self.assign_list(tree)
+        
     # TODO: list_access, list_access_var and repeat_list types can be inferred but for now use 'any'
     def list_access(self, tree):
         self.validate_args_type_allowed(tree.children[0], Command.list_access)
@@ -456,6 +498,12 @@ class TypeValidator(Transformer):
     def list_access_var(self, tree):
         self.save_type_to_lookup(tree.children[0].children[0], HedyType.any)
         return self.to_typed_tree(tree)
+
+    def list_access_var_is(self, tree):
+        return self.list_access_var(tree)
+
+    def list_access_var_equals(self, tree):
+        return self.list_access_var(tree)
 
     def add(self, tree):
         self.validate_args_type_allowed(tree.children[1], Command.add_to_list)
@@ -731,8 +779,7 @@ class AllCommands(Transformer):
         # some keywords have names that are not a valid name for a command
         # that's why we call them differently in the grammar
         # we have to translate them to the regular names here for further communciation
-
-        if keyword == 'assign' or keyword == 'assign_list':
+        if keyword in  ['assign', 'assign_is', 'assign_list', 'assign_list_is']:
             return 'is'
         if keyword == 'ifelse':
             return 'else'
@@ -748,6 +795,8 @@ class AllCommands(Transformer):
             return 'and'
         if keyword == 'while_loop':
             return 'while'
+        if keyword == 'ask_is' or keyword == 'ask_equals':
+            return 'ask'
         return keyword
 
     def __default__(self, args, children, meta):
@@ -846,6 +895,10 @@ class IsComplete(Filter):
         # in level 2 and up, ask without arguments is a list of 1, namely the var name
         incomplete = (args == [] and self.level == 1) or (len(args) == 1 and self.level >= 2)
         return not incomplete, ('ask', meta.line)
+    def ask_is(self, args, meta):
+        return self.ask(args, meta)
+    def ask_equals(self, args, meta):
+        return self.ask(args, meta)
     def print(self, args, meta):
         return args != [], ('print', meta.line)
     def input(self, args, meta):
@@ -1234,6 +1287,30 @@ class ConvertToPython_6(ConvertToPython_5):
             value = process_characters_needing_escape(value)
             return parameter + " = '" + value + "'"
 
+    def assign_is(self, args):
+        return self.assign(args)
+    
+    def assign_equals(self, args):
+        return self.assign(args)
+
+    def list_access_var_is(self, args):
+        return super().list_access_var(args)
+    
+    def list_access_var_equals(self, args):
+        return super().list_access_var(args)
+    
+    def ask_is(self, args):
+        return super().ask(args)
+    
+    def ask_equals(self, args):
+        return super().ask(args)
+    
+    def assign_list_is(self, args):
+        return super().assign_list(args)
+    
+    def assign_list_equals(self, args):
+        return super().assign_list(args)
+    
     def process_token_or_tree(self, argument):
         if type(argument) is Tree:
             return f'{str(argument.children[0])}'
@@ -1385,6 +1462,12 @@ class ConvertToPython_12(ConvertToPython_11):
           except ValueError:
             pass""")  # no number? leave as string
 
+    def ask_is(self, args):
+        return self.ask(args)
+    
+    def ask_equals(self, args):
+        return self.ask(args)
+
     def process_calculation(self, args, operator):
         # arguments of a sum are either a token or a
         # tree resulting from earlier processing
@@ -1403,6 +1486,12 @@ class ConvertToPython_12(ConvertToPython_11):
         parameter = args[0]
         values = args[1:]
         return parameter + " = [" + ", ".join(values) + "]"
+
+    def assign_list_is(self, args):
+        return self.assign_list(args)
+
+    def assign_list_equals(self, args):
+        return self.assign_list(args)
 
     def assign(self, args):
         right_hand_side = args[1]
@@ -1426,7 +1515,12 @@ class ConvertToPython_12(ConvertToPython_11):
         else:
             # we no longer escape quotes here because they are now needed
             return parameter + " = " + value + ""
-
+    
+    def assign_is(self, args):
+        return self.assign(args)
+    
+    def assign_equals(self, args):
+        return self.assign(args)
 @hedy_transpiler(level=13)
 class ConvertToPython_13(ConvertToPython_12):
     def andcondition(self, args):

--- a/hedy_translation.py
+++ b/hedy_translation.py
@@ -217,16 +217,37 @@ class ConvertToLang6(ConvertToLang5):
     def division(self, args):
         return args[0] + " / " + args[1]
 
-    def assign(self, args):
+    def assign_equals(self, args):
         return args[0] + " = " + ''.join([str(c) for c in args[1:]])
 
-    def ask(self, args):
+    def assign_is(self, args):
+        return args[0] + " "+ self.keywords["is"] + " " + ''.join([str(c) for c in args[1:]])
+
+    def ask_equals(self, args):
         var = args[0]
         remaining_args = args[1:]
         return var + " = " + self.keywords["ask"] + " " + ''.join(remaining_args)
 
-    def assign_list(self, args):
+    def ask_is(self, args):
+        var = args[0]
+        remaining_args = args[1:]
+        return var + " " + self.keywords["is"] + " " + self.keywords["ask"] + " " + ''.join(remaining_args)
+
+    def assign_list_is(self, args):
         return args[0] + " " + self.keywords["is"] + " " + ', '.join([str(c) for c in args[1:]])
+    
+    def assign_list_equals(self, args):
+        return args[0] + " " + " = " + " " + ', '.join([str(c) for c in args[1:]])
+
+    def list_access_var_equals(self, args):
+        var = args[0]
+        var_list = args[1]
+        return var + " = " + var_list + " " + self.keywords["at"] + " " + args[2]
+    
+    def list_access_var_is(self, args):
+        var = args[0]
+        var_list = args[1]
+        return var + " " + self.keywords["is"] + " " + var_list + " " + self.keywords["at"]  + " " + args[2]
 
 @hedy_translator(level=7)
 class ConvertToLang7(ConvertToLang6):
@@ -324,8 +345,11 @@ class ConvertToLang15(ConvertToLang14):
 
 @hedy_translator(level=16)
 class ConvertToLang16(ConvertToLang15):
-
-    def assign_list(self, args):
+    
+    def assign_list_is(self, args):
+        return args[0] + " " + self.keywords["is"] + " " + "[" + ', '.join([str(c) for c in args[1:]]) + "]"
+    
+    def assign_list_equals(self, args):
         return args[0] + " = [" + ', '.join([str(c) for c in args[1:]]) + "]"
 
     def list_access(self, args):

--- a/tests/Tester.py
+++ b/tests/Tester.py
@@ -98,7 +98,7 @@ class HedyTester(unittest.TestCase):
       all_commands = hedy.all_commands(code, level, lang)
       if expected_commands is not None:
         self.assertEqual(expected_commands, all_commands)
-      if (not 'ask' in all_commands) and (not 'input' in all_commands): #<- use this to run tests locally with unittest
+      if True: #(not 'ask' in all_commands) and (not 'input' in all_commands): #<- use this to run tests locally with unittest
         self.assertTrue(self.validate_Python_code(result))
       if output is not None:
         self.assertEqual(output, HedyTester.run_code(result))

--- a/tests/test_translation_level_06.py
+++ b/tests/test_translation_level_06.py
@@ -46,14 +46,22 @@ class TestsTranslationLevel6(HedyTester):
         expected = "angle = 360 / angles"
         self.assertEqual(expected, result)
     
-    def test_translate_back(self):
+    def test_translate_back_is(self):
         code ="breuk is 13 / 4"
 
         result = hedy_translation.translate_keywords(code, from_lang="en", to_lang="nl", level=self.level)
         result = hedy_translation.translate_keywords(result, from_lang="nl", to_lang="en", level=self.level)
 
         self.assertEqual(code, result)
-    
+
+    def test_translate_back_equals(self):
+        code = "breuk = 13 / 4"
+
+        result = hedy_translation.translate_keywords(code, from_lang="en", to_lang="nl", level=self.level)
+        result = hedy_translation.translate_keywords(result, from_lang="nl", to_lang="en", level=self.level)
+
+        self.assertEqual(code, result)
+
     def test_ask_with_equals_spanish_english(self):
         code = "nombre = preguntar '¿Cual es tu nombre?'"
 

--- a/tests/test_translation_level_06.py
+++ b/tests/test_translation_level_06.py
@@ -1,6 +1,7 @@
 import hedy
 from test_level_01 import HedyTester
 import hedy_translation
+import textwrap
 
 # tests should be ordered as follows:
 # * Translation from English to Dutch
@@ -18,7 +19,7 @@ class TestsTranslationLevel6(HedyTester):
         code = "vermenigvuldiging is 3 * 8"
 
         result = hedy_translation.translate_keywords(code, from_lang="en", to_lang="nl", level=self.level)
-        expected = "vermenigvuldiging = 3 * 8"
+        expected = "vermenigvuldiging is 3 * 8"
 
         self.assertEqual(expected, result)
 
@@ -34,22 +35,62 @@ class TestsTranslationLevel6(HedyTester):
         code = "angle is 360 / angles"
 
         result = hedy_translation.translate_keywords(code, from_lang="nl", to_lang="en", level=self.level)
-        expected = "angle = 360 / angles"
+        print(result)
+        expected = "angle is 360 / angles"
 
         self.assertEqual(expected, result)
 
     def test_division_with_equals_dutch_english(self):
-        code = "angle is 360 / angles"
+        code = "angle = 360 / angles"
 
         result = hedy_translation.translate_keywords(code, from_lang="nl", to_lang="en", level=self.level)
         expected = "angle = 360 / angles"
-
         self.assertEqual(expected, result)
-
+    
     def test_translate_back(self):
-        code ="breuk = 13 / 4"
+        code ="breuk is 13 / 4"
 
         result = hedy_translation.translate_keywords(code, from_lang="en", to_lang="nl", level=self.level)
         result = hedy_translation.translate_keywords(result, from_lang="nl", to_lang="en", level=self.level)
 
         self.assertEqual(code, result)
+    
+    def test_ask_with_equals_spanish_english(self):
+        code = "nombre = preguntar '¿Cual es tu nombre?'"
+
+        result = hedy_translation.translate_keywords(code, from_lang="es", to_lang="en", level=self.level)
+
+        expected = "nombre = ask '¿Cual es tu nombre?'"
+
+        self.assertEqual(expected, result)
+
+    def test_ask_with_is_spanish_english(self):
+        code = "nombre es preguntar '¿Cual es tu nombre?'"
+
+        result = hedy_translation.translate_keywords(code, from_lang="es", to_lang="en", level=self.level)
+
+        expected = "nombre is ask '¿Cual es tu nombre?'"
+
+        self.assertEqual(expected, result)
+    
+    def test_assign_list_is_spanish_english(self):
+        code = "lenguajes es Hedy, Python, C"
+
+        result = hedy_translation.translate_keywords(code, from_lang="es", to_lang="en", level=self.level)
+
+        expected = "lenguajes is Hedy, Python, C"
+
+        self.assertEqual(result, expected)
+
+    def test_assign_list_var_spanish_english(self):
+        code = textwrap.dedent("""\
+        lenguajes es Hedy, Python, C
+        a = lenguajes en 0""")
+
+        result = hedy_translation.translate_keywords(code, from_lang="es", to_lang="en", level=self.level)
+
+        expected = textwrap.dedent("""\
+        lenguajes is Hedy, Python, C
+        a = lenguajes at 0""")
+
+        self.assertEqual(result, expected)

--- a/tests/test_translation_level_06.py
+++ b/tests/test_translation_level_06.py
@@ -35,7 +35,6 @@ class TestsTranslationLevel6(HedyTester):
         code = "angle is 360 / angles"
 
         result = hedy_translation.translate_keywords(code, from_lang="nl", to_lang="en", level=self.level)
-        print(result)
         expected = "angle is 360 / angles"
 
         self.assertEqual(expected, result)


### PR DESCRIPTION
**Description**

As stated on issue #1579 translation code does not preserve = and `is` converting everything to =. To solve this I split the following rules into 2 rules, one for is, and one for = from level 6 on:
* `ask` 
* `list_access` 
*  `assign` 
* `assign_list`

**Fix for**

Fixes #1579 

**How to test**

The transpiler to Python should behave the same, but translating to English should handle correctly `is` and =. I added a few tests on `tests\test_translation_level_06.py` to test this behavior. 

**Checklist**

If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [ ] Links to an existing issue or discussion (if not, create an issue first)
- [ ] Describes changes clear in the format above (present tense, no subject)
- [ ] Has a "how to test" section
- [ ] Only one thing is done in this pull request (specifically please try to refrain from mixing textual changes to the yamls from code changes)

