### PR TITLE
Increase required Python version to 3.7

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ The [Discussion board](https://github.com/Felienne/hedy/discussions) has ideas t
 Run Hedy code on your machine
 ------------
 
-If you are going to contribute to the code of Hedy, you will probably want to run the code on your own computer. For this you need to install Python 3.6 or higher. Then, here's how to get started once you have downloaded or cloned the code:
+If you are going to contribute to the code of Hedy, you will probably want to run the code on your own computer. For this you need to install Python 3.7 or higher. Then, here's how to get started once you have downloaded or cloned the code:
 
 ```bash
 $ python3 -m venv .env

--- a/app.py
+++ b/app.py
@@ -2,8 +2,8 @@
 import sys
 from website.yaml_file import YamlFile
 
-if (sys.version_info.major < 3 or sys.version_info.minor < 6):
-    print('Hedy requires Python 3.6 or newer to run. However, your version of Python is',
+if (sys.version_info.major < 3 or sys.version_info.minor < 7):
+    print('Hedy requires Python 3.7 or newer to run. However, your version of Python is',
           '.'.join([str(sys.version_info.major), str(sys.version_info.minor), str(sys.version_info.micro)]))
     quit()
 


### PR DESCRIPTION
**Description**

Increase required Python version documented in `CONTRIBUTING.md` from 3.6 to 3.7.

**Fix for**

Installation does not work with Python 3.6.9 as at least PySumTypes requires Python 3.7.

**How to test**

Follow instructions in `CONTRIBUTING.md`:

~~~
$ python3 -m venv .env
$ source .env/bin/activate
(.env)$ pip install -r requirements.txt
~~~

Last command will fail with Python < 3.7.