### PR TITLE
Spliting equal comparison rules and addressing #1643

### DIFF
--- a/grammars/level12-Additions.lark
+++ b/grammars/level12-Additions.lark
@@ -7,7 +7,9 @@ assign_list_equals: var _SPACE _EQUALS _SPACE (text_in_quotes|NUMBER) ((_COMMA _
 
 ?atom: NUMBER | var //unsupported numbers are gone, we can now allow floats with NUMBER
 
-equality_check: (var | text_in_quotes | NUMBER) _SPACE _IS_OR_EQUALS _SPACE (var | text_in_quotes | NUMBER)
+equality_check_is: (var | text_in_quotes | NUMBER) _SPACE _IS _SPACE (var | text_in_quotes | NUMBER)
+equality_check_equals: (var | text_in_quotes | NUMBER) _SPACE _EQUALS _SPACE (var | text_in_quotes | NUMBER)
+
 in_list_check: (var | text_in_quotes | NUMBER) _SPACE _IN _SPACE var
 
 error_invalid: "Supercalifragilisticexpialidocious" //invalid node should be deleted but this probably never matches anything :D

--- a/grammars/level13-Additions.lark
+++ b/grammars/level13-Additions.lark
@@ -1,8 +1,6 @@
 //  adds and and or
 
 ifs: _IF _SPACE (condition|andcondition|orcondition) _EOL (_SPACE command) (_EOL _SPACE command)* _EOL _END_BLOCK //'if' cannot be used in Python, hence the name of the rule is 'ifs'
-condition: (equality_check|in_list_check)
 
-
-andcondition: (equality_check|in_list_check) (_SPACE _AND _SPACE condition)*
-orcondition: (equality_check|in_list_check) (_SPACE _OR _SPACE condition)*
+andcondition: (condition) (_SPACE _AND _SPACE condition)*
+orcondition: (condition) (_SPACE _OR _SPACE condition)*

--- a/grammars/level14-Additions.lark
+++ b/grammars/level14-Additions.lark
@@ -1,10 +1,10 @@
 // adds comparisons
 
-condition: equality_check | in_list_check | smaller | bigger | not_equal | smaller_equal | bigger_equal
+condition:+= equality_check_dequals | smaller | bigger | not_equal | smaller_equal | bigger_equal
 
-_IS_OR_EQUALS_OR_DEQUALS: _DOUBLE_EQUALS | _IS_OR_EQUALS
-
-equality_check: comparison_arg _SPACE? _IS_OR_EQUALS_OR_DEQUALS _SPACE? comparison_arg
+equality_check_is: comparison_arg _SPACE? _IS _SPACE? comparison_arg
+equality_check_equals: comparison_arg _SPACE? _EQUALS _SPACE? comparison_arg
+equality_check_dequals: comparison_arg _SPACE? _DOUBLE_EQUALS _SPACE? comparison_arg
 smaller: comparison_arg _SPACE? _SMALLER _SPACE? comparison_arg
 bigger: comparison_arg _SPACE? _LARGER _SPACE? comparison_arg
 smaller_equal: comparison_arg _SPACE? _SMALLER_EQUALS _SPACE? comparison_arg

--- a/grammars/level6-Additions.lark
+++ b/grammars/level6-Additions.lark
@@ -3,12 +3,13 @@ _print_argument: (_SPACE | quoted_text | list_access | var_access | sum)*
 //splitting  these commands into two rules, one for equals and one for is so they can be properly handled in the translator
 command:+= ask_is | ask_equals | list_access_var_equals | list_access_var_is | assign_is | assign_equals | assign_list_is | assign_list_equals -= ask | list_access | assign | assign_list
 
-_IS_OR_EQUALS: (_IS|_EQUALS)
-
 ask_is: var _SPACE _IS _SPACE _ASK (_SPACE _print_argument)?
 ask_equals: var _SPACE _EQUALS _SPACE _ASK (_SPACE _print_argument)?
 
-equality_check: textwithoutspaces _SPACE _IS_OR_EQUALS _SPACE textwithoutspaces (_SPACE textwithoutspaces)*
+condition:+= equality_check_is | equality_check_equals -= equality_check
+
+equality_check_is: textwithoutspaces _SPACE _IS _SPACE textwithoutspaces (_SPACE textwithoutspaces)*
+equality_check_equals: textwithoutspaces _SPACE _EQUALS _SPACE textwithoutspaces (_SPACE textwithoutspaces)*
 
 list_access_var_is: var _SPACE _IS _SPACE var _SPACE _AT _SPACE (INT | random)
 list_access_var_equals: var _SPACE _EQUALS _SPACE var _SPACE _AT _SPACE (INT | random)

--- a/hedy.py
+++ b/hedy.py
@@ -521,6 +521,12 @@ class TypeValidator(Transformer):
         rules = [int_to_float, int_to_string, float_to_string] if self.level < 12 else [int_to_float]
         self.validate_binary_command_args_type(Command.equality, tree, rules)
         return self.to_typed_tree(tree, HedyType.boolean)
+    
+    def equality_check_is(self, tree):
+        return self.equality_check(tree)
+    
+    def equality_check_equals(self, tree):
+        return self.equality_check(tree)
 
     def repeat_list(self, tree):
         self.save_type_to_lookup(tree.children[0].children[0], HedyType.any)
@@ -1346,8 +1352,11 @@ class ConvertToPython_6(ConvertToPython_5):
 
         return f"str({arg0}) == str({arg1})"
 
-        #TODO if we start using fstrings here, this str can go
+    def equality_check_is(self, args):
+        return self.equality_check(args)
 
+    def equality_check_equals(self, args):
+        return self.equality_check(args)
 
     def assign(self, args):
         parameter = args[0]
@@ -1611,6 +1620,8 @@ class ConvertToPython_14(ConvertToPython_13):
         else:
             return f"{simple_comparison} and {args[2]}"
 
+    def equality_check_dequals(self, args):
+        return super().equality_check(args)
 
     def smaller(self, args):
         return self.process_comparison(args, "<")

--- a/hedy_translation.py
+++ b/hedy_translation.py
@@ -248,6 +248,12 @@ class ConvertToLang6(ConvertToLang5):
         var = args[0]
         var_list = args[1]
         return var + " " + self.keywords["is"] + " " + var_list + " " + self.keywords["at"]  + " " + args[2]
+    
+    def equality_check_is(self, args):
+        return args[0] + " " + self.keywords["is"] + " " + " ".join([str(c) for c in args[1:]]) + " "
+
+    def equality_check_equals(self, args):
+        return args[0] + " = ".join([str(c) for c in args[1:]]) + " "
 
 @hedy_translator(level=7)
 class ConvertToLang7(ConvertToLang6):
@@ -269,8 +275,11 @@ class ConvertToLang8(ConvertToLang7):
     def elses(self, args):
         return self.keywords["else"] + indent(args[0:])
 
-    def equality_check(self, args):
+    def equality_check_is(self, args):
         return args[0] + " " + self.keywords["is"] + " " + " ".join([str(c) for c in args[1:]])
+
+    def equality_check_equals(self, args):
+        return args[0] + " = " + " ".join([str(c) for c in args[1:]])
 
     def end_block(self, args):
         return args
@@ -319,6 +328,9 @@ class ConvertToLang13(ConvertToLang12):
 
 @hedy_translator(level=14)
 class ConvertToLang14(ConvertToLang13):
+
+    def equality_check_dequals(self, args):
+       return args[0] + " == " + " ".join([str(c) for c in args[1:]])     
 
     def bigger(self, args):
         return args[0] + " > " + args[1]

--- a/tests/test_level_14.py
+++ b/tests/test_level_14.py
@@ -170,6 +170,36 @@ class TestsLevel14(HedyTester):
       expected=expected,
       max_level=16)
 
+
+  @parameterized.expand(HedyTester.comparison_commands)
+  def test_comparisons_with_boolean(self, comparison):
+    code = textwrap.dedent(f"""\
+      leeftijd is ask 'Hoe oud ben jij?'
+      if leeftijd {comparison} 12 or leeftijd {comparison} 15
+          print 'Dan ben je jonger dan ik!'
+      if leeftijd {comparison} 12 and leeftijd {comparison} 15
+          print 'Some other string!'""")
+      
+    expected = textwrap.dedent(f"""\
+      leeftijd = input(f'Hoe oud ben jij?')
+      try:
+        leeftijd = int(leeftijd)
+      except ValueError:
+        try:
+          leeftijd = float(leeftijd)
+        except ValueError:
+          pass
+      if str(leeftijd).zfill(100){comparison}str(12).zfill(100) or str(leeftijd).zfill(100){comparison}str(15).zfill(100):
+        print(f'Dan ben je jonger dan ik!')
+      if str(leeftijd).zfill(100){comparison}str(12).zfill(100) and str(leeftijd).zfill(100){comparison}str(15).zfill(100):
+        print(f'Some other string!')""")
+
+    self.multi_level_tester(
+      code=code,
+      max_level=16,
+      expected=expected,
+    )
+
   @parameterized.expand([
     ("'text'", '1'),      # text and number
     ('1, 2', '1'),        # list and number


### PR DESCRIPTION
**Description**

I edited the grammar rules in levels 6, 12 and 14 to split the production rules for comparison using equals, is and double equals. Now each one of these have their own rule.

I also edited the way the condition rule is defined to use the merging operator introduced a few PRs ago. Also,  because the rules `andcondition` and `orcondition` manually added the comparison rules they worked with in the beginning of the rule it caused issue #1643. Since this was a small fix and was related with the work I was doing I'm addressing that issue in this PR as well.

**Fix for**

Fixes #1599 and fixes #1643 

**How to test**

I added a test in level 14 for translation and the hedy transpiler.

