### PR TITLE
[BUG FIX] Achievements related data is stored in session

### DIFF
--- a/app.py
+++ b/app.py
@@ -206,10 +206,12 @@ def initialize_session():
     session_id()
     login_user_from_token_cookie()
 
-@app.after_request
+
+@app.before_request
 def initialize_achievements():
     if current_user()['username'] and 'achieved' not in session:
         ACHIEVEMENTS.initialize_user_data(current_user()['username'])
+
 
 if os.getenv('IS_PRODUCTION'):
     @app.before_request
@@ -491,9 +493,7 @@ def parse():
 
         try:
             if username and ACHIEVEMENTS.verify_run_achievements(username, code, level, response):
-                print("Hier komen we nog")
                 response['achievements'] = ACHIEVEMENTS.get_earned_achievements()
-                print("Hier niet meer?")
         except Exception as E:
             print(f"error determining achievements for {code} with {E}")
 

--- a/app.py
+++ b/app.py
@@ -205,6 +205,8 @@ def initialize_session():
     # Invoke session_id() for its side effect
     session_id()
     login_user_from_token_cookie()
+    if current_user()['username']:
+        ACHIEVEMENTS.initialize_user_data(current_user()['username'])
 
 
 if os.getenv('IS_PRODUCTION'):
@@ -274,7 +276,6 @@ def setup_language():
     # Check that requested language is supported, otherwise return 404
     if g.lang not in ALL_LANGUAGES.keys():
         return "Language " + g.lang + " not supported", 404
-    ACHIEVEMENTS.update_language(g.lang)
     # Also get the 'ui' translations into a global object for this language, these
     # are used a lot so we can clean up a fair bit by initializing here.
     g.ui_texts = TRANSLATIONS.get_translations(g.lang, 'ui')
@@ -489,7 +490,9 @@ def parse():
 
         try:
             if username and ACHIEVEMENTS.verify_run_achievements(username, code, level, response):
+                print("Hier komen we nog")
                 response['achievements'] = ACHIEVEMENTS.get_earned_achievements()
+                print("Hier niet meer?")
         except Exception as E:
             print(f"error determining achievements for {code} with {E}")
 

--- a/app.py
+++ b/app.py
@@ -205,9 +205,11 @@ def initialize_session():
     # Invoke session_id() for its side effect
     session_id()
     login_user_from_token_cookie()
-    if current_user()['username']:
-        ACHIEVEMENTS.initialize_user_data(current_user()['username'])
 
+@app.after_request
+def initialize_achievements():
+    if current_user()['username'] and 'achieved' not in session:
+        ACHIEVEMENTS.initialize_user_data(current_user()['username'])
 
 if os.getenv('IS_PRODUCTION'):
     @app.before_request
@@ -326,7 +328,6 @@ def set_security_headers(response):
     # and that's okay.
     response.headers.update(security_headers)
     return response
-
 
 @app.teardown_request
 def teardown_request_finish_logging(exc):

--- a/website/achievements.py
+++ b/website/achievements.py
@@ -69,149 +69,149 @@ class Achievements:
             session['submitted_programs'] = 0
 
     def add_single_achievement(self, username, achievement):
-        if not self.achieved:
+        if not session['achieved']:
             self.get_db_data(username)
-        if achievement not in self.achieved and achievement in self.TRANSLATIONS.get_translations(self.lang):
+        if achievement not in session['achieved'] and achievement in self.TRANSLATIONS.get_translations(self.lang):
             return self.verify_pushed_achievement(username, achievement)
         else:
             return None
 
     def verify_run_achievements(self, username, code=None, level=None, response=None):
-        if not self.achieved:
+        if not session['achieved']:
             self.get_db_data(username)
-        self.check_programs_run(self.run_programs)
+        self.check_programs_run()
         if code and level:
             self.check_code_achievements(code, level)
         if code and response:
             self.check_response_achievements(code, response)
 
-        if len(self.new_commands) > 0:
-            for command in self.new_commands:
-                self.commands.append(command)
-            self.DATABASE.add_commands_to_username(username, self.commands)
+        if len(session['commands']) > 0:
+            for command in session['new_commands']:
+                session['commands'].append(command)
+            self.DATABASE.add_commands_to_username(username, session['commands'])
 
-        if len(self.new_achieved) > 0:
-            self.DATABASE.add_achievements_to_username(username, self.new_achieved)
-            for achievement in self.new_achieved:
-                self.achieved.append(achievement)
+        if len(session['new_achieved']) > 0:
+            self.DATABASE.add_achievements_to_username(username, session['new_achieved'])
+            for achievement in session['new_achieved']:
+                session['achieved'].append(achievement)
             return True
         return False
 
     def verify_save_achievements(self, username, adventure=None):
-        if not self.achieved:
+        if not session['achieved']:
             self.get_db_data(username)
-        self.check_programs_saved(self.saved_programs)
-        if adventure and 'adventure_is_worthwhile' not in self.achieved:
-            self.new_achieved.append("adventure_is_worthwhile")
+        self.check_programs_saved(session['saved_programs'])
+        if adventure and 'adventure_is_worthwhile' not in session['achieved']:
+            session['new_achieved'].append("adventure_is_worthwhile")
 
-        if len(self.new_achieved) > 0:
-            self.DATABASE.add_achievements_to_username(username, self.new_achieved)
-            for achievement in self.new_achieved:
-                self.achieved.append(achievement)
+        if len(session['new_achieved']) > 0:
+            self.DATABASE.add_achievements_to_username(username, session['new_achieved'])
+            for achievement in session['new_achieved']:
+                session['achieved'].append(achievement)
             return True
         return False
 
     def verify_submit_achievements(self, username):
-        if not self.achieved:
+        if not session['achieved']:
             self.get_db_data(username)
-        self.check_programs_submitted(self.submitted_programs)
+        self.check_programs_submitted(session['submitted_programs'])
 
-        if len(self.new_achieved) > 0:
-            self.DATABASE.add_achievements_to_username(username, self.new_achieved)
-            for achievement in self.new_achieved:
-                self.achieved.append(achievement)
+        if len(session['new_achieved']) > 0:
+            self.DATABASE.add_achievements_to_username(username, session['new_achieved'])
+            for achievement in session['new_achieved']:
+                session['achieved'].append(achievement)
             return True
         return False
 
     def verify_pushed_achievement(self, username, achievement):
-        self.new_achieved = [achievement]
+        session['new_achieved'] = [achievement]
         self.DATABASE.add_achievement_to_username(username, achievement)
-        self.achieved.append(achievement)
+        session['achieved'].append(achievement)
         return self.get_earned_achievements()
 
     def get_earned_achievements(self):
-        translations = self.TRANSLATIONS.get_translations(self.lang)
+        translations = self.TRANSLATIONS.get_translations(session['lang'])
         translated_achievements = []
-        for achievement in self.new_achieved:
+        for achievement in session['new_achieved']:
             translated_achievements.append([translations[achievement]['title'], translations[achievement]['text'], translations[achievement]['image']])
-        self.new_achieved = [] #Once we get earned achievements -> empty the array with "waiting" ones
-        self.new_commands = []
+        session['new_achieved'] = [] #Once we get earned achievements -> empty the array with "waiting" ones
+        session['new_commands'] = []
         return translated_achievements
 
-    def check_programs_run(self, amount):
-        if 'getting_started_I' not in self.achieved and amount >= 1:
-            self.new_achieved.append("getting_started_I")
-        if 'getting_started_II' not in self.achieved and amount >= 10:
-            self.new_achieved.append("getting_started_II")
-        if 'getting_started_III' not in self.achieved and amount >= 50:
-            self.new_achieved.append("getting_started_III")
-        if 'getting_started_IV' not in self.achieved and amount >= 200:
-            self.new_achieved.append("getting_started_IV")
-        if 'getting_started_V' not in self.achieved and amount >= 500:
-            self.new_achieved.append("getting_started_V")
+    def check_programs_run(self):
+        if 'getting_started_I' not in session['achieved'] and session['run_programs'] >= 1:
+            session['new_achieved'].append("getting_started_I")
+        if 'getting_started_II' not in session['achieved'] and session['run_programs'] >= 10:
+            session['new_achieved'].append("getting_started_II")
+        if 'getting_started_III' not in session['achieved'] and session['run_programs'] >= 50:
+            session['new_achieved'].append("getting_started_III")
+        if 'getting_started_IV' not in session['achieved'] and session['run_programs'] >= 200:
+            session['new_achieved'].append("getting_started_IV")
+        if 'getting_started_V' not in session['achieved'] and session['run_programs'] >= 500:
+            session['new_achieved'].append("getting_started_V")
 
-    def check_programs_saved(self, amount):
-        if 'one_to_remember_I' not in self.achieved and amount >= 1:
-            self.new_achieved.append("one_to_remember_I")
-        if 'one_to_remember_II' not in self.achieved and amount >= 5:
-            self.new_achieved.append("one_to_remember_II")
-        if 'one_to_remember_III' not in self.achieved and amount >= 10:
-            self.new_achieved.append("one_to_remember_III")
-        if 'one_to_remember_IV' not in self.achieved and amount >= 25:
-            self.new_achieved.append("one_to_remember_IV")
-        if 'one_to_remember_V' not in self.achieved and amount >= 50:
-            self.new_achieved.append("one_to_remember_V")
+    def check_programs_saved(self):
+        if 'one_to_remember_I' not in session['achieved'] and session['saved_programs'] >= 1:
+            session['new_achieved'].append("one_to_remember_I")
+        if 'one_to_remember_II' not in session['achieved'] and session['saved_programs'] >= 5:
+            session['new_achieved'].append("one_to_remember_II")
+        if 'one_to_remember_III' not in session['achieved'] and session['saved_programs'] >= 10:
+            session['new_achieved'].append("one_to_remember_III")
+        if 'one_to_remember_IV' not in session['achieved'] and session['saved_programs'] >= 25:
+            session['new_achieved'].append("one_to_remember_IV")
+        if 'one_to_remember_V' not in session['achieved'] and session['saved_programs'] >= 50:
+            session['new_achieved'].append("one_to_remember_V")
 
-    def check_programs_submitted(self, amount):
-        if 'deadline_daredevil_I' not in self.achieved and amount >= 1:
-            self.new_achieved.append("deadline_daredevil_I")
-        if 'deadline_daredevil_II' not in self.achieved and amount >= 3:
-            self.new_achieved.append("deadline_daredevil_II")
-        if 'deadline_daredevil_III' not in self.achieved and amount >= 10:
-            self.new_achieved.append("deadline_daredevil_III")
+    def check_programs_submitted(self):
+        if 'deadline_daredevil_I' not in session['achieved'] and session['submitted_programs'] >= 1:
+            session['new_achieved'].append("deadline_daredevil_I")
+        if 'deadline_daredevil_II' not in session['achieved'] and session['submitted_programs'] >= 3:
+            session['new_achieved'].append("deadline_daredevil_II")
+        if 'deadline_daredevil_III' not in session['achieved'] and session['submitted_programs'] >= 10:
+            session['new_achieved'].append("deadline_daredevil_III")
 
     def check_code_achievements(self, code, level):
-        commands_in_code = hedy.all_commands(code, level, self.lang)
-        if 'trying_is_key' not in self.achieved:
+        commands_in_code = hedy.all_commands(code, level, session['lang'])
+        if 'trying_is_key' not in session['achieved']:
             for command in set(commands_in_code):
-                if command not in self.commands:
-                    self.new_commands.append(command)
-        if set(self.commands) == set(hedy.commands_per_level.get(hedy.HEDY_MAX_LEVEL)):
-            self.new_achieved.append("trying_is_key")
-        if 'did_you_say_please' not in self.achieved and "ask" in hedy.all_commands(code, level, self.lang):
-            self.new_achieved.append("did_you_say_please")
-        if 'talk-talk-talk' not in self.achieved and hedy.all_commands(code, level, self.lang).count("ask") >= 5:
-            self.new_achieved.append("talk-talk-talk")
-        if 'hedy_honor' not in self.achieved and "Hedy" in code:
-            self.new_achieved.append("hedy_honor")
-        if 'hedy-ious' not in self.achieved:
-            all_print_arguments = hedy.all_print_arguments(code, level, self.lang)
+                if command not in session['commands']:
+                    session['new_commands'].append(command)
+        if set(session['commands']) == set(hedy.commands_per_level.get(hedy.HEDY_MAX_LEVEL)):
+            session['new_achieved'].append("trying_is_key")
+        if 'did_you_say_please' not in session['achieved'] and "ask" in hedy.all_commands(code, level, session['lang']):
+            session['new_achieved'].append("did_you_say_please")
+        if 'talk-talk-talk' not in session['achieved'] and hedy.all_commands(code, level, session['lang']).count("ask") >= 5:
+            session['new_achieved'].append("talk-talk-talk")
+        if 'hedy_honor' not in session['achieved'] and "Hedy" in code:
+            session['new_achieved'].append("hedy_honor")
+        if 'hedy-ious' not in session['achieved']:
+            all_print_arguments = hedy.all_print_arguments(code, level, session['lang'])
             for argument in all_print_arguments:
                 if all_print_arguments.count(argument) >= 10:
-                    self.new_achieved.append("hedy-ious")
+                    session['new_achieved'].append("hedy-ious")
                     break
 
 
     def check_response_achievements(self, code, response):
-        if 'ninja_turtle' not in self.achieved and 'has_turtle' in response and response['has_turtle']:
-            self.new_achieved.append("ninja_turtle")
-        if 'watch_out' not in self.achieved and 'Warning' in response and response['Warning']:
-            self.new_achieved.append("watch_out")
+        if 'ninja_turtle' not in session['achieved'] and 'has_turtle' in response and response['has_turtle']:
+            session['new_achieved'].append("ninja_turtle")
+        if 'watch_out' not in session['achieved'] and 'Warning' in response and response['Warning']:
+            session['new_achieved'].append("watch_out")
         if 'Error' in response and response['Error']:
-            self.consecutive_errors += 1
-            if self.previous_code == code:
-                if self.identical_consecutive_errors == 0:
-                    self.identical_consecutive_errors += 2 #We have to count the first one too!
-                self.identical_consecutive_errors += 1
-            if self.identical_consecutive_errors >= 3:
-                if 'programming_panic' not in self.achieved:
-                    self.new_achieved.append("programming_panic")
-            self.previous_code = code
+            session['consecutive_errors'] += 1
+            if session['previous_code'] == code:
+                if session['identical_consecutive_errors'] == 0:
+                    session['identical_consecutive_errors'] += 2 #We have to count the first one too!
+                session['identical_consecutive_errors'] += 1
+            if session['identical_consecutive_errors'] >= 3:
+                if 'programming_panic' not in session['achieved']:
+                    session['new_achieved'].append("programming_panic")
+            session['previous_code'] = code
         else:
-            if 'programming_protagonist' not in self.achieved and self.consecutive_errors >= 1:
-                self.new_achieved.append("programming_protagonist")
-            self.consecutive_errors = 0
-            self.identical_consecutive_errors = 0
+            if 'programming_protagonist' not in session['achieved'] and session['consecutive_errors'] >= 1:
+                session['new_achieved'].append("programming_protagonist")
+            session['consecutive_errors'] = 0
+            session['identical_consecutive_errors'] = 0
 
 
 

--- a/website/achievements.py
+++ b/website/achievements.py
@@ -22,7 +22,7 @@ class Achievements:
             if "achievement" in body:
                 if not session['achieved']:
                     self.initialize_user_data(user['username'])
-                if body['achievement'] not in session['achieved'] and body['achievement'] in self.TRANSLATIONS.get_translations(self.lang):
+                if body['achievement'] not in session['achieved'] and body['achievement'] in self.TRANSLATIONS.get_translations(session['lang']):
                     return jsonify({"achievements": self.verify_pushed_achievement(user.get('username'), body['achievement'])})
             return jsonify({})
 

--- a/website/achievements.py
+++ b/website/achievements.py
@@ -41,7 +41,8 @@ class Achievements:
         session['previous_code'] = None
         session['identical_consecutive_errors'] = 0
         session['consecutive_errors'] = 0
-
+        if not achievements_data:
+            achievements_data = {}
         if 'achieved' in achievements_data:
             session['achieved'] = achievements_data['achieved']
         else:

--- a/website/achievements.py
+++ b/website/achievements.py
@@ -1,7 +1,7 @@
 from website import database
 from hedyweb import AchievementTranslations
 from website.auth import requires_login
-from flask import request, jsonify
+from flask import request, jsonify, session
 import hedy
 
 
@@ -10,20 +10,17 @@ class Achievements:
     def __init__(self):
         self.DATABASE = database.Database()
         self.TRANSLATIONS = AchievementTranslations()
-        self.achieved = None
-        self.new_achieved = []
-        self.commands = None
-        self.new_commands = []
-        self.lang = "en"
-        self.previous_code = None
-        self.run_programs = 0
-        self.saved_programs = 0
-        self.submitted_programs = 0
-        self.identical_consecutive_errors = 0
-        self.consecutive_errors = 0
 
-    def update_language(self, lang):
-        self.lang = lang
+        session['achieved'] = None
+        session['new_achieved'] = []
+        session['commands'] = None
+        session['new_commands'] = []
+        session['previous_code'] = None
+        session['run_programs'] = 0
+        session['saved_programs'] = 0
+        session['submitted_programs'] = 0
+        session['identical_consecutive_errors'] = 0
+        session['consecutive_errors'] = 0
 
     def routes(self, app, database):
         global DATABASE
@@ -34,42 +31,42 @@ class Achievements:
         def push_new_achievement(user):
             body = request.json
             if "achievement" in body:
-                if not self.achieved:
+                if not session['achieved']:
                     self.get_db_data(user['username'])
-                if body['achievement'] not in self.achieved and body['achievement'] in self.TRANSLATIONS.get_translations(self.lang):
+                if body['achievement'] not in session['achieved'] and body['achievement'] in self.TRANSLATIONS.get_translations(self.lang):
                     return jsonify({"achievements": self.verify_pushed_achievement(user.get('username'), body['achievement'])})
             return jsonify({})
 
     def increase_count(self, category):
         if category == "run":
-            self.run_programs += 1
+            session['run_programs'] += 1
         elif category == "saved":
-            self.saved_programs += 1
+            session['saved_programs'] += 1
         elif category == "submitted":
-            self.submitted_programs += 1
+            session['submitted_programs'] += 1
 
     def get_db_data(self, username):
         achievements_data = self.DATABASE.progress_by_username(username)
         if 'achieved' in achievements_data:
-            self.achieved = achievements_data['achieved']
+            session['achieved'] = achievements_data['achieved']
         else:
-            self.achieved = []
+            session['achieved'] = []
         if 'commands' in achievements_data:
-            self.commands = achievements_data['commands']
+            session['commands'] = achievements_data['commands']
         else:
-            self.commands = []
+            session['commands'] = []
         if 'run_programs' in achievements_data:
-            self.run_programs = achievements_data['run_programs']
+            session['run_programs'] = achievements_data['run_programs']
         else:
-            self.run_programs = 0
+            session['run_programs'] = 0
         if 'saved_programs' in achievements_data:
-            self.saved_programs = achievements_data['saved_programs']
+            session['saved_programs'] = achievements_data['saved_programs']
         else:
-            self.saved_programs = 0
+            session['saved_programs'] = 0
         if 'submitted_programs' in achievements_data:
-            self.submitted_programs = achievements_data['submitted_programs']
+            session['submitted_programs'] = achievements_data['submitted_programs']
         else:
-            self.submitted_programs = 0
+            session['submitted_programs'] = 0
 
     def add_single_achievement(self, username, achievement):
         if not self.achieved:


### PR DESCRIPTION
**Description**
Currently we use a global variable `achievements` to store the user progress and achievements. However, when multiple users are logged in at the same time they share this variable as well as the values. Resulting in the undesirable behavior that users where unable to achieve achievements (because another user already got them) or they received random pop-ups of other users their achievements. As pointed out by @rix0rrr we can solve this by storing all user-related data in a session.

In this PR the achievements implementation is re-written to store all user-related data in a session and compare the achievements against this data. Resulting in users no longer interfering with each other.

**How to test**
Use Hedy with multiple users at the same time and notice that they no longer interfere with each others achievements

**Checklist**

If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [ ] Links to an existing issue or discussion (if not, create an issue first)
- [ ] Describes changes clear in the format above (present tense, no subject)
- [ ] Has a "how to test" section
- [ ] Only one thing is done in this pull request (specifically please try to refrain from mixing textual changes to the yamls from code changes)

