### PR TITLE
[IMPROVEMENT] Changed clickable area of quiz answer to whole answer box

### DIFF
--- a/templates/quiz_question.html
+++ b/templates/quiz_question.html
@@ -45,44 +45,13 @@
                     <div class="flex flex-row">
                     {% for column in row %}
                         <div class="flex flex-col">
-                            {% if question.correct_answer == chosen_option %}
-                                <div class="p-1 border-blue-600 tw-border-3 rounded-lg shadow-lg radio-block flex flex-row"
-                                     id="{{ question_options[counter.value].char_index }}">
+                            {% if question_options[counter.value].char_index == chosen_option %}
+                                <div class="p-1 border-blue-600 tw-border-3 rounded-lg shadow-lg radio-block flex flex-row" id="answer-disabled-{{ question_options[counter.value].char_index }}">
                                     <label class="inline-flex items-center">
-                                    <div class="flex-1 flex-col justify-center items-center">
-                                          <p
-                                            class="text-3xl font-bold ml-3 mr-3 font-slab">
-                                        {{ question_options[counter.value].char_index }}</p>
-                                                          <input
-                                                type="radio"
-                                                name="radio_option"
-                                                value="{{ question_nr }}-{{ question_options[counter.value].char_index }}"
-                                                class="class form-radio size-input">
-                                        </div>
-
-                                        {% if not question_options[counter.value].option_text or question_options[counter.value].option_text == 'None' %}
-                                            <code class="ml-3 text-l">{{ question_options[counter.value].code|nl2br }}</code>
-                                        {% elif not question_options[counter.value].code or question_options[counter.value].code == 'None'  %}
-                                            <p class="ml-3 text-l font-bold"> {{ question_options[counter.value].option_text|nl2br }}</p>
-                                        {% endif %}
-                                    </label>
-                                </div>
-                            {% elif question_options[counter.value].char_index == chosen_option %}
-                                <div class="p-1 border-blue-600 tw-border-3 rounded-lg shadow-lg radio-block flex flex-row"
-                                     id="answer-disabled-{{ question_options[counter.value].char_index }}">
-                                    <label class="inline-flex items-center"><p
-                                            class="text-3xl font-bold ml-3 mr-3 font-slab">
                                         <div class="flex-1 flex-col justify-center items-center">
-                                            <p class="text-3xl font-bold ml-3 mr-3 font-slab">
-                                                 {{ question_options[counter.value].char_index }}</p>
-                                         <input
-                                                type="radio"
-                                                name="radio_option"
-                                                value="{{ question_nr }}-{{ question_options[counter.value].char_index }}"
-                                                class="class form-radio size-input" disabled="disabled">
-
-
-                                            </div>
+                                            <p class="text-3xl font-bold ml-3 mr-3 font-slab">{{ question_options[counter.value].char_index }}</p>
+                                            <input type="radio" name="radio_option" value="{{ question_nr }}-{{ question_options[counter.value].char_index }}" class="class form-radio size-input" disabled="disabled">
+                                        </div>
                                         {% if not question_options[counter.value].option_text or question_options[counter.value].option_text == 'None' %}
                                             <code class="ml-3 text-l">{{ question_options[counter.value].code | nl2br  }}</code>
                                         {% elif not question_options[counter.value].code or question_options[counter.value].code == 'None'   %}
@@ -91,24 +60,17 @@
                                     </label>
                                 </div>
                             {% else %}
-                                <div class="p-1 border-blue-600 tw-border-3 rounded-lg shadow-lg radio-block flex flex-row"
-                                     id={{ question_options[counter.value].char_index }}>
+                                <div class="p-1 border-blue-600 tw-border-3 rounded-lg shadow-lg radio-block flex flex-row" id={{ question_options[counter.value].char_index }}>
                                     <label class="inline-flex items-center">
                                          <div class="flex-1 flex-col justify-center items-center">
-                                              <p class="text-3xl font-bold ml-3 mr-3 font-slab">
-                                        {{ question_options[counter.value].char_index }}</p>
-                                        <input
-                                                type="radio"
-                                                name="radio_option"
-                                                value="{{ question_nr }}-{{ question_options[counter.value].char_index }}"
-                                                class="class form-radio size-input">
-
-                                           </div>
-                                                {% if not question_options[counter.value].option_text or question_options[counter.value].option_text == 'None' %}
-                                                    <code class="ml-3 text-l">{{ question_options[counter.value].code | nl2br }}</code>
-                                                {% elif not question_options[counter.value].code or question_options[counter.value].code == 'None'  %}
-                                                    <p class="ml-3 text-l font-bold"> {{ question_options[counter.value].option_text | nl2br }}</p>
-                                                {% endif %}
+                                             <p class="text-3xl font-bold ml-3 mr-3 font-slab">{{ question_options[counter.value].char_index }}</p>
+                                             <input type="radio" name="radio_option" value="{{ question_nr }}-{{ question_options[counter.value].char_index }}" class="class form-radio size-input">
+                                         </div>
+                                        {% if not question_options[counter.value].option_text or question_options[counter.value].option_text == 'None' %}
+                                            <code class="ml-3 text-l">{{ question_options[counter.value].code | nl2br }}</code>
+                                        {% elif not question_options[counter.value].code or question_options[counter.value].code == 'None'  %}
+                                            <p class="ml-3 text-l font-bold"> {{ question_options[counter.value].option_text | nl2br }}</p>
+                                        {% endif %}
                                     </label>
                                 </div>
                             {% endif %}

--- a/templates/quiz_question.html
+++ b/templates/quiz_question.html
@@ -13,8 +13,11 @@
                 }
             }
             function selectAnswer(value) {
-                $("#" + value).prop("checked", true);
-                $("input[name='submit-button']").prop("disabled", false);
+                // We only want to select an answer if it isn't disabled
+                if (!$("#" + value).prop("disabled")) {
+                    $("#" + value).prop("checked", true);
+                    $("input[name='submit-button']").prop("disabled", false);
+                }
             }
         </script>
     </head>

--- a/templates/quiz_question.html
+++ b/templates/quiz_question.html
@@ -4,12 +4,6 @@
     <head>
         <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
         <script type=text/javascript>
-            $(function () {
-                $("input[name='radio_option']").change(function () {
-                    $("input[name='submit-button']").prop("disabled", false);
-                });
-            });
-
             function changeHint() {
                 const btn = document.getElementById("hint-button");
                 if (btn.innerText === "{{ ui.hint }}") {
@@ -18,7 +12,10 @@
                     btn.innerText = "{{ ui.hint }}";
                 }
             }
-
+            function selectAnswer(value) {
+                $("#" + value).prop("checked", true);
+                $("input[name='submit-button']").prop("disabled", false);
+            }
         </script>
     </head>
     <body>
@@ -44,13 +41,13 @@
                 {% for row in question.mp_choice_options|batch(2) %}
                     <div class="flex flex-row">
                     {% for column in row %}
-                        <div class="flex flex-col">
+                        <div class="flex flex-col" onclick="selectAnswer('{{ question_nr }}-{{ question_options[counter.value].char_index }}')">
                             {% if question_options[counter.value].char_index == chosen_option %}
                                 <div class="p-1 border-blue-600 tw-border-3 rounded-lg shadow-lg radio-block flex flex-row" id="answer-disabled-{{ question_options[counter.value].char_index }}">
                                     <label class="inline-flex items-center">
                                         <div class="flex-1 flex-col justify-center items-center">
                                             <p class="text-3xl font-bold ml-3 mr-3 font-slab">{{ question_options[counter.value].char_index }}</p>
-                                            <input type="radio" name="radio_option" value="{{ question_nr }}-{{ question_options[counter.value].char_index }}" class="class form-radio size-input" disabled="disabled">
+                                            <input type="radio" name="radio_option" id="{{ question_nr }}-{{ question_options[counter.value].char_index }}" value="{{ question_nr }}-{{ question_options[counter.value].char_index }}" class="class form-radio size-input" disabled="disabled">
                                         </div>
                                         {% if not question_options[counter.value].option_text or question_options[counter.value].option_text == 'None' %}
                                             <code class="ml-3 text-l">{{ question_options[counter.value].code | nl2br  }}</code>
@@ -64,7 +61,7 @@
                                     <label class="inline-flex items-center">
                                          <div class="flex-1 flex-col justify-center items-center">
                                              <p class="text-3xl font-bold ml-3 mr-3 font-slab">{{ question_options[counter.value].char_index }}</p>
-                                             <input type="radio" name="radio_option" value="{{ question_nr }}-{{ question_options[counter.value].char_index }}" class="class form-radio size-input">
+                                             <input type="radio" name="radio_option" id="{{ question_nr }}-{{ question_options[counter.value].char_index }}" value="{{ question_nr }}-{{ question_options[counter.value].char_index }}" class="class form-radio size-input">
                                          </div>
                                         {% if not question_options[counter.value].option_text or question_options[counter.value].option_text == 'None' %}
                                             <code class="ml-3 text-l">{{ question_options[counter.value].code | nl2br }}</code>


### PR DESCRIPTION
**Description**
In this PR we perform a clean-up of the quiz question code. Some redundant html code is removed, a small bug were the wrong answers would be indented is solved and the whole answer box is set as clickable to select an answer. This way the quiz is more user-friendly for table and phone users. In the future I would like to remove the radio button all together and use the answer box itself with changing border colors as an indicator of the select answer. However, for know this is an easy and functional improvement.

**Fix for**
This PR fixes #1648.

**How to test**
When answering a question in the quiz, notice that now you're able to click the whole answer box to select an answer instead of only being able to click the radio button.

