### PR TITLE
[FIX] limits shown programs on explore page

### DIFF
--- a/website/database.py
+++ b/website/database.py
@@ -220,7 +220,7 @@ class Database:
                 if 'adventure_name' in program and program['adventure_name'] == adventure:
                     adventure_programs.append(program)
             result = adventure_programs
-        return result
+        return result[-50:]
 
     def all_programs_count(self):
         """Return the total number of all programs."""

--- a/website/database.py
+++ b/website/database.py
@@ -197,7 +197,10 @@ class Database:
         for program in programs:
             if 'public' in program:
                 public_programs.append(program)
-        return public_programs
+        return public_programs[-50:]
+        #Todo:
+        # This [-50:] is a bucket-fix, we would like to add a partition key to the programs table
+        # Enabling us to directly only retrieve the last x programs by using the filter() function
 
     def get_filtered_explore_programs(self, level=None, adventure=None):
         programs = PROGRAMS.scan()


### PR DESCRIPTION
**Description**
Currently we return all public programs to the user when visiting the `explore` page. This is undesirable as this amount will increase resulting in a very slow webpage. In this PR we implement a quick fix to limit this amount to `50` programs. This is only a temporary fix, the goal is to implement `Public` as a partition key on the db to enable us to use the new `filter()` function to retrieve the desired amount of programs.

**Fix for**
This has no related issue, just a (very) quick fix to prevent webpages from crashing

**How to test**
Navigate to the explore page and notice that the amount of shown programs is limited to 50.
