### PR TITLE
fix link syntax for the github repo

### DIFF
--- a/templates/translate-fromto.html
+++ b/templates/translate-fromto.html
@@ -31,7 +31,7 @@
       <li>Fill out all your translations in the field on the right.</li>
       <li>For each file with changes, a download button will appear in the green bar</li>
       <li>Download all these files to your computer.</li>
-      <li>Send the files to us via <a href="mailto:hedy@felienne.com">email</a> or send us a pull request on <a href=https://github.com/Felienne/hedy/">GitHub</a></li>
+      <li>Send the files to us via <a href="mailto:hedy@felienne.com">email</a> or send us a pull request on <a href="https://github.com/Felienne/hedy/">GitHub</a></li>
     </ol>
 
     <div class="m-4">


### PR DESCRIPTION
Provide a general summary of your changes in the Title of the PR

**Description**

Describe your changes in detail. Please use present tense without a subject to describe your PR, for example: "Fix**es** issue 123" or "Adds translations of levels 1 to 12 for Polish"

**Fix for**
Link in https://www.hedycode.com/translate/en/de to the Github repository currently does not work due to a double quote being inserted. It links to https://github.com/Felienne/hedy/%22 instead of https://github.com/Felienne/hedy/

**How to test**

**Checklist**

If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [ ] Links to an existing issue or discussion (if not, create an issue first)
- [ ] Describes changes clear in the format above (present tense, no subject)
- [ ] Has a "how to test" section
- [ ] Only one thing is done in this pull request (specifically please try to refrain from mixing textual changes to the yamls from code changes)

