### PR TITLE
[BUG FIX] Adds missing stats page title

### DIFF
--- a/coursedata/pages/pages.json
+++ b/coursedata/pages/pages.json
@@ -55,6 +55,10 @@
     "en": "Hedy - Customize class",
     "nl": "Hedy - Klas personaliseren"
   },
+  "class statistics": {
+    "en": "Hedy - Class statistics",
+    "nl": "Hedy - Klas statistieken"
+  },
   "explore": {
     "en": "Hedy - Explore",
     "nl": "Hedy - Ontdekken"

--- a/templates/class-overview.html
+++ b/templates/class-overview.html
@@ -44,7 +44,7 @@
     <button class="green-btn ml-4" onclick="hedyApp.rename_class ('{{class_info.id}}')">{{auth.rename_class}}</button>
     <button class="green-btn ml-4" onclick="hedyApp.copy_to_clipboard ('{{class_info.link}}')">{{auth.copy_class_link
       }}</button>
-    {% if not is_beta_teacher %}
+    {% if is_beta_teacher %}
     <button class="green-btn ml-4" onclick="window.location.href = '/stats/class/{{class_info.id}}'">{{auth
       .class_stats}}</button>
     {% endif %}

--- a/templates/class-overview.html
+++ b/templates/class-overview.html
@@ -44,7 +44,7 @@
     <button class="green-btn ml-4" onclick="hedyApp.rename_class ('{{class_info.id}}')">{{auth.rename_class}}</button>
     <button class="green-btn ml-4" onclick="hedyApp.copy_to_clipboard ('{{class_info.link}}')">{{auth.copy_class_link
       }}</button>
-    {% if is_beta_teacher %}
+    {% if not is_beta_teacher %}
     <button class="green-btn ml-4" onclick="window.location.href = '/stats/class/{{class_info.id}}'">{{auth
       .class_stats}}</button>
     {% endif %}

--- a/website/statistics.py
+++ b/website/statistics.py
@@ -1,5 +1,7 @@
 from collections import namedtuple
 from flask import request, jsonify
+
+import hedyweb
 from flask_helpers import render_template
 from website.auth import requires_login, is_admin, is_teacher
 
@@ -28,7 +30,8 @@ def routes(app, db):
         if not class_ or (class_['teacher'] != user['username'] and not is_admin(user)):
             return utils.error_page(error=404, ui_message='no_such_class')
 
-        return render_template('class-stats.html', class_info={'id': class_id})
+        return render_template('class-stats.html', class_info={'id': class_id},
+                               current_page='my-profile', page_title=hedyweb.get_page_title('class statistics'))
 
     @app.route('/class-stats/<class_id>', methods=['GET'])
     @requires_login

--- a/website/teacher.py
+++ b/website/teacher.py
@@ -60,7 +60,7 @@ def routes (app, database, achievements):
         teachers = os.getenv('BETA_TEACHERS', '').split(',')
         is_beta_teacher = user['username'] in teachers
 
-        return render_template ('class-overview.html', current_page='for-teachers',
+        return render_template ('class-overview.html', current_page='my-profile',
                                 page_title=hedyweb.get_page_title('class overview'),
                                 achievement=achievement,
                                 is_beta_teacher=is_beta_teacher,
@@ -210,7 +210,7 @@ def routes (app, database, achievements):
 
         return render_template('customize-class.html', page_title=hedyweb.get_page_title('customize class'),
                                class_info={'name': Class['name'], 'id': Class['id']}, levels=levels,
-                               adventures=adventures, preferences=preferences, current_page='for-teachers')
+                               adventures=adventures, preferences=preferences, current_page='my-profile')
 
     @app.route('/customize-class/<class_id>', methods=['PUT'])
     @requires_login


### PR DESCRIPTION
**Description**
Currently the class statistics page has no corresponding page title and no set current page. In this PR we fix both by adding them to the `render_template` as well as adding the correct title to `pages.json`.

**Fix for**
This PR fixes #1782.

**How to test**
Navigate to the class statistics and notice there is now a correct page title.

