### PR TITLE
spell "meantime" as one word without space

### DIFF
--- a/coursedata/texts/el.yaml
+++ b/coursedata/texts/el.yaml
@@ -24,7 +24,7 @@ ClientErrorMessages:
     Other_error: 'Ουπς! Ίσως να κάναμε κάποιο λαθάκι.'
     Execute_error: 'Κάτι πήγε στραβά όσο εκτελούσαμε το πρόγραμμα.'
     CheckInternet: "Have a look if your Internet connection is working properly?"
-    ServerError: "You wrote a program we weren't expecting. If you want to help, send us an email with the level and your program at hedy@felienne.com. In the mean time, try something a little different and take another look at the examples. Thanks!"
+    ServerError: "You wrote a program we weren't expecting. If you want to help, send us an email with the level and your program at hedy@felienne.com. In the meantime, try something a little different and take another look at the examples. Thanks!"
     Program_too_long: "Your program takes too long to run."
 HedyErrorMessages:
     Wrong Level: 'Αυτός ήταν σωστός κώδικας Hedy, αλλά όχι στο σωστό επίπεδο. Έγραψες κώδικα για το επίπεδο {working_level} στο επίπεδο {original_level}.'

--- a/coursedata/texts/en.yaml
+++ b/coursedata/texts/en.yaml
@@ -73,7 +73,7 @@ ClientErrorMessages:
     Execute_error: "Something went wrong while running the program."
     Empty_output: "This code works but does not print anything. Add a print command to your code or use the turtle to get output."
     CheckInternet: "Have a look if your Internet connection is working properly?"
-    ServerError: "You wrote a program we weren't expecting. If you want to help, send us an email with the level and your program at hedy@felienne.com. In the mean time, try something a little different and take another look at the examples. Thanks!"
+    ServerError: "You wrote a program we weren't expecting. If you want to help, send us an email with the level and your program at hedy@felienne.com. In the meantime, try something a little different and take another look at the examples. Thanks!"
     Program_too_long: "Your program takes too long to run."
     Program_repair: "This could be the correct code, can you fix it?"
 HedyErrorMessages:

--- a/coursedata/texts/es.yaml
+++ b/coursedata/texts/es.yaml
@@ -64,7 +64,7 @@ ClientErrorMessages:
     Other_error: "¡Ups! Quizás hemos cometido un pequeño error."
     Execute_error: "Algo salió mal mientras se ejecutaba el programa."
     CheckInternet: "Have a look if your Internet connection is working properly?"
-    ServerError: "You wrote a program we weren't expecting. If you want to help, send us an email with the level and your program at hedy@felienne.com. In the mean time, try something a little different and take another look at the examples. Thanks!"
+    ServerError: "You wrote a program we weren't expecting. If you want to help, send us an email with the level and your program at hedy@felienne.com. In the meantime, try something a little different and take another look at the examples. Thanks!"
     Program_too_long: "Tu programa toma demasiado tiempo en correr."
 HedyErrorMessages:
     Wrong Level: "Ese código es correcto, pero no pertenece al nivel correcto. Has escrito código para el nivel {working_level} mientras trabajabas en el nivel {original_level}."

--- a/coursedata/texts/fr.yaml
+++ b/coursedata/texts/fr.yaml
@@ -30,7 +30,7 @@ ClientErrorMessages:
     Other_error: "Oups! Nous avons rencontré une erreur."
     Execute_error: "Quelque chose s’est mal passé en exécutant ce programme."
     CheckInternet: "Have a look if your Internet connection is working properly?"
-    ServerError: "You wrote a program we weren't expecting. If you want to help, send us an email with the level and your program at hedy@felienne.com. In the mean time, try something a little different and take another look at the examples. Thanks!"
+    ServerError: "You wrote a program we weren't expecting. If you want to help, send us an email with the level and your program at hedy@felienne.com. In the meantime, try something a little different and take another look at the examples. Thanks!"
     Program_too_long: "Your program takes too long to run."
 HedyErrorMessages:
     Wrong Level: "Ce code est du code Hedy valide, mais pas du bon niveau. Tu as saisis du code {working_level} au niveau {original_level}."

--- a/coursedata/texts/it.yaml
+++ b/coursedata/texts/it.yaml
@@ -24,7 +24,7 @@ ClientErrorMessages:
     Other_error: "Ops! Forse abbiamo fatto un errore."
     Execute_error: "Qualcosa è andato storto nell'esecuzione del tuo codice."
     CheckInternet: "Have a look if your Internet connection is working properly?"
-    ServerError: "You wrote a program we weren't expecting. If you want to help, send us an email with the level and your program at hedy@felienne.com. In the mean time, try something a little different and take another look at the examples. Thanks!"
+    ServerError: "You wrote a program we weren't expecting. If you want to help, send us an email with the level and your program at hedy@felienne.com. In the meantime, try something a little different and take another look at the examples. Thanks!"
     Program_too_long: "Your program takes too long to run."
 HedyErrorMessages:
     Wrong Level: "Questo è il codice Hedy corretto ma non al livello giusto. Hai scritto un codice per il livello {working_level} al livello {original_level}."

--- a/coursedata/texts/sw.yaml
+++ b/coursedata/texts/sw.yaml
@@ -24,7 +24,7 @@ ClientErrorMessages:
   Other_error: "Oops! Labda tulifanya makosa kidogo."
   Execute_error: "Matatizo fulani ilitokea wakati wa kuendesha programu."
   CheckInternet: "Have a look if your Internet connection is working properly?"
-  ServerError: "You wrote a program we weren't expecting. If you want to help, send us an email with the level and your program at hedy@felienne.com. In the mean time, try something a little different and take another look at the examples. Thanks!"
+  ServerError: "You wrote a program we weren't expecting. If you want to help, send us an email with the level and your program at hedy@felienne.com. In the meantime, try something a little different and take another look at the examples. Thanks!"
   Program_too_long: "Your program takes too long to run."
 HedyErrorMessages:
   Wrong Level: "Ni sahihi, lakini sio jibu la kiwango hiki. Umeandika jibu la kiwango  {working_level} kwenye kiwango cha {original_level}."

--- a/coursedata/texts/zh.yaml
+++ b/coursedata/texts/zh.yaml
@@ -25,7 +25,7 @@ ClientErrorMessages:
     Other_error: "糟糕! 也许我们犯了一个小错误."
     Execute_error: "在运行程序时出了点问题."
     CheckInternet: "Have a look if your Internet connection is working properly?"
-    ServerError: "You wrote a program we weren't expecting. If you want to help, send us an email with the level and your program at hedy@felienne.com. In the mean time, try something a little different and take another look at the examples. Thanks!"
+    ServerError: "You wrote a program we weren't expecting. If you want to help, send us an email with the level and your program at hedy@felienne.com. In the meantime, try something a little different and take another look at the examples. Thanks!"
     Program_too_long: "Your program takes too long to run."
 HedyErrorMessages:
     Wrong Level: "这个 Hedy代码是正确的，但级别不对.你在第{original_level}级使用的是第{working_level}级的代码."


### PR DESCRIPTION
spell "meantime" as one word without space.

**Description**

replaces "mean time" by "meantime" in an error message and its (untranslated) translations


**Checklist**

- [ ] Links to an existing issue or discussion (if not, create an issue first)
  - Is that required? I didn't see anything about that in the [contributing guidelines](https://github.com/Felienne/hedy/blob/025068018d0bdfea0ddcd16962e8ef3a4fcba36b/CONTRIBUTING.md).
- [x] Describes changes clear in the format above (present tense, no subject)
- [x] Has a "how to test" section
  - (though I'm not sure how useful its content is)
- [x] Only one thing is done in this pull request (specifically please try to refrain from mixing textual changes to the yamls from code changes)

