### PR TITLE
fix quoting in example code in level 5

### DIFF
--- a/coursedata/level-defaults/en.yaml
+++ b/coursedata/level-defaults/en.yaml
@@ -167,7 +167,7 @@
 
          ## Example Hedy Code
          ```
-         name is ask 'what's your name?'
+         name is ask 'what is your name?'
          if name is Hedy print 'nice' else print 'boo!'
          ```
 
@@ -187,7 +187,7 @@
          ## Tip
          Sometimes code with an `if` gets really long and does not fit on the line well. <br> You may also divide the code over two lines, starting the second line at the `else` like this:
          ```
-         name is ask 'what's your name?'
+         name is ask 'what is your name?'
          if name is Hedy print 'nice'
          else print 'boo!'
          ```


### PR DESCRIPTION
fixes #1825

**Description**

Fixes Issue #1825 for English by replacing the contraction "what's" by spelled out "what is", so that the quoting character `'` doesn't occur in the string.

**Fix for**

#1825

**How to test**

In both affected sections of [level 5](https://www.hedycode.com/hedy/5), on the first tab ("Level 5"):
- Example Hedy Code
- Tip

respectively, do the following:

1. click the "Try" button (⇥) to copy the example code there into the code area
2. click the green "Run code" button below the code area
3. check whether the program has printed anything to the output area (it shouldn't have)
4. check whether the program asks `what is your name?` in the output area, with an input field for entering the name

**Checklist**

If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] Links to an existing issue or discussion (if not, create an issue first)
- [x] Describes changes clear in the format above (present tense, no subject)
- [x] Has a "how to test" section
- [x] Only one thing is done in this pull request (specifically please try to refrain from mixing textual changes to the yamls from code changes)