### PR TITLE
Log Search from fixes #1773

### DIFF
--- a/app.py
+++ b/app.py
@@ -726,11 +726,12 @@ def query_logs():
 
     class_id = body.get('class_id')
     if not is_admin(user):
-        if not class_id:
+        username_filter = body.get('username')
+        if not class_id or not username_filter:
             return 'unauthorized', 403
 
         class_ = DATABASE.get_class(class_id)
-        if not class_ or class_['teacher'] != user['username'] or body.get('username') not in class_.get('students'):
+        if not class_ or class_['teacher'] != user['username'] or username_filter not in class_.get('students', []):
             return 'unauthorized', 403
 
     (exec_id, status) = log_fetcher.query(body)

--- a/templates/stats-shared.html
+++ b/templates/stats-shared.html
@@ -65,15 +65,16 @@
       <label class="block uppercase tracking-wide text-gray-700 text-xs font-bold mb-2" for="logs-username">
         Username
       </label>
-      {% if usernames %}
-      <select id="logs-username" name="username" class="border-gray-400 border-2 px-4 py-2">
+      {% if class_id %}
+      <select id="logs-username" name="username" class="block appearance-none border-gray-400 border-2 px-4 py-2"
+              style="outline:none">
         {% for user in usernames %}
           <option value="{{user}}">{{user}}</option>
         {% endfor %}
       </select>
       {% else %}
-      <input class="block w-full py-2 px-4 outline-none border-2 border-gray-400" id="logs-username"
-             type="text" name="username" placeholder="e.g. hedy, h% or %hedy%">
+      <input id="logs-username" name="username" class="block w-full py-2 px-4 outline-none border-2 border-gray-400"
+             type="text" placeholder="e.g. hedy, h% or %hedy%">
       {% endif %}
     </div>
   </div>


### PR DESCRIPTION
**Description**

- Fix styling of the select element in log search form in Safari 
- Fix bug with log searching of empty classes

**Fix for**

#1773 

**How to test**

Locally:
- Log in as admin and go to /admin/stats page. Check that the log search form contains an input(text) for the username and that it is styled correctly in Safari
- Log in as a teacher and go to the /stats/class/$class_id page. Check that the log search form contains a select element that lets you select only the students from the current class. Check that the select is correctly styled in Safari.

On alpha:
- Check that the log search form does not yield errors when the class is empty. Ensure no data is returned.
