### PR TITLE
[FIX] Re-implements e-mail changing support from admin page

### DIFF
--- a/templates/admin-users.html
+++ b/templates/admin-users.html
@@ -98,7 +98,7 @@
           <tr>
             <td class="username_cell cursor-pointer"><a onclick="window.open('/programs?user={{ user.username }}', '_blank');">{{user.username}}</a></td>
             <td class="count_cell">{{user.program_count or 0}}</td>
-            <td class="email_cell">{{user.email}}</td>
+            <td class="email_cell cursor-pointer"><a onclick="hedyApp.auth.changeUserEmail ('{{user.username}}', '{{user.email}}')">{{user.email}}</a></td>
             <td class="created_cell">{{user.created}}</td>
             <td class="last_login_cell">{{user.last_login}}</td>
             <td class="birth_year_cell">{{user.birth_year}}</td>

--- a/templates/admin-users.html
+++ b/templates/admin-users.html
@@ -96,9 +96,9 @@
     <tbody>
       {% for user in users %}
           <tr>
-            <td class="username_cell cursor-pointer"><a onclick="window.open('/programs?user={{ user.username }}', '_blank');">{{user.username}}</a></td>
+            <td class="username_cell cursor-pointer"><a class="no-underline" onclick="window.open('/programs?user={{ user.username }}', '_blank');">{{user.username}}</a></td>
             <td class="count_cell">{{user.program_count or 0}}</td>
-            <td class="email_cell cursor-pointer"><a onclick="hedyApp.auth.changeUserEmail ('{{user.username}}', '{{user.email}}')">{{user.email}}</a></td>
+            <td class="email_cell cursor-pointer"><a class="no-underline" onclick="hedyApp.auth.changeUserEmail ('{{user.username}}', '{{user.email}}')">{{user.email}}</a></td>
             <td class="created_cell">{{user.created}}</td>
             <td class="last_login_cell">{{user.last_login}}</td>
             <td class="birth_year_cell">{{user.birth_year}}</td>

--- a/templates/admin-users.html
+++ b/templates/admin-users.html
@@ -96,7 +96,7 @@
     <tbody>
       {% for user in users %}
           <tr>
-            <td class="username_cell"><a href="programs?user={{user.username}}" target="_blank">{{user.username}}</a></td>
+            <td class="username_cell cursor-pointer"><a onclick="window.open('/programs?user={{ user.username }}', '_blank');">{{user.username}}</a></td>
             <td class="count_cell">{{user.program_count or 0}}</td>
             <td class="email_cell">{{user.email}}</td>
             <td class="created_cell">{{user.created}}</td>


### PR DESCRIPTION
**Description**
In this PR we re-implement an accidentally deleted e-mail changing function on the admin page. We also fix a bug where the programs page re-direct from the admin table was incorrect.

**Fix for**
No issue created

**How to test**
Navigate to admin page, verify that the mail column values are clickable, resulting in a pop-up to change the mail address of a user. Verify that this is indeed working.

