### PR TITLE
let bug reporters choose issue type

### DIFF
--- a/coursedata/pages/learn-more/cs.yaml
+++ b/coursedata/pages/learn-more/cs.yaml
@@ -14,7 +14,7 @@ sections:
       [Klikni zde a pošli nám zprávu.](mailto:hedy@felienne.com "About Hedy")
   - title: "Objevil jsi nějaký bug?"
     text: |
-      [Dej nám vědět na GitHubu.](https://github.com/Felienne/hedy/issues/new)
+      [Dej nám vědět na GitHubu.](https://github.com/Felienne/hedy/issues/new/choose)
   - title: "Záznam prezentace z Code Week"
     text: |
       Chceš se dozvědět více o Hedy? Podívej se na prezentaci, kterou Felienne přednesla na European Code Week 2020:

--- a/coursedata/pages/learn-more/de.yaml
+++ b/coursedata/pages/learn-more/de.yaml
@@ -14,7 +14,7 @@ sections:
       [Klick hier, um uns eine Nachricht zu senden](mailto:hedy@felienne.com "Über Hedy")
   - title: "Einen Fehler gefunden?"
     text: |
-      [Melde ihn uns auf GitHub](https://github.com/Felienne/hedy/issues/new)
+      [Melde ihn uns auf GitHub](https://github.com/Felienne/hedy/issues/new/choose)
   - title: "Code week talk"
     text: |
       Möchtest du mehr über Hedy erfahren?

--- a/coursedata/pages/learn-more/en.yaml
+++ b/coursedata/pages/learn-more/en.yaml
@@ -14,7 +14,7 @@ sections:
       [Click here to send us a message](mailto:hedy@felienne.com "About Hedy")
   - title: "Found a bug?"
     text: |
-      [Let us know on GitHub](https://github.com/Felienne/hedy/issues/new)
+      [Let us know on GitHub](https://github.com/Felienne/hedy/issues/new/choose)
   - title: "Code week talk"
     text: |
       Want to know more about Hedy? Check out this talk Felienne gave at the European Code Week 2020:

--- a/coursedata/pages/learn-more/es.yaml
+++ b/coursedata/pages/learn-more/es.yaml
@@ -14,7 +14,7 @@ sections:
       [Haz click aquí para escribirnos un mensaje](mailto:hedy@felienne.com "Enviar correo electrónico")
   - title: "¿Encontró un error?"
     text: |
-      [Transmítelo a través de GitHub](https://github.com/Felienne/hedy/issues/new)
+      [Transmítelo a través de GitHub](https://github.com/Felienne/hedy/issues/new/choose)
   - title: "Code week talk"
     text: |
       Want to know more about Hedy? Check out this talk Felienne gave at the European Code Week 2020:

--- a/coursedata/pages/learn-more/fr.yaml
+++ b/coursedata/pages/learn-more/fr.yaml
@@ -14,7 +14,7 @@ sections:
       [Cliquez ici pour nous envoyer un message](mailto:hedy@felienne.com "Hedy")
   - title: "Vous avez trouvé une erreur ?"
     text: |
-      [Remontez-la sur GitHub](https://github.com/Felienne/hedy/issues/new)
+      [Remontez-la sur GitHub](https://github.com/Felienne/hedy/issues/new/choose)
   - title: "Code week talk"
     text: |
       Want to know more about Hedy? Check out this talk Felienne gave at the European Code Week 2020:

--- a/coursedata/pages/learn-more/id.yaml
+++ b/coursedata/pages/learn-more/id.yaml
@@ -14,7 +14,7 @@ sections:
       [Klik disini untuk mengirimkan pesan](mailto:hedy@felienne.com "About Hedy")
   - title: "Menemukan bug?"
     text: |
-      [Beritahu kami di GitHub](https://github.com/Felienne/hedy/issues/new)
+      [Beritahu kami di GitHub](https://github.com/Felienne/hedy/issues/new/choose)
   - title: "Percakapan di Code Week"
     text: |
       Ingin tahu lebih jauh tentang Hedy? Cek pembicaraan yang diberikan Felienne pada European Code Week 2020:

--- a/coursedata/pages/learn-more/nl.yaml
+++ b/coursedata/pages/learn-more/nl.yaml
@@ -14,7 +14,7 @@ sections:
       [Klik hier om een mailtje te sturen](mailto:hedy@felienne.com "Stuur een mail")
   - title: "Foutje gevonden?"
     text: |
-      [Geef het door via GitHub](https://github.com/Felienne/hedy/issues/new)
+      [Geef het door via GitHub](https://github.com/Felienne/hedy/issues/new/choose)
   - title: "Code week talk"
     text: |
       Wil je meer weten? Felienne gaf een praatje op de European Code Week 2020 (in het Engels):

--- a/coursedata/pages/learn-more/pt_br.yaml
+++ b/coursedata/pages/learn-more/pt_br.yaml
@@ -14,7 +14,7 @@ sections:
       [Clique aqui para nos enviar uma mensagem](mailto:hedy@felienne.com "Hedy")
   - title: "Encontrou um erro?"
     text: |
-      [Passe adiante via GitHub](https://github.com/Felienne/hedy/issues/new)
+      [Passe adiante via GitHub](https://github.com/Felienne/hedy/issues/new/choose)
   - title: "Code week talk"
     text: |
       Want to know more about Hedy? Check out this talk Felienne gave at the European Code Week 2020:

--- a/coursedata/pages/learn-more/zh.yaml
+++ b/coursedata/pages/learn-more/zh.yaml
@@ -14,7 +14,7 @@ sections:
       [请点击这里给我们发送信息](mailto:hedy@felienne.com "About Hedy")
   - title: "你发现了一个错误？?"
     text: |
-      [请到GitHub告知我们](https://github.com/Felienne/hedy/issues/new)page_title: Contact — Hedy
+      [请到GitHub告知我们](https://github.com/Felienne/hedy/issues/new/choose)page_title: Contact — Hedy
   - title: "在欧洲编程周的讲座"
     text: |
       想要了解更多有关海迪的信息？请观看翡丽娜在2020年欧洲编程周活动上所做的学术报告:


### PR DESCRIPTION
fixes #1846 

**Description**

Changes (for all languages, where this occurs) the destination URL of the "Let us know on GitHub" link in the "Found a bug?" section of the Hedy website from https://github.com/Felienne/hedy/issues/new to https://github.com/Felienne/hedy/issues/new/choose, so that reporters can choose the type of issue they want to file and get the issue content pre-filled with the appropriate template.

**Fix for**

#1846 

**How to test**

1. On the Hedy website, click "Learn more" in the top navigation.
2. Click the "Let us know on GitHub" link in the "Found a bug?" section.
3. Check that you get a selection of issue types to choose from.

**Checklist**

If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] Links to an existing issue or discussion (if not, create an issue first)
- [x] Describes changes clear in the format above (present tense, no subject)
- [x] Has a "how to test" section
- [x] Only one thing is done in this pull request (specifically please try to refrain from mixing textual changes to the yamls from code changes)

