### PR TITLE
[BUG FIX] Public profiles also work with uppercase letters

### DIFF
--- a/app.py
+++ b/app.py
@@ -1726,9 +1726,11 @@ def update_yaml():
 
 
 @app.route('/user/<username>')
-@requires_login
-def public_user_page(user, username):
-    user = DATABASE.user_by_username(username.lower())
+def public_user_page(username):
+    if not current_user()['username']:
+        return utils.error_page(error=403, ui_message='unauthorized')
+    username = username.lower()
+    user = DATABASE.user_by_username(username)
     if not user:
         return utils.error_page(error=404, ui_message='user_not_private')
     user_public_info = DATABASE.get_public_profile_settings(username)


### PR DESCRIPTION
**Description**
All our usernames are stored using lowercase letters. When navigating to a public profile using uppercase letters this results in an error (as the username doesn't exist). We thought to have handled this using the `lower()` function, but the implementation was wrong. WE fix this in this PR.

**Fix for**
No related issue

**How to test**
Make sure you are logged in a navigate to a public profile, notice that it still works when replacing some letters with their uppercase letter.