### PR TITLE
spell "Markdown" without CamelCase and with capital first letter

### DIFF
--- a/coursedata/README.md
+++ b/coursedata/README.md
@@ -37,9 +37,9 @@ level if not supplied.
   commands: {as under course definitions}
 ```
 
-## MarkDown docs pages
+## Markdown docs pages
 
-MarkDown docs must end in `.md` extension and have a "front matter" section
+Markdown docs must end in `.md` extension and have a "front matter" section
 (which is a YAML object ending in `---` before the start of the real document).
 
 The front matter must have the following fields:

--- a/utils.py
+++ b/utils.py
@@ -187,8 +187,8 @@ def datetotimeordate(date):
 def random_id_generator(size=6, chars=string.ascii_uppercase + string.ascii_lowercase + string.digits):
     return ''.join(random.choice(chars) for _ in range(size))
 
-# This function takes a markdown string and returns a list with each of the HTML elements obtained
-# by rendering the markdown into HTML.
+# This function takes a Markdown string and returns a list with each of the HTML elements obtained
+# by rendering the Markdown into HTML.
 def markdown_to_html_tags(markdown):
     _html = commonmark_renderer.render(commonmark_parser.parse(markdown))
     soup = BeautifulSoup(_html, 'html.parser')

--- a/website/cdn.py
+++ b/website/cdn.py
@@ -38,7 +38,7 @@ class Cdn:
             # without a CDN.
             #
             # We still keep on hosting static assets in the "old" location as well for images in
-            # emails and content we forgot to replace or are unable to replace (like in MarkDowns).
+            # emails and content we forgot to replace or are unable to replace (like in Markdowns).
             self.static_prefix = '/static-' + commit
             app.add_url_rule(self.static_prefix + '/<path:filename>',
                     endpoint='cdn_static',


### PR DESCRIPTION
**Description**

Replaces the spellings "MarkDown" and "markdown" with "Markdown" in documentation and in code comments. (Excluding occurrences in comments of `build-tools/heroku/tailwind/styles.css`, as that seems to be part of a "vendored" 3rd-party dependency.)

**Fix for**

(no issue filed)

**How to test**

(shouldn't require any testing, I hope)

**Checklist**

If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [ ] Links to an existing issue or discussion (if not, create an issue first)
- [x] Describes changes clear in the format above (present tense, no subject)
- [ ] Has a "how to test" section
  - (well, kind off … )
- [x] Only one thing is done in this pull request (specifically please try to refrain from mixing textual changes to the yamls from code changes)

