### PR TITLE
chore: make "dompurify" import work

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "target": "es5",
     "module": "CommonJS",
     "lib": ["es2017", "dom"],
+    "esModuleInterop": true,
 
     /* Type Checking */
     "strict": true,                                      /* Enable all strict type-checking options. */


### PR DESCRIPTION
To make the following import work:

```ts
import DOMPurify from 'dompurify';
```

The `esModuleInterop` feature needs to be enabled in TypeScript.

Don't ask me why, I don't understand it either.
