### PR TITLE
[BUG] Support numeric values in list assignment

### DIFF
--- a/hedy.py
+++ b/hedy.py
@@ -1306,7 +1306,8 @@ class ConvertToPython_2(ConvertToPython_1):
 class ConvertToPython_3(ConvertToPython_2):
     def assign_list(self, args):
         parameter = args[0]
-        values = ["'" + a + "'" for a in args[1:]]
+        is_numeric = all(argument.isnumeric() for argument in args[1:])
+        values = [a if is_numeric else "'" + a + "'" for a in args[1:]]
         return parameter + " = [" + ", ".join(values) + "]"
     def list_access(self, args):
         # check the arguments (except when they are random or numbers, that is not quoted nor a var but is allowed)

--- a/tests/test_level_03.py
+++ b/tests/test_level_03.py
@@ -651,3 +651,15 @@ class TestsLevel3(HedyTester):
       code=code,
       exception=hedy.exceptions.WrongLevelException
     )
+
+  def test_list_assign_numeric(self):
+    code = textwrap.dedent("lengte is 50, 75, 100")
+    expected = textwrap.dedent("lengte = [50, 75, 100]")
+
+    self.single_level_tester(code=code, expected=expected)
+
+  def test_list_assign_alphanumeric(self):
+    code = textwrap.dedent("lengte is a, 75, 100")
+    expected = textwrap.dedent("lengte = ['a', '75', '100']")
+
+    self.single_level_tester(code=code, expected=expected)


### PR DESCRIPTION
**Description**

In order to support lists that fully consist of numbers, this commit
will not surround list values with quotes if all the values are in
a numerical format.

This will allow Hedy programs to use values from lists that require
the value to be a number, such as `forward` in turtle programs.


**Fix for**

This commit fixes #1777

**How to test**

Create a list with only numerical values and reference the list value in an expression that accepts a numeric value, such as `forward`.

**Checklist**

If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] Links to an existing issue or discussion (if not, create an issue first)
- [x] Describes changes clear in the format above (present tense, no subject)
- [x] Has a "how to test" section
- [x] Only one thing is done in this pull request (specifically please try to refrain from mixing textual changes to the yamls from code changes)

