### PR TITLE
Check if there are customizations for this user

### DIFF
--- a/templates/incl-editor-and-output.html
+++ b/templates/incl-editor-and-output.html
@@ -95,10 +95,10 @@
     </div>
     <div class="order-5">
       <div class="flex {% if prev_level %}justify-between{% else %}justify-end{%endif%}">
-        {% if prev_level and prev_level in customizations['levels'] %}
+        {% if prev_level and (customizations['levels']|length == 0 or prev_level in customizations['levels']) %}
           <button class="green-btn" onclick="hedyApp.prompt_unsaved (function () {window.location = '{{ hedy_link(prev_level, 1) }}'})">{{ui.regress_button}} {{ prev_level }}</button>
         {% endif %}
-        {% if next_level and next_level in customizations['levels'] %}
+        {% if next_level and (customizations['levels']|length == 0 or next_level in customizations['levels']) %}
             <button class="green-btn ltr:ml-1 rtl:mr-1" onclick="hedyApp.prompt_unsaved (function () {window.location = '{{ hedy_link(next_level, 1) }}'})">{{ ui.advance_button }} {{ next_level }}</button>
         {% endif %}
       </div>


### PR DESCRIPTION
It seems #1864 introduced an issue where levels would be closed for users not in classes since the next level would not be in their levels since that list would be empty. I think this fixes it but I would need confirmation from @TiBiBa (and I need to test a bit more)