### PR TITLE
fix grammar in German Level 4 intro & bring its text closer to the English version

### DIFF
--- a/coursedata/level-defaults/de.yaml
+++ b/coursedata/level-defaults/de.yaml
@@ -115,16 +115,16 @@
 4:
     start_code: "print 'Hallo Welt'"
     intro_text: |
-        In Level 4 `print` und `ask` ändern.
+        In Level 4 haben sich `print` und `ask` geändert.
 
         Du musst Text, den du genau so mit `print` ausgeben möchtest, in Anführungszeichen setzen.
 
-        Du kannst du jetzt alle Wörter ausgeben, die du möchtest. Auch die Wörter, mit denen du etwas mit `is` gespeichert hast.
+        Das ist nützlich, denn nun kannst du alle Wörter ausgeben, die du möchtest. Auch die Wörter, mit denen du etwas mit `is` gespeichert hast.
 
-        Die meisten Programmiersprachen verwenden beim `print` Befehl Anführungszeichen, sodass wir dem echten Programmieren einen Schritt näher kommen!
+        Die meisten Programmiersprachen verwenden beim `print`-Befehl Anführungszeichen, sodass wir dem echten Programmieren einen Schritt näher kommen!
 
         ## Aufgaben werden immer schwieriger
-        Du findest die Befehle wieder auf der linken Seite und die Aufgaben auf den folgenden Tabs. Die Aufgaben werden immer etwas schwieriger.
+        Du findest die Befehle wieder auf der linken Seite und die Aufgaben auf den folgenden Tabs. Die Aufgaben werden nun von Tab zu Tab immer schwieriger.
         Beginne darum links mit der Geschichte und arbeite dich für größere Herausforderungen weiter nach rechts vor.
     commands:
     -   name: "print"


### PR DESCRIPTION
**Description**

- Fixes the grammar in the German Level 4 intro text.
- Brings the German Level 4 intro closer in meaning to the current English Level 4 intro.

**Fix for**

(none filed)

**How to test**

1. Set Hedy to German (with the top right language chooser when not logged in or in your profile settings when logged in)
2. Read first tab of [Level 4](https://www.hedycode.com/hedy/4)

**Checklist**

If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [ ] Links to an existing issue or discussion (if not, create an issue first)
- [x] Describes changes clear in the format above (present tense, no subject)
- [x] Has a "how to test" section
- [ ] Only one thing is done in this pull request (specifically please try to refrain from mixing textual changes to the yamls from code changes)
   - well, kinda 