### PR TITLE
Added small new button containing list of commands per level

### DIFF
--- a/templates/level-page.html
+++ b/templates/level-page.html
@@ -14,15 +14,17 @@
       <div class="dropdown inline-block relative green-btn mx-2 cursor-pointer">
             <span class="ltr:mr-1 rtl:ml-1">{{ "🤔" }}</span>
           </button>
-          <ul class="dropdown-menu absolute hidden rounded-lg border-black mt-2 pt-1 list-none ltr:ml-0 rtl:mr-0 ltr:right-0 rtl:left-0 w-48" style="border-width: 1px; z-index: 15; background-color: #48BB78;">
+          <ul class="dropdown-menu absolute hidden rounded-lg border-black mt-2 pt-1 list-none ltr:ml-0 rtl:mr-0 ltr:right-0 rtl:left-0 w-48" style="width: 14rem; border-width: 1px; z-index: 15; background-color: #48BB78;">
           {% for command in commands %}
             <div class="justify-between my-2 shadow-md p-3 pl-4">
-              <div class="font-thin text-lg flex-grow mb-1" tabindex=0>
+              <div class="font-thin text-base flex-grow mb-1" tabindex=0>
                 {{ command.explanation|commonmark }}
               </div>
               <div class="flex">
                 <div class="font-thin text-sm flex-grow" tabindex=0>
                 </div>
+                <button class="btn block flex-none self-end ml-1" style="min-width:6em"
+                  onclick='hedyApp.tryPaletteCode({{command.demo_code|tojson}});'>{{ui.try_button}}</button>
               </div>
             </div>
             {% endfor %}

--- a/templates/level-page.html
+++ b/templates/level-page.html
@@ -11,7 +11,23 @@
     <input id="program_name" type="text" class="border border-green-400 rounded p-2 px-3 w-1/2 h-4/5" value="{{ (loaded_program or {}).name or (ui.level_title + ' ' + level_nr)}}">
     <input type="submit" class="green-btn mx-2 cursor-pointer" value="{{ ui.save_code_button }}" onclick="hedyApp.saveit({{ level }}, '{{ g.lang }}', $ ('#program_name').val (), hedyApp.get_trimmed_code());">
     <input type="submit" class="green-btn mx-2 cursor-pointer" value="{{ ui.share_code_button }}" onclick="hedyApp.share_program({{ level }}, '{{ g.lang }}', true, -1, true);">
-  </div>
+      <div class="dropdown inline-block relative green-btn mx-2 cursor-pointer">
+            <span class="ltr:mr-1 rtl:ml-1">{{ "🤔" }}</span>
+          </button>
+          <ul class="dropdown-menu click:bg-green-600 absolute hidden rounded-lg border-black bg-green-400 mt-2 pt-1 list-none ltr:ml-0 rtl:mr-0 ltr:right-0 rtl:left-0 w-48" style="border-width: 1px; z-index: 15; background-color: mediumseagreen;">
+          {% for command in commands %}
+            <div class="justify-between my-2 shadow-md p-3 pl-4">
+              <div class="font-thin text-lg flex-grow mb-1" tabindex=0>
+                {{ command.explanation|commonmark }}
+              </div>
+              <div class="flex">
+                <div class="font-thin text-sm flex-grow" tabindex=0>
+                </div>
+              </div>
+            </div>
+            {% endfor %}
+          </ul>
+      </div>  </div>
 </div>
 <div class="flex-grow flex items-stretch">
 {% block levelbody %}{% endblock %}

--- a/templates/level-page.html
+++ b/templates/level-page.html
@@ -14,7 +14,7 @@
       <div class="dropdown inline-block relative green-btn mx-2 cursor-pointer">
             <span class="ltr:mr-1 rtl:ml-1">{{ "🤔" }}</span>
           </button>
-          <ul class="dropdown-menu click:bg-green-600 absolute hidden rounded-lg border-black bg-green-400 mt-2 pt-1 list-none ltr:ml-0 rtl:mr-0 ltr:right-0 rtl:left-0 w-48" style="border-width: 1px; z-index: 15; background-color: mediumseagreen;">
+          <ul class="dropdown-menu absolute hidden rounded-lg border-black mt-2 pt-1 list-none ltr:ml-0 rtl:mr-0 ltr:right-0 rtl:left-0 w-48" style="border-width: 1px; z-index: 15; background-color: #48BB78;">
           {% for command in commands %}
             <div class="justify-between my-2 shadow-md p-3 pl-4">
               <div class="font-thin text-lg flex-grow mb-1" tabindex=0>


### PR DESCRIPTION
**Description**

In the discussion about removing the palette, I've added some ideas. This PR is the result of the last [idea](https://github.com/Felienne/hedy/discussions/1835#discussioncomment-2132503). 


**How to test**
Should show all the commands available per level, when hovering the "🤔" button. 

