### PR TITLE
Remove whitelisting for teachers accessing class stats #1950

### DIFF
--- a/templates/class-overview.html
+++ b/templates/class-overview.html
@@ -92,10 +92,7 @@
     <button class="green-btn" onclick="window.location.href = '/for-teachers/customize-class/{{class_info.id}}'">{{ auth.customize_class }}</button>
     <button class="green-btn ltr:ml-4 rtl:mr-4" onclick="hedyApp.rename_class ('{{class_info.id}}')">{{auth.rename_class}}</button>
     <button class="green-btn ltr:ml-4 rtl:mr-4" onclick="hedyApp.invite_student ('{{class_info.id}}')">{{ auth.invite_student }}</button>
-    {% if is_beta_teacher %}
-    <button class="green-btn ltr:ml-4 rtl:mr-4" onclick="window.location.href = '/stats/class/{{class_info.id}}'">{{auth
-      .class_stats}}</button>
-    {% endif %}
+    <button class="green-btn ltr:ml-4 rtl:mr-4" onclick="window.location.href = '/stats/class/{{class_info.id}}'">{{auth.class_stats}}</button>
   </div>
   <div class="mt-4 flex flex-row">
     <button class="blue-btn" onclick="window.location.href = '/for-teachers'">{{auth.back_to_teachers_page}}</button>

--- a/website/teacher.py
+++ b/website/teacher.py
@@ -58,9 +58,6 @@ def routes (app, database, achievements):
         if achievement:
             achievement = json.dumps(achievement)
 
-        teachers = os.getenv('BETA_TEACHERS', '').split(',')
-        is_beta_teacher = user['username'] in teachers
-
         invites = []
         for invite in DATABASE.get_class_invites(Class['id']):
             invites.append({'username': invite['username'], 'timestamp': utils.datetotimeordate (utils.mstoisostring (invite['timestamp']))})
@@ -68,7 +65,6 @@ def routes (app, database, achievements):
         return render_template ('class-overview.html', current_page='my-profile',
                                 page_title=hedyweb.get_page_title('class overview'),
                                 achievement=achievement, invites=invites,
-                                is_beta_teacher=is_beta_teacher,
                                 class_info={'students': students, 'link': os.getenv('BASE_URL') + '/hedy/l/' + Class ['link'],
                                             'name': Class ['name'], 'id': Class ['id']})
 


### PR DESCRIPTION
**Please fill out this template by replacing all content between < >**

< Remove whitelisting for teachers' access to the class stats page >

**Description**

< Remove whitelisting for teachers' access to the class stats page > Use present tense without a subject to describe your PR, for example: "Adds translations of levels 1 to 12 to Polish"

**Fixes < #1950  >**

< Always link the number of the issue or of the discussion that your pr concerns. >
Notable exception: adding content may be done without an accompanying issue 

**How to test**

- Run Hedy locally and log in a teacher. Ensure that you do not have a BETA_TEACHERS environment variable set.
- Go to /for-teachers and select one of the existing classes
- Ensure that the /for-teachers/class/$class-id page contains a show class statistics button which successfully redirects to the /stats/class page

**Checklist**
Done? Check if you have it all in place using this list*
  
- [ ] Describes changes in the format above (present tense)
- [ ] Links to an existing issue or discussion 
- [ ] Has a "How to test" section

* If you're unsure about any of these, don't hesitate to ask. We're here to help!
