### PR TITLE
Make use of keyword is instead of '='

### DIFF
--- a/content/adventures/de.yaml
+++ b/content/adventures/de.yaml
@@ -1187,7 +1187,7 @@ adventures:
                     ## Example Hedy code
 
                     ```
-                    options = rock, paper, scissors
+                    options is rock, paper, scissors
                     computer_choice is _
                     choice is ask What do you choose?
                     print 'you chose ' _

--- a/content/adventures/en.yaml
+++ b/content/adventures/en.yaml
@@ -1117,7 +1117,7 @@ adventures:
                     ## Example Hedy code
 
                     ```
-                    options = rock, paper, scissors
+                    options is rock, paper, scissors
                     computer_choice is _
                     choice is ask What do you choose?
                     print 'you chose ' _

--- a/content/adventures/nl.yaml
+++ b/content/adventures/nl.yaml
@@ -1043,7 +1043,7 @@ adventures:
             5:
                 story_text: |
                     ## Steen, papier, schaar
-                    In level 4 kunnen we gaan bepalen wie er gewonnen heeft.
+                    In level 5 kunnen we gaan bepalen wie er gewonnen heeft.
                     Daarvoor heb je de nieuwe `if` code nodig.
 
                     Sla jouw keuze op met de naam keuze en de keuze van de computer als computerkeuze.


### PR DESCRIPTION
**Description**

Fixes issue #1986 by replacing assignment operator by keyword 'is'

**Fix for**

Fixes #1986

**How to test**

Check out branch, open level 5, adventure "rock, papers, scissors". Sample code now show keyword is in line 1

**Checklist**

If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [ ] Links to an existing issue or discussion (if not, create an issue first)
- [ ] Describes changes clear in the format above (present tense, no subject)
- [ ] Has a "how to test" section
- [ ] Only one thing is done in this pull request (specifically please try to refrain from mixing textual changes to the yamls from code changes)

