### PR TITLE
[BUG FIX] Downgrades MarkupSafe from 2.1.0 to 2.0.1 to prevent unittest failing

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -16,6 +16,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - uses: aws-actions/setup-sam@v1
+      with:
+        version: 1.37.0
     - uses: actions/checkout@v2
     - name: Set up Python 3.9
       uses: actions/setup-python@v1

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -16,9 +16,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: aws-actions/setup-sam@v1
-      with:
-        version: 1.37.0
     - uses: actions/checkout@v2
     - name: Set up Python 3.9
       uses: actions/setup-python@v1

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -16,15 +16,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: aws-actions/setup-sam@v1
-      with:
-        version: 1.37.0
     - uses: actions/checkout@v2
     - name: Set up Python 3.9
       uses: actions/setup-python@v1
       with:
         python-version: 3.9
     - name: Install Python dependencies
+      uses: aws-actions/setup-sam@v1
+      with:
+        version: 1.37.0
       run: |
         python3 -m pip install --upgrade pip
         pip3 install -r requirements.txt

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -22,9 +22,6 @@ jobs:
       with:
         python-version: 3.9
     - name: Install Python dependencies
-      uses: aws-actions/setup-sam@v1
-      with:
-        version: 1.37.0
       run: |
         python3 -m pip install --upgrade pip
         pip3 install -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ attrs==19.3.0
 Flask-Commonmark==0.8
 bcrypt==3.2.0
 boto3>=1.16.50
+MarkupSafe==2.0.1
 ruamel.yaml==0.17.4
 docopt==0.6.2
 pydantic==1.8.2


### PR DESCRIPTION
**Description**
Jinja2 has a dependency on the `MarkupSafe` library. With the recent update of this library to `2.1.0` the `soft_unicode` function is no longer supported: but required by Jinja2. We solve this by temporary downgrading the MarkupSafe library until Jinja2 has come up with a solution. The following error occurred when running unittests:

`ImportError: cannot import name 'soft_unicode' from 'markupsafe' (/usr/local/lib/python3.7/site-packages/markupsafe/__init__.py)`

**Fix for**
This PR fixes #2027 

**How to test**
This is a back-end bug fix, it works when the unittests work again.

**Checklist**

If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [ ] Links to an existing issue or discussion (if not, create an issue first)
- [ ] Describes changes clear in the format above (present tense, no subject)
- [ ] Has a "how to test" section
- [ ] Only one thing is done in this pull request (specifically please try to refrain from mixing textual changes to the yamls from code changes)

