### PR TITLE
[BUG FIX] Adds keyword form "reset" instead of hard-coded string

### DIFF
--- a/templates/programs.html
+++ b/templates/programs.html
@@ -23,7 +23,7 @@
                 {% endfor %}
             </select>
             <div class="flex flex-row ltr:ml-auto rtl:mr-auto">
-                <button type="reset" class="red-btn" onclick="window.open('/programs{% if from_user %}?user={{ from_user }}{% endif %}', '_self');">Reset</button>
+                <button type="reset" class="red-btn" onclick="window.open('/programs{% if from_user %}?user={{ from_user }}{% endif %}', '_self');">{{ auth.reset_view }}</button>
                 <button type="submit" class="green-btn ltr:ml-4 rtl:mr-4 px-4">{{ texts.search }}</button>
             </div>
         </div>


### PR DESCRIPTION
**Description**
In this PR we fix an issue where the "Reset" string on the program filtering was accidentally hard-coded instead of using the corresponding yaml value.

**Fixes**
This PR fixes #2058.

**How to test**
Login, navigate to your programs page and verify that the red "reset" button is now language-dependent.

**Checklist**
Done? Check if you have it all in place using this list*
  
- [ ] Describes changes in the format above (present tense)
- [ ] Links to an existing issue or discussion 
- [ ] Has a "How to test" section

* If you're unsure about any of these, don't hesitate to ask. We're here to help!
