### PR TITLE
[BUG FIX] Correctly displays newlines on quiz answers

### DIFF
--- a/templates/feedback.html
+++ b/templates/feedback.html
@@ -2,49 +2,52 @@
 
 {% block question %}
     <div class="p-8">
-
         <div class="flex flex-col">
             <div class="text-green-900 text-2xl text-center flex flex-row justify-center font-slab">
                 <p>{{ ui.question }} {{ question_nr }} / {{ questions|length }} </p>
             </div>
             <p class="italic text-3xl font-bold tracking-wide text-blue-900 text-center justify-center font-slab"> {{ question.question_text }} </p>
             {% if answer_was_correct %}
-
                 <div class="rounded-full bg-green-500  flex h-32 w-32 text-center flex items-center justify-center place-self-center">
-                    <p
-                            class="m-4 text-white  font-extrabold text-center text-4xl font-slab ">{{ ui.feedback_success }}</p></div>
+                    <p class="m-4 text-white  font-extrabold text-center text-4xl font-slab ">
+                        {{ ui.feedback_success }}
+                    </p>
+                </div>
             {% else %}
                 <div class="rounded-full bg-red-500 flex h-32 w-32 text-center flex items-center justify-center place-self-center">
-                    <p
-                            class="m-4 text-white  text-center font-extrabold  text-4xl font-slab ">{{ ui.feedback_failure }}</p></div>
+                    <p class="m-4 text-white  text-center font-extrabold  text-4xl font-slab ">
+                        {{ ui.feedback_failure }}
+                    </p>
+                </div>
             {% endif %}
             <p class="text-2xl text-center">
-            <p class="text-2xl text-center"><i>{% if question_options[index_option].feedback %}
-                {{ question_options[index_option].feedback }} {% endif %}</i></p>
-            <p
-                    class="m-4 text-black  text-center font-extrabold  text-4xl font-slab ">{{ ui.correct_answer }}
-                {% if correct_option.option_text %}
-                    {{ correct_option.option_text }}
-                {% elif correct_option.code %}
-                    {{ correct_option.code }}
-                {% endif %}</p></div>
-    </div>
+            <p class="text-2xl text-center">
+                <i>
+                    {% if question_options[index_option].feedback %}
+                        {{ question_options[index_option].feedback }}
+                    {% endif %}
+                </i>
+            </p>
+            <div class="flex flex-col justify-center">
+                <p class="text-black text-center font-extrabold text-4xl font-slab">{{ ui.correct_answer }}</p>
+                <div class="italic text-2xl mx-auto">
+                    {% if correct_option.option_text %}{{ correct_option.option_text|nl2br }}
+                    {% elif correct_option.code %}{{ correct_option.code|nl2br }}{% endif %}
+                </div>
+            </div>
 
+        </div>
+    </div>
     <div class="p-10 button-bar border-t-8 border-green-600">
         {% if question_nr < questions|length %}
-            <div></div>
             <button class="green-btn ltr:ml-1 rtl:mr-1 ltr:text-right-0 rtl:text-left-0"
                     onclick="window.location = '/quiz/quiz_questions/{{ level_source }}/{{ question_nr + 1 }}/1?lang={{lang}}'">
                 {{ ui.go_to_question }} {{ question_nr + 1 }}</button>
         {% else %}
-            <div></div>
             <button class="green-btn ltr:ml-1 rtl:mr-1 ltr:right-0 rtl:left-0"
                     onclick="window.location = '/quiz/quiz_questions/{{ level_source }}/{{ question_nr + 1 }}/1?lang={{lang}}'">
                 {{ ui.go_to_quiz_result }}
             </button>
-
         {% endif %}
     </div>
-    </div>
-
 {% endblock %}

--- a/templates/quiz.html
+++ b/templates/quiz.html
@@ -18,7 +18,7 @@
           <div class="arrow-steps clearfix">
               {% for i in range(questions|length)%}
                    {% if i + 1 == question_nr %}
-                    <div class="step current"><span><a class="step-text" href="#">Vraag {{ i + 1 }}<br>Poging {{ attempt }}</a></span></div>
+                    <div class="step current"><span><a class="step-text" href="#">{{ ui.question }} {{ i + 1 }}<br>{{ ui.attempt }} {{ attempt }}</a></span></div>
                    {% elif not quiz_answers[i + 1] %}
                        <div class="step"><span><a class="step-text" href="#">{{ i + 1 }}</a></span></div>
                    {% elif quiz_answers[i + 1][-1] != questions[i + 1].correct_answer %}

--- a/templates/quiz_question.html
+++ b/templates/quiz_question.html
@@ -41,7 +41,7 @@
         <div class="flex flex-row justify-center">
             <button type="button" onclick="changeHint()"
                     class="ml-1 bg-blue-500 text-white px-6 py-2 rounded font-medium mx-3 hover:bg-blue-600"
-                    name="hint-button" id="hint-button">Hint?
+                    name="hint-button" id="hint-button">{{ ui.hint }}
             </button>
         </div>
         <form action="{{ url_for('submit_answer', level_source=level_source, question_nr=question_nr, attempt=attempt, lang=lang) }}"


### PR DESCRIPTION
**Description**
In this PR we fix an issue where newlines where not correctly displayed when showing the correct quiz answer. This was solved by adding the `nl2br` function to the `jinja2` variable. We also slightly improved some quiz styling by removing redundant empty(?) `div` elements, removing `<br>` elements as we can style this with dedicated elements and margins as well as decreased the size of the correct quiz answer. We also fix another small bug where the strings `Vraag`, `Poging` and `Hint?` where hard-coded instead of the (already existing) yaml keywords.

**Fixes**
This PR fixes #1291 and fixes #2069.

**How to test**
Navigate to a quiz where the answer contains multiple lines. For example, level 8 question 1 in Dutch. Verify that the answer now correctly displays with the newlines and a smaller font. Also notice that the progress header bar is now correctly localized with the yamls.

**Checklist**
Done? Check if you have it all in place using this list*
  
- [ ] Describes changes in the format above (present tense)
- [ ] Links to an existing issue or discussion 
- [ ] Has a "How to test" section

* If you're unsure about any of these, don't hesitate to ask. We're here to help!
