### PR TITLE
[BUG FIX] Email template no longer crashes due to incorrect concatenation

### DIFF
--- a/website/auth.py
+++ b/website/auth.py
@@ -713,9 +713,9 @@ def send_email_template(template, email, link, lang="en", username=None):
     subject = texts['email_' + template + '_subject']
     body = texts['email_' + template + '_body'].split('\n')
     if username:
-        body = [texts['email_hello']] + " " + username + "!" + body
+        body = [texts['email_hello']] + [" "] + [username] + ["!"] + body
     else:
-        body = [texts['email_hello']] + "!" + body
+        body = [texts['email_hello']] + ["!"] + body
     if link:
         body[len(body) - 1] = body[len(body ) - 1] + ' @@LINK@@'
     body = body + texts['email_goodbye'].split('\n')


### PR DESCRIPTION
**Description**
In this PR we fix an issue where the e-mail template function would crash due to an incorrect concat function.

**Fixes**
No related issue.

**How to test**
Can only test on Alpha, deploy and verify that signup is working correctly again.

**Checklist**
Done? Check if you have it all in place using this list*
  
- [ ] Describes changes in the format above (present tense)
- [ ] Links to an existing issue or discussion 
- [ ] Has a "How to test" section

* If you're unsure about any of these, don't hesitate to ask. We're here to help!
