### PR TITLE
Exclude if/else in all supported languages

### DIFF
--- a/grammars/level18-Additions.lark
+++ b/grammars/level18-Additions.lark
@@ -1,11 +1,10 @@
 // adds round brackets in print() and range(), and changes ask to input
 
-command:+= input | input_is_empty_brackets |  input_equals_empty_brackets | print_empty_brackets -= ask > assign
+command:+= input | input_empty_brackets | print_empty_brackets -= ask > assign
 
 print: _PRINT (_SPACE* _LEFT_BRACKET _SPACE* (quoted_text | list_access | var_access | sum) (_COMMA (quoted_text | list_access | var_access | sum))* _SPACE* _RIGHT_BRACKET _SPACE*)?
 print_empty_brackets: _PRINT _SPACE* _LEFT_BRACKET _SPACE* _RIGHT_BRACKET
-input_is_empty_brackets: var _SPACE _IS _SPACE _INPUT _SPACE* (_LEFT_BRACKET _SPACE? _RIGHT_BRACKET)
-input_equals_empty_brackets: var _SPACE* _EQUALS _SPACE* _INPUT _SPACE* (_LEFT_BRACKET _SPACE* _RIGHT_BRACKET)
+input_empty_brackets: var (_SPACE _IS _SPACE | _SPACE? _EQUALS _SPACE?) _INPUT _SPACE* (_LEFT_BRACKET _SPACE? _RIGHT_BRACKET)
 input: var (_SPACE _IS _SPACE | _EQUALS) _INPUT _SPACE* (_LEFT_BRACKET  ((quoted_text | list_access | var_access | sum) (_COMMA (quoted_text | list_access | var_access | sum))*) _RIGHT_BRACKET)?
 // todo: some of these vars sould alse be var_access (things that do not define like the loop var)
 for_loop: _FOR _SPACE (NAME | var) _SPACE _IN _SPACE _RANGE _LEFT_BRACKET (NUMBER | var) _COMMA (NUMBER | var) (_COMMA (NUMBER | var))? _RIGHT_BRACKET _COLON _EOL (_SPACE command) (_EOL _SPACE command)* _EOL _END_BLOCK

--- a/grammars/level18-Additions.lark
+++ b/grammars/level18-Additions.lark
@@ -1,12 +1,11 @@
 // adds round brackets in print() and range(), and changes ask to input
 
-command:+= input_is | input_equals | input_is_empty_brackets |  input_equals_empty_brackets | print_empty_brackets -= ask > assign
+command:+= input | input_is_empty_brackets |  input_equals_empty_brackets | print_empty_brackets -= ask > assign
 
 print: _PRINT (_SPACE* _LEFT_BRACKET _SPACE* (quoted_text | list_access | var_access | sum) (_COMMA (quoted_text | list_access | var_access | sum))* _SPACE* _RIGHT_BRACKET _SPACE*)?
 print_empty_brackets: _PRINT _SPACE* _LEFT_BRACKET _SPACE* _RIGHT_BRACKET
 input_is_empty_brackets: var _SPACE _IS _SPACE _INPUT _SPACE* (_LEFT_BRACKET _SPACE? _RIGHT_BRACKET)
 input_equals_empty_brackets: var _SPACE* _EQUALS _SPACE* _INPUT _SPACE* (_LEFT_BRACKET _SPACE* _RIGHT_BRACKET)
-input_is: var _SPACE _IS _SPACE _INPUT _SPACE* (_LEFT_BRACKET  ((quoted_text | list_access | var_access | sum) (_COMMA (quoted_text | list_access | var_access | sum))*) _RIGHT_BRACKET)?
-input_equals: var _SPACE* _EQUALS _SPACE* _INPUT _SPACE* (_LEFT_BRACKET  ((quoted_text | list_access | var_access | sum) (_COMMA (quoted_text | list_access | var_access | sum))*) _RIGHT_BRACKET)?
+input: var (_SPACE _IS _SPACE | _EQUALS) _INPUT _SPACE* (_LEFT_BRACKET  ((quoted_text | list_access | var_access | sum) (_COMMA (quoted_text | list_access | var_access | sum))*) _RIGHT_BRACKET)?
 // todo: some of these vars sould alse be var_access (things that do not define like the loop var)
 for_loop: _FOR _SPACE (NAME | var) _SPACE _IN _SPACE _RANGE _LEFT_BRACKET (NUMBER | var) _COMMA (NUMBER | var) (_COMMA (NUMBER | var))? _RIGHT_BRACKET _COLON _EOL (_SPACE command) (_EOL _SPACE command)* _EOL _END_BLOCK

--- a/grammars/level5-Additions.lark
+++ b/grammars/level5-Additions.lark
@@ -25,10 +25,10 @@ in_list_check: textwithoutspaces _SPACE _IN _SPACE var
 
 nospace: /[^\n, ]/
 
-textwithspaces: /(?:[^\n،, ]| (?!else|anders))+/ -> text //anything can be parsed except for a newline and a comma for list separators
+textwithspaces: /(?:[^\n،, ]| (?!else|anders|sinon|sino|وإلا))+/ -> text //anything can be parsed except for a newline and a comma for list separators
 //a space is allowed, but it may not be followed by an else. The part " (?!else))" means space not followed by (negative look ahead) else
 //That is because allowing else in strings leads to issue #303
-textwithoutspaces: /(?:[^\n،, eia]|e(?!lse)|i(?!f)|a(?!nders)|a(?!ls))+/ -> text //anything can be parsed except for spaces (plus: a newline and a comma for list separators)
+textwithoutspaces: /(?:[^\n،, eias]|e(?!lse)|i(?!f)|s(?!i|inon|ino)|a(?!nders|ls))+/ -> text //anything can be parsed except for spaces (plus: a newline and a comma for list separators)
 //the part e(?!lse)|i(?!f)) means e not followed by lse, and i not followed by f
 // this is because allowing else and if in invalid leads to ambiguity in the grammar                                            
 

--- a/hedy.py
+++ b/hedy.py
@@ -808,7 +808,7 @@ class AllCommands(Transformer):
             return 'while'
         if keyword == 'in_list_check':
             return 'in'
-        if keyword in ['input_is', 'input_equals', 'input_is_empty_brackets', 'input_equals_empty_brackets']:
+        if keyword == 'input_empty_brackets':
             return 'input'
         if keyword == 'print_empty_brackets':
             return 'print'
@@ -1682,11 +1682,8 @@ class ConvertToPython_18(ConvertToPython_17):
 
     def input_equals(self, args):
         return self.input(args)
-    
-    def input_is_empty_brackets(self, args):
-        return self.input(args)
 
-    def input_equals_empty_brackets(self, args):
+    def input_empty_brackets(self, args):
         return self.input(args)
     
     def print_empty_brackets(self, args):

--- a/hedy.py
+++ b/hedy.py
@@ -393,12 +393,6 @@ class LookupEntryCollector(visitors.Visitor):
         var_name = tree.children[0].children[0]
         self.add_to_lookup(var_name, tree)
 
-    def input_is(self, tree):
-        self.input(tree)
-    
-    def input_equals(self, tree):
-        self.input(tree)
-
     def assign(self, tree):
         var_name = tree.children[0].children[0]
         self.add_to_lookup(var_name, tree.children[1])
@@ -966,10 +960,7 @@ class IsComplete(Filter):
         return args != [], ('print', meta.line)
     def input(self, meta, args):
         return len(args) > 1, ('input', meta.line)
-    def input_is(self, meta, args):
-        return self.input(meta, args)
-    def input_equals(self, meta, args):
-        return self.input(meta, args)
+
     def length(self, meta, args):
         return args != [], ('len', meta.line)
     def error_print_nq(self, meta, args):
@@ -1694,7 +1685,7 @@ class ConvertToPython_18(ConvertToPython_17):
     
     def input_is_empty_brackets(self, args):
         return self.input(args)
-    
+
     def input_equals_empty_brackets(self, args):
         return self.input(args)
     

--- a/hedy_translation.py
+++ b/hedy_translation.py
@@ -193,11 +193,8 @@ class Translator(Visitor):
     def orcondition(self, tree):
         self.add_rule('_OR', 'or', tree)
 
-    def input_is(self, tree):
+    def input(self, tree):
         self.add_rule('_IS', 'is', tree)
-        self.add_rule('_INPUT', 'input', tree)
-
-    def input_equals(self, tree):
         self.add_rule('_INPUT', 'input', tree)
 
     def input_is_empty_brackets(self, tree):

--- a/hedy_translation.py
+++ b/hedy_translation.py
@@ -197,11 +197,8 @@ class Translator(Visitor):
         self.add_rule('_IS', 'is', tree)
         self.add_rule('_INPUT', 'input', tree)
 
-    def input_is_empty_brackets(self, tree):
+    def input_empty_brackets(self, tree):
         self.add_rule('_IS', 'is', tree)
-        self.add_rule('_INPUT', 'input', tree)
-
-    def input_equals_empty_brackets(self, tree):
         self.add_rule('_INPUT', 'input', tree)
 
     def add_rule(self, token_name, token_keyword, tree):

--- a/tests/test_level_05.py
+++ b/tests/test_level_05.py
@@ -191,8 +191,8 @@ class TestsLevel5(HedyTester):
     dishwasher is people at random
     if dishwasher is Sophie
     print 'too bad I have to do the dishes'
-    else print 'luckily no dishes because' dishwasher 'is already washing up'""")
-    # @TODO: Felienne, if the above line starts with "else\nprint", then the test fails intermittently due to ambiguity
+    else
+    print 'luckily no dishes because' dishwasher 'is already washing up'""")
 
     expected = textwrap.dedent("""\
     people = ['mom', 'dad', 'Emma', 'Sophie']
@@ -230,6 +230,7 @@ class TestsLevel5(HedyTester):
       code=code,
       expected=expected
     )
+
   def test_print_if_linebreak_statement(self):
     # Breaking an if statement and its following statement should be
     # permited until level 7
@@ -238,8 +239,8 @@ class TestsLevel5(HedyTester):
     people is 1, 2, 3, 3
     dishwasher is people at random
     test is 1
-    if dishwasher is test print 'too bad I have to do the dishes!'""")
-    # @TODO: Felienne, if the above line changes to "test\nprint", then the test fails intermittently due to ambiguity
+    if dishwasher is test
+    print 'too bad I have to do the dishes!'""")
 
     expected = textwrap.dedent("""\
     people = ['1', '2', '3', '3']

--- a/tests/test_level_06.py
+++ b/tests/test_level_06.py
@@ -69,6 +69,16 @@ class TestsLevel6(HedyTester):
 
     self.single_level_tester(code=code, expected=expected)
 
+  def test_ask_equals(self):
+    code = textwrap.dedent("""\
+    antwoord = ask 'wat is je lievelingskleur?'""")
+
+    expected = textwrap.dedent("""\
+    antwoord = input(f'wat is je lievelingskleur?')""")
+
+    self.single_level_tester(code=code, expected=expected)
+
+
   def test_chained_ask(self):
     code = textwrap.dedent("""\
     a is ask 'What is a?'

--- a/tests/test_translation_level_05.py
+++ b/tests/test_translation_level_05.py
@@ -82,6 +82,26 @@ class TestsTranslationLevel5(HedyTester):
 
         self.assertEqual(expected, result)
 
+    def test_2116(self):
+        code = textwrap.dedent("""\
+            people is mom, dad, Emma, Sophie
+            dishwasher is people op willekeurig
+            als dishwasher is Sophie
+            print 'too bad I have to do the dishes'
+            anders
+            print 'luckily no dishes because' dishwasher 'is already washing up'""")
+
+        result = hedy_translation.translate_keywords(code, from_lang="nl", to_lang="en", level=self.level)
+        expected = textwrap.dedent("""\
+            people is mom, dad, Emma, Sophie
+            dishwasher is people at random
+            if dishwasher is Sophie
+            print 'too bad I have to do the dishes'
+            else
+            print 'luckily no dishes because' dishwasher 'is already washing up'""")
+
+        self.assertEqual(expected, result)
+
     def test_if_else_dutch_english(self):
         code = textwrap.dedent("als answer is far vooruit 100 anders vooruit 5")
 


### PR DESCRIPTION
Fixes #2116 

It is a bit of a hack (it always was!) but this disallows the use of if/else in strings allowing us to fix #2116. We now do so in the grammar of level 5 for all languages, at one point we might want put this in each language because otherwise legal programs become problematic for no good reason because there can be many words for if/else in all languages. But this will do for now. Left in the extra test too.