### PR TITLE
Tiny fix so weblate does not delete this content in other languages

### DIFF
--- a/coursedata/adventures/en.yaml
+++ b/coursedata/adventures/en.yaml
@@ -2703,7 +2703,7 @@ adventures:
                     ## End
                     This is the end of the level! Take the quiz now to test your knowledge.
                 ## start_code is only added because it is required by the schema of Adventures
-                start_code: ""
+                start_code: """"
             9:
                 story_text: |
                     ## End


### PR DESCRIPTION
I suspect that this is why level 8 end start_code got removed in languages in #2152 