### PR TITLE
fill last empty strings for translation

### DIFF
--- a/coursedata/adventures/en.yaml
+++ b/coursedata/adventures/en.yaml
@@ -2378,7 +2378,7 @@ adventures:
     next:
         name: "What's next?"
         description: "What's Next?"
-        image: " "
+        image: "hedy-logo.png"
         default_save_name: "next"
         levels:
             1:
@@ -2653,8 +2653,8 @@ adventures:
     end:
         name: "End"
         description: "Test your Hedy knowledge"
-        image: " "
-        default_save_name: " "
+        image: "hedy-logo.png"
+        default_save_name: "none"
         levels:
             1:
                 story_text: |

--- a/coursedata/pages/for-teachers/en.yaml
+++ b/coursedata/pages/for-teachers/en.yaml
@@ -50,7 +50,7 @@ sections:
     - title: "Teaching with Hedy"
       key: "teaching"
       subsections:
-        - title: " "
+        - title: "Teaching with Hedy"
           text: |
             Hedy contains a lot of different levels that each teach a different new skill. We recommend to teach one level per lesson.
             This gives your students the time to fully grasp a new command or concept and practice with it, before moving on to the next level.

--- a/coursedata/texts/en.yaml
+++ b/coursedata/texts/en.yaml
@@ -396,7 +396,7 @@ Programs:
     minutes: "minutes"
     hours: "hours"
     days: "days"
-    ago-1: " "
+    ago-1: "-"
     ago-2: "ago"
     open: "Open"
     delete: "Delete"


### PR DESCRIPTION
last empty strings are now filled in en.yaml files. Since all languages have empty strings as translations, these additions will show up as "fuzzy" or "needs edit" in Weblate. 
From now on, empty strings should be avoided.