### PR TITLE
[CHORE] Adds extra e2e tests for language and keyword language changes

### DIFF
--- a/tests_e2e.py
+++ b/tests_e2e.py
@@ -539,6 +539,37 @@ class TestAuth(AuthHelper):
         self.user['email'] = new_email
         self.user['verify_token'] = body['token']
 
+    def test_invalid_change_language(self):
+        # GIVEN a logged in user
+        self.given_user_is_logged_in()
+
+        # WHEN trying to update the profile with an invalid language
+        body = {
+            'email': self.user['email'],
+            'language': 'abc',
+            'keyword_language': self.user['keyword_language']
+        }
+        # THEN receive an invalid response code from the server
+        self.post_data('profile', body, expect_http_code=400)
+
+    def test_valid_change_language(self):
+        # GIVEN a logged in user
+        self.given_user_is_logged_in()
+
+        # WHEN trying to update the profile with a valid language
+        body = {
+            'email': self.user['email'],
+            'language': 'nl',
+            'keyword_language': self.user['keyword_language']
+        }
+        # THEN receive a valid response code from the server
+        self.post_data('profile', body, expect_http_code=200)
+
+        # WHEN trying to retrieve the current profile
+        profile = self.get_data('profile')
+        # THEN verify that the language is successfully changed
+        self.assertEqual(profile['language'], body['language'])
+
 
     def test_invalid_recover_password(self):
         # GIVEN an existing user

--- a/tests_e2e.py
+++ b/tests_e2e.py
@@ -590,6 +590,18 @@ class TestAuth(AuthHelper):
             # THEN receive an invalid response code from the server
             self.post_data('profile', body, expect_http_code=400)
 
+    def test_valid_keyword_language(self):
+        # GIVEN a logged in user
+        self.given_user_is_logged_in()
+
+        # WHEN trying to update the profile with a valid keyword language
+        body = {
+            'email': self.user['email'],
+            'language': 'nl',
+            'keyword_language': 'nl'
+        }
+        # THEN receive a valid response code from the server
+        self.post_data('profile', body, expect_http_code=200)
 
     def test_invalid_recover_password(self):
         # GIVEN an existing user

--- a/tests_e2e.py
+++ b/tests_e2e.py
@@ -560,7 +560,7 @@ class TestAuth(AuthHelper):
         body = {
             'email': self.user['email'],
             'language': 'nl',
-            'keyword_language': self.user['keyword_language']
+            'keyword_language': 'nl'
         }
         # THEN receive a valid response code from the server
         self.post_data('profile', body, expect_http_code=200)
@@ -569,6 +569,26 @@ class TestAuth(AuthHelper):
         profile = self.get_data('profile')
         # THEN verify that the language is successfully changed
         self.assertEqual(profile['language'], body['language'])
+
+    def test_invalid_keyword_language(self):
+        # GIVEN a logged in user
+        self.given_user_is_logged_in()
+
+        # WHEN trying to update the profile with an invalid keyword language
+        invalid_keyword_language = [
+            'nl',
+            123,
+            'panda'
+        ]
+
+        body = {
+            'email': self.user['email'],
+            'language': 'en'
+        }
+        for invalid_lang in invalid_keyword_language:
+            body['keyword_language'] = invalid_lang
+            # THEN receive an invalid response code from the server
+            self.post_data('profile', body, expect_http_code=400)
 
 
     def test_invalid_recover_password(self):

--- a/website/auth.py
+++ b/website/auth.py
@@ -620,7 +620,7 @@ def routes(app, database):
         # The user object we got from 'requires_login' is not fully hydrated yet. Look up the database user.
         user = DATABASE.user_by_username(user['username'])
 
-        output = {'username': user['username'], 'email': user['email']}
+        output = {'username': user['username'], 'email': user['email'], 'language': user.get('language', 'en')}
         for field in ['birth_year', 'country', 'gender', 'prog_experience', 'experience_languages']:
             if field in user:
                 output[field] = user[field]

--- a/website/auth.py
+++ b/website/auth.py
@@ -1,7 +1,7 @@
 import collections
 import os
 import utils
-from hedy import ALL_LANGUAGES
+from hedy import ALL_LANGUAGES, ALL_KEYWORD_LANGUAGES
 from website.yaml_file import YamlFile
 import bcrypt
 import re
@@ -538,7 +538,7 @@ def routes(app, database):
         if not isinstance(body.get('language'), str) or body.get('language') not in ALL_LANGUAGES.keys():
             return g.auth_texts.get('language_invalid'), 400
         if not isinstance(body.get('keyword_language'), str) or body.get('keyword_language') not in ['en', body.get(
-                'language')]:
+                'language')] or body.get('keyword_language') not in ALL_KEYWORD_LANGUAGES.keys():
             return g.auth_texts.get('keyword_language_invalid'), 400
 
         # Validations, optional fields


### PR DESCRIPTION
**Description**
In this PR we add some additional tests for language and keyword language changes. These were not already implemented within the `profile_modify` function as they are mandatory and should be handled separately to test.

**Fixes**
This PR fixes ##2229

**How to test**
This is only a validation chore run by the server, if it passes it works.