### PR TITLE
semantics change level 1 turn

### DIFF
--- a/SEMANTICS.md
+++ b/SEMANTICS.md
@@ -31,7 +31,7 @@ Level 1 supports:
   </tr>
   <tr>
     <td>turn</td>
-    <td>'right' + integer | 'left' + integer | empty</td>
+    <td>'right' | 'left' | empty</td>
   </tr>
   <tr>
     <td>echo</td>
@@ -74,10 +74,6 @@ Level 1 supports:
   <tr>
     <td>turn right</td>
     <td>t = turtle.Turtle()<br>t.right(90)</td>
-  </tr>
-  <tr>
-    <td>turn 100</td>
-    <td>t = turtle.Turtle()<br>t.right(100)</td>
   </tr>
   <tr>
     <td>ask x</td>


### PR DESCRIPTION
**Please fill out this template by replacing all content between < >**

< Provide a one line summary of your changes in the Title of the PR >

**Description**

< In level 1, `turn` could be used with `left` or `right` and then an integer, or with nothing, and if I remember correctly also with just an integer. Now, in level 1, `turn` can only be just with only `left`, `right`, or nothing. So not yet with integers (this changes in level 2 already, when `left` and `right` are not used anymore and `turn` is used with nothing or only an integer). This pull request is to update the semantics. > Use present tense without a subject to describe your PR, for example: "Adds translations of levels 1 to 12 to Polish"

**Fixes < n.a. >**

< Always link the number of the issue or of the discussion that your pr concerns. >
Notable exception: adding content may be done without an accompanying issue 

**How to test**

< If this is a UI change, describe how to run your code to see it in action. See this https://github.com/Felienne/hedy/pull/880#issue-1016304308 for an example >
< If this is a language change, add a few tests showing the difference >

Documentation change only. See SEMANTICS.md file, under level 1, under commands and types the type for command `turn` changed, and one example of a correct program is deleted, where `turn` was already used with an integer. 

**Checklist**
Done? Check if you have it all in place using this list*
  
- [x] Describes changes in the format above (present tense)
- [ ] Links to an existing issue or discussion 
- [x] Has a "How to test" section

* If you're unsure about any of these, don't hesitate to ask. We're here to help!
