### PR TITLE
Space In String Assignment Fix for levels 6 to 11

### DIFF
--- a/grammars/level6-Additions.lark
+++ b/grammars/level6-Additions.lark
@@ -12,7 +12,7 @@ condition:+= equality_check -= equality_check
 
 list_access_var: var (_SPACE _IS _SPACE | _EQUALS) var _SPACE _AT _SPACE (INT | random)
 assign_list: var (_SPACE _IS _SPACE | _EQUALS) textwithspaces (_COMMA textwithspaces)+
-assign: var (_SPACE _IS _SPACE | _EQUALS) expression | var (_SPACE _IS _SPACE | _EQUALS) textwithoutspaces
+assign: var (_SPACE _IS _SPACE | _EQUALS) expression | var (_SPACE _IS _SPACE | _EQUALS) textwithoutspaces | var (_SPACE _IS _SPACE | _EQUALS) textwithspaces
 
 ?expression: simple_expression | expression _MULTIPLY atom -> multiplication | expression _DIVIDE atom -> division | expression _PLUS atom -> addition | expression _MINUS atom -> subtraction
 ?simple_expression: atom _MULTIPLY atom -> multiplication | atom _DIVIDE atom -> division | atom _PLUS atom -> addition | atom _MINUS atom -> subtraction

--- a/tests/test_level_06.py
+++ b/tests/test_level_06.py
@@ -663,3 +663,33 @@ class TestsLevel6(HedyTester):
       code=code,
       exception=hedy.exceptions.InvalidArgumentTypeException
     )
+
+  def test_space_in_string_assignment(self):
+    code = textwrap.dedent("""\
+      a is 'Hello World'
+      print a
+      
+      a = 'Hello World'
+      print a
+
+      a is Hello World
+      print a
+
+      a = Hello World
+      print a""")
+  
+    expected = textwrap.dedent("""\
+      a = '\\'Hello World\\''
+      print(f'{a}')
+      a = '\\'Hello World\\''
+      print(f'{a}')
+      a = 'Hello World'
+      print(f'{a}')
+      a = 'Hello World'
+      print(f'{a}')""")
+    
+    self.multi_level_tester(
+      max_level=11,
+      code=code,
+      expected=expected
+    )


### PR DESCRIPTION
This PR will allow for users to have spaces in their string assignments in levels 6 through 11.

**Description**

Adds `textwithspace` to the assignment in the `grammars/Level6-Additions.lark` file

**Fixes #2073**

**How to test**

Added a unit test to `tests/test_level_06.py` called `test_space_in_string_assignment` that checks for spaces in string assignments with and without quotes both using `is` and `=`. The unit test does not pass without the change in `grammars/Level6-Additions.lark`, and the test uses `multi_level_tester` to assess levels 6 through 11.
