### PR TITLE
[BUG FIX] Saving programs works again

### DIFF
--- a/website/programs.py
+++ b/website/programs.py
@@ -112,7 +112,7 @@ def routes(app, database, achievements):
             'code': body['code'],
             'name': body['name'],
             'username': user['username'],
-            'public': program_public,
+            'public': 1 if program_public else None,
             'error': 1 if error else None
         }
 


### PR DESCRIPTION
**Description**
Due to a type mismatch of the `Public` value program saving was no longer possible. This is due to Dynamo expecting a number as index key, but we store the `public` value as a boolean. We fix this in this PR.

**Fixes**
No related issue.

**How to test**
This can only be tested on Alpha as the local db file doesn't care about type mismatching. Deploy to Alpha and verify that storing programs is working once again.