### PR TITLE
Refactor the error_invalid grammar rule #1632

### DIFF
--- a/grammars/level12-Additions.lark
+++ b/grammars/level12-Additions.lark
@@ -7,7 +7,6 @@ assign_list: var (_SPACE _IS _SPACE | _EQUALS) (text_in_quotes|NUMBER) (_COMMA (
 equality_check: (var_access | text_in_quotes | NUMBER) (_SPACE _IS _SPACE | _EQUALS) (var_access | text_in_quotes | NUMBER)
 
 in_list_check: (var_access | text_in_quotes | NUMBER) _SPACE _IN _SPACE var_access
-error_invalid: "Supercalifragilisticexpialidocious" //invalid node should be deleted but this probably never matches anything :D
 
 // all literal strings have to be quoted now, so arithmetic operators don't need to be excluded anymore
 textwithspaces: /(?:[^\n،,' ]| (?!else))+/ -> text

--- a/grammars/level5-Additions.lark
+++ b/grammars/level5-Additions.lark
@@ -1,14 +1,15 @@
 program: _EOL* (command | error_invalid) (_SPACE)* (_EOL+ (command | error_invalid) (_SPACE)*)* _EOL* //lines may end on spaces and might be separated by many newlines
-//placing assing at the end
-command:+= ifelse | ifs  |  list_access_var -= error_invalid | error_ask_no_quotes > assign
+
 //placing assign after print means print is will print 'is' and print is Felienne will print 'is Felienne'
+command:+= ifelse | ifs | list_access_var -= error_invalid | error_ask_no_quotes > assign
+
+// error_invalid is moved from to command to program, so that command rules have priority over error_invalid
+error_invalid: textwithoutspaces _SPACE* (quoted_text | textwithspaces)?
 
 //todo: list_access_var can be merged with var? would simplify rewriting a bit, some duplication now in processing
 list_access_var: var _SPACE _IS _SPACE var _SPACE _AT _SPACE (INT | random)
 assign_list: var _SPACE _IS _SPACE textwithspaces (_COMMA textwithspaces)+
 assign: var _SPACE _IS _SPACE textwithspaces
-// Why are we redefining this rule if it's not used in further levels? JP Dec-2021
-error_invalid: textwithoutspaces (_SPACE quoted_text | _SPACE textwithspaces)?
 
 error_print_no_quotes: _PRINT _SPACE (textwithoutspaces | list_access | var_access) (_SPACE (textwithoutspaces | list_access | var_access))*  -> error_print_nq
 


### PR DESCRIPTION
**Please fill out this template by replacing all content between < >**

< Refactor the error_invalid grammar rule >

**Description**

< Change a comment in level 5 which clarifies the error_invalid changes; Remove a redefinition of the error_invalid rule in level 12 > Use present tense without a subject to describe your PR, for example: "Adds translations of levels 1 to 12 to Polish"

**Fixes < TODO for #1632  >**

< Always link the number of the issue or of the discussion that your pr concerns. >
Notable exception: adding content may be done without an accompanying issue 

**How to test**

< See the comment change in level 5. Is it clear? >
< If this is a language change, add a few tests showing the difference >

**Checklist**
Done? Check if you have it all in place using this list*
  
- [ ] Describes changes in the format above (present tense)
- [ ] Links to an existing issue or discussion 
- [ ] Has a "How to test" section

* If you're unsure about any of these, don't hesitate to ask. We're here to help!
