### PR TITLE
[BUG FIX] Arabic level 1 works again

### DIFF
--- a/coursedata/level-defaults/ar.yaml
+++ b/coursedata/level-defaults/ar.yaml
@@ -36,9 +36,9 @@
         demo_code: "{forward} 25\n{turn} left\n{forward} 25\n{turn} right"
         explanation: turn the drawing turtle with `{turn}`
         name: '{turn}'
-    intro_text_2: "يمكنك أن تسأل عن معلومة معينة وتعيد ترديدها من خلال الأمر `{ردد}`.\nجرب الكود الموجود على اليسار. \n\nلا تعرف بعد ما الذي تريد برمجته؟ في علامات التبويب التالية يمكنك أن تجد بعض الأفكار لما يمكنك صنعه.\n"
-    example_code_2: "##مثال توضيحي\n```\n{اسأل} ما اسمك؟\n{ردد} مرحبا\n```\n"
-    example_code: "## مثال توضيحي\n```\n{قول}  مرحبا!\n{قول} أهلاً بكم في هيدي!\n```\n"
+    intro_text_2: "يمكنك أن تسأل عن معلومة معينة وتعيد ترديدها من خلال الأمر `{echo}`.\nجرب الكود الموجود على اليسار. \n\nلا تعرف بعد ما الذي تريد برمجته؟ في علامات التبويب التالية يمكنك أن تجد بعض الأفكار لما يمكنك صنعه.\n"
+    example_code_2: "##مثال توضيحي\n```\n{ask} ما اسمك؟\n{echo} مرحبا\n```\n"
+    example_code: "## مثال توضيحي\n```\n{print}  مرحبا!\n{print} أهلاً بكم في هيدي!\n```\n"
     intro_text_3: "Let's get started! Don't know what to create? In the next tabs you will find ideas for programs to build.\n"
 2:
     intro_text: |-

--- a/coursedata/level-defaults/ar.yaml
+++ b/coursedata/level-defaults/ar.yaml
@@ -36,9 +36,9 @@
         demo_code: "{forward} 25\n{turn} left\n{forward} 25\n{turn} right"
         explanation: turn the drawing turtle with `{turn}`
         name: '{turn}'
-    intro_text_2: "يمكنك أن تسأل عن معلومة معينة وتعيد ترديدها من خلال الأمر `{echo}`.\nجرب الكود الموجود على اليسار. \n\nلا تعرف بعد ما الذي تريد برمجته؟ في علامات التبويب التالية يمكنك أن تجد بعض الأفكار لما يمكنك صنعه.\n"
-    example_code_2: "##مثال توضيحي\n```\n{ask} ما اسمك؟\n{echo} مرحبا\n```\n"
-    example_code: "## مثال توضيحي\n```\n{print}  مرحبا!\n{print} أهلاً بكم في هيدي!\n```\n"
+    intro_text_2: "يمكنك أن تسأل عن معلومة معينة وتعيد ترديدها من خلال الأمر `ردد`.\nجرب الكود الموجود على اليسار. \n\nلا تعرف بعد ما الذي تريد برمجته؟ في علامات التبويب التالية يمكنك أن تجد بعض الأفكار لما يمكنك صنعه.\n"
+    example_code_2: "##مثال توضيحي\n```\nاسأل ما اسمك؟\nردد مرحبا\n```\n"
+    example_code: "## مثال توضيحي\n```\nقول  مرحبا!\nقول أهلاً بكم في هيدي!\n```\n"
     intro_text_3: "Let's get started! Don't know what to create? In the next tabs you will find ideas for programs to build.\n"
 2:
     intro_text: |-


### PR DESCRIPTION
**Description**
In this PR we fix Arabic level 1. It was broken due to keywords being surrounded by curly brackets but without using the placeholder values. So the translated values where already in the strings, resulting in a key error when parsing the translated keywords.

**Fixes**
No related issue.

**How to test**
Verify that level 1 of Hedy is loading without an error in Arabic. All other levels should already be working as the error does not exist there.
