### PR TITLE
[CONTENT FIX] Localizes left/right keyword

### DIFF
--- a/coursedata/adventures/en.yaml
+++ b/coursedata/adventures/en.yaml
@@ -595,7 +595,7 @@ adventures:
                     ## Let's draw
                     You can also use Hedy to draw. By combining turns and lines, you can make a square or stairs!
 
-                    Using `{forward}` you draw a line forwards. The number behind it determines how far the turtle will walk. `{turn} right` turns a quarter turn in clockwise direction, `{turn} left` turns counter clockwise.
+                    Using `{forward}` you draw a line forwards. The number behind it determines how far the turtle will walk. `{turn} {right}` turns a quarter turn in clockwise direction, `{turn} {left}` turns counter clockwise.
 
                     This is the start of a little staircase. Can you make it have 5 steps?
 
@@ -603,14 +603,14 @@ adventures:
                     ## Example Hedy code
 
                     ```
-                    {turn} right
+                    {turn} {right}
                     {forward} 50
-                    {turn} left
+                    {turn} {left}
                     {forward} 50
                     ```
 
 
-                start_code: "{forward} 50\n{turn} left"
+                start_code: "{forward} 50\n{turn} {left}"
             2:
                 story_text: |
                     ## Turtle

--- a/coursedata/adventures/en.yaml
+++ b/coursedata/adventures/en.yaml
@@ -2244,7 +2244,7 @@ adventures:
 
                     ```
                     numbers = [1, 2, 3]
-                    i = numbers[random]
+                    i = numbers[{random}]
                     hint = ['growling', 'a cackling laugh', 'fluttering batwings']
                     monsters = ['zombie', 'witch', 'vampire']
                     bad_fate = ['Your brain is eaten', 'You are forever cursed', 'You are bitten']

--- a/coursedata/adventures/nl.yaml
+++ b/coursedata/adventures/nl.yaml
@@ -571,7 +571,7 @@ adventures:
                     {turn} {left}
                     {forward} 50
                     ```
-                start_code: "{forward} 50\n{turn} right"
+                start_code: "{forward} 50\n{turn} {right}"
             2:
                 story_text: |
                     ## Tekenen maar

--- a/coursedata/level-defaults/en.yaml
+++ b/coursedata/level-defaults/en.yaml
@@ -55,9 +55,9 @@
       example: "Example: {turn}"
       demo_code: |-
         {forward} 25
-        {turn} left
+        {turn} {left}
         {forward} 25
-        {turn} right
+        {turn} {right}
 2:
   intro_text: |
     ## Variables

--- a/coursedata/level-defaults/nl.yaml
+++ b/coursedata/level-defaults/nl.yaml
@@ -710,18 +710,18 @@
             fruit = ['appel', 'banaan', 'kers']
             {print} fruit
     -   name: "Pak iets uit een lijst"
-        explanation: "Om een item uit een lijst te krijgen gebruiken we [nummer] dus met fruit[1] krijg je de eerste fruit uit de lijst !"
+        explanation: "Om een item uit een lijst te krijgen gebruiken we [nummer] dus met fruit[1] krijg je de eerste fruit uit de lijst!"
         example: "Bijvoorbeeld: eerstefruit = fruit[1]"
         demo_code: |-
             fruit = ['banaan', 'appel', 'kers']
             eerstefruit = fruit[1]
             {print} eerstefruit
     -   name: "Pak een random item uit een lijst"
-        explanation: "Om een random item uit een lijst te pakken, gebruiken we [random]. Dus fruit[random] {is} pak een random fruit uit de lijst!"
-        example: "Bijvoorbeeld: randomfruit = fruit[random]"
+        explanation: "Om een random item uit een lijst te pakken, gebruiken we [{random}]. Dus fruit[{random}] pakt een random fruit uit de lijst!"
+        example: "Bijvoorbeeld: randomfruit = fruit[{random}]"
         demo_code: |-
             fruit = ['banaan', 'appel', 'kers']
-            randomfruit = fruit[random]
+            randomfruit = fruit[{random}]
             {print} randomfruit 
 
 
@@ -738,7 +738,7 @@
         Kijk maar...
         ```
         prijzen = ['1 miljoen euro', 'een appeltaart', 'niets']
-        jouw_prijs = prijzen[random]
+        jouw_prijs = prijzen[{random}]
         {print} 'Jij wint ' jouw_prijs
         {if} jouw_prijs == '1 miljoen euro' :
             {print} 'Joepie! Je bent rijk!'


### PR DESCRIPTION
**Description**
In this PR we localize the left/right **and** random keywords in both the English and dutch version. As the translations are all using English as a starting point we hope that this fixes ambiguity when translating. The curly brackets should clarify that the keywords should not be translated.

**Fixes**
This PR fixes #2335

**How to test**
Small clean-up, doesn't have to be tested.
