### PR TITLE
Adds Norwegian to supported keyword languages

### DIFF
--- a/hedy.py
+++ b/hedy.py
@@ -66,11 +66,12 @@ FALL_BACK_ADVENTURE = {
 
 ALL_KEYWORD_LANGUAGES = {
     'en': 'EN',
-    'nl': 'NL',
-    'ar': 'AR',
+    'es': 'ES',
     'fr': 'FR',
-    'hi': 'HI',
-    'es': 'ES'
+    'nl': 'NL',
+    'nb_NO': 'NB',
+    'ar': 'AR',
+    'hi': 'HI'
 }
 
 

--- a/hedy.py
+++ b/hedy.py
@@ -70,6 +70,7 @@ ALL_KEYWORD_LANGUAGES = {
     'fr': 'FR',
     'nl': 'NL',
     'nb_NO': 'NB',
+    'tr': 'TR',
     'ar': 'AR',
     'hi': 'HI'
 }

--- a/hedy_translation.py
+++ b/hedy_translation.py
@@ -5,8 +5,7 @@ import operator
 import yaml
 from os import path
 
-# TODO, FH mar 2022, why don't we grab ALL_KEYW_LANGS from hedy?
-KEYWORD_LANGUAGES = ['en', 'nl', 'es', 'fr', 'ar', 'tr', 'hi', 'nb_NO']
+KEYWORD_LANGUAGES = hedy.ALL_KEYWORD_LANGUAGES.keys()
 
 # Holds the token that needs to be translated, its line number, start and end indexes and its value (e.g. ", ").
 Rule = namedtuple("Rule", "keyword line start end value")

--- a/hedy_translation.py
+++ b/hedy_translation.py
@@ -5,7 +5,7 @@ import operator
 import yaml
 from os import path
 
-KEYWORD_LANGUAGES = hedy.ALL_KEYWORD_LANGUAGES.keys()
+KEYWORD_LANGUAGES = list(hedy.ALL_KEYWORD_LANGUAGES.keys())
 
 # Holds the token that needs to be translated, its line number, start and end indexes and its value (e.g. ", ").
 Rule = namedtuple("Rule", "keyword line start end value")


### PR DESCRIPTION
**Description**
In this PR we add Norwegian to supported keyword languages. This was already added in the translation file but not yet in the dict on which we base the front-end options. I assume this was an error which make sense as it doesn't make sense to keep track of two identical dictionaries. Therefore in this PR we also remove one of them to include the other one.

**Fixes**
No related issue.

**How to test**
Verify that Norsk is now a keyword language option on profile creation and updating. Verify that Norks only works if your profile language is actually set at Norks. Verify that it is all working correctly and all placeholders are correctly parsed.

