### PR TITLE
[REVERSE FIX] Reversed new achievements structure

### DIFF
--- a/coursedata/achievements/nl.yaml
+++ b/coursedata/achievements/nl.yaml
@@ -107,23 +107,23 @@ categories:
       - title: ""
         achievements:
           - key: ready_set_education
-            title: "Ready, Set, Education!"
-            text: "Create a class"
+            title: "Klaar om te leren!"
+            text: "Maak een nieuwe klas aan"
           - key: end_of_semester
-            title: "End of Semester"
-            text: "Delete a class"
+            title: "Tijd voor vakantie"
+            text: "Verwijder een klas"
           - key: on_second_thoughts
-            title: "On Second Thoughts"
-            text: "Rename a class"
+            title: "Wacht is..."
+            text: "Hernoem een klas"
           - key: my_class_my_rules
-            title: "My Class, my Rules"
-            text: "Customize a class"
+            title: "Mijn klas, mijn regels"
+            text: "Personaliseer een klas"
           - key: full_house
-            title: "Full House"
-            text: "Have a class with more than 20 students"
+            title: "Volle bak"
+            text: "Heb een klas met meer dan 20 leerlingen"
           - key: detention
-            title: "Detention!"
-            text: "Remove a student from a class"
+            title: "Strafwerk!"
+            text: "Verwijder een leerling uit een klas"
   - key: hidden
     title: "Verborgen"
     subcategories:
@@ -131,236 +131,19 @@ categories:
         achievements:
           - key: hedy-ious
             title: "Hedy-ious"
-            text: "Print 10 times the same string without using a loop"
+            text: "Print 10 keer dezelfde zin zonder een 'loop' te gebruiken"
           - key: talk-talk-talk
-            title: "Talk-talk-talk"
-            text: "Create a program with a least 5 ask keywords"
+            title: "Praat-praat-praat"
+            text: "Maak een programma met minimaal 5 keer het 'ask' commando"
           - key: hedy_hacking
             title: "Hedy Hacking"
-            text: "Create a timeout due to your program running too long"
+            text: "Maak een programma dat te lang duurt (en vastloopt)"
           - key: hedy_honor
             title: "Hedy Honor"
-            text: "Run a program that prints the text 'Hedy'"
+            text: "Maak een programma dat de tekst 'Hedy' print"
           - key: programming_panic
-            title: "Programming Panic"
-            text: "Try to run a faulty program 3 times in a row"
+            title: "Programmeer-paniek"
+            text: "Maak 3 keer achter elkaar dezelfde fout"
           - key: watch_out
-            title: "Watch out!"
-            text: "Create a program that results in a (non-empty) warning"
-
-
-adventure_is_worthwhile:
-    title: "Avontuuurrrrr!"
-    image: "achievement.png"
-    text: |
-        Sla een programma van een avontuur op
-programming_protagonist:
-    title: "Doorzetter!"
-    image: "achievement.png"
-    text: |
-        Maak een goed programma na een error
-did_you_say_please:
-    title: "Zei je alsjeblieft?"
-    image: "achievement.png"
-    text: |
-        Maak een programma met het 'ask' commando
-error_or_empty:
-    title: "Die lijkt kapot..."
-    image: "achievement.png"
-    text: |
-        Maak een programma dat niks laat zien
-trying_is_key:
-    title: "En wat nu?"
-    image: "achievement.png"
-    text: |
-        Gebruik alle Hedy commando's minimaal 1 keer
-ninja_turtle:
-    title: "Ninja Turtle"
-    image: "achievement.png"
-    text: |
-        Maak een programma met de teken turtle
-sharing_is_caring:
-    title: "Komt dat zien!"
-    image: "achievement.png"
-    text: |
-        Deel een opgeslagen programma
-do_you_have_copy:
-    title: "Laat maar zitten"
-    image: "achievement.png"
-    text: |
-        Verwijder een opgeslagen programma
-epic_education:
-    title: "Super scholier"
-    image: "achievement.png"
-    text: |
-        Voeg je account toe aan een klas
-lets_focus:
-    title: "1,2,3 focus"
-    image: "achievement.png"
-    text: |
-        Gebruik de programmeurs modus
-make_some_noise:
-    title: "Ik hoor je niet?!"
-    image: "achievement.png"
-    text: |
-        Laat jouw programma voorlezen
-next_question:
-    title: "Volgende vraag..."
-    image: "achievement.png"
-    text: |
-        Maak een Hedy quiz
-quiz_master:
-    title: "Quiz Master"
-    image: "achievement.png"
-    text: |
-        Behaal maximale score in een quiz
-double_check:
-    title: "Even checken..."
-    image: "achievement.png"
-    text: |
-        Krijg een "dezelfde naam" waarschuwing
-go_live:
-    title: "Open boek"
-    image: "achievement.png"
-    text: |
-        Maak een openbaar profiel
-fresh_look:
-    image: achievement.png
-    title: "Frisse blik"
-    text: "Verander je profielfoto"
-indiana_jones:
-    title: "Indiana Jones"
-    image: "achievement.png"
-    text: |
-        Zoek op de "Ontdekken" pagina
-
-#Programming counting achievements
-getting_started_I:
-    title: "Goed begin I"
-    image: "achievement.png"
-    text: |
-        Maak 1 Hedy programma
-getting_started_II:
-    title: "Goed begin II"
-    image: "achievement.png"
-    text: |
-        Maak 10 Hedy programma's
-getting_started_III:
-    title: "Goed begin III"
-    image: "achievement.png"
-    text: |
-        Maak 50 Hedy programma's
-getting_started_IV:
-    title: "Goed begin IV"
-    image: "achievement.png"
-    text: |
-        Maak 200 Hedy programma's
-getting_started_V:
-    title: "Goed begin V"
-    image: "achievement.png"
-    text: |
-        Maak 500 Hedy programma's
-one_to_remember_I:
-    title: "Niet te vergeten I"
-    image: "achievement.png"
-    text: |
-        Sla 1 Hedy programma op
-one_to_remember_II:
-    title: "Niet te vergeten II"
-    image: "achievement.png"
-    text: |
-        Sla 5 Hedy programma's op
-one_to_remember_III:
-    title: "Niet te vergeten III"
-    image: "achievement.png"
-    text: |
-        Sla 10 Hedy programma's op
-one_to_remember_IV:
-    title: "Niet te vergeten IV"
-    image: "achievement.png"
-    text: |
-        Sla 25 Hedy programma's op
-one_to_remember_V:
-    title: "Niet te vergeten V"
-    image: "achievement.png"
-    text: |
-        Sla 50 Hedy programma's op
-deadline_daredevil_I:
-    title: "Deadline Durfval I"
-    image: "achievement.png"
-    text: |
-        Lever 1 Hedy programma in
-deadline_daredevil_II:
-    title: "Deadline Durfval II"
-    image: "achievement.png"
-    text: |
-        Level 3 Hedy programma's in
-deadline_daredevil_III:
-    title: "Deadline Durfval III"
-    image: "achievement.png"
-    text: |
-        Level 10 Hedy programma's in
-
-#Teacher achievements
-ready_set_education:
-    title: "Klaar om te leren!"
-    image: "achievement.png"
-    text: |
-        Maak een nieuwe klas aan
-end_of_semester:
-    title: "Tijd voor vakantie"
-    image: "achievement.png"
-    text: |
-        Verwijder een klas
-on_second_thoughts:
-    title: "Wacht is..."
-    image: "achievement.png"
-    text: |
-        Hernoem een klas
-my_class_my_rules:
-    title: "Mijn klas, mijn regels"
-    image: "achievement.png"
-    text: |
-        Personaliseer een klas
-full_house:
-    title: "Volle bak"
-    image: "achievement.png"
-    text: |
-        Heb een klas met meer dan 20 leerlingen
-detention:
-    title: "Strafwerk!"
-    image: "achievement.png"
-    text: |
-        Verwijder een leerling uit een klas    
-
-#Hidden achievements
-hedy-ious:
-    title: "Hedy-ious"
-    image: "achievement.png"
-    text: |
-        Print 10 keer dezelfde zin zonder een 'loop' te gebruiken
-talk-talk-talk:
-    title: "Praat-praat-praat"
-    image: "achievement.png"
-    text: |
-        Maak een programma met minimaal 5 keer het 'ask' commando
-hedy_hacking:
-    title: "Hedy Hacking"
-    image: "achievement.png"
-    text: |
-        Maak een programma dat te lang duurt (en vastloopt)
-hedy_honor:
-    title: "Hedy Honor"
-    image: "achievement.png"
-    text: |
-        Maak een programma dat de tekst 'Hedy' print
-programming_panic:
-    title: "Programmeer-paniek"
-    image: "achievement.png"
-    text: |
-        Maak 3 keer achter elkaar dezelfde fout
-watch_out:
-    title: "Kijk uit!"
-    image: "achievement.png"
-    text: |
-        Maak een programma dat een (niet-leeg) waarschuwing geeft
+            title: "Kijk uit!"
+            text: "Maak een programma dat een (niet-leeg) waarschuwing geeft"

--- a/coursedata/achievements/nl.yaml
+++ b/coursedata/achievements/nl.yaml
@@ -11,96 +11,96 @@ categories:
             title: "Doorzetter!"
             text: "Maak een goed programma na een error"
           - key: did_you_say_please
-            title: "Did you say please?"
-            text: "Create a program with the 'ask' command"
+            title: "Zei je alsjeblieft?"
+            text: "Maak een programma met het 'ask' commando"
           - key: error_or_empty
-            title: "Error or empty?"
-            text: "Create a program that has no output"
+            title: "Die lijkt kapot..."
+            text: "Maak een programma dat niks laat zien"
           - key: trying_is_key
-            title: "Gotta Use Them All"
-            text: "Use all Hedy commands at least once"
+            title: "En wat nu?"
+            text: "Gebruik alle Hedy commando's minimaal 1 keer"
           - key: ninja_turtle
             title: "Ninja Turtle"
-            text: "Create a program with the turtle"
+            text: "Maak een programma met de teken turtle"
           - key: sharing_is_caring
-            title: "Sharing is Caring"
-            text: "Share a saved program"
+            title: "Komt dat zien!"
+            text: "Deel een opgeslagen programma"
           - key: do_you_have_copy
-            title: "Do you have a copy?"
-            text: "Delete a saved program"
+            title: "Laat maar zitten"
+            text: "Verwijder een opgeslagen programma"
           - key: epic_education
-            title: "Epic Education"
-            text: "Join a class"
+            title: "Super scholier"
+            text: "Voeg je account toe aan een klas"
           - key: lets_focus
-            title: "Let's Focus"
-            text: "Turn on the programmers mode"
+            title: "1,2,3 focus"
+            text: "Gebruik de programmeurs modus"
           - key: make_some_noise
-            title: "Make Some Noise"
-            text: "Let your program be read aloud"
+            title: "Ik hoor je niet?!"
+            text: "Laat jouw programma voorlezen"
           - key: next_question
-            title: "Next Question..."
-            text: "Finish a Hedy quiz"
+            title: "Volgende vraag..."
+            text: "Maak een Hedy quiz"
           - key: quiz_master
             title: "Quiz Master"
-            text: "Get the maximum score on a quiz"
+            text: "Behaal maximale score in een quiz"
           - key: double_check
-            title: "Double-check"
-            text: "Get a duplicate program name warning"
+            title: "Even checken..."
+            text: "Krijg een \"dezelfde naam\" waarschuwing"
           - key: go_live
-            title: "Let's Go Live"
-            text: "Create a public profile"
+            title: "Open boek"
+            text: "Maak een openbaar profiel"
           - key: fresh_look
-            title: "Fresh Look"
-            text: "Change your profile picture"
+            title: "Frisse blik"
+            text: "Verander je profielfoto"
           - key: indiana_jones
             title: "Indiana Jones"
-            text: "Search within the explore page"
+            text: "Zoek op de \"Ontdekken\" pagina"
       - title: "Programma's gemaakt"
         achievements:
           - key: getting_started_I
-            title: "Getting Started I"
-            text: "Run 1 Hedy program"
+            title: "Goed begin I"
+            text: "Maak 1 Hedy programma"
           - key: getting_started_II
-            title: "Getting Started II"
+            title: "Goed begin II"
             image: "achievement.png"
-            text: "Run 10 Hedy programs"
+            text: "Maak 10 Hedy programma's"
           - key: getting_started_III
-            title: "Getting Started III"
-            text: "Run 50 Hedy programs"
+            title: "Goed begin III"
+            text: "Maak 50 Hedy programma's"
           - key: getting_started_IV
-            title: "Getting Started IV"
-            text: "Run 200 Hedy programs"
+            title: "Goed begin IV"
+            text: "Maak 200 Hedy programma's"
           - key: getting_started_V
-            title: "Getting Started V"
-            text: "Run 500 Hedy programs"
+            title: "Goed begin V"
+            text: "Maak 500 Hedy programma's"
       - title: "Programma's opgeslagen"
         achievements:
           - key: one_to_remember_I
-            title: "One to Remember I"
-            text: "Save 1 Hedy program"
+            title: "Niet te vergeten I"
+            text: "Sla 1 Hedy programma op"
           - key: one_to_remember_II
-            title: "One to Remember II"
-            text: "Save 5 Hedy programs"
+            title: "Niet te vergeten II"
+            text: "Sla 5 Hedy programma's op"
           - key: one_to_remember_III
-            title: "One to Remember III"
-            text: "Save 10 Hedy programs"
+            title: "Niet te vergeten III"
+            text: "Sla 10 Hedy programma's op"
           - key: one_to_remember_IV
-            title: "One to Remember IV"
-            text: "Save 25 Hedy programs"
+            title: "Niet te vergeten IV"
+            text: "Sla 25 Hedy programma's op"
           - key: one_to_remember_V
-            title: "One to Remember V"
-            text: "Save 50 Hedy programs"
+            title: "Niet te vergeten V"
+            text: "Sla 50 Hedy programma's op"
       - title: "Programma's ingeleverd"
         achievements:
           - key: deadline_daredevil_I
-            title: "Deadline Daredevil I"
-            text: "Submit 1 Hedy program"
+            title: "Deadline Durfval I"
+            text: "Lever 1 Hedy programma in"
           - key: deadline_daredevil_II
-            title: "Deadline Daredevil II"
-            text: "Submit 3 Hedy programs"
+            title: "Deadline Durfval II"
+            text: "Level 3 Hedy programma's in"
           - key: deadline_daredevil_III
-            title: "Deadline Daredevil III"
-            text: "Submit 10 Hedy programs"
+            title: "Deadline Durfval III"
+            text: "Level 10 Hedy programma's in"
   - key: teacher
     title: "Leraren"
     subcategories:

--- a/coursedata/achievements/nl.yaml
+++ b/coursedata/achievements/nl.yaml
@@ -1,15 +1,154 @@
-#Here we store the title, categories and subcategories
-hedy_achievements: "Hedy Badges"
-general: "Algemeen"
-programs_created: "Programma's gemaakt"
-programs_saved: "Programma's opgeslagen"
-programs_submitted: "Programma's ingeleverd"
-levels: "Levels"
-teacher: "Leraren"
-hidden: "Verborgen badges"
+categories:
+  - key: general
+    title: "Algemeen"
+    subcategories:
+      - title: ""
+        achievements:
+          - key: adventure_is_worthwhile
+            title: "Avontuuurrrrr!"
+            text: "Sla een programma van een avontuur op"
+          - key: programming_protagonist
+            title: "Doorzetter!"
+            text: "Maak een goed programma na een error"
+          - key: did_you_say_please
+            title: "Did you say please?"
+            text: "Create a program with the 'ask' command"
+          - key: error_or_empty
+            title: "Error or empty?"
+            text: "Create a program that has no output"
+          - key: trying_is_key
+            title: "Gotta Use Them All"
+            text: "Use all Hedy commands at least once"
+          - key: ninja_turtle
+            title: "Ninja Turtle"
+            text: "Create a program with the turtle"
+          - key: sharing_is_caring
+            title: "Sharing is Caring"
+            text: "Share a saved program"
+          - key: do_you_have_copy
+            title: "Do you have a copy?"
+            text: "Delete a saved program"
+          - key: epic_education
+            title: "Epic Education"
+            text: "Join a class"
+          - key: lets_focus
+            title: "Let's Focus"
+            text: "Turn on the programmers mode"
+          - key: make_some_noise
+            title: "Make Some Noise"
+            text: "Let your program be read aloud"
+          - key: next_question
+            title: "Next Question..."
+            text: "Finish a Hedy quiz"
+          - key: quiz_master
+            title: "Quiz Master"
+            text: "Get the maximum score on a quiz"
+          - key: double_check
+            title: "Double-check"
+            text: "Get a duplicate program name warning"
+          - key: go_live
+            title: "Let's Go Live"
+            text: "Create a public profile"
+          - key: fresh_look
+            title: "Fresh Look"
+            text: "Change your profile picture"
+          - key: indiana_jones
+            title: "Indiana Jones"
+            text: "Search within the explore page"
+      - title: "Programma's gemaakt"
+        achievements:
+          - key: getting_started_I
+            title: "Getting Started I"
+            text: "Run 1 Hedy program"
+          - key: getting_started_II
+            title: "Getting Started II"
+            image: "achievement.png"
+            text: "Run 10 Hedy programs"
+          - key: getting_started_III
+            title: "Getting Started III"
+            text: "Run 50 Hedy programs"
+          - key: getting_started_IV
+            title: "Getting Started IV"
+            text: "Run 200 Hedy programs"
+          - key: getting_started_V
+            title: "Getting Started V"
+            text: "Run 500 Hedy programs"
+      - title: "Programma's opgeslagen"
+        achievements:
+          - key: one_to_remember_I
+            title: "One to Remember I"
+            text: "Save 1 Hedy program"
+          - key: one_to_remember_II
+            title: "One to Remember II"
+            text: "Save 5 Hedy programs"
+          - key: one_to_remember_III
+            title: "One to Remember III"
+            text: "Save 10 Hedy programs"
+          - key: one_to_remember_IV
+            title: "One to Remember IV"
+            text: "Save 25 Hedy programs"
+          - key: one_to_remember_V
+            title: "One to Remember V"
+            text: "Save 50 Hedy programs"
+      - title: "Programma's ingeleverd"
+        achievements:
+          - key: deadline_daredevil_I
+            title: "Deadline Daredevil I"
+            text: "Submit 1 Hedy program"
+          - key: deadline_daredevil_II
+            title: "Deadline Daredevil II"
+            text: "Submit 3 Hedy programs"
+          - key: deadline_daredevil_III
+            title: "Deadline Daredevil III"
+            text: "Submit 10 Hedy programs"
+  - key: teacher
+    title: "Leraren"
+    subcategories:
+      - title: ""
+        achievements:
+          - key: ready_set_education
+            title: "Ready, Set, Education!"
+            text: "Create a class"
+          - key: end_of_semester
+            title: "End of Semester"
+            text: "Delete a class"
+          - key: on_second_thoughts
+            title: "On Second Thoughts"
+            text: "Rename a class"
+          - key: my_class_my_rules
+            title: "My Class, my Rules"
+            text: "Customize a class"
+          - key: full_house
+            title: "Full House"
+            text: "Have a class with more than 20 students"
+          - key: detention
+            title: "Detention!"
+            text: "Remove a student from a class"
+  - key: hidden
+    title: "Verborgen"
+    subcategories:
+      - title: ""
+        achievements:
+          - key: hedy-ious
+            title: "Hedy-ious"
+            text: "Print 10 times the same string without using a loop"
+          - key: talk-talk-talk
+            title: "Talk-talk-talk"
+            text: "Create a program with a least 5 ask keywords"
+          - key: hedy_hacking
+            title: "Hedy Hacking"
+            text: "Create a timeout due to your program running too long"
+          - key: hedy_honor
+            title: "Hedy Honor"
+            text: "Run a program that prints the text 'Hedy'"
+          - key: programming_panic
+            title: "Programming Panic"
+            text: "Try to run a faulty program 3 times in a row"
+          - key: watch_out
+            title: "Watch out!"
+            text: "Create a program that results in a (non-empty) warning"
 
-#Here we store the actual achievements
-#General achievements
+
 adventure_is_worthwhile:
     title: "Avontuuurrrrr!"
     image: "achievement.png"

--- a/translations/ar/LC_MESSAGES/messages.po
+++ b/translations/ar/LC_MESSAGES/messages.po
@@ -1,19 +1,19 @@
+
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-03-29 10:01+0200\n"
+"POT-Creation-Date: 2022-03-30 08:43+0200\n"
 "PO-Revision-Date: 2022-03-30 09:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
-"Language-Team: Arabic <https://hosted.weblate.org/projects/hedy/web-texts/ar/"
-">\n"
 "Language: ar\n"
+"Language-Team: Arabic <https://hosted.weblate.org/projects/hedy/web-"
+"texts/ar/>\n"
+"Plural-Forms: nplurals=6; plural=(n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : "
+"n%100>=3 && n%100<=10 ? 3 : n%100>=0 && n%100<=2 ? 4 : 5)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=6; plural=(n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 "
-"&& n%100<=10 ? 3 : n%100>=0 && n%100<=2 ? 4 : 5);\n"
-"X-Generator: Weblate 4.12-dev\n"
 "Generated-By: Babel 2.9.1\n"
 
 #: app.py:571
@@ -21,27 +21,27 @@ msgstr ""
 msgid "program_contains_error"
 msgstr "This program contains an error, are you sure you want to share it?"
 
-#: app.py:723
+#: app.py:722
 #, fuzzy
 msgid "title_achievements"
 msgstr "Hedy - My achievements"
 
-#: app.py:740 app.py:1111 website/teacher.py:365 website/teacher.py:374
+#: app.py:739 app.py:1110 website/teacher.py:365 website/teacher.py:374
 #, fuzzy
 msgid "not_teacher"
 msgstr "Looks like you are not a teacher!"
 
-#: app.py:743
+#: app.py:742
 #, fuzzy
 msgid "not_enrolled"
 msgstr "Looks like you are not in this class!"
 
-#: app.py:775
+#: app.py:774
 #, fuzzy
 msgid "title_programs"
 msgstr "Hedy - My programs"
 
-#: app.py:785 app.py:795 app.py:799 app.py:813 app.py:1054 app.py:1357
+#: app.py:784 app.py:794 app.py:798 app.py:812 app.py:1053 app.py:1356
 #: website/admin.py:17 website/admin.py:25 website/admin.py:95
 #: website/admin.py:112 website/admin.py:130 website/auth.py:711
 #: website/auth.py:738 website/statistics.py:86
@@ -49,125 +49,125 @@ msgstr "Hedy - My programs"
 msgid "unauthorized"
 msgstr "You don't have access rights for this page"
 
-#: app.py:823
+#: app.py:822
 #, fuzzy
 msgid "minutes"
 msgstr "minutes"
 
-#: app.py:826
+#: app.py:825
 #, fuzzy
 msgid "hours"
 msgstr "hours"
 
-#: app.py:829
+#: app.py:828
 #, fuzzy
 msgid "days"
 msgstr "days"
 
-#: app.py:832
+#: app.py:831
 #, fuzzy
 msgid "ago"
 msgstr "{time} ago"
 
-#: app.py:848 app.py:850 app.py:976
+#: app.py:847 app.py:849 app.py:975
 #, fuzzy
 msgid "no_such_level"
 msgstr "No such Hedy level!"
 
-#: app.py:858 app.py:865 app.py:931 app.py:937
+#: app.py:857 app.py:864 app.py:930 app.py:936
 #, fuzzy
 msgid "no_such_program"
 msgstr "No such Hedy program!"
 
-#: app.py:891
+#: app.py:890
 #, fuzzy
 msgid "level_not_translated"
 msgstr "This level is not translated in your language (yet)"
 
-#: app.py:893
+#: app.py:892
 #, fuzzy
 msgid "level_not_class"
 msgstr "You're in a class where this level has not been made available yet"
 
-#: app.py:986 website/teacher.py:432 website/teacher.py:448
+#: app.py:985 website/teacher.py:432 website/teacher.py:448
 #: website/teacher.py:477 website/teacher.py:503
 #, fuzzy
 msgid "no_such_adventure"
 msgstr "This adventure doesn't exist!"
 
-#: app.py:1005
+#: app.py:1004
 #, fuzzy
 msgid "page_not_found"
 msgstr "We could not find that page!"
 
-#: app.py:1025
+#: app.py:1024
 #, fuzzy
 msgid "title_signup"
 msgstr "Hedy - Create an account"
 
-#: app.py:1032
+#: app.py:1031
 #, fuzzy
 msgid "title_login"
 msgstr "Hedy - Login"
 
-#: app.py:1039
+#: app.py:1038
 #, fuzzy
 msgid "title_recover"
 msgstr "Hedy - Recover account"
 
-#: app.py:1055
+#: app.py:1054
 #, fuzzy
 msgid "title_reset"
 msgstr "Hedy - Reset password"
 
-#: app.py:1064
+#: app.py:1063
 #, fuzzy
 msgid "title_my-profile"
 msgstr "Hedy - My account"
 
-#: app.py:1078
+#: app.py:1077
 #, fuzzy
 msgid "title_learn-more"
 msgstr "Hedy - Learn more"
 
-#: app.py:1083
+#: app.py:1082
 #, fuzzy
 msgid "title_privacy"
 msgstr "Hedy - Privacy terms"
 
-#: app.py:1090
+#: app.py:1089
 #, fuzzy
 msgid "title_landing-page"
 msgstr "Welcome to Hedy!"
 
-#: app.py:1092
+#: app.py:1091
 #, fuzzy
 msgid "not_user"
 msgstr "Looks like you are not logged in!"
 
-#: app.py:1107
+#: app.py:1106
 #, fuzzy
 msgid "title_for-teacher"
 msgstr "Hedy - For teachers"
 
-#: app.py:1118
+#: app.py:1117
 #, fuzzy
 msgid "title_start"
 msgstr "Hedy - A gradual programming language"
 
-#: app.py:1171
+#: app.py:1170
 #, fuzzy
 msgid "title_explore"
 msgstr "Hedy - Explore"
 
-#: app.py:1190 app.py:1192
+#: app.py:1189 app.py:1191
 #, fuzzy
 msgid "translate_error"
 msgstr ""
-"Something went wrong while translating the code. Try running the code to see "
-"if it has an error. Code with errors can not be translated."
+"Something went wrong while translating the code. Try running the code to "
+"see if it has an error. Code with errors can not be translated."
 
-#: app.py:1301 website/auth.py:299 website/auth.py:347 website/auth.py:483
+#: app.py:1300 website/auth.py:299 website/auth.py:347 website/auth.py:483
 #: website/auth.py:509 website/auth.py:539 website/auth.py:645
 #: website/auth.py:677 website/auth.py:717 website/auth.py:744
 #: website/teacher.py:90 website/teacher.py:125 website/teacher.py:197
@@ -177,37 +177,37 @@ msgstr ""
 msgid "ajax_error"
 msgstr "There was an error, please try again."
 
-#: app.py:1304
+#: app.py:1303
 #, fuzzy
 msgid "image_invalid"
 msgstr "Your chosen image is invalid."
 
-#: app.py:1306
+#: app.py:1305
 #, fuzzy
 msgid "personal_text_invalid"
 msgstr "Your personal text is invalid."
 
-#: app.py:1308 app.py:1314
+#: app.py:1307 app.py:1313
 #, fuzzy
 msgid "favourite_program_invalid"
 msgstr "Your chosen favourite program is invalid."
 
-#: app.py:1326 app.py:1327
+#: app.py:1325 app.py:1326
 #, fuzzy
 msgid "public_profile_updated"
 msgstr "Public profile updated."
 
-#: app.py:1361 app.py:1385
+#: app.py:1360 app.py:1384
 #, fuzzy
 msgid "user_not_private"
 msgstr "This user doesn't exist or doesn't have a public profile"
 
-#: app.py:1394
+#: app.py:1393
 #, fuzzy
 msgid "invalid_teacher_invitation_code"
 msgstr ""
-"The teacher invitation code is invalid. To become a teacher, reach out to "
-"hedy@felienne.com."
+"The teacher invitation code is invalid. To become a teacher, reach out to"
+" hedy@felienne.com."
 
 #: utils.py:203
 #, fuzzy
@@ -228,7 +228,8 @@ msgstr "Something went wrong..."
 #, fuzzy
 msgid "Empty Program"
 msgstr ""
-"You created an empty program. Type Hedy code in the left field and try again"
+"You created an empty program. Type Hedy code in the left field and try "
+"again"
 
 #: coursedata/error-messages.txt:2
 #, fuzzy
@@ -255,53 +256,53 @@ msgstr ""
 #, fuzzy
 msgid "Invalid Space"
 msgstr ""
-"Oops! You started a line with a space on line {line_number}. Spaces confuse "
-"computers, can you remove it?"
+"Oops! You started a line with a space on line {line_number}. Spaces "
+"confuse computers, can you remove it?"
 
 #: coursedata/error-messages.txt:6
 #, fuzzy
 msgid "Has Blanks"
 msgstr ""
-"Your code is incomplete. It contains blanks that you have to replace with "
-"code."
+"Your code is incomplete. It contains blanks that you have to replace with"
+" code."
 
 #: coursedata/error-messages.txt:7
 #, fuzzy
 msgid "No Indentation"
 msgstr ""
 "You used too few spaces in line {line_number}. You used {leading_spaces} "
-"spaces, which is not enough. Start every new block with {indent_size} spaces "
-"more than the line before."
+"spaces, which is not enough. Start every new block with {indent_size} "
+"spaces more than the line before."
 
 #: coursedata/error-messages.txt:8
 #, fuzzy
 msgid "Unexpected Indentation"
 msgstr ""
-"You used too many spaces in line {line_number}. You used {leading_spaces} "
-"spaces, which is too much. Start every new block with {indent_size} spaces "
-"more than the line before."
+"You used too many spaces in line {line_number}. You used {leading_spaces}"
+" spaces, which is too much. Start every new block with {indent_size} "
+"spaces more than the line before."
 
 #: coursedata/error-messages.txt:9
 #, fuzzy
 msgid "Parse"
 msgstr ""
 "The code you entered is not valid Hedy code. There is a mistake on line "
-"{location[0]}, at position {location[1]}. You typed {character_found}, but "
-"that is not allowed."
+"{location[0]}, at position {location[1]}. You typed {character_found}, "
+"but that is not allowed."
 
 #: coursedata/error-messages.txt:10
 #, fuzzy
 msgid "Unquoted Text"
 msgstr ""
-"Be careful. If you ask or print something the text should start and finish "
-"with a quotation mark. You forgot one somewhere."
+"Be careful. If you ask or print something the text should start and "
+"finish with a quotation mark. You forgot one somewhere."
 
 #: coursedata/error-messages.txt:11
 #, fuzzy
 msgid "Unquoted Assignment"
 msgstr ""
-"From this level, you need to place texts to the right of the `is` between "
-"quotes. You forgot that for the text {text}."
+"From this level, you need to place texts to the right of the `is` between"
+" quotes. You forgot that for the text {text}."
 
 #: coursedata/error-messages.txt:12
 #, fuzzy
@@ -315,15 +316,15 @@ msgstr ""
 msgid "Var Undefined"
 msgstr ""
 "You tried to use the variable {name}, but you did not set it. It is also "
-"possible that you were trying to use the word {name} but forgot quotation "
-"marks."
+"possible that you were trying to use the word {name} but forgot quotation"
+" marks."
 
 #: coursedata/error-messages.txt:14
 #, fuzzy
 msgid "Cyclic Var Definition"
 msgstr ""
-"The name {variable} needs to be set before you can use it on the right-hand "
-"side of the is command"
+"The name {variable} needs to be set before you can use it on the right-"
+"hand side of the is command"
 
 #: coursedata/error-messages.txt:15
 #, fuzzy
@@ -336,46 +337,46 @@ msgstr ""
 #, fuzzy
 msgid "Too Big"
 msgstr ""
-"Wow! Your program has an impressive {lines_of_code} lines of code! But we "
-"can only process {max_lines} lines in this level. Make your program smaller "
-"and try again."
+"Wow! Your program has an impressive {lines_of_code} lines of code! But we"
+" can only process {max_lines} lines in this level. Make your program "
+"smaller and try again."
 
 #: coursedata/error-messages.txt:17
 #, fuzzy
 msgid "Invalid Argument Type"
 msgstr ""
-"You cannot use the command {command} with {invalid_argument} because it is "
-"{invalid_type}. Try changing {invalid_argument} to {allowed_types}."
+"You cannot use the command {command} with {invalid_argument} because it "
+"is {invalid_type}. Try changing {invalid_argument} to {allowed_types}."
 
 #: coursedata/error-messages.txt:18
 #, fuzzy
 msgid "Invalid Argument"
 msgstr ""
-"You cannot use the command {command} with {invalid_argument} . Try changing "
-"{invalid_argument} to {allowed_types}."
+"You cannot use the command {command} with {invalid_argument} . Try "
+"changing {invalid_argument} to {allowed_types}."
 
 #: coursedata/error-messages.txt:19
 #, fuzzy
 msgid "Invalid Type Combination"
 msgstr ""
-"You cannot use {invalid_argument} and {invalid_argument_2} in {operation} "
-"because one is {invalid_type} and the other is {invalid_type_2}. Try "
-"changing {invalid_argument} to {invalid_type_2} or {invalid_argument_2} to "
-"{invalid_type}."
+"You cannot use {invalid_argument} and {invalid_argument_2} in {operation}"
+" because one is {invalid_type} and the other is {invalid_type_2}. Try "
+"changing {invalid_argument} to {invalid_type_2} or {invalid_argument_2} "
+"to {invalid_type}."
 
 #: coursedata/error-messages.txt:20
 #, fuzzy
 msgid "Unsupported Float"
 msgstr ""
-"Non-integer numbers are not supported yet but they will be in a few levels. "
-"For now change {value} to an integer."
+"Non-integer numbers are not supported yet but they will be in a few "
+"levels. For now change {value} to an integer."
 
 #: coursedata/error-messages.txt:21
 #, fuzzy
 msgid "Locked Language Feature"
 msgstr ""
-"You are using {concept}! That is awesome, but {concept} is not unlocked yet! "
-"It will be unlocked in a later level."
+"You are using {concept}! That is awesome, but {concept} is not unlocked "
+"yet! It will be unlocked in a later level."
 
 #: coursedata/error-messages.txt:22
 #, fuzzy
@@ -386,15 +387,16 @@ msgstr "It looks like you forgot to use a command on line {line_number}."
 #, fuzzy
 msgid "ask_needs_var"
 msgstr ""
-"Starting in level 2, ask needs to be used with a variable. Example: name is "
-"ask What are you called?"
+"Starting in level 2, ask needs to be used with a variable. Example: name "
+"is ask What are you called?"
 
 #: coursedata/error-messages.txt:24
 #, fuzzy
 msgid "echo_out"
 msgstr ""
-"Starting in level 2 echo is no longer needed. You can repeat an answer with "
-"ask and print now. Example: name is ask What are you called? print hello name"
+"Starting in level 2 echo is no longer needed. You can repeat an answer "
+"with ask and print now. Example: name is ask What are you called? print "
+"hello name"
 
 #: coursedata/error-messages.txt:25
 #, fuzzy
@@ -490,6 +492,11 @@ msgstr "a list"
 #, fuzzy
 msgid "input"
 msgstr "input from ask"
+
+#: templates/achievements.html:4
+#, fuzzy
+msgid "achievements_title"
+msgstr "achievements"
 
 #: templates/class-overview.html:16
 #, fuzzy
@@ -662,22 +669,21 @@ msgstr "Do you want to join this class?"
 #: templates/class-prejoin.html:17 website/teacher.py:183
 #, fuzzy
 msgid "join_prompt"
-msgstr ""
-"You need to have an account to join a class. Would you like to login now?"
+msgstr "You need to have an account to join a class. Would you like to login now?"
 
 #: templates/class-prejoin.html:17 templates/profile.html:14
 #, fuzzy
 msgid "join_class"
 msgstr "Join class"
 
-#: templates/class-stats.html:22 templates/customize-class.html:155
+#: templates/class-stats.html:22 templates/customize-class.html:150
 #, fuzzy
 msgid "back_to_class"
 msgstr "Go back to class"
 
 #: templates/code-page.html:25 templates/code-page.html:34
-#: templates/customize-class.html:28 templates/customize-class.html:64
-#: templates/customize-class.html:71 templates/customize-class.html:94
+#: templates/customize-class.html:23 templates/customize-class.html:59
+#: templates/customize-class.html:66 templates/customize-class.html:89
 #: templates/incl-adventure-tabs.html:5 templates/level-page.html:6
 #: templates/level-page.html:11 templates/quiz/startquiz.html:10
 #: templates/view-program-page.html:12 templates/view-program-page.html:28
@@ -694,21 +700,21 @@ msgstr "Create multiple accounts"
 #, fuzzy
 msgid "accounts_intro"
 msgstr ""
-"On this page you can create accounts for multiple students at the same time. "
-"It is also possible to directly add them to one of your classes. By pressing "
-"the green + on the bottom right of the page you can add extra rows. You can "
-"delete a row by pressing the corresponding red cross. Make sure no rows are "
-"empty when you press \"Create accounts\". Please keep in mind that every "
-"username and mail address needs to be unique and the password needs to be "
-"<b>at least</b> 6 characters."
+"On this page you can create accounts for multiple students at the same "
+"time. It is also possible to directly add them to one of your classes. By"
+" pressing the green + on the bottom right of the page you can add extra "
+"rows. You can delete a row by pressing the corresponding red cross. Make "
+"sure no rows are empty when you press \"Create accounts\". Please keep in"
+" mind that every username and mail address needs to be unique and the "
+"password needs to be <b>at least</b> 6 characters."
 
 #: templates/create-accounts.html:10
 #, fuzzy
 msgid "create_accounts_prompt"
 msgstr "Are you sure you want to create these accounts?"
 
-#: templates/create-accounts.html:17 templates/learn-more.html:10
-#: templates/profile.html:96 templates/recover.html:8 templates/signup.html:13
+#: templates/create-accounts.html:17 templates/profile.html:96
+#: templates/recover.html:8 templates/signup.html:13
 #, fuzzy
 msgid "email"
 msgstr "Email"
@@ -767,10 +773,10 @@ msgstr "Level"
 #, fuzzy
 msgid "adventure_exp_1"
 msgstr ""
-"Type your adventure of choice on the right-hand side. After creating your "
-"adventure you can include it in one of your classes under \"customizations"
-"\". If you want to include a command in your adventure please use code "
-"anchors like this:"
+"Type your adventure of choice on the right-hand side. After creating your"
+" adventure you can include it in one of your classes under "
+"\"customizations\". If you want to include a command in your adventure "
+"please use code anchors like this:"
 
 #: templates/customize-adventure.html:31
 #, fuzzy
@@ -784,11 +790,11 @@ msgstr ""
 msgid "adventure_exp_3"
 msgstr ""
 "You can use the \"preview\" button to view a styled version of your "
-"adventure. To view the adventure on a dedicated page, select \"view\" from "
-"the teachers page."
+"adventure. To view the adventure on a dedicated page, select \"view\" "
+"from the teachers page."
 
-#: templates/customize-adventure.html:43 templates/customize-class.html:28
-#: templates/customize-class.html:93 templates/explore.html:26
+#: templates/customize-adventure.html:43 templates/customize-class.html:23
+#: templates/customize-class.html:88 templates/explore.html:26
 #: templates/programs.html:18 templates/programs.html:48
 #: templates/view-adventure.html:6
 #, fuzzy
@@ -819,7 +825,7 @@ msgstr "I agree that my adventure might be made publicly available on Hedy."
 msgid "preview"
 msgstr "Preview"
 
-#: templates/customize-adventure.html:51 templates/customize-class.html:150
+#: templates/customize-adventure.html:51 templates/customize-class.html:145
 #, fuzzy
 msgid "save"
 msgstr "Save"
@@ -829,82 +835,32 @@ msgstr "Save"
 msgid "delete_adventure_prompt"
 msgstr "Are you sure you want to remove this adventure?"
 
-#: templates/customize-class.html:7
-#, fuzzy
-msgid "customize_class_exp_1"
-msgstr "Customize class"
-
-#: templates/customize-class.html:10
-#, fuzzy
-msgid "customize_class_step_1"
-msgstr "Customize class"
-
-#: templates/customize-class.html:11
-#, fuzzy
-msgid "customize_class_step_2"
-msgstr "Customize class"
-
-#: templates/customize-class.html:12
-#, fuzzy
-msgid "customize_class_step_3"
-msgstr "Customize class"
-
-#: templates/customize-class.html:13
-#, fuzzy
-msgid "customize_class_step_4"
-msgstr "Customize class"
-
-#: templates/customize-class.html:14
-#, fuzzy
-msgid "customize_class_step_5"
-msgstr "Customize class"
-
-#: templates/customize-class.html:15
-#, fuzzy
-msgid "customize_class_step_6"
-msgstr "Customize class"
-
-#: templates/customize-class.html:16
-#, fuzzy
-msgid "customize_class_step_7"
-msgstr "Customize class"
-
-#: templates/customize-class.html:17
-#, fuzzy
-msgid "customize_class_step_8"
-msgstr "Customize class"
-
-#: templates/customize-class.html:20
-#, fuzzy
-msgid "customize_class_exp_2"
-msgstr "Customize class"
-
-#: templates/customize-class.html:23
+#: templates/customize-class.html:18
 #, fuzzy
 msgid "select_adventures"
 msgstr "Select adventures"
 
-#: templates/customize-class.html:59
+#: templates/customize-class.html:54
 #, fuzzy
 msgid "opening_dates"
 msgstr "Opening dates"
 
-#: templates/customize-class.html:65
+#: templates/customize-class.html:60
 #, fuzzy
 msgid "opening_date"
 msgstr "Opening date"
 
-#: templates/customize-class.html:77
+#: templates/customize-class.html:72
 #, fuzzy
 msgid "directly_available"
 msgstr "Directly open"
 
-#: templates/customize-class.html:88
+#: templates/customize-class.html:83
 #, fuzzy
 msgid "select_own_adventures"
 msgstr "Select own adventures"
 
-#: templates/customize-class.html:95 templates/customize-class.html:121
+#: templates/customize-class.html:90 templates/customize-class.html:116
 #: templates/profile.html:47 templates/profile.html:128
 #: templates/profile.html:137 templates/signup.html:26 templates/signup.html:45
 #: templates/signup.html:53
@@ -912,46 +868,46 @@ msgstr "Select own adventures"
 msgid "select"
 msgstr "Select"
 
-#: templates/customize-class.html:115
+#: templates/customize-class.html:110
 #, fuzzy
 msgid "other_settings"
 msgstr "Other settings"
 
-#: templates/customize-class.html:120
+#: templates/customize-class.html:115
 #, fuzzy
 msgid "option"
 msgstr "Option"
 
-#: templates/customize-class.html:126
+#: templates/customize-class.html:121
 #, fuzzy
 msgid "mandatory_mode"
 msgstr "Mandatory developer's mode"
 
-#: templates/customize-class.html:132
+#: templates/customize-class.html:127
 #, fuzzy
 msgid "hide_cheatsheet"
 msgstr "Hide cheatsheet"
 
-#: templates/customize-class.html:138
+#: templates/customize-class.html:133
 msgid "hide_keyword_switcher"
 msgstr ""
 
-#: templates/customize-class.html:149
+#: templates/customize-class.html:144
 #, fuzzy
 msgid "reset_adventure_prompt"
 msgstr "Are you sure you want to reset all selected adventures?"
 
-#: templates/customize-class.html:149
+#: templates/customize-class.html:144
 #, fuzzy
 msgid "reset_adventures"
 msgstr "Reset selected adventures"
 
-#: templates/customize-class.html:153
+#: templates/customize-class.html:148
 #, fuzzy
 msgid "remove_customizations_prompt"
 msgstr "Are you sure you want to remove this class their customizations?"
 
-#: templates/customize-class.html:154
+#: templates/customize-class.html:149
 #, fuzzy
 msgid "remove_customization"
 msgstr "Remove customization"
@@ -970,13 +926,13 @@ msgstr "Explore programs"
 #, fuzzy
 msgid "explore_explanation"
 msgstr ""
-"On this page you can look through programs created by other Hedy users. You "
-"can filter on both a Hedy level and adventure. Click on \"View program\" to "
-"open a program and run it. Programs with a red header contain a mistake. You "
-"can still open the program, but running it will result in an error. You can "
-"of course try to fix it! If the creator has a public profile you can click "
-"their username to visit their profile. There you will find all their shared "
-"programs and much more!"
+"On this page you can look through programs created by other Hedy users. "
+"You can filter on both a Hedy level and adventure. Click on \"View "
+"program\" to open a program and run it. Programs with a red header "
+"contain a mistake. You can still open the program, but running it will "
+"result in an error. You can of course try to fix it! If the creator has a"
+" public profile you can click their username to visit their profile. "
+"There you will find all their shared programs and much more!"
 
 #: templates/explore.html:35 templates/programs.html:27
 #, fuzzy
@@ -1043,8 +999,8 @@ msgstr "Create student accounts"
 #, fuzzy
 msgid "teacher_welcome"
 msgstr ""
-"Welcome to Hedy! Your are now the proud owner of a teachers account which "
-"allows you to create classes and invite students."
+"Welcome to Hedy! Your are now the proud owner of a teachers account which"
+" allows you to create classes and invite students."
 
 #: templates/incl-adventure-tabs.html:22
 #, fuzzy
@@ -1166,9 +1122,9 @@ msgstr "Welcome"
 msgid "intro_text_landing_page"
 msgstr ""
 "Welcome to the wonderful world of Hedy! Here you can learn to program in "
-"small steps, without unnecessary complicated stuff. We start easy at level "
-"1, and slowly build towards bigger and more complex programs! Choose one of "
-"the options below to get started"
+"small steps, without unnecessary complicated stuff. We start easy at "
+"level 1, and slowly build towards bigger and more complex programs! "
+"Choose one of the options below to get started"
 
 #: templates/landing-page.html:14 templates/landing-page.html:36
 #, fuzzy
@@ -1184,14 +1140,14 @@ msgstr "Start programming"
 #: templates/landing-page.html:21
 #, fuzzy
 msgid "create_class_text"
-msgstr ""
-"Group your students into classes and change the content for each class."
+msgstr "Group your students into classes and change the content for each class."
 
 #: templates/landing-page.html:28
 #, fuzzy
 msgid "read_docs_text"
 msgstr ""
-"Visit our teacher's manual for lesson plans and common mistakes by students."
+"Visit our teacher's manual for lesson plans and common mistakes by "
+"students."
 
 #: templates/landing-page.html:30
 #, fuzzy
@@ -1238,50 +1194,14 @@ msgstr "Copy link to share"
 #, fuzzy
 msgid "set_preferred_lang"
 msgstr ""
-"Hedy now supports preferred user languages. You can set one for your profile "
-"in \"My profile\""
+"Hedy now supports preferred user languages. You can set one for your "
+"profile in \"My profile\""
 
 #: templates/layout.html:86 templates/quiz/endquiz.html:18
 #: templates/quiz/quiz.html:29
 #, fuzzy
 msgid "achievement_earned"
 msgstr "You've earned an achievement!"
-
-#: templates/learn-more.html:7
-#, fuzzy
-msgid "mailing_title"
-msgstr "Title"
-
-#: templates/learn-more.html:14
-#, fuzzy
-msgid "surname"
-msgstr "Username"
-
-#: templates/learn-more.html:18
-#, fuzzy
-msgid "lastname"
-msgstr "Name"
-
-#: templates/learn-more.html:22 templates/profile.html:135
-#: templates/signup.html:52
-#, fuzzy
-msgid "country"
-msgstr "Country"
-
-#: templates/learn-more.html:31
-#, fuzzy
-msgid "subscribe"
-msgstr "Subscribe to the newsletter"
-
-#: templates/learn-more.html:32
-#, fuzzy
-msgid "required_field"
-msgstr "Fields marked with an * are required"
-
-#: templates/learn-more.html:35
-#, fuzzy
-msgid "previous_campaigns"
-msgstr "View previous campaigns"
 
 #: templates/level-page.html:8
 #, fuzzy
@@ -1322,21 +1242,6 @@ msgstr "Create account"
 #, fuzzy
 msgid "forgot_password"
 msgstr "Forgot your password?"
-
-#: templates/main-page.html:9
-#, fuzzy
-msgid "main_title"
-msgstr "Title"
-
-#: templates/main-page.html:10
-#, fuzzy
-msgid "main_subtitle"
-msgstr "programs submitted"
-
-#: templates/main-page.html:13
-#, fuzzy
-msgid "try_it"
-msgstr "Try"
 
 #: templates/profile.html:4
 #, fuzzy
@@ -1402,9 +1307,9 @@ msgstr "Favourite program"
 #, fuzzy
 msgid "public_profile_info"
 msgstr ""
-"By selecting this box I make my profile visible for everyone. Be careful not "
-"to share personal information like your name or home address, because "
-"everyone will be able to see it!"
+"By selecting this box I make my profile visible for everyone. Be careful "
+"not to share personal information like your name or home address, because"
+" everyone will be able to see it!"
 
 #: templates/profile.html:59
 #, fuzzy
@@ -1475,6 +1380,11 @@ msgstr "Male"
 #, fuzzy
 msgid "other"
 msgstr "Other"
+
+#: templates/profile.html:135 templates/signup.html:52
+#, fuzzy
+msgid "country"
+msgstr "Country"
 
 #: templates/profile.html:141
 #, fuzzy
@@ -1702,8 +1612,8 @@ msgstr "Already have an account?"
 #, fuzzy
 msgid "teacher_invitation_require_login"
 msgstr ""
-"To set up your profile as a teacher we will need you to log in. If you don't "
-"have an account, please create one."
+"To set up your profile as a teacher we will need you to log in. If you "
+"don't have an account, please create one."
 
 #: templates/view-program-page.html:13
 #, fuzzy
@@ -1873,7 +1783,8 @@ msgstr "You have to agree with the privacy terms."
 #, fuzzy
 msgid "keyword_language_invalid"
 msgstr ""
-"Please select a valid keyword language (select English or your own language)."
+"Please select a valid keyword language (select English or your own "
+"language)."
 
 #: website/auth.py:371 website/auth.py:551
 #, fuzzy
@@ -1957,8 +1868,8 @@ msgstr "Your token is invalid."
 #, fuzzy
 msgid "password_resetted"
 msgstr ""
-"Your password has been successfully reset. You are being redirected to the "
-"login page."
+"Your password has been successfully reset. You are being redirected to "
+"the login page."
 
 #: website/auth.py:721
 #, fuzzy
@@ -1974,8 +1885,8 @@ msgstr "Program deleted successfully."
 #, fuzzy
 msgid "save_prompt"
 msgstr ""
-"You need to have an account to save your program. Would you like to login "
-"now?"
+"You need to have an account to save your program. Would you like to login"
+" now?"
 
 #: website/programs.py:60
 #, fuzzy
@@ -2188,3 +2099,61 @@ msgstr "The adventure has been updated!"
 #, fuzzy
 msgid "adventure_empty"
 msgstr "You didn't enter an adventure name!"
+
+#~ msgid "customize_class_exp_1"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_1"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_2"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_3"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_4"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_5"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_6"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_7"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_8"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_exp_2"
+#~ msgstr "Customize class"
+
+#~ msgid "mailing_title"
+#~ msgstr "Title"
+
+#~ msgid "surname"
+#~ msgstr "Username"
+
+#~ msgid "lastname"
+#~ msgstr "Name"
+
+#~ msgid "subscribe"
+#~ msgstr "Subscribe to the newsletter"
+
+#~ msgid "required_field"
+#~ msgstr "Fields marked with an * are required"
+
+#~ msgid "previous_campaigns"
+#~ msgstr "View previous campaigns"
+
+#~ msgid "main_title"
+#~ msgstr "Title"
+
+#~ msgid "main_subtitle"
+#~ msgstr "programs submitted"
+
+#~ msgid "try_it"
+#~ msgstr "Try"
+

--- a/translations/bg/LC_MESSAGES/messages.po
+++ b/translations/bg/LC_MESSAGES/messages.po
@@ -1,18 +1,18 @@
+
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-03-29 10:01+0200\n"
+"POT-Creation-Date: 2022-03-30 08:43+0200\n"
 "PO-Revision-Date: 2022-03-30 09:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
-"Language-Team: Bulgarian <https://hosted.weblate.org/projects/hedy/web-texts/"
-"bg/>\n"
 "Language: bg\n"
+"Language-Team: Bulgarian <https://hosted.weblate.org/projects/hedy/web-"
+"texts/bg/>\n"
+"Plural-Forms: nplurals=2; plural=n != 1\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.12-dev\n"
 "Generated-By: Babel 2.9.1\n"
 
 #: app.py:571
@@ -20,27 +20,27 @@ msgstr ""
 msgid "program_contains_error"
 msgstr "This program contains an error, are you sure you want to share it?"
 
-#: app.py:723
+#: app.py:722
 #, fuzzy
 msgid "title_achievements"
 msgstr "Hedy - My achievements"
 
-#: app.py:740 app.py:1111 website/teacher.py:365 website/teacher.py:374
+#: app.py:739 app.py:1110 website/teacher.py:365 website/teacher.py:374
 #, fuzzy
 msgid "not_teacher"
 msgstr "Looks like you are not a teacher!"
 
-#: app.py:743
+#: app.py:742
 #, fuzzy
 msgid "not_enrolled"
 msgstr "Looks like you are not in this class!"
 
-#: app.py:775
+#: app.py:774
 #, fuzzy
 msgid "title_programs"
 msgstr "Hedy - My programs"
 
-#: app.py:785 app.py:795 app.py:799 app.py:813 app.py:1054 app.py:1357
+#: app.py:784 app.py:794 app.py:798 app.py:812 app.py:1053 app.py:1356
 #: website/admin.py:17 website/admin.py:25 website/admin.py:95
 #: website/admin.py:112 website/admin.py:130 website/auth.py:711
 #: website/auth.py:738 website/statistics.py:86
@@ -48,122 +48,122 @@ msgstr "Hedy - My programs"
 msgid "unauthorized"
 msgstr "You don't have access rights for this page"
 
-#: app.py:823
+#: app.py:822
 msgid "minutes"
 msgstr "минути"
 
-#: app.py:826
+#: app.py:825
 msgid "hours"
 msgstr "часа"
 
-#: app.py:829
+#: app.py:828
 msgid "days"
 msgstr "дни"
 
-#: app.py:832
+#: app.py:831
 #, fuzzy
 msgid "ago"
 msgstr "{time} ago"
 
-#: app.py:848 app.py:850 app.py:976
+#: app.py:847 app.py:849 app.py:975
 #, fuzzy
 msgid "no_such_level"
 msgstr "No such Hedy level!"
 
-#: app.py:858 app.py:865 app.py:931 app.py:937
+#: app.py:857 app.py:864 app.py:930 app.py:936
 #, fuzzy
 msgid "no_such_program"
 msgstr "No such Hedy program!"
 
-#: app.py:891
+#: app.py:890
 #, fuzzy
 msgid "level_not_translated"
 msgstr "This level is not translated in your language (yet)"
 
-#: app.py:893
+#: app.py:892
 #, fuzzy
 msgid "level_not_class"
 msgstr "You're in a class where this level has not been made available yet"
 
-#: app.py:986 website/teacher.py:432 website/teacher.py:448
+#: app.py:985 website/teacher.py:432 website/teacher.py:448
 #: website/teacher.py:477 website/teacher.py:503
 #, fuzzy
 msgid "no_such_adventure"
 msgstr "This adventure doesn't exist!"
 
-#: app.py:1005
+#: app.py:1004
 #, fuzzy
 msgid "page_not_found"
 msgstr "We could not find that page!"
 
-#: app.py:1025
+#: app.py:1024
 #, fuzzy
 msgid "title_signup"
 msgstr "Hedy - Create an account"
 
-#: app.py:1032
+#: app.py:1031
 #, fuzzy
 msgid "title_login"
 msgstr "Hedy - Login"
 
-#: app.py:1039
+#: app.py:1038
 #, fuzzy
 msgid "title_recover"
 msgstr "Hedy - Recover account"
 
-#: app.py:1055
+#: app.py:1054
 #, fuzzy
 msgid "title_reset"
 msgstr "Hedy - Reset password"
 
-#: app.py:1064
+#: app.py:1063
 #, fuzzy
 msgid "title_my-profile"
 msgstr "Hedy - My account"
 
-#: app.py:1078
+#: app.py:1077
 #, fuzzy
 msgid "title_learn-more"
 msgstr "Hedy - Learn more"
 
-#: app.py:1083
+#: app.py:1082
 #, fuzzy
 msgid "title_privacy"
 msgstr "Hedy - Privacy terms"
 
-#: app.py:1090
+#: app.py:1089
 #, fuzzy
 msgid "title_landing-page"
 msgstr "Welcome to Hedy!"
 
-#: app.py:1092
+#: app.py:1091
 #, fuzzy
 msgid "not_user"
 msgstr "Looks like you are not logged in!"
 
-#: app.py:1107
+#: app.py:1106
 #, fuzzy
 msgid "title_for-teacher"
 msgstr "Hedy - For teachers"
 
-#: app.py:1118
+#: app.py:1117
 #, fuzzy
 msgid "title_start"
 msgstr "Hedy - A gradual programming language"
 
-#: app.py:1171
+#: app.py:1170
 #, fuzzy
 msgid "title_explore"
 msgstr "Hedy - Explore"
 
-#: app.py:1190 app.py:1192
+#: app.py:1189 app.py:1191
 #, fuzzy
 msgid "translate_error"
 msgstr ""
-"Something went wrong while translating the code. Try running the code to see "
-"if it has an error. Code with errors can not be translated."
+"Something went wrong while translating the code. Try running the code to "
+"see if it has an error. Code with errors can not be translated."
 
-#: app.py:1301 website/auth.py:299 website/auth.py:347 website/auth.py:483
+#: app.py:1300 website/auth.py:299 website/auth.py:347 website/auth.py:483
 #: website/auth.py:509 website/auth.py:539 website/auth.py:645
 #: website/auth.py:677 website/auth.py:717 website/auth.py:744
 #: website/teacher.py:90 website/teacher.py:125 website/teacher.py:197
@@ -173,32 +173,32 @@ msgstr ""
 msgid "ajax_error"
 msgstr "There was an error, please try again."
 
-#: app.py:1304
+#: app.py:1303
 #, fuzzy
 msgid "image_invalid"
 msgstr "Your chosen image is invalid."
 
-#: app.py:1306
+#: app.py:1305
 #, fuzzy
 msgid "personal_text_invalid"
 msgstr "Your personal text is invalid."
 
-#: app.py:1308 app.py:1314
+#: app.py:1307 app.py:1313
 #, fuzzy
 msgid "favourite_program_invalid"
 msgstr "Your chosen favourite program is invalid."
 
-#: app.py:1326 app.py:1327
+#: app.py:1325 app.py:1326
 #, fuzzy
 msgid "public_profile_updated"
 msgstr "Public profile updated."
 
-#: app.py:1361 app.py:1385
+#: app.py:1360 app.py:1384
 #, fuzzy
 msgid "user_not_private"
 msgstr "This user doesn't exist or doesn't have a public profile"
 
-#: app.py:1394
+#: app.py:1393
 msgid "invalid_teacher_invitation_code"
 msgstr "Този код не е валиден."
 
@@ -224,20 +224,20 @@ msgstr "Липсва код. Напиши го в лявото поле и пр�
 #: coursedata/error-messages.txt:2
 msgid "Wrong Level"
 msgstr ""
-"Кодът ти беше перфектен, но принадлежи към друго ниво. Ти написа код за ниво "
-"{working_level} при настоящо ниво {original_level}."
+"Кодът ти беше перфектен, но принадлежи към друго ниво. Ти написа код за "
+"ниво {working_level} при настоящо ниво {original_level}."
 
 #: coursedata/error-messages.txt:3
 msgid "Incomplete"
 msgstr ""
-"Момент, кодът ти не е пълен! На ред {line_number} е нужно да напишеш текст "
-"след {incomplete_command}."
+"Момент, кодът ти не е пълен! На ред {line_number} е нужно да напишеш "
+"текст след {incomplete_command}."
 
 #: coursedata/error-messages.txt:4
 msgid "Invalid"
 msgstr ""
-"{invalid_command} не е валидна команда в ниво {level} на Хеди. Може би имаш "
-"предвид {guessed_command}?"
+"{invalid_command} не е валидна команда в ниво {level} на Хеди. Може би "
+"имаш предвид {guessed_command}?"
 
 #: coursedata/error-messages.txt:5
 msgid "Invalid Space"
@@ -256,16 +256,16 @@ msgstr ""
 msgid "No Indentation"
 msgstr ""
 "You used too few spaces in line {line_number}. You used {leading_spaces} "
-"spaces, which is not enough. Start every new block with {indent_size} spaces "
-"more than the line before."
+"spaces, which is not enough. Start every new block with {indent_size} "
+"spaces more than the line before."
 
 #: coursedata/error-messages.txt:8
 #, fuzzy
 msgid "Unexpected Indentation"
 msgstr ""
-"You used too many spaces in line {line_number}. You used {leading_spaces} "
-"spaces, which is too much. Start every new block with {indent_size} spaces "
-"more than the line before."
+"You used too many spaces in line {line_number}. You used {leading_spaces}"
+" spaces, which is too much. Start every new block with {indent_size} "
+"spaces more than the line before."
 
 #: coursedata/error-messages.txt:9
 msgid "Parse"
@@ -283,8 +283,8 @@ msgstr ""
 #, fuzzy
 msgid "Unquoted Assignment"
 msgstr ""
-"From this level, you need to place texts to the right of the `is` between "
-"quotes. You forgot that for the text {text}."
+"From this level, you need to place texts to the right of the `is` between"
+" quotes. You forgot that for the text {text}."
 
 #: coursedata/error-messages.txt:12
 #, fuzzy
@@ -304,58 +304,58 @@ msgstr ""
 #, fuzzy
 msgid "Cyclic Var Definition"
 msgstr ""
-"The name {variable} needs to be set before you can use it on the right-hand "
-"side of the is command"
+"The name {variable} needs to be set before you can use it on the right-"
+"hand side of the is command"
 
 #: coursedata/error-messages.txt:15
 msgid "Lonely Echo"
 msgstr ""
-"Използваш командата echo пред командата ask, или echo без ask преди него. "
-"Правило: първо е ask, а после echo."
+"Използваш командата echo пред командата ask, или echo без ask преди него."
+" Правило: първо е ask, а после echo."
 
 #: coursedata/error-messages.txt:16
 msgid "Too Big"
 msgstr ""
-"Уау! Написал(а) си много код, цели {lines_of_code} реда! в това ниво Хеди "
-"има лимит за обработка до {max_lines} реда. Пренапиши си редовете то лимита "
-"и пробвай пак!"
+"Уау! Написал(а) си много код, цели {lines_of_code} реда! в това ниво Хеди"
+" има лимит за обработка до {max_lines} реда. Пренапиши си редовете то "
+"лимита и пробвай пак!"
 
 #: coursedata/error-messages.txt:17
 #, fuzzy
 msgid "Invalid Argument Type"
 msgstr ""
-"You cannot use the command {command} with {invalid_argument} because it is "
-"{invalid_type}. Try changing {invalid_argument} to {allowed_types}."
+"You cannot use the command {command} with {invalid_argument} because it "
+"is {invalid_type}. Try changing {invalid_argument} to {allowed_types}."
 
 #: coursedata/error-messages.txt:18
 #, fuzzy
 msgid "Invalid Argument"
 msgstr ""
-"You cannot use the command {command} with {invalid_argument} . Try changing "
-"{invalid_argument} to {allowed_types}."
+"You cannot use the command {command} with {invalid_argument} . Try "
+"changing {invalid_argument} to {allowed_types}."
 
 #: coursedata/error-messages.txt:19
 #, fuzzy
 msgid "Invalid Type Combination"
 msgstr ""
-"You cannot use {invalid_argument} and {invalid_argument_2} in {operation} "
-"because one is {invalid_type} and the other is {invalid_type_2}. Try "
-"changing {invalid_argument} to {invalid_type_2} or {invalid_argument_2} to "
-"{invalid_type}."
+"You cannot use {invalid_argument} and {invalid_argument_2} in {operation}"
+" because one is {invalid_type} and the other is {invalid_type_2}. Try "
+"changing {invalid_argument} to {invalid_type_2} or {invalid_argument_2} "
+"to {invalid_type}."
 
 #: coursedata/error-messages.txt:20
 #, fuzzy
 msgid "Unsupported Float"
 msgstr ""
-"Non-integer numbers are not supported yet but they will be in a few levels. "
-"For now change {value} to an integer."
+"Non-integer numbers are not supported yet but they will be in a few "
+"levels. For now change {value} to an integer."
 
 #: coursedata/error-messages.txt:21
 #, fuzzy
 msgid "Locked Language Feature"
 msgstr ""
-"You are using {concept}! That is awesome, but {concept} is not unlocked yet! "
-"It will be unlocked in a later level."
+"You are using {concept}! That is awesome, but {concept} is not unlocked "
+"yet! It will be unlocked in a later level."
 
 #: coursedata/error-messages.txt:22
 #, fuzzy
@@ -366,15 +366,16 @@ msgstr "It looks like you forgot to use a command on line {line_number}."
 #, fuzzy
 msgid "ask_needs_var"
 msgstr ""
-"Starting in level 2, ask needs to be used with a variable. Example: name is "
-"ask What are you called?"
+"Starting in level 2, ask needs to be used with a variable. Example: name "
+"is ask What are you called?"
 
 #: coursedata/error-messages.txt:24
 #, fuzzy
 msgid "echo_out"
 msgstr ""
-"Starting in level 2 echo is no longer needed. You can repeat an answer with "
-"ask and print now. Example: name is ask What are you called? print hello name"
+"Starting in level 2 echo is no longer needed. You can repeat an answer "
+"with ask and print now. Example: name is ask What are you called? print "
+"hello name"
 
 #: coursedata/error-messages.txt:25
 msgid "space"
@@ -459,6 +460,11 @@ msgstr "a list"
 #, fuzzy
 msgid "input"
 msgstr "input from ask"
+
+#: templates/achievements.html:4
+#, fuzzy
+msgid "achievements_title"
+msgstr "achievements"
 
 #: templates/class-overview.html:16
 #, fuzzy
@@ -629,22 +635,21 @@ msgstr "Do you want to join this class?"
 #: templates/class-prejoin.html:17 website/teacher.py:183
 #, fuzzy
 msgid "join_prompt"
-msgstr ""
-"You need to have an account to join a class. Would you like to login now?"
+msgstr "You need to have an account to join a class. Would you like to login now?"
 
 #: templates/class-prejoin.html:17 templates/profile.html:14
 #, fuzzy
 msgid "join_class"
 msgstr "Join class"
 
-#: templates/class-stats.html:22 templates/customize-class.html:155
+#: templates/class-stats.html:22 templates/customize-class.html:150
 #, fuzzy
 msgid "back_to_class"
 msgstr "Go back to class"
 
 #: templates/code-page.html:25 templates/code-page.html:34
-#: templates/customize-class.html:28 templates/customize-class.html:64
-#: templates/customize-class.html:71 templates/customize-class.html:94
+#: templates/customize-class.html:23 templates/customize-class.html:59
+#: templates/customize-class.html:66 templates/customize-class.html:89
 #: templates/incl-adventure-tabs.html:5 templates/level-page.html:6
 #: templates/level-page.html:11 templates/quiz/startquiz.html:10
 #: templates/view-program-page.html:12 templates/view-program-page.html:28
@@ -660,21 +665,21 @@ msgstr "Create multiple accounts"
 #, fuzzy
 msgid "accounts_intro"
 msgstr ""
-"On this page you can create accounts for multiple students at the same time. "
-"It is also possible to directly add them to one of your classes. By pressing "
-"the green + on the bottom right of the page you can add extra rows. You can "
-"delete a row by pressing the corresponding red cross. Make sure no rows are "
-"empty when you press \"Create accounts\". Please keep in mind that every "
-"username and mail address needs to be unique and the password needs to be "
-"<b>at least</b> 6 characters."
+"On this page you can create accounts for multiple students at the same "
+"time. It is also possible to directly add them to one of your classes. By"
+" pressing the green + on the bottom right of the page you can add extra "
+"rows. You can delete a row by pressing the corresponding red cross. Make "
+"sure no rows are empty when you press \"Create accounts\". Please keep in"
+" mind that every username and mail address needs to be unique and the "
+"password needs to be <b>at least</b> 6 characters."
 
 #: templates/create-accounts.html:10
 #, fuzzy
 msgid "create_accounts_prompt"
 msgstr "Are you sure you want to create these accounts?"
 
-#: templates/create-accounts.html:17 templates/learn-more.html:10
-#: templates/profile.html:96 templates/recover.html:8 templates/signup.html:13
+#: templates/create-accounts.html:17 templates/profile.html:96
+#: templates/recover.html:8 templates/signup.html:13
 msgid "email"
 msgstr "Имейл адрес"
 
@@ -730,10 +735,10 @@ msgstr "Ниво"
 #, fuzzy
 msgid "adventure_exp_1"
 msgstr ""
-"Type your adventure of choice on the right-hand side. After creating your "
-"adventure you can include it in one of your classes under \"customizations"
-"\". If you want to include a command in your adventure please use code "
-"anchors like this:"
+"Type your adventure of choice on the right-hand side. After creating your"
+" adventure you can include it in one of your classes under "
+"\"customizations\". If you want to include a command in your adventure "
+"please use code anchors like this:"
 
 #: templates/customize-adventure.html:31
 #, fuzzy
@@ -747,11 +752,11 @@ msgstr ""
 msgid "adventure_exp_3"
 msgstr ""
 "You can use the \"preview\" button to view a styled version of your "
-"adventure. To view the adventure on a dedicated page, select \"view\" from "
-"the teachers page."
+"adventure. To view the adventure on a dedicated page, select \"view\" "
+"from the teachers page."
 
-#: templates/customize-adventure.html:43 templates/customize-class.html:28
-#: templates/customize-class.html:93 templates/explore.html:26
+#: templates/customize-adventure.html:43 templates/customize-class.html:23
+#: templates/customize-class.html:88 templates/explore.html:26
 #: templates/programs.html:18 templates/programs.html:48
 #: templates/view-adventure.html:6
 msgid "adventure"
@@ -781,7 +786,7 @@ msgstr "I agree that my adventure might be made publicly available on Hedy."
 msgid "preview"
 msgstr "Preview"
 
-#: templates/customize-adventure.html:51 templates/customize-class.html:150
+#: templates/customize-adventure.html:51 templates/customize-class.html:145
 #, fuzzy
 msgid "save"
 msgstr "Save"
@@ -791,128 +796,78 @@ msgstr "Save"
 msgid "delete_adventure_prompt"
 msgstr "Are you sure you want to remove this adventure?"
 
-#: templates/customize-class.html:7
-#, fuzzy
-msgid "customize_class_exp_1"
-msgstr "Customize class"
-
-#: templates/customize-class.html:10
-#, fuzzy
-msgid "customize_class_step_1"
-msgstr "Customize class"
-
-#: templates/customize-class.html:11
-#, fuzzy
-msgid "customize_class_step_2"
-msgstr "Customize class"
-
-#: templates/customize-class.html:12
-#, fuzzy
-msgid "customize_class_step_3"
-msgstr "Customize class"
-
-#: templates/customize-class.html:13
-#, fuzzy
-msgid "customize_class_step_4"
-msgstr "Customize class"
-
-#: templates/customize-class.html:14
-#, fuzzy
-msgid "customize_class_step_5"
-msgstr "Customize class"
-
-#: templates/customize-class.html:15
-#, fuzzy
-msgid "customize_class_step_6"
-msgstr "Customize class"
-
-#: templates/customize-class.html:16
-#, fuzzy
-msgid "customize_class_step_7"
-msgstr "Customize class"
-
-#: templates/customize-class.html:17
-#, fuzzy
-msgid "customize_class_step_8"
-msgstr "Customize class"
-
-#: templates/customize-class.html:20
-#, fuzzy
-msgid "customize_class_exp_2"
-msgstr "Customize class"
-
-#: templates/customize-class.html:23
+#: templates/customize-class.html:18
 #, fuzzy
 msgid "select_adventures"
 msgstr "Select adventures"
 
-#: templates/customize-class.html:59
+#: templates/customize-class.html:54
 #, fuzzy
 msgid "opening_dates"
 msgstr "Opening dates"
 
-#: templates/customize-class.html:65
+#: templates/customize-class.html:60
 #, fuzzy
 msgid "opening_date"
 msgstr "Opening date"
 
-#: templates/customize-class.html:77
+#: templates/customize-class.html:72
 #, fuzzy
 msgid "directly_available"
 msgstr "Directly open"
 
-#: templates/customize-class.html:88
+#: templates/customize-class.html:83
 #, fuzzy
 msgid "select_own_adventures"
 msgstr "Select own adventures"
 
-#: templates/customize-class.html:95 templates/customize-class.html:121
+#: templates/customize-class.html:90 templates/customize-class.html:116
 #: templates/profile.html:47 templates/profile.html:128
 #: templates/profile.html:137 templates/signup.html:26 templates/signup.html:45
 #: templates/signup.html:53
 msgid "select"
 msgstr "Избери"
 
-#: templates/customize-class.html:115
+#: templates/customize-class.html:110
 #, fuzzy
 msgid "other_settings"
 msgstr "Other settings"
 
-#: templates/customize-class.html:120
+#: templates/customize-class.html:115
 #, fuzzy
 msgid "option"
 msgstr "Option"
 
-#: templates/customize-class.html:126
+#: templates/customize-class.html:121
 #, fuzzy
 msgid "mandatory_mode"
 msgstr "Mandatory developer's mode"
 
-#: templates/customize-class.html:132
+#: templates/customize-class.html:127
 #, fuzzy
 msgid "hide_cheatsheet"
 msgstr "Hide cheatsheet"
 
-#: templates/customize-class.html:138
+#: templates/customize-class.html:133
 msgid "hide_keyword_switcher"
 msgstr ""
 
-#: templates/customize-class.html:149
+#: templates/customize-class.html:144
 #, fuzzy
 msgid "reset_adventure_prompt"
 msgstr "Are you sure you want to reset all selected adventures?"
 
-#: templates/customize-class.html:149
+#: templates/customize-class.html:144
 #, fuzzy
 msgid "reset_adventures"
 msgstr "Reset selected adventures"
 
-#: templates/customize-class.html:153
+#: templates/customize-class.html:148
 #, fuzzy
 msgid "remove_customizations_prompt"
 msgstr "Are you sure you want to remove this class their customizations?"
 
-#: templates/customize-class.html:154
+#: templates/customize-class.html:149
 #, fuzzy
 msgid "remove_customization"
 msgstr "Remove customization"
@@ -931,13 +886,13 @@ msgstr "Explore programs"
 #, fuzzy
 msgid "explore_explanation"
 msgstr ""
-"On this page you can look through programs created by other Hedy users. You "
-"can filter on both a Hedy level and adventure. Click on \"View program\" to "
-"open a program and run it. Programs with a red header contain a mistake. You "
-"can still open the program, but running it will result in an error. You can "
-"of course try to fix it! If the creator has a public profile you can click "
-"their username to visit their profile. There you will find all their shared "
-"programs and much more!"
+"On this page you can look through programs created by other Hedy users. "
+"You can filter on both a Hedy level and adventure. Click on \"View "
+"program\" to open a program and run it. Programs with a red header "
+"contain a mistake. You can still open the program, but running it will "
+"result in an error. You can of course try to fix it! If the creator has a"
+" public profile you can click their username to visit their profile. "
+"There you will find all their shared programs and much more!"
 
 #: templates/explore.html:35 templates/programs.html:27
 #, fuzzy
@@ -1004,8 +959,8 @@ msgstr "Create student accounts"
 #, fuzzy
 msgid "teacher_welcome"
 msgstr ""
-"Welcome to Hedy! Your are now the proud owner of a teachers account which "
-"allows you to create classes and invite students."
+"Welcome to Hedy! Your are now the proud owner of a teachers account which"
+" allows you to create classes and invite students."
 
 #: templates/incl-adventure-tabs.html:22
 #, fuzzy
@@ -1119,9 +1074,9 @@ msgstr "Welcome"
 msgid "intro_text_landing_page"
 msgstr ""
 "Welcome to the wonderful world of Hedy! Here you can learn to program in "
-"small steps, without unnecessary complicated stuff. We start easy at level "
-"1, and slowly build towards bigger and more complex programs! Choose one of "
-"the options below to get started"
+"small steps, without unnecessary complicated stuff. We start easy at "
+"level 1, and slowly build towards bigger and more complex programs! "
+"Choose one of the options below to get started"
 
 #: templates/landing-page.html:14 templates/landing-page.html:36
 #, fuzzy
@@ -1137,14 +1092,14 @@ msgstr "Start programming"
 #: templates/landing-page.html:21
 #, fuzzy
 msgid "create_class_text"
-msgstr ""
-"Group your students into classes and change the content for each class."
+msgstr "Group your students into classes and change the content for each class."
 
 #: templates/landing-page.html:28
 #, fuzzy
 msgid "read_docs_text"
 msgstr ""
-"Visit our teacher's manual for lesson plans and common mistakes by students."
+"Visit our teacher's manual for lesson plans and common mistakes by "
+"students."
 
 #: templates/landing-page.html:30
 #, fuzzy
@@ -1189,49 +1144,14 @@ msgstr "Copy link to share"
 #, fuzzy
 msgid "set_preferred_lang"
 msgstr ""
-"Hedy now supports preferred user languages. You can set one for your profile "
-"in \"My profile\""
+"Hedy now supports preferred user languages. You can set one for your "
+"profile in \"My profile\""
 
 #: templates/layout.html:86 templates/quiz/endquiz.html:18
 #: templates/quiz/quiz.html:29
 #, fuzzy
 msgid "achievement_earned"
 msgstr "You've earned an achievement!"
-
-#: templates/learn-more.html:7
-#, fuzzy
-msgid "mailing_title"
-msgstr "Hedy"
-
-#: templates/learn-more.html:14
-#, fuzzy
-msgid "surname"
-msgstr "Потребителско име"
-
-#: templates/learn-more.html:18
-#, fuzzy
-msgid "lastname"
-msgstr "Name"
-
-#: templates/learn-more.html:22 templates/profile.html:135
-#: templates/signup.html:52
-msgid "country"
-msgstr "Държава"
-
-#: templates/learn-more.html:31
-#, fuzzy
-msgid "subscribe"
-msgstr "Абонирай се за нашия журнал"
-
-#: templates/learn-more.html:32
-#, fuzzy
-msgid "required_field"
-msgstr "Fields marked with an * are required"
-
-#: templates/learn-more.html:35
-#, fuzzy
-msgid "previous_campaigns"
-msgstr "View previous campaigns"
 
 #: templates/level-page.html:8
 msgid "step_title"
@@ -1267,18 +1187,6 @@ msgstr "Направи си акаунт"
 #, fuzzy
 msgid "forgot_password"
 msgstr "Forgot your password?"
-
-#: templates/main-page.html:9
-msgid "main_title"
-msgstr "Hedy"
-
-#: templates/main-page.html:10
-msgid "main_subtitle"
-msgstr "Градуален език за програмиране"
-
-#: templates/main-page.html:13
-msgid "try_it"
-msgstr "Опитай"
 
 #: templates/profile.html:4
 #, fuzzy
@@ -1344,9 +1252,9 @@ msgstr "Favourite program"
 #, fuzzy
 msgid "public_profile_info"
 msgstr ""
-"By selecting this box I make my profile visible for everyone. Be careful not "
-"to share personal information like your name or home address, because "
-"everyone will be able to see it!"
+"By selecting this box I make my profile visible for everyone. Be careful "
+"not to share personal information like your name or home address, because"
+" everyone will be able to see it!"
 
 #: templates/profile.html:59
 #, fuzzy
@@ -1411,6 +1319,10 @@ msgstr "Мъжки"
 #: templates/profile.html:131 templates/signup.html:48
 msgid "other"
 msgstr "Друг"
+
+#: templates/profile.html:135 templates/signup.html:52
+msgid "country"
+msgstr "Държава"
 
 #: templates/profile.html:141
 msgid "update_profile"
@@ -1622,8 +1534,8 @@ msgstr "Вече имаш акаунт?"
 #, fuzzy
 msgid "teacher_invitation_require_login"
 msgstr ""
-"To set up your profile as a teacher we will need you to log in. If you don't "
-"have an account, please create one."
+"To set up your profile as a teacher we will need you to log in. If you "
+"don't have an account, please create one."
 
 #: templates/view-program-page.html:13
 msgid "by"
@@ -1785,7 +1697,8 @@ msgstr "You have to agree with the privacy terms."
 #, fuzzy
 msgid "keyword_language_invalid"
 msgstr ""
-"Please select a valid keyword language (select English or your own language)."
+"Please select a valid keyword language (select English or your own "
+"language)."
 
 #: website/auth.py:371 website/auth.py:551
 #, fuzzy
@@ -1869,8 +1782,8 @@ msgstr "Your token is invalid."
 #, fuzzy
 msgid "password_resetted"
 msgstr ""
-"Your password has been successfully reset. You are being redirected to the "
-"login page."
+"Your password has been successfully reset. You are being redirected to "
+"the login page."
 
 #: website/auth.py:721
 #, fuzzy
@@ -1886,8 +1799,8 @@ msgstr "Program deleted successfully."
 #, fuzzy
 msgid "save_prompt"
 msgstr ""
-"You need to have an account to save your program. Would you like to login "
-"now?"
+"You need to have an account to save your program. Would you like to login"
+" now?"
 
 #: website/programs.py:60
 #, fuzzy
@@ -2100,3 +2013,61 @@ msgstr "The adventure has been updated!"
 #, fuzzy
 msgid "adventure_empty"
 msgstr "You didn't enter an adventure name!"
+
+#~ msgid "customize_class_exp_1"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_1"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_2"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_3"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_4"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_5"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_6"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_7"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_8"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_exp_2"
+#~ msgstr "Customize class"
+
+#~ msgid "mailing_title"
+#~ msgstr "Hedy"
+
+#~ msgid "surname"
+#~ msgstr "Потребителско име"
+
+#~ msgid "lastname"
+#~ msgstr "Name"
+
+#~ msgid "subscribe"
+#~ msgstr "Абонирай се за нашия журнал"
+
+#~ msgid "required_field"
+#~ msgstr "Fields marked with an * are required"
+
+#~ msgid "previous_campaigns"
+#~ msgstr "View previous campaigns"
+
+#~ msgid "main_title"
+#~ msgstr "Hedy"
+
+#~ msgid "main_subtitle"
+#~ msgstr "Градуален език за програмиране"
+
+#~ msgid "try_it"
+#~ msgstr "Опитай"
+

--- a/translations/bn/LC_MESSAGES/messages.po
+++ b/translations/bn/LC_MESSAGES/messages.po
@@ -1,18 +1,18 @@
+
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-03-29 10:01+0200\n"
+"POT-Creation-Date: 2022-03-30 08:43+0200\n"
 "PO-Revision-Date: 2022-03-30 09:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
-"Language-Team: Bengali <https://hosted.weblate.org/projects/hedy/web-texts/"
-"bn/>\n"
 "Language: bn\n"
+"Language-Team: Bengali <https://hosted.weblate.org/projects/hedy/web-"
+"texts/bn/>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Weblate 4.12-dev\n"
 "Generated-By: Babel 2.9.1\n"
 
 #: app.py:571
@@ -20,27 +20,27 @@ msgstr ""
 msgid "program_contains_error"
 msgstr "This program contains an error, are you sure you want to share it?"
 
-#: app.py:723
+#: app.py:722
 #, fuzzy
 msgid "title_achievements"
 msgstr "Hedy - My achievements"
 
-#: app.py:740 app.py:1111 website/teacher.py:365 website/teacher.py:374
+#: app.py:739 app.py:1110 website/teacher.py:365 website/teacher.py:374
 #, fuzzy
 msgid "not_teacher"
 msgstr "Looks like you are not a teacher!"
 
-#: app.py:743
+#: app.py:742
 #, fuzzy
 msgid "not_enrolled"
 msgstr "Looks like you are not in this class!"
 
-#: app.py:775
+#: app.py:774
 #, fuzzy
 msgid "title_programs"
 msgstr "Hedy - My programs"
 
-#: app.py:785 app.py:795 app.py:799 app.py:813 app.py:1054 app.py:1357
+#: app.py:784 app.py:794 app.py:798 app.py:812 app.py:1053 app.py:1356
 #: website/admin.py:17 website/admin.py:25 website/admin.py:95
 #: website/admin.py:112 website/admin.py:130 website/auth.py:711
 #: website/auth.py:738 website/statistics.py:86
@@ -48,125 +48,125 @@ msgstr "Hedy - My programs"
 msgid "unauthorized"
 msgstr "You don't have access rights for this page"
 
-#: app.py:823
+#: app.py:822
 #, fuzzy
 msgid "minutes"
 msgstr "minutes"
 
-#: app.py:826
+#: app.py:825
 #, fuzzy
 msgid "hours"
 msgstr "hours"
 
-#: app.py:829
+#: app.py:828
 #, fuzzy
 msgid "days"
 msgstr "days"
 
-#: app.py:832
+#: app.py:831
 #, fuzzy
 msgid "ago"
 msgstr "{time} ago"
 
-#: app.py:848 app.py:850 app.py:976
+#: app.py:847 app.py:849 app.py:975
 #, fuzzy
 msgid "no_such_level"
 msgstr "No such Hedy level!"
 
-#: app.py:858 app.py:865 app.py:931 app.py:937
+#: app.py:857 app.py:864 app.py:930 app.py:936
 #, fuzzy
 msgid "no_such_program"
 msgstr "No such Hedy program!"
 
-#: app.py:891
+#: app.py:890
 #, fuzzy
 msgid "level_not_translated"
 msgstr "This level is not translated in your language (yet)"
 
-#: app.py:893
+#: app.py:892
 #, fuzzy
 msgid "level_not_class"
 msgstr "You're in a class where this level has not been made available yet"
 
-#: app.py:986 website/teacher.py:432 website/teacher.py:448
+#: app.py:985 website/teacher.py:432 website/teacher.py:448
 #: website/teacher.py:477 website/teacher.py:503
 #, fuzzy
 msgid "no_such_adventure"
 msgstr "This adventure doesn't exist!"
 
-#: app.py:1005
+#: app.py:1004
 #, fuzzy
 msgid "page_not_found"
 msgstr "We could not find that page!"
 
-#: app.py:1025
+#: app.py:1024
 #, fuzzy
 msgid "title_signup"
 msgstr "Hedy - Create an account"
 
-#: app.py:1032
+#: app.py:1031
 #, fuzzy
 msgid "title_login"
 msgstr "Hedy - Login"
 
-#: app.py:1039
+#: app.py:1038
 #, fuzzy
 msgid "title_recover"
 msgstr "Hedy - Recover account"
 
-#: app.py:1055
+#: app.py:1054
 #, fuzzy
 msgid "title_reset"
 msgstr "Hedy - Reset password"
 
-#: app.py:1064
+#: app.py:1063
 #, fuzzy
 msgid "title_my-profile"
 msgstr "Hedy - My account"
 
-#: app.py:1078
+#: app.py:1077
 #, fuzzy
 msgid "title_learn-more"
 msgstr "Hedy - Learn more"
 
-#: app.py:1083
+#: app.py:1082
 #, fuzzy
 msgid "title_privacy"
 msgstr "Hedy - Privacy terms"
 
-#: app.py:1090
+#: app.py:1089
 #, fuzzy
 msgid "title_landing-page"
 msgstr "Welcome to Hedy!"
 
-#: app.py:1092
+#: app.py:1091
 #, fuzzy
 msgid "not_user"
 msgstr "Looks like you are not logged in!"
 
-#: app.py:1107
+#: app.py:1106
 #, fuzzy
 msgid "title_for-teacher"
 msgstr "Hedy - For teachers"
 
-#: app.py:1118
+#: app.py:1117
 #, fuzzy
 msgid "title_start"
 msgstr "Hedy - A gradual programming language"
 
-#: app.py:1171
+#: app.py:1170
 #, fuzzy
 msgid "title_explore"
 msgstr "Hedy - Explore"
 
-#: app.py:1190 app.py:1192
+#: app.py:1189 app.py:1191
 #, fuzzy
 msgid "translate_error"
 msgstr ""
-"Something went wrong while translating the code. Try running the code to see "
-"if it has an error. Code with errors can not be translated."
+"Something went wrong while translating the code. Try running the code to "
+"see if it has an error. Code with errors can not be translated."
 
-#: app.py:1301 website/auth.py:299 website/auth.py:347 website/auth.py:483
+#: app.py:1300 website/auth.py:299 website/auth.py:347 website/auth.py:483
 #: website/auth.py:509 website/auth.py:539 website/auth.py:645
 #: website/auth.py:677 website/auth.py:717 website/auth.py:744
 #: website/teacher.py:90 website/teacher.py:125 website/teacher.py:197
@@ -176,37 +176,37 @@ msgstr ""
 msgid "ajax_error"
 msgstr "There was an error, please try again."
 
-#: app.py:1304
+#: app.py:1303
 #, fuzzy
 msgid "image_invalid"
 msgstr "Your chosen image is invalid."
 
-#: app.py:1306
+#: app.py:1305
 #, fuzzy
 msgid "personal_text_invalid"
 msgstr "Your personal text is invalid."
 
-#: app.py:1308 app.py:1314
+#: app.py:1307 app.py:1313
 #, fuzzy
 msgid "favourite_program_invalid"
 msgstr "Your chosen favourite program is invalid."
 
-#: app.py:1326 app.py:1327
+#: app.py:1325 app.py:1326
 #, fuzzy
 msgid "public_profile_updated"
 msgstr "Public profile updated."
 
-#: app.py:1361 app.py:1385
+#: app.py:1360 app.py:1384
 #, fuzzy
 msgid "user_not_private"
 msgstr "This user doesn't exist or doesn't have a public profile"
 
-#: app.py:1394
+#: app.py:1393
 #, fuzzy
 msgid "invalid_teacher_invitation_code"
 msgstr ""
-"The teacher invitation code is invalid. To become a teacher, reach out to "
-"hedy@felienne.com."
+"The teacher invitation code is invalid. To become a teacher, reach out to"
+" hedy@felienne.com."
 
 #: utils.py:203
 #, fuzzy
@@ -227,7 +227,8 @@ msgstr "Something went wrong..."
 #, fuzzy
 msgid "Empty Program"
 msgstr ""
-"You created an empty program. Type Hedy code in the left field and try again"
+"You created an empty program. Type Hedy code in the left field and try "
+"again"
 
 #: coursedata/error-messages.txt:2
 #, fuzzy
@@ -254,53 +255,53 @@ msgstr ""
 #, fuzzy
 msgid "Invalid Space"
 msgstr ""
-"Oops! You started a line with a space on line {line_number}. Spaces confuse "
-"computers, can you remove it?"
+"Oops! You started a line with a space on line {line_number}. Spaces "
+"confuse computers, can you remove it?"
 
 #: coursedata/error-messages.txt:6
 #, fuzzy
 msgid "Has Blanks"
 msgstr ""
-"Your code is incomplete. It contains blanks that you have to replace with "
-"code."
+"Your code is incomplete. It contains blanks that you have to replace with"
+" code."
 
 #: coursedata/error-messages.txt:7
 #, fuzzy
 msgid "No Indentation"
 msgstr ""
 "You used too few spaces in line {line_number}. You used {leading_spaces} "
-"spaces, which is not enough. Start every new block with {indent_size} spaces "
-"more than the line before."
+"spaces, which is not enough. Start every new block with {indent_size} "
+"spaces more than the line before."
 
 #: coursedata/error-messages.txt:8
 #, fuzzy
 msgid "Unexpected Indentation"
 msgstr ""
-"You used too many spaces in line {line_number}. You used {leading_spaces} "
-"spaces, which is too much. Start every new block with {indent_size} spaces "
-"more than the line before."
+"You used too many spaces in line {line_number}. You used {leading_spaces}"
+" spaces, which is too much. Start every new block with {indent_size} "
+"spaces more than the line before."
 
 #: coursedata/error-messages.txt:9
 #, fuzzy
 msgid "Parse"
 msgstr ""
 "The code you entered is not valid Hedy code. There is a mistake on line "
-"{location[0]}, at position {location[1]}. You typed {character_found}, but "
-"that is not allowed."
+"{location[0]}, at position {location[1]}. You typed {character_found}, "
+"but that is not allowed."
 
 #: coursedata/error-messages.txt:10
 #, fuzzy
 msgid "Unquoted Text"
 msgstr ""
-"Be careful. If you ask or print something the text should start and finish "
-"with a quotation mark. You forgot one somewhere."
+"Be careful. If you ask or print something the text should start and "
+"finish with a quotation mark. You forgot one somewhere."
 
 #: coursedata/error-messages.txt:11
 #, fuzzy
 msgid "Unquoted Assignment"
 msgstr ""
-"From this level, you need to place texts to the right of the `is` between "
-"quotes. You forgot that for the text {text}."
+"From this level, you need to place texts to the right of the `is` between"
+" quotes. You forgot that for the text {text}."
 
 #: coursedata/error-messages.txt:12
 #, fuzzy
@@ -314,15 +315,15 @@ msgstr ""
 msgid "Var Undefined"
 msgstr ""
 "You tried to use the variable {name}, but you did not set it. It is also "
-"possible that you were trying to use the word {name} but forgot quotation "
-"marks."
+"possible that you were trying to use the word {name} but forgot quotation"
+" marks."
 
 #: coursedata/error-messages.txt:14
 #, fuzzy
 msgid "Cyclic Var Definition"
 msgstr ""
-"The name {variable} needs to be set before you can use it on the right-hand "
-"side of the is command"
+"The name {variable} needs to be set before you can use it on the right-"
+"hand side of the is command"
 
 #: coursedata/error-messages.txt:15
 #, fuzzy
@@ -335,46 +336,46 @@ msgstr ""
 #, fuzzy
 msgid "Too Big"
 msgstr ""
-"Wow! Your program has an impressive {lines_of_code} lines of code! But we "
-"can only process {max_lines} lines in this level. Make your program smaller "
-"and try again."
+"Wow! Your program has an impressive {lines_of_code} lines of code! But we"
+" can only process {max_lines} lines in this level. Make your program "
+"smaller and try again."
 
 #: coursedata/error-messages.txt:17
 #, fuzzy
 msgid "Invalid Argument Type"
 msgstr ""
-"You cannot use the command {command} with {invalid_argument} because it is "
-"{invalid_type}. Try changing {invalid_argument} to {allowed_types}."
+"You cannot use the command {command} with {invalid_argument} because it "
+"is {invalid_type}. Try changing {invalid_argument} to {allowed_types}."
 
 #: coursedata/error-messages.txt:18
 #, fuzzy
 msgid "Invalid Argument"
 msgstr ""
-"You cannot use the command {command} with {invalid_argument} . Try changing "
-"{invalid_argument} to {allowed_types}."
+"You cannot use the command {command} with {invalid_argument} . Try "
+"changing {invalid_argument} to {allowed_types}."
 
 #: coursedata/error-messages.txt:19
 #, fuzzy
 msgid "Invalid Type Combination"
 msgstr ""
-"You cannot use {invalid_argument} and {invalid_argument_2} in {operation} "
-"because one is {invalid_type} and the other is {invalid_type_2}. Try "
-"changing {invalid_argument} to {invalid_type_2} or {invalid_argument_2} to "
-"{invalid_type}."
+"You cannot use {invalid_argument} and {invalid_argument_2} in {operation}"
+" because one is {invalid_type} and the other is {invalid_type_2}. Try "
+"changing {invalid_argument} to {invalid_type_2} or {invalid_argument_2} "
+"to {invalid_type}."
 
 #: coursedata/error-messages.txt:20
 #, fuzzy
 msgid "Unsupported Float"
 msgstr ""
-"Non-integer numbers are not supported yet but they will be in a few levels. "
-"For now change {value} to an integer."
+"Non-integer numbers are not supported yet but they will be in a few "
+"levels. For now change {value} to an integer."
 
 #: coursedata/error-messages.txt:21
 #, fuzzy
 msgid "Locked Language Feature"
 msgstr ""
-"You are using {concept}! That is awesome, but {concept} is not unlocked yet! "
-"It will be unlocked in a later level."
+"You are using {concept}! That is awesome, but {concept} is not unlocked "
+"yet! It will be unlocked in a later level."
 
 #: coursedata/error-messages.txt:22
 #, fuzzy
@@ -385,15 +386,16 @@ msgstr "It looks like you forgot to use a command on line {line_number}."
 #, fuzzy
 msgid "ask_needs_var"
 msgstr ""
-"Starting in level 2, ask needs to be used with a variable. Example: name is "
-"ask What are you called?"
+"Starting in level 2, ask needs to be used with a variable. Example: name "
+"is ask What are you called?"
 
 #: coursedata/error-messages.txt:24
 #, fuzzy
 msgid "echo_out"
 msgstr ""
-"Starting in level 2 echo is no longer needed. You can repeat an answer with "
-"ask and print now. Example: name is ask What are you called? print hello name"
+"Starting in level 2 echo is no longer needed. You can repeat an answer "
+"with ask and print now. Example: name is ask What are you called? print "
+"hello name"
 
 #: coursedata/error-messages.txt:25
 #, fuzzy
@@ -489,6 +491,11 @@ msgstr "a list"
 #, fuzzy
 msgid "input"
 msgstr "input from ask"
+
+#: templates/achievements.html:4
+#, fuzzy
+msgid "achievements_title"
+msgstr "achievements"
 
 #: templates/class-overview.html:16
 #, fuzzy
@@ -661,22 +668,21 @@ msgstr "Do you want to join this class?"
 #: templates/class-prejoin.html:17 website/teacher.py:183
 #, fuzzy
 msgid "join_prompt"
-msgstr ""
-"You need to have an account to join a class. Would you like to login now?"
+msgstr "You need to have an account to join a class. Would you like to login now?"
 
 #: templates/class-prejoin.html:17 templates/profile.html:14
 #, fuzzy
 msgid "join_class"
 msgstr "Join class"
 
-#: templates/class-stats.html:22 templates/customize-class.html:155
+#: templates/class-stats.html:22 templates/customize-class.html:150
 #, fuzzy
 msgid "back_to_class"
 msgstr "Go back to class"
 
 #: templates/code-page.html:25 templates/code-page.html:34
-#: templates/customize-class.html:28 templates/customize-class.html:64
-#: templates/customize-class.html:71 templates/customize-class.html:94
+#: templates/customize-class.html:23 templates/customize-class.html:59
+#: templates/customize-class.html:66 templates/customize-class.html:89
 #: templates/incl-adventure-tabs.html:5 templates/level-page.html:6
 #: templates/level-page.html:11 templates/quiz/startquiz.html:10
 #: templates/view-program-page.html:12 templates/view-program-page.html:28
@@ -693,21 +699,21 @@ msgstr "Create multiple accounts"
 #, fuzzy
 msgid "accounts_intro"
 msgstr ""
-"On this page you can create accounts for multiple students at the same time. "
-"It is also possible to directly add them to one of your classes. By pressing "
-"the green + on the bottom right of the page you can add extra rows. You can "
-"delete a row by pressing the corresponding red cross. Make sure no rows are "
-"empty when you press \"Create accounts\". Please keep in mind that every "
-"username and mail address needs to be unique and the password needs to be "
-"<b>at least</b> 6 characters."
+"On this page you can create accounts for multiple students at the same "
+"time. It is also possible to directly add them to one of your classes. By"
+" pressing the green + on the bottom right of the page you can add extra "
+"rows. You can delete a row by pressing the corresponding red cross. Make "
+"sure no rows are empty when you press \"Create accounts\". Please keep in"
+" mind that every username and mail address needs to be unique and the "
+"password needs to be <b>at least</b> 6 characters."
 
 #: templates/create-accounts.html:10
 #, fuzzy
 msgid "create_accounts_prompt"
 msgstr "Are you sure you want to create these accounts?"
 
-#: templates/create-accounts.html:17 templates/learn-more.html:10
-#: templates/profile.html:96 templates/recover.html:8 templates/signup.html:13
+#: templates/create-accounts.html:17 templates/profile.html:96
+#: templates/recover.html:8 templates/signup.html:13
 #, fuzzy
 msgid "email"
 msgstr "Email"
@@ -766,10 +772,10 @@ msgstr "Level"
 #, fuzzy
 msgid "adventure_exp_1"
 msgstr ""
-"Type your adventure of choice on the right-hand side. After creating your "
-"adventure you can include it in one of your classes under \"customizations"
-"\". If you want to include a command in your adventure please use code "
-"anchors like this:"
+"Type your adventure of choice on the right-hand side. After creating your"
+" adventure you can include it in one of your classes under "
+"\"customizations\". If you want to include a command in your adventure "
+"please use code anchors like this:"
 
 #: templates/customize-adventure.html:31
 #, fuzzy
@@ -783,11 +789,11 @@ msgstr ""
 msgid "adventure_exp_3"
 msgstr ""
 "You can use the \"preview\" button to view a styled version of your "
-"adventure. To view the adventure on a dedicated page, select \"view\" from "
-"the teachers page."
+"adventure. To view the adventure on a dedicated page, select \"view\" "
+"from the teachers page."
 
-#: templates/customize-adventure.html:43 templates/customize-class.html:28
-#: templates/customize-class.html:93 templates/explore.html:26
+#: templates/customize-adventure.html:43 templates/customize-class.html:23
+#: templates/customize-class.html:88 templates/explore.html:26
 #: templates/programs.html:18 templates/programs.html:48
 #: templates/view-adventure.html:6
 #, fuzzy
@@ -818,7 +824,7 @@ msgstr "I agree that my adventure might be made publicly available on Hedy."
 msgid "preview"
 msgstr "Preview"
 
-#: templates/customize-adventure.html:51 templates/customize-class.html:150
+#: templates/customize-adventure.html:51 templates/customize-class.html:145
 #, fuzzy
 msgid "save"
 msgstr "Save"
@@ -828,82 +834,32 @@ msgstr "Save"
 msgid "delete_adventure_prompt"
 msgstr "Are you sure you want to remove this adventure?"
 
-#: templates/customize-class.html:7
-#, fuzzy
-msgid "customize_class_exp_1"
-msgstr "Customize class"
-
-#: templates/customize-class.html:10
-#, fuzzy
-msgid "customize_class_step_1"
-msgstr "Customize class"
-
-#: templates/customize-class.html:11
-#, fuzzy
-msgid "customize_class_step_2"
-msgstr "Customize class"
-
-#: templates/customize-class.html:12
-#, fuzzy
-msgid "customize_class_step_3"
-msgstr "Customize class"
-
-#: templates/customize-class.html:13
-#, fuzzy
-msgid "customize_class_step_4"
-msgstr "Customize class"
-
-#: templates/customize-class.html:14
-#, fuzzy
-msgid "customize_class_step_5"
-msgstr "Customize class"
-
-#: templates/customize-class.html:15
-#, fuzzy
-msgid "customize_class_step_6"
-msgstr "Customize class"
-
-#: templates/customize-class.html:16
-#, fuzzy
-msgid "customize_class_step_7"
-msgstr "Customize class"
-
-#: templates/customize-class.html:17
-#, fuzzy
-msgid "customize_class_step_8"
-msgstr "Customize class"
-
-#: templates/customize-class.html:20
-#, fuzzy
-msgid "customize_class_exp_2"
-msgstr "Customize class"
-
-#: templates/customize-class.html:23
+#: templates/customize-class.html:18
 #, fuzzy
 msgid "select_adventures"
 msgstr "Select adventures"
 
-#: templates/customize-class.html:59
+#: templates/customize-class.html:54
 #, fuzzy
 msgid "opening_dates"
 msgstr "Opening dates"
 
-#: templates/customize-class.html:65
+#: templates/customize-class.html:60
 #, fuzzy
 msgid "opening_date"
 msgstr "Opening date"
 
-#: templates/customize-class.html:77
+#: templates/customize-class.html:72
 #, fuzzy
 msgid "directly_available"
 msgstr "Directly open"
 
-#: templates/customize-class.html:88
+#: templates/customize-class.html:83
 #, fuzzy
 msgid "select_own_adventures"
 msgstr "Select own adventures"
 
-#: templates/customize-class.html:95 templates/customize-class.html:121
+#: templates/customize-class.html:90 templates/customize-class.html:116
 #: templates/profile.html:47 templates/profile.html:128
 #: templates/profile.html:137 templates/signup.html:26 templates/signup.html:45
 #: templates/signup.html:53
@@ -911,46 +867,46 @@ msgstr "Select own adventures"
 msgid "select"
 msgstr "Select"
 
-#: templates/customize-class.html:115
+#: templates/customize-class.html:110
 #, fuzzy
 msgid "other_settings"
 msgstr "Other settings"
 
-#: templates/customize-class.html:120
+#: templates/customize-class.html:115
 #, fuzzy
 msgid "option"
 msgstr "Option"
 
-#: templates/customize-class.html:126
+#: templates/customize-class.html:121
 #, fuzzy
 msgid "mandatory_mode"
 msgstr "Mandatory developer's mode"
 
-#: templates/customize-class.html:132
+#: templates/customize-class.html:127
 #, fuzzy
 msgid "hide_cheatsheet"
 msgstr "Hide cheatsheet"
 
-#: templates/customize-class.html:138
+#: templates/customize-class.html:133
 msgid "hide_keyword_switcher"
 msgstr ""
 
-#: templates/customize-class.html:149
+#: templates/customize-class.html:144
 #, fuzzy
 msgid "reset_adventure_prompt"
 msgstr "Are you sure you want to reset all selected adventures?"
 
-#: templates/customize-class.html:149
+#: templates/customize-class.html:144
 #, fuzzy
 msgid "reset_adventures"
 msgstr "Reset selected adventures"
 
-#: templates/customize-class.html:153
+#: templates/customize-class.html:148
 #, fuzzy
 msgid "remove_customizations_prompt"
 msgstr "Are you sure you want to remove this class their customizations?"
 
-#: templates/customize-class.html:154
+#: templates/customize-class.html:149
 #, fuzzy
 msgid "remove_customization"
 msgstr "Remove customization"
@@ -969,13 +925,13 @@ msgstr "Explore programs"
 #, fuzzy
 msgid "explore_explanation"
 msgstr ""
-"On this page you can look through programs created by other Hedy users. You "
-"can filter on both a Hedy level and adventure. Click on \"View program\" to "
-"open a program and run it. Programs with a red header contain a mistake. You "
-"can still open the program, but running it will result in an error. You can "
-"of course try to fix it! If the creator has a public profile you can click "
-"their username to visit their profile. There you will find all their shared "
-"programs and much more!"
+"On this page you can look through programs created by other Hedy users. "
+"You can filter on both a Hedy level and adventure. Click on \"View "
+"program\" to open a program and run it. Programs with a red header "
+"contain a mistake. You can still open the program, but running it will "
+"result in an error. You can of course try to fix it! If the creator has a"
+" public profile you can click their username to visit their profile. "
+"There you will find all their shared programs and much more!"
 
 #: templates/explore.html:35 templates/programs.html:27
 #, fuzzy
@@ -1042,8 +998,8 @@ msgstr "Create student accounts"
 #, fuzzy
 msgid "teacher_welcome"
 msgstr ""
-"Welcome to Hedy! Your are now the proud owner of a teachers account which "
-"allows you to create classes and invite students."
+"Welcome to Hedy! Your are now the proud owner of a teachers account which"
+" allows you to create classes and invite students."
 
 #: templates/incl-adventure-tabs.html:22
 #, fuzzy
@@ -1169,9 +1125,9 @@ msgstr "Welcome"
 msgid "intro_text_landing_page"
 msgstr ""
 "Welcome to the wonderful world of Hedy! Here you can learn to program in "
-"small steps, without unnecessary complicated stuff. We start easy at level "
-"1, and slowly build towards bigger and more complex programs! Choose one of "
-"the options below to get started"
+"small steps, without unnecessary complicated stuff. We start easy at "
+"level 1, and slowly build towards bigger and more complex programs! "
+"Choose one of the options below to get started"
 
 #: templates/landing-page.html:14 templates/landing-page.html:36
 #, fuzzy
@@ -1187,14 +1143,14 @@ msgstr "Start programming"
 #: templates/landing-page.html:21
 #, fuzzy
 msgid "create_class_text"
-msgstr ""
-"Group your students into classes and change the content for each class."
+msgstr "Group your students into classes and change the content for each class."
 
 #: templates/landing-page.html:28
 #, fuzzy
 msgid "read_docs_text"
 msgstr ""
-"Visit our teacher's manual for lesson plans and common mistakes by students."
+"Visit our teacher's manual for lesson plans and common mistakes by "
+"students."
 
 #: templates/landing-page.html:30
 #, fuzzy
@@ -1241,50 +1197,14 @@ msgstr "Copy link to share"
 #, fuzzy
 msgid "set_preferred_lang"
 msgstr ""
-"Hedy now supports preferred user languages. You can set one for your profile "
-"in \"My profile\""
+"Hedy now supports preferred user languages. You can set one for your "
+"profile in \"My profile\""
 
 #: templates/layout.html:86 templates/quiz/endquiz.html:18
 #: templates/quiz/quiz.html:29
 #, fuzzy
 msgid "achievement_earned"
 msgstr "You've earned an achievement!"
-
-#: templates/learn-more.html:7
-#, fuzzy
-msgid "mailing_title"
-msgstr "Title"
-
-#: templates/learn-more.html:14
-#, fuzzy
-msgid "surname"
-msgstr "Username"
-
-#: templates/learn-more.html:18
-#, fuzzy
-msgid "lastname"
-msgstr "Name"
-
-#: templates/learn-more.html:22 templates/profile.html:135
-#: templates/signup.html:52
-#, fuzzy
-msgid "country"
-msgstr "Country"
-
-#: templates/learn-more.html:31
-#, fuzzy
-msgid "subscribe"
-msgstr "Subscribe to the newsletter"
-
-#: templates/learn-more.html:32
-#, fuzzy
-msgid "required_field"
-msgstr "Fields marked with an * are required"
-
-#: templates/learn-more.html:35
-#, fuzzy
-msgid "previous_campaigns"
-msgstr "View previous campaigns"
 
 #: templates/level-page.html:8
 #, fuzzy
@@ -1325,21 +1245,6 @@ msgstr "Create account"
 #, fuzzy
 msgid "forgot_password"
 msgstr "Forgot your password?"
-
-#: templates/main-page.html:9
-#, fuzzy
-msgid "main_title"
-msgstr "Title"
-
-#: templates/main-page.html:10
-#, fuzzy
-msgid "main_subtitle"
-msgstr "programs submitted"
-
-#: templates/main-page.html:13
-#, fuzzy
-msgid "try_it"
-msgstr "Try"
 
 #: templates/profile.html:4
 #, fuzzy
@@ -1405,9 +1310,9 @@ msgstr "Favourite program"
 #, fuzzy
 msgid "public_profile_info"
 msgstr ""
-"By selecting this box I make my profile visible for everyone. Be careful not "
-"to share personal information like your name or home address, because "
-"everyone will be able to see it!"
+"By selecting this box I make my profile visible for everyone. Be careful "
+"not to share personal information like your name or home address, because"
+" everyone will be able to see it!"
 
 #: templates/profile.html:59
 #, fuzzy
@@ -1478,6 +1383,11 @@ msgstr "Male"
 #, fuzzy
 msgid "other"
 msgstr "Other"
+
+#: templates/profile.html:135 templates/signup.html:52
+#, fuzzy
+msgid "country"
+msgstr "Country"
 
 #: templates/profile.html:141
 #, fuzzy
@@ -1705,8 +1615,8 @@ msgstr "Already have an account?"
 #, fuzzy
 msgid "teacher_invitation_require_login"
 msgstr ""
-"To set up your profile as a teacher we will need you to log in. If you don't "
-"have an account, please create one."
+"To set up your profile as a teacher we will need you to log in. If you "
+"don't have an account, please create one."
 
 #: templates/view-program-page.html:13
 #, fuzzy
@@ -1876,7 +1786,8 @@ msgstr "You have to agree with the privacy terms."
 #, fuzzy
 msgid "keyword_language_invalid"
 msgstr ""
-"Please select a valid keyword language (select English or your own language)."
+"Please select a valid keyword language (select English or your own "
+"language)."
 
 #: website/auth.py:371 website/auth.py:551
 #, fuzzy
@@ -1960,8 +1871,8 @@ msgstr "Your token is invalid."
 #, fuzzy
 msgid "password_resetted"
 msgstr ""
-"Your password has been successfully reset. You are being redirected to the "
-"login page."
+"Your password has been successfully reset. You are being redirected to "
+"the login page."
 
 #: website/auth.py:721
 #, fuzzy
@@ -1977,8 +1888,8 @@ msgstr "Program deleted successfully."
 #, fuzzy
 msgid "save_prompt"
 msgstr ""
-"You need to have an account to save your program. Would you like to login "
-"now?"
+"You need to have an account to save your program. Would you like to login"
+" now?"
 
 #: website/programs.py:60
 #, fuzzy
@@ -2191,3 +2102,61 @@ msgstr "The adventure has been updated!"
 #, fuzzy
 msgid "adventure_empty"
 msgstr "You didn't enter an adventure name!"
+
+#~ msgid "customize_class_exp_1"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_1"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_2"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_3"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_4"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_5"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_6"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_7"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_8"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_exp_2"
+#~ msgstr "Customize class"
+
+#~ msgid "mailing_title"
+#~ msgstr "Title"
+
+#~ msgid "surname"
+#~ msgstr "Username"
+
+#~ msgid "lastname"
+#~ msgstr "Name"
+
+#~ msgid "subscribe"
+#~ msgstr "Subscribe to the newsletter"
+
+#~ msgid "required_field"
+#~ msgstr "Fields marked with an * are required"
+
+#~ msgid "previous_campaigns"
+#~ msgstr "View previous campaigns"
+
+#~ msgid "main_title"
+#~ msgstr "Title"
+
+#~ msgid "main_subtitle"
+#~ msgstr "programs submitted"
+
+#~ msgid "try_it"
+#~ msgstr "Try"
+

--- a/translations/cs/LC_MESSAGES/messages.po
+++ b/translations/cs/LC_MESSAGES/messages.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-03-29 10:01+0200\n"
+"POT-Creation-Date: 2022-03-30 08:43+0200\n"
 "PO-Revision-Date: 2022-03-23 11:48+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: cs\n"
@@ -20,27 +20,27 @@ msgstr ""
 msgid "program_contains_error"
 msgstr "This program contains an error, are you sure you want to share it?"
 
-#: app.py:723
+#: app.py:722
 #, fuzzy
 msgid "title_achievements"
 msgstr "Hedy - My achievements"
 
-#: app.py:740 app.py:1111 website/teacher.py:365 website/teacher.py:374
+#: app.py:739 app.py:1110 website/teacher.py:365 website/teacher.py:374
 #, fuzzy
 msgid "not_teacher"
 msgstr "Looks like you are not a teacher!"
 
-#: app.py:743
+#: app.py:742
 #, fuzzy
 msgid "not_enrolled"
 msgstr "Looks like you are not in this class!"
 
-#: app.py:775
+#: app.py:774
 #, fuzzy
 msgid "title_programs"
 msgstr "Hedy - My programs"
 
-#: app.py:785 app.py:795 app.py:799 app.py:813 app.py:1054 app.py:1357
+#: app.py:784 app.py:794 app.py:798 app.py:812 app.py:1053 app.py:1356
 #: website/admin.py:17 website/admin.py:25 website/admin.py:95
 #: website/admin.py:112 website/admin.py:130 website/auth.py:711
 #: website/auth.py:738 website/statistics.py:86
@@ -48,125 +48,125 @@ msgstr "Hedy - My programs"
 msgid "unauthorized"
 msgstr "You don't have access rights for this page"
 
-#: app.py:823
+#: app.py:822
 #, fuzzy
 msgid "minutes"
 msgstr "minutes"
 
-#: app.py:826
+#: app.py:825
 #, fuzzy
 msgid "hours"
 msgstr "hours"
 
-#: app.py:829
+#: app.py:828
 #, fuzzy
 msgid "days"
 msgstr "days"
 
-#: app.py:832
+#: app.py:831
 #, fuzzy
 msgid "ago"
 msgstr "{time} ago"
 
-#: app.py:848 app.py:850 app.py:976
+#: app.py:847 app.py:849 app.py:975
 #, fuzzy
 msgid "no_such_level"
 msgstr "No such Hedy level!"
 
-#: app.py:858 app.py:865 app.py:931 app.py:937
+#: app.py:857 app.py:864 app.py:930 app.py:936
 #, fuzzy
 msgid "no_such_program"
 msgstr "No such Hedy program!"
 
-#: app.py:891
+#: app.py:890
 #, fuzzy
 msgid "level_not_translated"
 msgstr "This level is not translated in your language (yet)"
 
-#: app.py:893
+#: app.py:892
 #, fuzzy
 msgid "level_not_class"
 msgstr "You're in a class where this level has not been made available yet"
 
-#: app.py:986 website/teacher.py:432 website/teacher.py:448
+#: app.py:985 website/teacher.py:432 website/teacher.py:448
 #: website/teacher.py:477 website/teacher.py:503
 #, fuzzy
 msgid "no_such_adventure"
 msgstr "This adventure doesn't exist!"
 
-#: app.py:1005
+#: app.py:1004
 #, fuzzy
 msgid "page_not_found"
 msgstr "We could not find that page!"
 
-#: app.py:1025
+#: app.py:1024
 #, fuzzy
 msgid "title_signup"
 msgstr "Hedy - Create an account"
 
-#: app.py:1032
+#: app.py:1031
 #, fuzzy
 msgid "title_login"
 msgstr "Hedy - Login"
 
-#: app.py:1039
+#: app.py:1038
 #, fuzzy
 msgid "title_recover"
 msgstr "Hedy - Recover account"
 
-#: app.py:1055
+#: app.py:1054
 #, fuzzy
 msgid "title_reset"
 msgstr "Hedy - Reset password"
 
-#: app.py:1064
+#: app.py:1063
 #, fuzzy
 msgid "title_my-profile"
 msgstr "Hedy - My account"
 
-#: app.py:1078
+#: app.py:1077
 #, fuzzy
 msgid "title_learn-more"
 msgstr "Hedy - Learn more"
 
-#: app.py:1083
+#: app.py:1082
 #, fuzzy
 msgid "title_privacy"
 msgstr "Hedy - Privacy terms"
 
-#: app.py:1090
+#: app.py:1089
 #, fuzzy
 msgid "title_landing-page"
 msgstr "Welcome to Hedy!"
 
-#: app.py:1092
+#: app.py:1091
 #, fuzzy
 msgid "not_user"
 msgstr "Looks like you are not logged in!"
 
-#: app.py:1107
+#: app.py:1106
 #, fuzzy
 msgid "title_for-teacher"
 msgstr "Hedy - For teachers"
 
-#: app.py:1118
+#: app.py:1117
 #, fuzzy
 msgid "title_start"
 msgstr "Hedy - A gradual programming language"
 
-#: app.py:1171
+#: app.py:1170
 #, fuzzy
 msgid "title_explore"
 msgstr "Hedy - Explore"
 
-#: app.py:1190 app.py:1192
+#: app.py:1189 app.py:1191
 #, fuzzy
 msgid "translate_error"
 msgstr ""
 "Something went wrong while translating the code. Try running the code to "
 "see if it has an error. Code with errors can not be translated."
 
-#: app.py:1301 website/auth.py:299 website/auth.py:347 website/auth.py:483
+#: app.py:1300 website/auth.py:299 website/auth.py:347 website/auth.py:483
 #: website/auth.py:509 website/auth.py:539 website/auth.py:645
 #: website/auth.py:677 website/auth.py:717 website/auth.py:744
 #: website/teacher.py:90 website/teacher.py:125 website/teacher.py:197
@@ -175,32 +175,32 @@ msgstr ""
 msgid "ajax_error"
 msgstr "Nastala chyba, prosím zkus to znova."
 
-#: app.py:1304
+#: app.py:1303
 #, fuzzy
 msgid "image_invalid"
 msgstr "Your chosen image is invalid."
 
-#: app.py:1306
+#: app.py:1305
 #, fuzzy
 msgid "personal_text_invalid"
 msgstr "Your personal text is invalid."
 
-#: app.py:1308 app.py:1314
+#: app.py:1307 app.py:1313
 #, fuzzy
 msgid "favourite_program_invalid"
 msgstr "Your chosen favourite program is invalid."
 
-#: app.py:1326 app.py:1327
+#: app.py:1325 app.py:1326
 #, fuzzy
 msgid "public_profile_updated"
 msgstr "Public profile updated."
 
-#: app.py:1361 app.py:1385
+#: app.py:1360 app.py:1384
 #, fuzzy
 msgid "user_not_private"
 msgstr "This user doesn't exist or doesn't have a public profile"
 
-#: app.py:1394
+#: app.py:1393
 #, fuzzy
 msgid "invalid_teacher_invitation_code"
 msgstr ""
@@ -375,16 +375,16 @@ msgstr "It looks like you forgot to use a command on line {line_number}."
 #, fuzzy
 msgid "ask_needs_var"
 msgstr ""
-"Starting in level 2, ask needs to be used with a variable. "
-"Example: name is ask What are you called?"
+"Starting in level 2, ask needs to be used with a variable. Example: name "
+"is ask What are you called?"
 
 #: coursedata/error-messages.txt:24
 #, fuzzy
 msgid "echo_out"
 msgstr ""
 "Starting in level 2 echo is no longer needed. You can repeat an answer "
-"with ask and print now. Example: name is ask What are you called? print"
-" hello name"
+"with ask and print now. Example: name is ask What are you called? print "
+"hello name"
 
 #: coursedata/error-messages.txt:25
 msgid "space"
@@ -469,6 +469,11 @@ msgstr "a list"
 #, fuzzy
 msgid "input"
 msgstr "input from ask"
+
+#: templates/achievements.html:4
+#, fuzzy
+msgid "achievements_title"
+msgstr "achievements"
 
 #: templates/class-overview.html:16
 #, fuzzy
@@ -646,14 +651,14 @@ msgstr "You need to have an account to join a class. Would you like to login now
 msgid "join_class"
 msgstr "Join class"
 
-#: templates/class-stats.html:22 templates/customize-class.html:155
+#: templates/class-stats.html:22 templates/customize-class.html:150
 #, fuzzy
 msgid "back_to_class"
 msgstr "Go back to class"
 
 #: templates/code-page.html:25 templates/code-page.html:34
-#: templates/customize-class.html:28 templates/customize-class.html:64
-#: templates/customize-class.html:71 templates/customize-class.html:94
+#: templates/customize-class.html:23 templates/customize-class.html:59
+#: templates/customize-class.html:66 templates/customize-class.html:89
 #: templates/incl-adventure-tabs.html:5 templates/level-page.html:6
 #: templates/level-page.html:11 templates/quiz/startquiz.html:10
 #: templates/view-program-page.html:12 templates/view-program-page.html:28
@@ -682,8 +687,8 @@ msgstr ""
 msgid "create_accounts_prompt"
 msgstr "Are you sure you want to create these accounts?"
 
-#: templates/create-accounts.html:17 templates/learn-more.html:10
-#: templates/profile.html:96 templates/recover.html:8 templates/signup.html:13
+#: templates/create-accounts.html:17 templates/profile.html:96
+#: templates/recover.html:8 templates/signup.html:13
 msgid "email"
 msgstr "Email"
 
@@ -760,8 +765,8 @@ msgstr ""
 "adventure. To view the adventure on a dedicated page, select \"view\" "
 "from the teachers page."
 
-#: templates/customize-adventure.html:43 templates/customize-class.html:28
-#: templates/customize-class.html:93 templates/explore.html:26
+#: templates/customize-adventure.html:43 templates/customize-class.html:23
+#: templates/customize-class.html:88 templates/explore.html:26
 #: templates/programs.html:18 templates/programs.html:48
 #: templates/view-adventure.html:6
 msgid "adventure"
@@ -791,7 +796,7 @@ msgstr "I agree that my adventure might be made publicly available on Hedy."
 msgid "preview"
 msgstr "Preview"
 
-#: templates/customize-adventure.html:51 templates/customize-class.html:150
+#: templates/customize-adventure.html:51 templates/customize-class.html:145
 #, fuzzy
 msgid "save"
 msgstr "Save"
@@ -801,128 +806,78 @@ msgstr "Save"
 msgid "delete_adventure_prompt"
 msgstr "Are you sure you want to remove this adventure?"
 
-#: templates/customize-class.html:7
-#, fuzzy
-msgid "customize_class_exp_1"
-msgstr "Customize class"
-
-#: templates/customize-class.html:10
-#, fuzzy
-msgid "customize_class_step_1"
-msgstr "Customize class"
-
-#: templates/customize-class.html:11
-#, fuzzy
-msgid "customize_class_step_2"
-msgstr "Customize class"
-
-#: templates/customize-class.html:12
-#, fuzzy
-msgid "customize_class_step_3"
-msgstr "Customize class"
-
-#: templates/customize-class.html:13
-#, fuzzy
-msgid "customize_class_step_4"
-msgstr "Customize class"
-
-#: templates/customize-class.html:14
-#, fuzzy
-msgid "customize_class_step_5"
-msgstr "Customize class"
-
-#: templates/customize-class.html:15
-#, fuzzy
-msgid "customize_class_step_6"
-msgstr "Customize class"
-
-#: templates/customize-class.html:16
-#, fuzzy
-msgid "customize_class_step_7"
-msgstr "Customize class"
-
-#: templates/customize-class.html:17
-#, fuzzy
-msgid "customize_class_step_8"
-msgstr "Customize class"
-
-#: templates/customize-class.html:20
-#, fuzzy
-msgid "customize_class_exp_2"
-msgstr "Customize class"
-
-#: templates/customize-class.html:23
+#: templates/customize-class.html:18
 #, fuzzy
 msgid "select_adventures"
 msgstr "Select adventures"
 
-#: templates/customize-class.html:59
+#: templates/customize-class.html:54
 #, fuzzy
 msgid "opening_dates"
 msgstr "Opening dates"
 
-#: templates/customize-class.html:65
+#: templates/customize-class.html:60
 #, fuzzy
 msgid "opening_date"
 msgstr "Opening date"
 
-#: templates/customize-class.html:77
+#: templates/customize-class.html:72
 #, fuzzy
 msgid "directly_available"
 msgstr "Directly open"
 
-#: templates/customize-class.html:88
+#: templates/customize-class.html:83
 #, fuzzy
 msgid "select_own_adventures"
 msgstr "Select own adventures"
 
-#: templates/customize-class.html:95 templates/customize-class.html:121
+#: templates/customize-class.html:90 templates/customize-class.html:116
 #: templates/profile.html:47 templates/profile.html:128
 #: templates/profile.html:137 templates/signup.html:26 templates/signup.html:45
 #: templates/signup.html:53
 msgid "select"
 msgstr "Vyber"
 
-#: templates/customize-class.html:115
+#: templates/customize-class.html:110
 #, fuzzy
 msgid "other_settings"
 msgstr "Other settings"
 
-#: templates/customize-class.html:120
+#: templates/customize-class.html:115
 #, fuzzy
 msgid "option"
 msgstr "Option"
 
-#: templates/customize-class.html:126
+#: templates/customize-class.html:121
 #, fuzzy
 msgid "mandatory_mode"
 msgstr "Mandatory developer's mode"
 
-#: templates/customize-class.html:132
+#: templates/customize-class.html:127
 #, fuzzy
 msgid "hide_cheatsheet"
 msgstr "Hide cheatsheet"
 
-#: templates/customize-class.html:138
+#: templates/customize-class.html:133
 msgid "hide_keyword_switcher"
 msgstr ""
 
-#: templates/customize-class.html:149
+#: templates/customize-class.html:144
 #, fuzzy
 msgid "reset_adventure_prompt"
 msgstr "Are you sure you want to reset all selected adventures?"
 
-#: templates/customize-class.html:149
+#: templates/customize-class.html:144
 #, fuzzy
 msgid "reset_adventures"
 msgstr "Reset selected adventures"
 
-#: templates/customize-class.html:153
+#: templates/customize-class.html:148
 #, fuzzy
 msgid "remove_customizations_prompt"
 msgstr "Are you sure you want to remove this class their customizations?"
 
-#: templates/customize-class.html:154
+#: templates/customize-class.html:149
 #, fuzzy
 msgid "remove_customization"
 msgstr "Remove customization"
@@ -1207,35 +1162,6 @@ msgstr ""
 msgid "achievement_earned"
 msgstr "You've earned an achievement!"
 
-#: templates/learn-more.html:7
-msgid "mailing_title"
-msgstr "Přihlaš se k odběru Hedy newsletteru"
-
-#: templates/learn-more.html:14
-msgid "surname"
-msgstr "Jméno"
-
-#: templates/learn-more.html:18
-msgid "lastname"
-msgstr "Příjmení"
-
-#: templates/learn-more.html:22 templates/profile.html:135
-#: templates/signup.html:52
-msgid "country"
-msgstr "Země"
-
-#: templates/learn-more.html:31
-msgid "subscribe"
-msgstr "Potvrdit"
-
-#: templates/learn-more.html:32
-msgid "required_field"
-msgstr "* povinná pole"
-
-#: templates/learn-more.html:35
-msgid "previous_campaigns"
-msgstr "Prohlédnout si zprávy z minulosti"
-
 #: templates/level-page.html:8
 msgid "step_title"
 msgstr "Úkol"
@@ -1267,18 +1193,6 @@ msgstr "Vytvořit účet"
 #: templates/login.html:33
 msgid "forgot_password"
 msgstr "Zapomněl*a jsi heslo?"
-
-#: templates/main-page.html:9
-msgid "main_title"
-msgstr "Hedy"
-
-#: templates/main-page.html:10
-msgid "main_subtitle"
-msgstr "Stupňovitý programovací jazyk"
-
-#: templates/main-page.html:13
-msgid "try_it"
-msgstr "Vyzkoušej to"
 
 #: templates/profile.html:4
 #, fuzzy
@@ -1411,6 +1325,10 @@ msgstr "Muž"
 #: templates/profile.html:131 templates/signup.html:48
 msgid "other"
 msgstr "Jiné"
+
+#: templates/profile.html:135 templates/signup.html:52
+msgid "country"
+msgstr "Země"
 
 #: templates/profile.html:141
 msgid "update_profile"
@@ -2096,4 +2014,61 @@ msgstr "You didn't enter an adventure name!"
 
 #~ msgid "required"
 #~ msgstr ""
+
+#~ msgid "customize_class_exp_1"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_1"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_2"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_3"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_4"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_5"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_6"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_7"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_8"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_exp_2"
+#~ msgstr "Customize class"
+
+#~ msgid "mailing_title"
+#~ msgstr "Přihlaš se k odběru Hedy newsletteru"
+
+#~ msgid "surname"
+#~ msgstr "Jméno"
+
+#~ msgid "lastname"
+#~ msgstr "Příjmení"
+
+#~ msgid "subscribe"
+#~ msgstr "Potvrdit"
+
+#~ msgid "required_field"
+#~ msgstr "* povinná pole"
+
+#~ msgid "previous_campaigns"
+#~ msgstr "Prohlédnout si zprávy z minulosti"
+
+#~ msgid "main_title"
+#~ msgstr "Hedy"
+
+#~ msgid "main_subtitle"
+#~ msgstr "Stupňovitý programovací jazyk"
+
+#~ msgid "try_it"
+#~ msgstr "Vyzkoušej to"
 

--- a/translations/de/LC_MESSAGES/messages.po
+++ b/translations/de/LC_MESSAGES/messages.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-03-29 10:01+0200\n"
+"POT-Creation-Date: 2022-03-30 08:43+0200\n"
 "PO-Revision-Date: 2022-03-23 11:48+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: de\n"
@@ -20,27 +20,27 @@ msgstr ""
 msgid "program_contains_error"
 msgstr "This program contains an error, are you sure you want to share it?"
 
-#: app.py:723
+#: app.py:722
 #, fuzzy
 msgid "title_achievements"
 msgstr "Hedy - My achievements"
 
-#: app.py:740 app.py:1111 website/teacher.py:365 website/teacher.py:374
+#: app.py:739 app.py:1110 website/teacher.py:365 website/teacher.py:374
 #, fuzzy
 msgid "not_teacher"
 msgstr "Looks like you are not a teacher!"
 
-#: app.py:743
+#: app.py:742
 #, fuzzy
 msgid "not_enrolled"
 msgstr "Looks like you are not in this class!"
 
-#: app.py:775
+#: app.py:774
 #, fuzzy
 msgid "title_programs"
 msgstr "Hedy - My programs"
 
-#: app.py:785 app.py:795 app.py:799 app.py:813 app.py:1054 app.py:1357
+#: app.py:784 app.py:794 app.py:798 app.py:812 app.py:1053 app.py:1356
 #: website/admin.py:17 website/admin.py:25 website/admin.py:95
 #: website/admin.py:112 website/admin.py:130 website/auth.py:711
 #: website/auth.py:738 website/statistics.py:86
@@ -48,122 +48,122 @@ msgstr "Hedy - My programs"
 msgid "unauthorized"
 msgstr "You don't have access rights for this page"
 
-#: app.py:823
+#: app.py:822
 msgid "minutes"
 msgstr "Minuten"
 
-#: app.py:826
+#: app.py:825
 msgid "hours"
 msgstr "Stunden"
 
-#: app.py:829
+#: app.py:828
 msgid "days"
 msgstr "Tage"
 
-#: app.py:832
+#: app.py:831
 #, fuzzy
 msgid "ago"
 msgstr "{time} ago"
 
-#: app.py:848 app.py:850 app.py:976
+#: app.py:847 app.py:849 app.py:975
 #, fuzzy
 msgid "no_such_level"
 msgstr "No such Hedy level!"
 
-#: app.py:858 app.py:865 app.py:931 app.py:937
+#: app.py:857 app.py:864 app.py:930 app.py:936
 #, fuzzy
 msgid "no_such_program"
 msgstr "No such Hedy program!"
 
-#: app.py:891
+#: app.py:890
 #, fuzzy
 msgid "level_not_translated"
 msgstr "This level is not translated in your language (yet)"
 
-#: app.py:893
+#: app.py:892
 #, fuzzy
 msgid "level_not_class"
 msgstr "You're in a class where this level has not been made available yet"
 
-#: app.py:986 website/teacher.py:432 website/teacher.py:448
+#: app.py:985 website/teacher.py:432 website/teacher.py:448
 #: website/teacher.py:477 website/teacher.py:503
 #, fuzzy
 msgid "no_such_adventure"
 msgstr "This adventure doesn't exist!"
 
-#: app.py:1005
+#: app.py:1004
 #, fuzzy
 msgid "page_not_found"
 msgstr "We could not find that page!"
 
-#: app.py:1025
+#: app.py:1024
 #, fuzzy
 msgid "title_signup"
 msgstr "Hedy - Create an account"
 
-#: app.py:1032
+#: app.py:1031
 #, fuzzy
 msgid "title_login"
 msgstr "Hedy - Login"
 
-#: app.py:1039
+#: app.py:1038
 #, fuzzy
 msgid "title_recover"
 msgstr "Hedy - Recover account"
 
-#: app.py:1055
+#: app.py:1054
 #, fuzzy
 msgid "title_reset"
 msgstr "Hedy - Reset password"
 
-#: app.py:1064
+#: app.py:1063
 #, fuzzy
 msgid "title_my-profile"
 msgstr "Hedy - My account"
 
-#: app.py:1078
+#: app.py:1077
 #, fuzzy
 msgid "title_learn-more"
 msgstr "Hedy - Learn more"
 
-#: app.py:1083
+#: app.py:1082
 #, fuzzy
 msgid "title_privacy"
 msgstr "Hedy - Privacy terms"
 
-#: app.py:1090
+#: app.py:1089
 #, fuzzy
 msgid "title_landing-page"
 msgstr "Welcome to Hedy!"
 
-#: app.py:1092
+#: app.py:1091
 #, fuzzy
 msgid "not_user"
 msgstr "Looks like you are not logged in!"
 
-#: app.py:1107
+#: app.py:1106
 #, fuzzy
 msgid "title_for-teacher"
 msgstr "Hedy - For teachers"
 
-#: app.py:1118
+#: app.py:1117
 #, fuzzy
 msgid "title_start"
 msgstr "Hedy - A gradual programming language"
 
-#: app.py:1171
+#: app.py:1170
 #, fuzzy
 msgid "title_explore"
 msgstr "Hedy - Explore"
 
-#: app.py:1190 app.py:1192
+#: app.py:1189 app.py:1191
 #, fuzzy
 msgid "translate_error"
 msgstr ""
 "Something went wrong while translating the code. Try running the code to "
 "see if it has an error. Code with errors can not be translated."
 
-#: app.py:1301 website/auth.py:299 website/auth.py:347 website/auth.py:483
+#: app.py:1300 website/auth.py:299 website/auth.py:347 website/auth.py:483
 #: website/auth.py:509 website/auth.py:539 website/auth.py:645
 #: website/auth.py:677 website/auth.py:717 website/auth.py:744
 #: website/teacher.py:90 website/teacher.py:125 website/teacher.py:197
@@ -172,32 +172,32 @@ msgstr ""
 msgid "ajax_error"
 msgstr "Ein Fehler ist aufgetreten. Bitte nochmal versuchen."
 
-#: app.py:1304
+#: app.py:1303
 #, fuzzy
 msgid "image_invalid"
 msgstr "Your chosen image is invalid."
 
-#: app.py:1306
+#: app.py:1305
 #, fuzzy
 msgid "personal_text_invalid"
 msgstr "Your personal text is invalid."
 
-#: app.py:1308 app.py:1314
+#: app.py:1307 app.py:1313
 #, fuzzy
 msgid "favourite_program_invalid"
 msgstr "Your chosen favourite program is invalid."
 
-#: app.py:1326 app.py:1327
+#: app.py:1325 app.py:1326
 #, fuzzy
 msgid "public_profile_updated"
 msgstr "Public profile updated."
 
-#: app.py:1361 app.py:1385
+#: app.py:1360 app.py:1384
 #, fuzzy
 msgid "user_not_private"
 msgstr "This user doesn't exist or doesn't have a public profile"
 
-#: app.py:1394
+#: app.py:1393
 #, fuzzy
 msgid "invalid_teacher_invitation_code"
 msgstr ""
@@ -364,16 +364,16 @@ msgstr "It looks like you forgot to use a command on line {line_number}."
 #, fuzzy
 msgid "ask_needs_var"
 msgstr ""
-"Starting in level 2, ask needs to be used with a variable. "
-"Example: name is ask What are you called?"
+"Starting in level 2, ask needs to be used with a variable. Example: name "
+"is ask What are you called?"
 
 #: coursedata/error-messages.txt:24
 #, fuzzy
 msgid "echo_out"
 msgstr ""
 "Starting in level 2 echo is no longer needed. You can repeat an answer "
-"with ask and print now. Example: name is ask What are you called? print"
-" hello name"
+"with ask and print now. Example: name is ask What are you called? print "
+"hello name"
 
 #: coursedata/error-messages.txt:25
 msgid "space"
@@ -451,6 +451,11 @@ msgstr "eine Liste"
 #, fuzzy
 msgid "input"
 msgstr "input from ask"
+
+#: templates/achievements.html:4
+#, fuzzy
+msgid "achievements_title"
+msgstr "achievements"
 
 #: templates/class-overview.html:16
 #, fuzzy
@@ -608,13 +613,13 @@ msgstr "Zum beitreten benötigst du einen Account. Möchtest du dich einloggen?"
 msgid "join_class"
 msgstr "Klasse beitreten"
 
-#: templates/class-stats.html:22 templates/customize-class.html:155
+#: templates/class-stats.html:22 templates/customize-class.html:150
 msgid "back_to_class"
 msgstr "Gehe zurück zur Klasse"
 
 #: templates/code-page.html:25 templates/code-page.html:34
-#: templates/customize-class.html:28 templates/customize-class.html:64
-#: templates/customize-class.html:71 templates/customize-class.html:94
+#: templates/customize-class.html:23 templates/customize-class.html:59
+#: templates/customize-class.html:66 templates/customize-class.html:89
 #: templates/incl-adventure-tabs.html:5 templates/level-page.html:6
 #: templates/level-page.html:11 templates/quiz/startquiz.html:10
 #: templates/view-program-page.html:12 templates/view-program-page.html:28
@@ -643,8 +648,8 @@ msgstr ""
 msgid "create_accounts_prompt"
 msgstr "Are you sure you want to create these accounts?"
 
-#: templates/create-accounts.html:17 templates/learn-more.html:10
-#: templates/profile.html:96 templates/recover.html:8 templates/signup.html:13
+#: templates/create-accounts.html:17 templates/profile.html:96
+#: templates/recover.html:8 templates/signup.html:13
 msgid "email"
 msgstr "E-mail"
 
@@ -719,8 +724,8 @@ msgstr ""
 "adventure. To view the adventure on a dedicated page, select \"view\" "
 "from the teachers page."
 
-#: templates/customize-adventure.html:43 templates/customize-class.html:28
-#: templates/customize-class.html:93 templates/explore.html:26
+#: templates/customize-adventure.html:43 templates/customize-class.html:23
+#: templates/customize-class.html:88 templates/explore.html:26
 #: templates/programs.html:18 templates/programs.html:48
 #: templates/view-adventure.html:6
 #, fuzzy
@@ -751,7 +756,7 @@ msgstr "I agree that my adventure might be made publicly available on Hedy."
 msgid "preview"
 msgstr "Preview"
 
-#: templates/customize-adventure.html:51 templates/customize-class.html:150
+#: templates/customize-adventure.html:51 templates/customize-class.html:145
 msgid "save"
 msgstr "Speichern"
 
@@ -760,126 +765,76 @@ msgstr "Speichern"
 msgid "delete_adventure_prompt"
 msgstr "Are you sure you want to remove this adventure?"
 
-#: templates/customize-class.html:7
-#, fuzzy
-msgid "customize_class_exp_1"
-msgstr "Passe eine Klasse an"
-
-#: templates/customize-class.html:10
-#, fuzzy
-msgid "customize_class_step_1"
-msgstr "Passe eine Klasse an"
-
-#: templates/customize-class.html:11
-#, fuzzy
-msgid "customize_class_step_2"
-msgstr "Passe eine Klasse an"
-
-#: templates/customize-class.html:12
-#, fuzzy
-msgid "customize_class_step_3"
-msgstr "Passe eine Klasse an"
-
-#: templates/customize-class.html:13
-#, fuzzy
-msgid "customize_class_step_4"
-msgstr "Passe eine Klasse an"
-
-#: templates/customize-class.html:14
-#, fuzzy
-msgid "customize_class_step_5"
-msgstr "Passe eine Klasse an"
-
-#: templates/customize-class.html:15
-#, fuzzy
-msgid "customize_class_step_6"
-msgstr "Passe eine Klasse an"
-
-#: templates/customize-class.html:16
-#, fuzzy
-msgid "customize_class_step_7"
-msgstr "Passe eine Klasse an"
-
-#: templates/customize-class.html:17
-#, fuzzy
-msgid "customize_class_step_8"
-msgstr "Passe eine Klasse an"
-
-#: templates/customize-class.html:20
-#, fuzzy
-msgid "customize_class_exp_2"
-msgstr "Passe eine Klasse an"
-
-#: templates/customize-class.html:23
+#: templates/customize-class.html:18
 msgid "select_adventures"
 msgstr "Welches Abenteuer möchtest du verfügbar machen?"
 
-#: templates/customize-class.html:59
+#: templates/customize-class.html:54
 #, fuzzy
 msgid "opening_dates"
 msgstr "Opening dates"
 
-#: templates/customize-class.html:65
+#: templates/customize-class.html:60
 #, fuzzy
 msgid "opening_date"
 msgstr "Opening date"
 
-#: templates/customize-class.html:77
+#: templates/customize-class.html:72
 #, fuzzy
 msgid "directly_available"
 msgstr "Directly open"
 
-#: templates/customize-class.html:88
+#: templates/customize-class.html:83
 #, fuzzy
 msgid "select_own_adventures"
 msgstr "Select own adventures"
 
-#: templates/customize-class.html:95 templates/customize-class.html:121
+#: templates/customize-class.html:90 templates/customize-class.html:116
 #: templates/profile.html:47 templates/profile.html:128
 #: templates/profile.html:137 templates/signup.html:26 templates/signup.html:45
 #: templates/signup.html:53
 msgid "select"
 msgstr "Auswahl"
 
-#: templates/customize-class.html:115
+#: templates/customize-class.html:110
 msgid "other_settings"
 msgstr "Andere Einstellungen"
 
-#: templates/customize-class.html:120
+#: templates/customize-class.html:115
 #, fuzzy
 msgid "option"
 msgstr "Option"
 
-#: templates/customize-class.html:126
+#: templates/customize-class.html:121
 #, fuzzy
 msgid "mandatory_mode"
 msgstr "Mandatory developer's mode"
 
-#: templates/customize-class.html:132
+#: templates/customize-class.html:127
 #, fuzzy
 msgid "hide_cheatsheet"
 msgstr "Hide cheatsheet"
 
-#: templates/customize-class.html:138
+#: templates/customize-class.html:133
 msgid "hide_keyword_switcher"
 msgstr ""
 
-#: templates/customize-class.html:149
+#: templates/customize-class.html:144
 #, fuzzy
 msgid "reset_adventure_prompt"
 msgstr "Are you sure you want to reset all selected adventures?"
 
-#: templates/customize-class.html:149
+#: templates/customize-class.html:144
 #, fuzzy
 msgid "reset_adventures"
 msgstr "Reset selected adventures"
 
-#: templates/customize-class.html:153
+#: templates/customize-class.html:148
 #, fuzzy
 msgid "remove_customizations_prompt"
 msgstr "Are you sure you want to remove this class their customizations?"
 
-#: templates/customize-class.html:154
+#: templates/customize-class.html:149
 #, fuzzy
 msgid "remove_customization"
 msgstr "Remove customization"
@@ -1142,35 +1097,6 @@ msgstr ""
 msgid "achievement_earned"
 msgstr "Du hast eine Leistung erbracht!"
 
-#: templates/learn-more.html:7
-msgid "mailing_title"
-msgstr "Abonniere den Hedy-Newsletter"
-
-#: templates/learn-more.html:14
-msgid "surname"
-msgstr "Vorname"
-
-#: templates/learn-more.html:18
-msgid "lastname"
-msgstr "Nachname"
-
-#: templates/learn-more.html:22 templates/profile.html:135
-#: templates/signup.html:52
-msgid "country"
-msgstr "Land"
-
-#: templates/learn-more.html:31
-msgid "subscribe"
-msgstr "Abonnieren"
-
-#: templates/learn-more.html:32
-msgid "required_field"
-msgstr "* zeigt erforderliche Felder an"
-
-#: templates/learn-more.html:35
-msgid "previous_campaigns"
-msgstr "Bisherige Newsletter anzeigen"
-
 #: templates/level-page.html:8
 msgid "step_title"
 msgstr "Aufgabe"
@@ -1205,18 +1131,6 @@ msgstr "Neues Konto anlegen"
 #: templates/login.html:33
 msgid "forgot_password"
 msgstr "Passwort vergessen?"
-
-#: templates/main-page.html:9
-msgid "main_title"
-msgstr "Hedy"
-
-#: templates/main-page.html:10
-msgid "main_subtitle"
-msgstr "Eine mitwachsende Programmiersprache"
-
-#: templates/main-page.html:13
-msgid "try_it"
-msgstr "Probier es aus"
 
 #: templates/profile.html:4
 msgid "account_overview"
@@ -1344,6 +1258,10 @@ msgstr "männlich"
 #: templates/profile.html:131 templates/signup.html:48
 msgid "other"
 msgstr "divers"
+
+#: templates/profile.html:135 templates/signup.html:52
+msgid "country"
+msgstr "Land"
 
 #: templates/profile.html:141
 msgid "update_profile"
@@ -2003,4 +1921,61 @@ msgstr "You didn't enter an adventure name!"
 
 #~ msgid "required"
 #~ msgstr ""
+
+#~ msgid "customize_class_exp_1"
+#~ msgstr "Passe eine Klasse an"
+
+#~ msgid "customize_class_step_1"
+#~ msgstr "Passe eine Klasse an"
+
+#~ msgid "customize_class_step_2"
+#~ msgstr "Passe eine Klasse an"
+
+#~ msgid "customize_class_step_3"
+#~ msgstr "Passe eine Klasse an"
+
+#~ msgid "customize_class_step_4"
+#~ msgstr "Passe eine Klasse an"
+
+#~ msgid "customize_class_step_5"
+#~ msgstr "Passe eine Klasse an"
+
+#~ msgid "customize_class_step_6"
+#~ msgstr "Passe eine Klasse an"
+
+#~ msgid "customize_class_step_7"
+#~ msgstr "Passe eine Klasse an"
+
+#~ msgid "customize_class_step_8"
+#~ msgstr "Passe eine Klasse an"
+
+#~ msgid "customize_class_exp_2"
+#~ msgstr "Passe eine Klasse an"
+
+#~ msgid "mailing_title"
+#~ msgstr "Abonniere den Hedy-Newsletter"
+
+#~ msgid "surname"
+#~ msgstr "Vorname"
+
+#~ msgid "lastname"
+#~ msgstr "Nachname"
+
+#~ msgid "subscribe"
+#~ msgstr "Abonnieren"
+
+#~ msgid "required_field"
+#~ msgstr "* zeigt erforderliche Felder an"
+
+#~ msgid "previous_campaigns"
+#~ msgstr "Bisherige Newsletter anzeigen"
+
+#~ msgid "main_title"
+#~ msgstr "Hedy"
+
+#~ msgid "main_subtitle"
+#~ msgstr "Eine mitwachsende Programmiersprache"
+
+#~ msgid "try_it"
+#~ msgstr "Probier es aus"
 

--- a/translations/el/LC_MESSAGES/messages.po
+++ b/translations/el/LC_MESSAGES/messages.po
@@ -1,18 +1,18 @@
+
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-03-29 10:01+0200\n"
+"POT-Creation-Date: 2022-03-30 08:43+0200\n"
 "PO-Revision-Date: 2022-03-30 09:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
-"Language-Team: Greek <https://hosted.weblate.org/projects/hedy/web-texts/el/"
-">\n"
 "Language: el\n"
+"Language-Team: Greek <https://hosted.weblate.org/projects/hedy/web-"
+"texts/el/>\n"
+"Plural-Forms: nplurals=2; plural=n != 1\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.12-dev\n"
 "Generated-By: Babel 2.9.1\n"
 
 #: app.py:571
@@ -20,25 +20,25 @@ msgstr ""
 msgid "program_contains_error"
 msgstr "This program contains an error, are you sure you want to share it?"
 
-#: app.py:723
+#: app.py:722
 #, fuzzy
 msgid "title_achievements"
 msgstr "Hedy - My achievements"
 
-#: app.py:740 app.py:1111 website/teacher.py:365 website/teacher.py:374
+#: app.py:739 app.py:1110 website/teacher.py:365 website/teacher.py:374
 msgid "not_teacher"
 msgstr "Φαίνεται πως δεν είσαι καθηγητής!"
 
-#: app.py:743
+#: app.py:742
 msgid "not_enrolled"
 msgstr "Φαίνεται πως δεν είστε σ' αυτήν την τάξη!"
 
-#: app.py:775
+#: app.py:774
 #, fuzzy
 msgid "title_programs"
 msgstr "Hedy - My programs"
 
-#: app.py:785 app.py:795 app.py:799 app.py:813 app.py:1054 app.py:1357
+#: app.py:784 app.py:794 app.py:798 app.py:812 app.py:1053 app.py:1356
 #: website/admin.py:17 website/admin.py:25 website/admin.py:95
 #: website/admin.py:112 website/admin.py:130 website/auth.py:711
 #: website/auth.py:738 website/statistics.py:86
@@ -46,115 +46,115 @@ msgstr "Hedy - My programs"
 msgid "unauthorized"
 msgstr "You don't have access rights for this page"
 
-#: app.py:823
+#: app.py:822
 msgid "minutes"
 msgstr "λεπτά"
 
-#: app.py:826
+#: app.py:825
 msgid "hours"
 msgstr "ώρες"
 
-#: app.py:829
+#: app.py:828
 msgid "days"
 msgstr "ημέρες"
 
-#: app.py:832
+#: app.py:831
 #, fuzzy
 msgid "ago"
 msgstr "{time} ago"
 
-#: app.py:848 app.py:850 app.py:976
+#: app.py:847 app.py:849 app.py:975
 msgid "no_such_level"
 msgstr "Δεν υπάρχει τέτοιο επίπεδο Hedy!"
 
-#: app.py:858 app.py:865 app.py:931 app.py:937
+#: app.py:857 app.py:864 app.py:930 app.py:936
 msgid "no_such_program"
 msgstr "Δεν υπάρχει τέτοιο πρόγραμμα Hedy!"
 
-#: app.py:891
+#: app.py:890
 msgid "level_not_translated"
 msgstr "Αυτό το επίπεδο δεν είναι μεταφρασμένο στη γλώσσα σου (ακόμα)"
 
-#: app.py:893
+#: app.py:892
 msgid "level_not_class"
 msgstr "Είσαι σε μια τάξη στην οποία δεν είναι ακόμα διαθέσιμο αυτό το επίπεδο"
 
-#: app.py:986 website/teacher.py:432 website/teacher.py:448
+#: app.py:985 website/teacher.py:432 website/teacher.py:448
 #: website/teacher.py:477 website/teacher.py:503
 msgid "no_such_adventure"
 msgstr "Αυτή η περιπέτεια δεν υπάρχει!"
 
-#: app.py:1005
+#: app.py:1004
 msgid "page_not_found"
 msgstr "Δεν μπορούμε να βρούμε αυτήν τη σελίδα!"
 
-#: app.py:1025
+#: app.py:1024
 #, fuzzy
 msgid "title_signup"
 msgstr "Hedy - Create an account"
 
-#: app.py:1032
+#: app.py:1031
 #, fuzzy
 msgid "title_login"
 msgstr "Hedy - Login"
 
-#: app.py:1039
+#: app.py:1038
 #, fuzzy
 msgid "title_recover"
 msgstr "Hedy - Recover account"
 
-#: app.py:1055
+#: app.py:1054
 #, fuzzy
 msgid "title_reset"
 msgstr "Hedy - Reset password"
 
-#: app.py:1064
+#: app.py:1063
 #, fuzzy
 msgid "title_my-profile"
 msgstr "Hedy - My account"
 
-#: app.py:1078
+#: app.py:1077
 #, fuzzy
 msgid "title_learn-more"
 msgstr "Hedy - Learn more"
 
-#: app.py:1083
+#: app.py:1082
 #, fuzzy
 msgid "title_privacy"
 msgstr "Hedy - Privacy terms"
 
-#: app.py:1090
+#: app.py:1089
 #, fuzzy
 msgid "title_landing-page"
 msgstr "Welcome to Hedy!"
 
-#: app.py:1092
+#: app.py:1091
 msgid "not_user"
 msgstr "Φαίνεται ότι δεν είστε συνδεδεμένοι!"
 
-#: app.py:1107
+#: app.py:1106
 #, fuzzy
 msgid "title_for-teacher"
 msgstr "Hedy - For teachers"
 
-#: app.py:1118
+#: app.py:1117
 #, fuzzy
 msgid "title_start"
 msgstr "Hedy - A gradual programming language"
 
-#: app.py:1171
+#: app.py:1170
 #, fuzzy
 msgid "title_explore"
 msgstr "Hedy - Explore"
 
-#: app.py:1190 app.py:1192
+#: app.py:1189 app.py:1191
 msgid "translate_error"
 msgstr ""
-"Κάτι πήγε στραβά κατά τη μετάφραση του κώδικα. Δοκίμασε να εκτελέσεις τον "
-"κώδικα για να δεις αν έχει κάποιο σφάλμα. Ο κώδικας με σφάλματα δεν μπορεί "
-"να μεταφραστεί."
+"Κάτι πήγε στραβά κατά τη μετάφραση του κώδικα. Δοκίμασε να εκτελέσεις τον"
+" κώδικα για να δεις αν έχει κάποιο σφάλμα. Ο κώδικας με σφάλματα δεν "
+"μπορεί να μεταφραστεί."
 
-#: app.py:1301 website/auth.py:299 website/auth.py:347 website/auth.py:483
+#: app.py:1300 website/auth.py:299 website/auth.py:347 website/auth.py:483
 #: website/auth.py:509 website/auth.py:539 website/auth.py:645
 #: website/auth.py:677 website/auth.py:717 website/auth.py:744
 #: website/teacher.py:90 website/teacher.py:125 website/teacher.py:197
@@ -163,31 +163,31 @@ msgstr ""
 msgid "ajax_error"
 msgstr "Παρουσιάστηκε κάποιο σφάλμα, παρακαλώ ξαναπροσπάθησε."
 
-#: app.py:1304
+#: app.py:1303
 msgid "image_invalid"
 msgstr "Η εικόνα σου δεν είναι έγκυρη"
 
-#: app.py:1306
+#: app.py:1305
 msgid "personal_text_invalid"
 msgstr "Το προσωπικό σου κείμενο δεν είναι έγκυρο"
 
-#: app.py:1308 app.py:1314
+#: app.py:1307 app.py:1313
 msgid "favourite_program_invalid"
 msgstr "Το αγαπημένο σου πρόγραμμα δεν είναι έγκυρο"
 
-#: app.py:1326 app.py:1327
+#: app.py:1325 app.py:1326
 msgid "public_profile_updated"
 msgstr "Το δημόσιο προφίλ έχει ενημερωθεί."
 
-#: app.py:1361 app.py:1385
+#: app.py:1360 app.py:1384
 msgid "user_not_private"
 msgstr "Αυτός ο χρήστης δεν υπάρχει ή δεν έχει δημόσιο προφίλ"
 
-#: app.py:1394
+#: app.py:1393
 msgid "invalid_teacher_invitation_code"
 msgstr ""
-"Ο κωδικός πρόσκλησης καθηγητή δεν είναι έγκυρος. Για να γίνετε καθηγητής, "
-"απευθυνθείτε στο hedy@felienne.com."
+"Ο κωδικός πρόσκλησης καθηγητή δεν είναι έγκυρος. Για να γίνετε καθηγητής,"
+" απευθυνθείτε στο hedy@felienne.com."
 
 #: utils.py:203
 msgid "default_404"
@@ -204,8 +204,8 @@ msgstr "Κάτι πήγε λάθος..."
 #: coursedata/error-messages.txt:1
 msgid "Empty Program"
 msgstr ""
-"Δημιούργησες ένα κενό πρόγραμμα. Πληκτρολόγησε τον κώδικα Hedy στο αριστερό "
-"πεδίο και δοκίμασε ξανά"
+"Δημιούργησες ένα κενό πρόγραμμα. Πληκτρολόγησε τον κώδικα Hedy στο "
+"αριστερό πεδίο και δοκίμασε ξανά"
 
 #: coursedata/error-messages.txt:2
 msgid "Wrong Level"
@@ -234,80 +234,80 @@ msgstr ""
 #: coursedata/error-messages.txt:6
 msgid "Has Blanks"
 msgstr ""
-"Ο κώδικάς σου δεν είναι πλήρης. Περιέχει κενά που πρέπει να αντικαταστήσεις "
-"με κώδικα."
+"Ο κώδικάς σου δεν είναι πλήρης. Περιέχει κενά που πρέπει να "
+"αντικαταστήσεις με κώδικα."
 
 #: coursedata/error-messages.txt:7
 msgid "No Indentation"
 msgstr ""
 "Χρησιμοποίησες πολύ λίγα κενά στη γραμμή {line_number}. Χρησιμοποίησες "
-"{leading_spaces} κενά, τα οποία δεν είναι αρκετά. Ξεκίνα κάθε νέο μπλοκ με "
-"{indent_size} κενά περισσότερα από την προηγούμενη γραμμή."
+"{leading_spaces} κενά, τα οποία δεν είναι αρκετά. Ξεκίνα κάθε νέο μπλοκ "
+"με {indent_size} κενά περισσότερα από την προηγούμενη γραμμή."
 
 #: coursedata/error-messages.txt:8
 msgid "Unexpected Indentation"
 msgstr ""
 "Χρησιμοποίησες πάρα πολλά κενά στη γραμμή {line_number}. Χρησιμοποίησες "
-"{leading_spaces} κενά, τα οποία είναι πάρα πολλά. Ξεκίνα κάθε νέο μπλοκ με "
-"{indent_size} κενά περισσότερα από την προηγούμενη γραμμή ."
+"{leading_spaces} κενά, τα οποία είναι πάρα πολλά. Ξεκίνα κάθε νέο μπλοκ "
+"με {indent_size} κενά περισσότερα από την προηγούμενη γραμμή ."
 
 #: coursedata/error-messages.txt:9
 msgid "Parse"
 msgstr ""
-"Ο κώδικας που εισήγαγες δεν είναι έγκυρος κώδικας Hedy. Υπάρχει ένα σφάλμα "
-"στη γραμμή {location[0]}, στη θέση {location[1]}. Πληκτρολόγησες "
+"Ο κώδικας που εισήγαγες δεν είναι έγκυρος κώδικας Hedy. Υπάρχει ένα "
+"σφάλμα στη γραμμή {location[0]}, στη θέση {location[1]}. Πληκτρολόγησες "
 "{character_found}, όμως αυτό δεν επιτρέπεται."
 
 #: coursedata/error-messages.txt:10
 msgid "Unquoted Text"
 msgstr ""
-"Πρόσεξε. Όταν ζητάς ή εμφανίζεις κάτι, το κείμενο θα πρέπει να ξεκινάει και "
-"να τελειώνει με εισαγωγικά. Κάπου ξέχασες ένα."
+"Πρόσεξε. Όταν ζητάς ή εμφανίζεις κάτι, το κείμενο θα πρέπει να ξεκινάει "
+"και να τελειώνει με εισαγωγικά. Κάπου ξέχασες ένα."
 
 #: coursedata/error-messages.txt:11
 msgid "Unquoted Assignment"
 msgstr ""
-"Από αυτό το επίπεδο, πρέπει να τοποθετήσεις κείμενα στα δεξιά του `is` μέσα "
-"σε εισαγωγικά. Το ξέχασες για το κείμενο {text}."
+"Από αυτό το επίπεδο, πρέπει να τοποθετήσεις κείμενα στα δεξιά του `is` "
+"μέσα σε εισαγωγικά. Το ξέχασες για το κείμενο {text}."
 
 #: coursedata/error-messages.txt:12
 msgid "Unquoted Equality Check"
 msgstr ""
-"Εάν θέλεις να ελέγξεις εάν μια μεταβλητή ισούται με πολλές λέξεις, οι λέξεις "
-"θα πρέπει να περιβάλλονται από εισαγωγικά!"
+"Εάν θέλεις να ελέγξεις εάν μια μεταβλητή ισούται με πολλές λέξεις, οι "
+"λέξεις θα πρέπει να περιβάλλονται από εισαγωγικά!"
 
 #: coursedata/error-messages.txt:13
 msgid "Var Undefined"
 msgstr ""
-"Προσπάθησες να εμφανίσεις τη μεταβλητή {name}, όμως δεν την αρχικοποίησες. "
-"Είναι επίσης πιθανό ότι προσπαθούσες να χρησιμοποιήσεις τη λέξη {name} αλλά "
-"ξέχασες τα εισαγωγικά."
+"Προσπάθησες να εμφανίσεις τη μεταβλητή {name}, όμως δεν την "
+"αρχικοποίησες. Είναι επίσης πιθανό ότι προσπαθούσες να χρησιμοποιήσεις τη"
+" λέξη {name} αλλά ξέχασες τα εισαγωγικά."
 
 #: coursedata/error-messages.txt:14
 msgid "Cyclic Var Definition"
 msgstr ""
-"Το όνομα {variable} πρέπει να οριστεί για να μπορέσεις να το χρησιμοποιήσεις "
-"στη δεξιά πλευρά της εντολής is"
+"Το όνομα {variable} πρέπει να οριστεί για να μπορέσεις να το "
+"χρησιμοποιήσεις στη δεξιά πλευρά της εντολής is"
 
 #: coursedata/error-messages.txt:15
 msgid "Lonely Echo"
 msgstr ""
-"Χρησιμοποίησες μια echo πριν από μια ask, ή μια echo χωρίς ask. Πρώτα ζήτησε "
-"εισαγωγή και μετά echo."
+"Χρησιμοποίησες μια echo πριν από μια ask, ή μια echo χωρίς ask. Πρώτα "
+"ζήτησε εισαγωγή και μετά echo."
 
 #: coursedata/error-messages.txt:16
 msgid "Too Big"
 msgstr ""
-"Ουάου! Το πρόγραμμά σου έχει {lines_of_code} εντυπωσιακές γραμμές κώδικα! "
-"Αλλά μπορούμε να επεξεργαστούμε μόνο {max_lines} γραμμές σε αυτό το επίπεδο. "
-"Μείωσε το πρόγραμμά σου και δοκίμασε ξανά."
+"Ουάου! Το πρόγραμμά σου έχει {lines_of_code} εντυπωσιακές γραμμές κώδικα!"
+" Αλλά μπορούμε να επεξεργαστούμε μόνο {max_lines} γραμμές σε αυτό το "
+"επίπεδο. Μείωσε το πρόγραμμά σου και δοκίμασε ξανά."
 
 #: coursedata/error-messages.txt:17
 msgid "Invalid Argument Type"
 msgstr ""
-"Δεν μπορείς να χρησιμοποιήσεις την εντολή {command} με το {invalid_argument} "
-"επειδή είναι {invalid_type}. Δοκίμασε να αλλάξεις το {invalid_argument} σε "
-"{allowed_types}."
+"Δεν μπορείς να χρησιμοποιήσεις την εντολή {command} με το "
+"{invalid_argument} επειδή είναι {invalid_type}. Δοκίμασε να αλλάξεις το "
+"{invalid_argument} σε {allowed_types}."
 
 #: coursedata/error-messages.txt:18
 msgid "Invalid Argument"
@@ -320,9 +320,10 @@ msgstr ""
 msgid "Invalid Type Combination"
 msgstr ""
 "Δεν μπορείς να χρησιμοποιήσεις τα {invalid_argument} και "
-"{invalid_argument_2} στο {operation} επειδή το ένα είναι {invalid_type} και "
-"το άλλο είναι {invalid_type_2}. Δοκίμασε να αλλάξεις το {invalid_argument} "
-"σε {invalid_type_2} ή το {invalid_argument_2} σε {invalid_type}."
+"{invalid_argument_2} στο {operation} επειδή το ένα είναι {invalid_type} "
+"και το άλλο είναι {invalid_type_2}. Δοκίμασε να αλλάξεις το "
+"{invalid_argument} σε {invalid_type_2} ή το {invalid_argument_2} σε "
+"{invalid_type}."
 
 #: coursedata/error-messages.txt:20
 msgid "Unsupported Float"
@@ -333,26 +334,27 @@ msgstr ""
 #: coursedata/error-messages.txt:21
 msgid "Locked Language Feature"
 msgstr ""
-"Χρησιμοποιείς το {concept}! Αυτό είναι φοβερό, αλλά το {concept} δεν έχει "
-"ξεκλειδωθεί ακόμα! Θα ξεκλειδωθεί σε μεταγενέστερο επίπεδο."
+"Χρησιμοποιείς το {concept}! Αυτό είναι φοβερό, αλλά το {concept} δεν έχει"
+" ξεκλειδωθεί ακόμα! Θα ξεκλειδωθεί σε μεταγενέστερο επίπεδο."
 
 #: coursedata/error-messages.txt:22
 msgid "Missing Command"
 msgstr ""
-"Φαίνεται ότι ξέχασες να χρησιμοποιήσεις μια εντολή στη γραμμή {line_number}."
+"Φαίνεται ότι ξέχασες να χρησιμοποιήσεις μια εντολή στη γραμμή "
+"{line_number}."
 
 #: coursedata/error-messages.txt:23
 msgid "ask_needs_var"
 msgstr ""
-"Ξεκινώντας από το επίπεδο 2, το ask πρέπει να χρησιμοποιείται με μεταβλητή. "
-"Παράδειγμα: name is ask Πώς σε λένε;"
+"Ξεκινώντας από το επίπεδο 2, το ask πρέπει να χρησιμοποιείται με "
+"μεταβλητή. Παράδειγμα: name is ask Πώς σε λένε;"
 
 #: coursedata/error-messages.txt:24
 msgid "echo_out"
 msgstr ""
-"Ξεκινώντας το επίπεδο 2, η echo δεν χρειάζεται πλέον. Μπορείς να επαναλάβεις "
-"μια απάντηση με την ask και την print τώρα. Παράδειγμα: name is ask Πώς σε "
-"λένε; print γεια name"
+"Ξεκινώντας το επίπεδο 2, η echo δεν χρειάζεται πλέον. Μπορείς να "
+"επαναλάβεις μια απάντηση με την ask και την print τώρα. Παράδειγμα: name "
+"is ask Πώς σε λένε; print γεια name"
 
 #: coursedata/error-messages.txt:25
 msgid "space"
@@ -429,6 +431,11 @@ msgstr "μια λίστα"
 #: coursedata/error-messages.txt:43
 msgid "input"
 msgstr "είσοδος από την ask"
+
+#: templates/achievements.html:4
+#, fuzzy
+msgid "achievements_title"
+msgstr "επιτεύγματα"
 
 #: templates/class-overview.html:16
 msgid "visible_columns"
@@ -578,13 +585,13 @@ msgstr ""
 msgid "join_class"
 msgstr "Συμμετοχή σε τάξη"
 
-#: templates/class-stats.html:22 templates/customize-class.html:155
+#: templates/class-stats.html:22 templates/customize-class.html:150
 msgid "back_to_class"
 msgstr "Επιστροφή στην τάξη"
 
 #: templates/code-page.html:25 templates/code-page.html:34
-#: templates/customize-class.html:28 templates/customize-class.html:64
-#: templates/customize-class.html:71 templates/customize-class.html:94
+#: templates/customize-class.html:23 templates/customize-class.html:59
+#: templates/customize-class.html:66 templates/customize-class.html:89
 #: templates/incl-adventure-tabs.html:5 templates/level-page.html:6
 #: templates/level-page.html:11 templates/quiz/startquiz.html:10
 #: templates/view-program-page.html:12 templates/view-program-page.html:28
@@ -599,22 +606,23 @@ msgstr "Create multiple accounts"
 #: templates/create-accounts.html:7
 msgid "accounts_intro"
 msgstr ""
-"Σε αυτή τη σελίδα μπορείς να δημιουργήσεις λογαριασμούς για πολλούς μαθητές "
-"ταυτόχρονα. Είναι επίσης δυνατό να τους προσθέσεις απευθείας σε μία από τις "
-"τάξεις σου.\n"
-"Πατώντας το πράσινο + κάτω δεξιά στη σελίδα μπορείς να προσθέσεις επιπλέον "
-"σειρές. Μπορείς να διαγράψεις μια σειρά πατώντας τον αντίστοιχο κόκκινο "
-"σταυρό.\n"
-"Βεβαιώσου ότι δεν υπάρχουν κενές σειρές όταν πατάς \"Δημιουργία λογαριασμών"
-"\". Λάβε υπόψη ότι κάθε όνομα χρήστη και διεύθυνση mail πρέπει να είναι "
-"μοναδικά και το συνθηματικό πρέπει να έχει <b>τουλάχιστον</b> 6 χαρακτήρες.\n"
+"Σε αυτή τη σελίδα μπορείς να δημιουργήσεις λογαριασμούς για πολλούς "
+"μαθητές ταυτόχρονα. Είναι επίσης δυνατό να τους προσθέσεις απευθείας σε "
+"μία από τις τάξεις σου.\n"
+"Πατώντας το πράσινο + κάτω δεξιά στη σελίδα μπορείς να προσθέσεις "
+"επιπλέον σειρές. Μπορείς να διαγράψεις μια σειρά πατώντας τον αντίστοιχο "
+"κόκκινο σταυρό.\n"
+"Βεβαιώσου ότι δεν υπάρχουν κενές σειρές όταν πατάς \"Δημιουργία "
+"λογαριασμών\". Λάβε υπόψη ότι κάθε όνομα χρήστη και διεύθυνση mail πρέπει"
+" να είναι μοναδικά και το συνθηματικό πρέπει να έχει <b>τουλάχιστον</b> 6"
+" χαρακτήρες.\n"
 
 #: templates/create-accounts.html:10
 msgid "create_accounts_prompt"
 msgstr "Είσαι σίγουρος ότι θέλεις να δημιουργήσεις αυτούς τους λογαριασμούς;"
 
-#: templates/create-accounts.html:17 templates/learn-more.html:10
-#: templates/profile.html:96 templates/recover.html:8 templates/signup.html:13
+#: templates/create-accounts.html:17 templates/profile.html:96
+#: templates/recover.html:8 templates/signup.html:13
 msgid "email"
 msgstr "Email"
 
@@ -663,26 +671,26 @@ msgstr "Επίπεδο"
 msgid "adventure_exp_1"
 msgstr ""
 "Πληκτρολόγησε την περιπέτεια της επιλογής σου στη δεξιά πλευρά. Αφού "
-"δημιουργήσεις την περιπέτειά σου, μπορείς να τη συμπεριλάβεις σε μία από τις "
-"τάξεις σου στην ενότητα \"προσαρμογές\". Αν θέλεις να συμπεριλάβεις μια "
-"εντολή στην περιπέτειά σου, χρησιμοποίησε άγκυρες κώδικα όπως αυτή:"
+"δημιουργήσεις την περιπέτειά σου, μπορείς να τη συμπεριλάβεις σε μία από "
+"τις τάξεις σου στην ενότητα \"προσαρμογές\". Αν θέλεις να συμπεριλάβεις "
+"μια εντολή στην περιπέτειά σου, χρησιμοποίησε άγκυρες κώδικα όπως αυτή:"
 
 #: templates/customize-adventure.html:31
 msgid "adventure_exp_2"
 msgstr ""
-"Εάν θέλεις να εμφανίσεις πραγματικά αποσπάσματα κώδικα, για παράδειγμα για "
-"να δώσεις στον μαθητή ένα πρότυπο ή παράδειγμα του κώδικα. Χρησιμοποίησε "
-"προηγούμενες άγκυρες όπως αυτή:"
+"Εάν θέλεις να εμφανίσεις πραγματικά αποσπάσματα κώδικα, για παράδειγμα "
+"για να δώσεις στον μαθητή ένα πρότυπο ή παράδειγμα του κώδικα. "
+"Χρησιμοποίησε προηγούμενες άγκυρες όπως αυτή:"
 
 #: templates/customize-adventure.html:39
 msgid "adventure_exp_3"
 msgstr ""
 "Μπορείς να χρησιμοποιήσεις το κουμπί \"προεπισκόπηση\" για να δεις μια "
-"στυλιζαρισμένη έκδοση της περιπέτειάς σου. Για να δεις την περιπέτεια σε μια "
-"ειδική σελίδα, επίλεξε \"προβολή\" από τη σελίδα καθηγητών."
+"στυλιζαρισμένη έκδοση της περιπέτειάς σου. Για να δεις την περιπέτεια σε "
+"μια ειδική σελίδα, επίλεξε \"προβολή\" από τη σελίδα καθηγητών."
 
-#: templates/customize-adventure.html:43 templates/customize-class.html:28
-#: templates/customize-class.html:93 templates/explore.html:26
+#: templates/customize-adventure.html:43 templates/customize-class.html:23
+#: templates/customize-class.html:88 templates/explore.html:26
 #: templates/programs.html:18 templates/programs.html:48
 #: templates/view-adventure.html:6
 msgid "adventure"
@@ -695,7 +703,8 @@ msgstr ""
 "\n"
 "Με αυτόν τον τρόπο μπορώ να δείξω μια εντολή: <code>print</code>\n"
 "\n"
-"Αλλά μερικές φορές μπορεί να θέλω να δείξω ένα κομμάτι κώδικα, όπως αυτό:\n"
+"Αλλά μερικές φορές μπορεί να θέλω να δείξω ένα κομμάτι κώδικα, όπως αυτό:"
+"\n"
 "<pre>\n"
 "ask Ποιο έιναι το όνομά σου;\n"
 "echo άρα το όνομά σου είναι\n"
@@ -703,14 +712,13 @@ msgstr ""
 
 #: templates/customize-adventure.html:47
 msgid "adventure_terms"
-msgstr ""
-"Συμφωνώ ότι η περιπέτειά μου μπορεί να γίνει δημόσια διαθέσιμη στο Hedy."
+msgstr "Συμφωνώ ότι η περιπέτειά μου μπορεί να γίνει δημόσια διαθέσιμη στο Hedy."
 
 #: templates/customize-adventure.html:50
 msgid "preview"
 msgstr "Προεπισκόπηση"
 
-#: templates/customize-adventure.html:51 templates/customize-class.html:150
+#: templates/customize-adventure.html:51 templates/customize-class.html:145
 msgid "save"
 msgstr "Αποθήκευση"
 
@@ -718,129 +726,66 @@ msgstr "Αποθήκευση"
 msgid "delete_adventure_prompt"
 msgstr "Είσαι σίγουρος ότι θέλεις να διαγράψεις την περιπέτεια;"
 
-#: templates/customize-class.html:7
-#, fuzzy
-msgid "customize_class_exp_1"
-msgstr ""
-"Γεια! Σε αυτή τη σελίδα μπορείς να προσαρμόσεις την τάξη σου. Επιλέγοντας "
-"επίπεδα και περιπέτειες μπορείς να επιλέξεις τι μπορεί να δουν οι μαθητές "
-"και οι μαθήτριές σου.\n"
-"Μπορείς επίσης να προσθέσεις τις περιπέτειες που δημιούργησες στα επίπεδα. "
-"<b>Σημείωση:</b> Δεν είναι όλες οι περιπέτειες διαθέσιμες για κάθε επίπεδο!\n"
-"Οι ρυθμίσεις των προσαρμογών σου γίνονται ως εξής:"
-
-#: templates/customize-class.html:10
-msgid "customize_class_step_1"
-msgstr "Επίλεξε επίπεδα για την τάξη σου πατώντας το \"κουμπιά επιπέδων\""
-
-#: templates/customize-class.html:11
-msgid "customize_class_step_2"
-msgstr ""
-"Θα εμφανιστούν \"Πλαίσια ελέγχου\" για τις περιπέτειες που είναι διαθέσιμες "
-"για τα επιλεγμένα επίπεδα"
-
-#: templates/customize-class.html:12
-msgid "customize_class_step_3"
-msgstr "Επίλεξε τις περιπέπτειες που θέλεις να κάνεις διαθέσιμες"
-
-#: templates/customize-class.html:13
-msgid "customize_class_step_4"
-msgstr ""
-"Κάνε κλικ στο όνομα μιας περιπέτειας για να την (απ)επιλέξεις για όλα τα "
-"επίπεδα"
-
-#: templates/customize-class.html:14
-msgid "customize_class_step_5"
-msgstr "Προσθήκη προσωπικών περιπετειών"
-
-#: templates/customize-class.html:15
-msgid "customize_class_step_6"
-msgstr ""
-"Επιλογή ημερομηνίας έναρξης για κάθε επίπεδο (μπορείς επίσης να το αφήσεις "
-"κενό)"
-
-#: templates/customize-class.html:16
-msgid "customize_class_step_7"
-msgstr "Επιλογή άλλων ρυθμίσεων"
-
-#: templates/customize-class.html:17
-msgid "customize_class_step_8"
-msgstr "Επίλεξε \"Αποθήκευση\" -> Ολοκλήρωσες!"
-
-#: templates/customize-class.html:20
-#, fuzzy
-msgid "customize_class_exp_2"
-msgstr ""
-"Μπορείς πάντα να αλλάξεις αυτές τις ρυθμίσεις αργότερα. Για παράδειγμα, "
-"μπορείς να κάνεις διαθέσιμες συγκεκριμένες περιπέτειες ή επίπεδα κατά τη "
-"διδασκαλία μιας τάξης.\n"
-"Με αυτόν τον τρόπο σου είναι εύκολο για να προσδιορίσεις σε ποιο επίπεδο και "
-"σε ποιες περιπέτειες θα εργαστούν οι μαθητές σου.\n"
-"Εάν θέλεις να κάνεις τα πάντα διαθέσιμα για την τάξη σου, είναι πιο εύκολο "
-"να καταργήσεις την προσαρμογή συνολικά."
-
-#: templates/customize-class.html:23
+#: templates/customize-class.html:18
 msgid "select_adventures"
 msgstr "Επίλεξε περιπέτειες"
 
-#: templates/customize-class.html:59
+#: templates/customize-class.html:54
 msgid "opening_dates"
 msgstr "Ημερομηνίες έναρξης λειτουργίας"
 
-#: templates/customize-class.html:65
+#: templates/customize-class.html:60
 msgid "opening_date"
 msgstr "Ημερομηνία έναρξης λειτουργίας"
 
-#: templates/customize-class.html:77
+#: templates/customize-class.html:72
 msgid "directly_available"
 msgstr "Άμεσα ανοιχτό"
 
-#: templates/customize-class.html:88
+#: templates/customize-class.html:83
 msgid "select_own_adventures"
 msgstr "Επίλεξε τις δικές σου περιπέτειες"
 
-#: templates/customize-class.html:95 templates/customize-class.html:121
+#: templates/customize-class.html:90 templates/customize-class.html:116
 #: templates/profile.html:47 templates/profile.html:128
 #: templates/profile.html:137 templates/signup.html:26 templates/signup.html:45
 #: templates/signup.html:53
 msgid "select"
 msgstr "Επίλεξε"
 
-#: templates/customize-class.html:115
+#: templates/customize-class.html:110
 msgid "other_settings"
 msgstr "Άλλες ρυθμίσεις"
 
-#: templates/customize-class.html:120
+#: templates/customize-class.html:115
 msgid "option"
 msgstr "Επιλογή"
 
-#: templates/customize-class.html:126
+#: templates/customize-class.html:121
 msgid "mandatory_mode"
 msgstr "Υποχρεωτική λειτουργία προγραμματιστή"
 
-#: templates/customize-class.html:132
+#: templates/customize-class.html:127
 msgid "hide_cheatsheet"
 msgstr "Απόκρυψη των σημειώσεων"
 
-#: templates/customize-class.html:138
+#: templates/customize-class.html:133
 msgid "hide_keyword_switcher"
 msgstr ""
 
-#: templates/customize-class.html:149
+#: templates/customize-class.html:144
 msgid "reset_adventure_prompt"
-msgstr ""
-"Είσαι βέβαιος ότι θέλεις να επαναφέρεις όλες τις επιλεγμένες περιπέτειες;"
+msgstr "Είσαι βέβαιος ότι θέλεις να επαναφέρεις όλες τις επιλεγμένες περιπέτειες;"
 
-#: templates/customize-class.html:149
+#: templates/customize-class.html:144
 msgid "reset_adventures"
 msgstr "Επανάφερε επιλεγμένες περιπέτειες"
 
-#: templates/customize-class.html:153
+#: templates/customize-class.html:148
 msgid "remove_customizations_prompt"
-msgstr ""
-"Είσαι βέβαιος ότι θέλεις να καταργήσεις τις προσαρμογές αυτής της τάξης;"
+msgstr "Είσαι βέβαιος ότι θέλεις να καταργήσεις τις προσαρμογές αυτής της τάξης;"
 
-#: templates/customize-class.html:154
+#: templates/customize-class.html:149
 msgid "remove_customization"
 msgstr "Κατάργηση προσαρμογής"
 
@@ -856,15 +801,15 @@ msgstr "Εξερεύνηση προγραμμάτων"
 msgid "explore_explanation"
 msgstr ""
 "Σε αυτή τη σελίδα μπορείς να δεις προγράμματα που έχουν δημιουργηθεί από "
-"άλλους χρήστες του Hedy. Μπορείς να φιλτράρεις σύμφωνα με επίπεδο Hedy όσο "
-"και με επίπεδο περιπέτειας.\n"
+"άλλους χρήστες του Hedy. Μπορείς να φιλτράρεις σύμφωνα με επίπεδο Hedy "
+"όσο και με επίπεδο περιπέτειας.\n"
 "Κάνε κλικ στο \"Προβολή προγράμματος\" για να ανοίξεις ένα πρόγραμμα και "
-"εκτέλεσέ το. Τα προγράμματα με κόκκινη κεφαλίδα περιέχουν ένα λάθος. Μπορείς "
-"ακόμα να ανοίξεις το πρόγραμμα, αλλά η εκτέλεσή του θα οδηγήσει σε σφάλμα. "
-"Μπορείς φυσικά να προσπαθήσεις να το διορθώσεις!\n"
+"εκτέλεσέ το. Τα προγράμματα με κόκκινη κεφαλίδα περιέχουν ένα λάθος. "
+"Μπορείς ακόμα να ανοίξεις το πρόγραμμα, αλλά η εκτέλεσή του θα οδηγήσει "
+"σε σφάλμα. Μπορείς φυσικά να προσπαθήσεις να το διορθώσεις!\n"
 "Εάν ο δημιουργός έχει δημόσιο προφίλ, μπορείς να κάνεις κλικ στο όνομα "
-"χρήστη του για να επισκεφτείς το προφίλ του. Εκεί θα βρεις όλα τα κοινά τους "
-"προγράμματα και πολλά άλλα!\n"
+"χρήστη του για να επισκεφτείς το προφίλ του. Εκεί θα βρεις όλα τα κοινά "
+"τους προγράμματα και πολλά άλλα!\n"
 
 #: templates/explore.html:35 templates/programs.html:27
 #, fuzzy
@@ -920,7 +865,8 @@ msgstr "Δημιουργία λογαριασμών μαθητών"
 msgid "teacher_welcome"
 msgstr ""
 "Καλώς ήρθες στη Hedy! Είσαι πλέον περήφανος κάτοχος ενός λογαριασμού "
-"καθηγητή που σου επιτρέπει να δημιουργείς μαθήματα και να προσκαλείς μαθητές."
+"καθηγητή που σου επιτρέπει να δημιουργείς μαθήματα και να προσκαλείς "
+"μαθητές."
 
 #: templates/incl-adventure-tabs.html:22
 #, fuzzy
@@ -1025,8 +971,8 @@ msgid "intro_text_landing_page"
 msgstr ""
 "Καλώς ήρθες στον υπέροχο κόσμο της Hedy! Εδώ μπορείς να μάθεις να "
 "προγραμματίζεις με μικρά βήματα, χωρίς περιττά περίπλοκα πράγματα.\n"
-"Ξεκινάμε εύκολα στο επίπεδο 1, και σιγά-σιγά χτίζουμε προς μεγαλύτερα και "
-"πιο πολύπλοκα προγράμματα!\n"
+"Ξεκινάμε εύκολα στο επίπεδο 1, και σιγά-σιγά χτίζουμε προς μεγαλύτερα και"
+" πιο πολύπλοκα προγράμματα!\n"
 "\n"
 "Διάλεξε μία από τις παρακάτω επιλογές για να ξεκινήσεις."
 
@@ -1042,8 +988,8 @@ msgstr "Ξεκίνα τον προγραμματισμό"
 #: templates/landing-page.html:21
 msgid "create_class_text"
 msgstr ""
-"Ομαδοποίησε τους μαθητές σου σε τάξεις και άλλαξε το περιεχόμενο για κάθε "
-"τάξη"
+"Ομαδοποίησε τους μαθητές σου σε τάξεις και άλλαξε το περιεχόμενο για κάθε"
+" τάξη"
 
 #: templates/landing-page.html:28
 msgid "read_docs_text"
@@ -1087,43 +1033,13 @@ msgstr "Αντίγραψε τον σύνδεσμο για κοινή χρήση"
 #: templates/layout.html:78
 msgid "set_preferred_lang"
 msgstr ""
-"Το Hedy υποστηρίζει πλέον προτιμώμενες γλώσσες χρήστη. Μπορείς να ορίσεις "
-"μια για το προφίλ σου στο \"Το προφίλ μου\""
+"Το Hedy υποστηρίζει πλέον προτιμώμενες γλώσσες χρήστη. Μπορείς να ορίσεις"
+" μια για το προφίλ σου στο \"Το προφίλ μου\""
 
 #: templates/layout.html:86 templates/quiz/endquiz.html:18
 #: templates/quiz/quiz.html:29
 msgid "achievement_earned"
 msgstr "Κέρδισες ένα επίτευγμα!"
-
-#: templates/learn-more.html:7
-msgid "mailing_title"
-msgstr "Εγγραφή για Hedy newsletter"
-
-#: templates/learn-more.html:14
-msgid "surname"
-msgstr "Μικρό Όνομα"
-
-#: templates/learn-more.html:18
-msgid "lastname"
-msgstr "Επίθετο"
-
-#: templates/learn-more.html:22 templates/profile.html:135
-#: templates/signup.html:52
-msgid "country"
-msgstr "Χώρα"
-
-#: templates/learn-more.html:31
-msgid "subscribe"
-msgstr "Εγγραφή"
-
-#: templates/learn-more.html:32
-msgid "required_field"
-msgstr "Τα πεδία με * απαιτείται να συμπληρωθούν"
-
-#: templates/learn-more.html:35
-#, fuzzy
-msgid "previous_campaigns"
-msgstr "View previous campaigns"
 
 #: templates/level-page.html:8
 msgid "step_title"
@@ -1156,18 +1072,6 @@ msgstr "Δημιουργία λογαριασμού"
 #: templates/login.html:33
 msgid "forgot_password"
 msgstr "Ξέχασες το συνθηματικό σου;"
-
-#: templates/main-page.html:9
-msgid "main_title"
-msgstr "Hedy"
-
-#: templates/main-page.html:10
-msgid "main_subtitle"
-msgstr "Μια βαθμιαία γλώσσα προγραμματισμού"
-
-#: templates/main-page.html:13
-msgid "try_it"
-msgstr "Δοκίμασέ τη"
 
 #: templates/profile.html:4
 msgid "account_overview"
@@ -1220,8 +1124,8 @@ msgstr "Αγαπημένο πρόγραμμα"
 #: templates/profile.html:56
 msgid "public_profile_info"
 msgstr ""
-"Επιλέγοντας αυτό το πλαίσιο κάνω το προφίλ μου ορατό σε όλους. Πρόσεξε να "
-"μην κοινοποιείς προσωπικές πληροφορίες όπως το όνομα ή τη διεύθυνση του "
+"Επιλέγοντας αυτό το πλαίσιο κάνω το προφίλ μου ορατό σε όλους. Πρόσεξε να"
+" μην κοινοποιείς προσωπικές πληροφορίες όπως το όνομα ή τη διεύθυνση του "
 "σπιτιού σου, γιατί θα μπορούν να τα δουν όλοι!"
 
 #: templates/profile.html:59
@@ -1280,6 +1184,10 @@ msgstr "Άνδρας"
 msgid "other"
 msgstr "Άλλο"
 
+#: templates/profile.html:135 templates/signup.html:52
+msgid "country"
+msgstr "Χώρα"
+
 #: templates/profile.html:141
 msgid "update_profile"
 msgstr "Ενημέρωση προφίλ"
@@ -1319,7 +1227,8 @@ msgstr "Τελευταία επεξεργασία"
 #: templates/programs.html:59
 msgid "favourite_confirm"
 msgstr ""
-"Είσαι βέβαιος/α ότι θέλεις να ορίσεις αυτό το πρόγραμμα ως το αγαπημένο σου;"
+"Είσαι βέβαιος/α ότι θέλεις να ορίσεις αυτό το πρόγραμμα ως το αγαπημένο "
+"σου;"
 
 #: templates/programs.html:67 templates/programs.html:72
 msgid "open"
@@ -1466,8 +1375,8 @@ msgstr "Έχεις ήδη λογαριασμό;"
 #: templates/teacher-invitation.html:5
 msgid "teacher_invitation_require_login"
 msgstr ""
-"Για να ρυθμίσεις το προφίλ σου ως καθηγητής, θα χρειαστεί να συνδεθείς. Εάν "
-"δεν έχεις λογαριασμό, δημιούργησε έναν."
+"Για να ρυθμίσεις το προφίλ σου ως καθηγητής, θα χρειαστεί να συνδεθείς. "
+"Εάν δεν έχεις λογαριασμό, δημιούργησε έναν."
 
 #: templates/view-program-page.html:13
 #, fuzzy
@@ -1611,8 +1520,8 @@ msgstr "Πρέπει να συμφωνήσεις με το απόρρητο κα
 #: website/auth.py:366 website/auth.py:546
 msgid "keyword_language_invalid"
 msgstr ""
-"Επίλεξε μια έγκυρη γλώσσα λέξεων-κλειδιών (επιλέξτε Αγγλικά ή τη δική σας "
-"γλώσσα)"
+"Επίλεξε μια έγκυρη γλώσσα λέξεων-κλειδιών (επιλέξτε Αγγλικά ή τη δική σας"
+" γλώσσα)"
 
 #: website/auth.py:371 website/auth.py:551
 msgid "year_invalid"
@@ -1681,8 +1590,8 @@ msgstr "Το διακριτικό σου δεν είναι έγκυρο"
 #: website/auth.py:703
 msgid "password_resetted"
 msgstr ""
-"Έγινε επιτυχής επαναφορά του συνθηματικού σου. Θα ανακατευθυνθείς στη σελίδα "
-"σύνδεσης."
+"Έγινε επιτυχής επαναφορά του συνθηματικού σου. Θα ανακατευθυνθείς στη "
+"σελίδα σύνδεσης."
 
 #: website/auth.py:721
 msgid "teacher_invalid"
@@ -1885,3 +1794,94 @@ msgstr "Δεν έδωσες όνομα περιπέτειας!"
 
 #~ msgid "ago-2"
 #~ msgstr "πριν"
+
+#~ msgid "customize_class_exp_1"
+#~ msgstr ""
+#~ "Γεια! Σε αυτή τη σελίδα μπορείς να"
+#~ " προσαρμόσεις την τάξη σου. Επιλέγοντας "
+#~ "επίπεδα και περιπέτειες μπορείς να "
+#~ "επιλέξεις τι μπορεί να δουν οι "
+#~ "μαθητές και οι μαθήτριές σου.\n"
+#~ "Μπορείς επίσης να προσθέσεις τις "
+#~ "περιπέτειες που δημιούργησες στα επίπεδα. "
+#~ "<b>Σημείωση:</b> Δεν είναι όλες οι "
+#~ "περιπέτειες διαθέσιμες για κάθε επίπεδο!\n"
+#~ ""
+#~ "Οι ρυθμίσεις των προσαρμογών σου γίνονται ως εξής:"
+
+#~ msgid "customize_class_step_1"
+#~ msgstr "Επίλεξε επίπεδα για την τάξη σου πατώντας το \"κουμπιά επιπέδων\""
+
+#~ msgid "customize_class_step_2"
+#~ msgstr ""
+#~ "Θα εμφανιστούν \"Πλαίσια ελέγχου\" για "
+#~ "τις περιπέτειες που είναι διαθέσιμες για"
+#~ " τα επιλεγμένα επίπεδα"
+
+#~ msgid "customize_class_step_3"
+#~ msgstr "Επίλεξε τις περιπέπτειες που θέλεις να κάνεις διαθέσιμες"
+
+#~ msgid "customize_class_step_4"
+#~ msgstr ""
+#~ "Κάνε κλικ στο όνομα μιας περιπέτειας "
+#~ "για να την (απ)επιλέξεις για όλα "
+#~ "τα επίπεδα"
+
+#~ msgid "customize_class_step_5"
+#~ msgstr "Προσθήκη προσωπικών περιπετειών"
+
+#~ msgid "customize_class_step_6"
+#~ msgstr ""
+#~ "Επιλογή ημερομηνίας έναρξης για κάθε "
+#~ "επίπεδο (μπορείς επίσης να το αφήσεις"
+#~ " κενό)"
+
+#~ msgid "customize_class_step_7"
+#~ msgstr "Επιλογή άλλων ρυθμίσεων"
+
+#~ msgid "customize_class_step_8"
+#~ msgstr "Επίλεξε \"Αποθήκευση\" -> Ολοκλήρωσες!"
+
+#~ msgid "customize_class_exp_2"
+#~ msgstr ""
+#~ "Μπορείς πάντα να αλλάξεις αυτές τις "
+#~ "ρυθμίσεις αργότερα. Για παράδειγμα, μπορείς"
+#~ " να κάνεις διαθέσιμες συγκεκριμένες "
+#~ "περιπέτειες ή επίπεδα κατά τη διδασκαλία"
+#~ " μιας τάξης.\n"
+#~ "Με αυτόν τον τρόπο σου είναι "
+#~ "εύκολο για να προσδιορίσεις σε ποιο "
+#~ "επίπεδο και σε ποιες περιπέτειες θα "
+#~ "εργαστούν οι μαθητές σου.\n"
+#~ "Εάν θέλεις να κάνεις τα πάντα "
+#~ "διαθέσιμα για την τάξη σου, είναι "
+#~ "πιο εύκολο να καταργήσεις την προσαρμογή"
+#~ " συνολικά."
+
+#~ msgid "mailing_title"
+#~ msgstr "Εγγραφή για Hedy newsletter"
+
+#~ msgid "surname"
+#~ msgstr "Μικρό Όνομα"
+
+#~ msgid "lastname"
+#~ msgstr "Επίθετο"
+
+#~ msgid "subscribe"
+#~ msgstr "Εγγραφή"
+
+#~ msgid "required_field"
+#~ msgstr "Τα πεδία με * απαιτείται να συμπληρωθούν"
+
+#~ msgid "previous_campaigns"
+#~ msgstr "View previous campaigns"
+
+#~ msgid "main_title"
+#~ msgstr "Hedy"
+
+#~ msgid "main_subtitle"
+#~ msgstr "Μια βαθμιαία γλώσσα προγραμματισμού"
+
+#~ msgid "try_it"
+#~ msgstr "Δοκίμασέ τη"
+

--- a/translations/en/LC_MESSAGES/messages.po
+++ b/translations/en/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-03-29 10:01+0200\n"
+"POT-Creation-Date: 2022-03-30 08:43+0200\n"
 "PO-Revision-Date: 2022-02-25 13:01+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: en\n"
@@ -22,125 +22,125 @@ msgstr ""
 msgid "program_contains_error"
 msgstr "This program contains an error, are you sure you want to share it?"
 
-#: app.py:723
+#: app.py:722
 msgid "title_achievements"
 msgstr "Hedy - My achievements"
 
-#: app.py:740 app.py:1111 website/teacher.py:365 website/teacher.py:374
+#: app.py:739 app.py:1110 website/teacher.py:365 website/teacher.py:374
 msgid "not_teacher"
 msgstr "Looks like you are not a teacher!"
 
-#: app.py:743
+#: app.py:742
 msgid "not_enrolled"
 msgstr "Looks like you are not in this class!"
 
-#: app.py:775
+#: app.py:774
 msgid "title_programs"
 msgstr "Hedy - My programs"
 
-#: app.py:785 app.py:795 app.py:799 app.py:813 app.py:1054 app.py:1357
+#: app.py:784 app.py:794 app.py:798 app.py:812 app.py:1053 app.py:1356
 #: website/admin.py:17 website/admin.py:25 website/admin.py:95
 #: website/admin.py:112 website/admin.py:130 website/auth.py:711
 #: website/auth.py:738 website/statistics.py:86
 msgid "unauthorized"
 msgstr "You don't have access rights for this page"
 
-#: app.py:823
+#: app.py:822
 msgid "minutes"
 msgstr "minutes"
 
-#: app.py:826
+#: app.py:825
 msgid "hours"
 msgstr "hours"
 
-#: app.py:829
+#: app.py:828
 msgid "days"
 msgstr "days"
 
-#: app.py:832
+#: app.py:831
 msgid "ago"
 msgstr "{time} ago"
 
-#: app.py:848 app.py:850 app.py:976
+#: app.py:847 app.py:849 app.py:975
 msgid "no_such_level"
 msgstr "No such Hedy level!"
 
-#: app.py:858 app.py:865 app.py:931 app.py:937
+#: app.py:857 app.py:864 app.py:930 app.py:936
 msgid "no_such_program"
 msgstr "No such Hedy program!"
 
-#: app.py:891
+#: app.py:890
 msgid "level_not_translated"
 msgstr "This level is not translated in your language (yet)"
 
-#: app.py:893
+#: app.py:892
 msgid "level_not_class"
 msgstr "You're in a class where this level has not been made available yet"
 
-#: app.py:986 website/teacher.py:432 website/teacher.py:448
+#: app.py:985 website/teacher.py:432 website/teacher.py:448
 #: website/teacher.py:477 website/teacher.py:503
 msgid "no_such_adventure"
 msgstr "This adventure doesn't exist!"
 
-#: app.py:1005
+#: app.py:1004
 msgid "page_not_found"
 msgstr "We could not find that page!"
 
-#: app.py:1025
+#: app.py:1024
 msgid "title_signup"
 msgstr "Hedy - Create an account"
 
-#: app.py:1032
+#: app.py:1031
 msgid "title_login"
 msgstr "Hedy - Login"
 
-#: app.py:1039
+#: app.py:1038
 msgid "title_recover"
 msgstr "Hedy - Recover account"
 
-#: app.py:1055
+#: app.py:1054
 msgid "title_reset"
 msgstr "Hedy - Reset password"
 
-#: app.py:1064
+#: app.py:1063
 msgid "title_my-profile"
 msgstr "Hedy - My account"
 
-#: app.py:1078
+#: app.py:1077
 msgid "title_learn-more"
 msgstr "Hedy - Learn more"
 
-#: app.py:1083
+#: app.py:1082
 msgid "title_privacy"
 msgstr "Hedy - Privacy terms"
 
-#: app.py:1090
+#: app.py:1089
 msgid "title_landing-page"
 msgstr "Welcome to Hedy!"
 
-#: app.py:1092
+#: app.py:1091
 msgid "not_user"
 msgstr "Looks like you are not logged in!"
 
-#: app.py:1107
+#: app.py:1106
 msgid "title_for-teacher"
 msgstr "Hedy - For teachers"
 
-#: app.py:1118
+#: app.py:1117
 msgid "title_start"
 msgstr "Hedy - A gradual programming language"
 
-#: app.py:1171
+#: app.py:1170
 msgid "title_explore"
 msgstr "Hedy - Explore"
 
-#: app.py:1190 app.py:1192
+#: app.py:1189 app.py:1191
 msgid "translate_error"
 msgstr ""
 "Something went wrong while translating the code. Try running the code to "
 "see if it has an error. Code with errors can not be translated."
 
-#: app.py:1301 website/auth.py:299 website/auth.py:347 website/auth.py:483
+#: app.py:1300 website/auth.py:299 website/auth.py:347 website/auth.py:483
 #: website/auth.py:509 website/auth.py:539 website/auth.py:645
 #: website/auth.py:677 website/auth.py:717 website/auth.py:744
 #: website/teacher.py:90 website/teacher.py:125 website/teacher.py:197
@@ -149,27 +149,27 @@ msgstr ""
 msgid "ajax_error"
 msgstr "There was an error, please try again."
 
-#: app.py:1304
+#: app.py:1303
 msgid "image_invalid"
 msgstr "Your chosen image is invalid."
 
-#: app.py:1306
+#: app.py:1305
 msgid "personal_text_invalid"
 msgstr "Your personal text is invalid."
 
-#: app.py:1308 app.py:1314
+#: app.py:1307 app.py:1313
 msgid "favourite_program_invalid"
 msgstr "Your chosen favourite program is invalid."
 
-#: app.py:1326 app.py:1327
+#: app.py:1325 app.py:1326
 msgid "public_profile_updated"
 msgstr "Public profile updated."
 
-#: app.py:1361 app.py:1385
+#: app.py:1360 app.py:1384
 msgid "user_not_private"
 msgstr "This user doesn't exist or doesn't have a public profile"
 
-#: app.py:1394
+#: app.py:1393
 msgid "invalid_teacher_invitation_code"
 msgstr ""
 "The teacher invitation code is invalid. To become a teacher, reach out to"
@@ -327,15 +327,15 @@ msgstr "It looks like you forgot to use a command on line {line_number}."
 #: coursedata/error-messages.txt:23
 msgid "ask_needs_var"
 msgstr ""
-"Starting in level 2, ask needs to be used with a variable. "
-"Example: name is ask What are you called?"
+"Starting in level 2, ask needs to be used with a variable. Example: name "
+"is ask What are you called?"
 
 #: coursedata/error-messages.txt:24
 msgid "echo_out"
 msgstr ""
 "Starting in level 2 echo is no longer needed. You can repeat an answer "
-"with ask and print now. Example: name is ask What are you called? print"
-"hello name"
+"with ask and print now. Example: name is ask What are you called? "
+"printhello name"
 
 #: coursedata/error-messages.txt:25
 msgid "space"
@@ -412,6 +412,10 @@ msgstr "a list"
 #: coursedata/error-messages.txt:43
 msgid "input"
 msgstr "input from ask"
+
+#: templates/achievements.html:4
+msgid "achievements_title"
+msgstr "Hedy Achievements"
 
 #: templates/class-overview.html:16
 msgid "visible_columns"
@@ -557,13 +561,13 @@ msgstr "You need to have an account to join a class. Would you like to login now
 msgid "join_class"
 msgstr "Join class"
 
-#: templates/class-stats.html:22 templates/customize-class.html:155
+#: templates/class-stats.html:22 templates/customize-class.html:150
 msgid "back_to_class"
 msgstr "Go back to class"
 
 #: templates/code-page.html:25 templates/code-page.html:34
-#: templates/customize-class.html:28 templates/customize-class.html:64
-#: templates/customize-class.html:71 templates/customize-class.html:94
+#: templates/customize-class.html:23 templates/customize-class.html:59
+#: templates/customize-class.html:66 templates/customize-class.html:89
 #: templates/incl-adventure-tabs.html:5 templates/level-page.html:6
 #: templates/level-page.html:11 templates/quiz/startquiz.html:10
 #: templates/view-program-page.html:12 templates/view-program-page.html:28
@@ -589,8 +593,8 @@ msgstr ""
 msgid "create_accounts_prompt"
 msgstr "Are you sure you want to create these accounts?"
 
-#: templates/create-accounts.html:17 templates/learn-more.html:10
-#: templates/profile.html:96 templates/recover.html:8 templates/signup.html:13
+#: templates/create-accounts.html:17 templates/profile.html:96
+#: templates/recover.html:8 templates/signup.html:13
 msgid "email"
 msgstr "Email"
 
@@ -656,8 +660,8 @@ msgstr ""
 "adventure. To view the adventure on a dedicated page, select \"view\" "
 "from the teachers page."
 
-#: templates/customize-adventure.html:43 templates/customize-class.html:28
-#: templates/customize-class.html:93 templates/explore.html:26
+#: templates/customize-adventure.html:43 templates/customize-class.html:23
+#: templates/customize-class.html:88 templates/explore.html:26
 #: templates/programs.html:18 templates/programs.html:48
 #: templates/view-adventure.html:6
 msgid "adventure"
@@ -684,7 +688,7 @@ msgstr "I agree that my adventure might be made publicly available on Hedy."
 msgid "preview"
 msgstr "Preview"
 
-#: templates/customize-adventure.html:51 templates/customize-class.html:150
+#: templates/customize-adventure.html:51 templates/customize-class.html:145
 msgid "save"
 msgstr "Save"
 
@@ -692,116 +696,66 @@ msgstr "Save"
 msgid "delete_adventure_prompt"
 msgstr "Are you sure you want to remove this adventure?"
 
-#: templates/customize-class.html:7
-msgid "customize_class_exp_1"
-msgstr ""
-"Hi! On this page you can customize your class. By selecting levels and "
-"adventures you can choose what you student can see. You can also add you "
-"own created adventures to levels. All levels and default adventures will "
-"be selected by default. <b>Notice:</b> Not every adventure is available "
-"for every level! Settings up your customizations goes as follows:"
-
-#: templates/customize-class.html:10
-msgid "customize_class_step_1"
-msgstr "Select levels for your class by pressing the \"level buttons\""
-
-#: templates/customize-class.html:11
-msgid "customize_class_step_2"
-msgstr "\"Checkboxes\" will appear for the adventures available for the chosen levels"
-
-#: templates/customize-class.html:12
-msgid "customize_class_step_3"
-msgstr "Select the adventures you want to make available"
-
-#: templates/customize-class.html:13
-msgid "customize_class_step_4"
-msgstr "Click the name of an adventure to (de)select for all levels"
-
-#: templates/customize-class.html:14
-msgid "customize_class_step_5"
-msgstr "Add personal adventures"
-
-#: templates/customize-class.html:15
-msgid "customize_class_step_6"
-msgstr "Selecting an opening date for each level (you can also leave it empty)"
-
-#: templates/customize-class.html:16
-msgid "customize_class_step_7"
-msgstr "Selection other settings"
-
-#: templates/customize-class.html:17
-msgid "customize_class_step_8"
-msgstr "Choose \"Save\" -> You're done!"
-
-#: templates/customize-class.html:20
-msgid "customize_class_exp_2"
-msgstr ""
-"You can always change these settings later on. For example, you can make "
-"specific adventures or levels available while teaching a class. This way "
-"it's easy for you to determine which level and adventures your students "
-"will be working on. If you want to make everything available for your "
-"class it is easiest to remove the customization all together."
-
-#: templates/customize-class.html:23
+#: templates/customize-class.html:18
 msgid "select_adventures"
 msgstr "Select adventures"
 
-#: templates/customize-class.html:59
+#: templates/customize-class.html:54
 msgid "opening_dates"
 msgstr "Opening dates"
 
-#: templates/customize-class.html:65
+#: templates/customize-class.html:60
 msgid "opening_date"
 msgstr "Opening date"
 
-#: templates/customize-class.html:77
+#: templates/customize-class.html:72
 msgid "directly_available"
 msgstr "Directly open"
 
-#: templates/customize-class.html:88
+#: templates/customize-class.html:83
 msgid "select_own_adventures"
 msgstr "Select own adventures"
 
-#: templates/customize-class.html:95 templates/customize-class.html:121
+#: templates/customize-class.html:90 templates/customize-class.html:116
 #: templates/profile.html:47 templates/profile.html:128
 #: templates/profile.html:137 templates/signup.html:26 templates/signup.html:45
 #: templates/signup.html:53
 msgid "select"
 msgstr "Select"
 
-#: templates/customize-class.html:115
+#: templates/customize-class.html:110
 msgid "other_settings"
 msgstr "Other settings"
 
-#: templates/customize-class.html:120
+#: templates/customize-class.html:115
 msgid "option"
 msgstr "Option"
 
-#: templates/customize-class.html:126
+#: templates/customize-class.html:121
 msgid "mandatory_mode"
 msgstr "Mandatory developer's mode"
 
-#: templates/customize-class.html:132
+#: templates/customize-class.html:127
 msgid "hide_cheatsheet"
 msgstr "Hide cheatsheet"
 
-#: templates/customize-class.html:138
+#: templates/customize-class.html:133
 msgid "hide_keyword_switcher"
 msgstr ""
 
-#: templates/customize-class.html:149
+#: templates/customize-class.html:144
 msgid "reset_adventure_prompt"
 msgstr "Are you sure you want to reset all selected adventures?"
 
-#: templates/customize-class.html:149
+#: templates/customize-class.html:144
 msgid "reset_adventures"
 msgstr "Reset selected adventures"
 
-#: templates/customize-class.html:153
+#: templates/customize-class.html:148
 msgid "remove_customizations_prompt"
 msgstr "Are you sure you want to remove this class their customizations?"
 
-#: templates/customize-class.html:154
+#: templates/customize-class.html:149
 msgid "remove_customization"
 msgstr "Remove customization"
 
@@ -1047,35 +1001,6 @@ msgstr ""
 msgid "achievement_earned"
 msgstr "You've earned an achievement!"
 
-#: templates/learn-more.html:7
-msgid "mailing_title"
-msgstr "Subscribe to the Hedy newsletter"
-
-#: templates/learn-more.html:14
-msgid "surname"
-msgstr "First Name"
-
-#: templates/learn-more.html:18
-msgid "lastname"
-msgstr "Last Name"
-
-#: templates/learn-more.html:22 templates/profile.html:135
-#: templates/signup.html:52
-msgid "country"
-msgstr "Country"
-
-#: templates/learn-more.html:31
-msgid "subscribe"
-msgstr "Subscribe"
-
-#: templates/learn-more.html:32
-msgid "required_field"
-msgstr "Fields marked with an * are required"
-
-#: templates/learn-more.html:35
-msgid "previous_campaigns"
-msgstr "View previous campaigns"
-
 #: templates/level-page.html:8
 msgid "step_title"
 msgstr "Assignment"
@@ -1107,19 +1032,6 @@ msgstr "Create account"
 #: templates/login.html:33
 msgid "forgot_password"
 msgstr "Forgot your password?"
-
-#: templates/main-page.html:9
-msgid "main_title"
-msgstr "Hedy"
-
-#: templates/main-page.html:10
-msgid "main_subtitle"
-msgstr "A gradual programming language"
-
-#: templates/main-page.html:13
-#, fuzzy
-msgid "try_it"
-msgstr "Try it"
 
 #: templates/profile.html:4
 msgid "account_overview"
@@ -1231,6 +1143,10 @@ msgstr "Male"
 #: templates/profile.html:131 templates/signup.html:48
 msgid "other"
 msgstr "Other"
+
+#: templates/profile.html:135 templates/signup.html:52
+msgid "country"
+msgstr "Country"
 
 #: templates/profile.html:141
 msgid "update_profile"
@@ -1814,4 +1730,85 @@ msgstr "You didn't enter an adventure name!"
 
 #~ msgid "required"
 #~ msgstr ""
+
+#~ msgid "customize_class_exp_1"
+#~ msgstr ""
+#~ "Hi! On this page you can customize"
+#~ " your class. By selecting levels and"
+#~ " adventures you can choose what you"
+#~ " student can see. You can also "
+#~ "add you own created adventures to "
+#~ "levels. All levels and default "
+#~ "adventures will be selected by default."
+#~ " <b>Notice:</b> Not every adventure is "
+#~ "available for every level! Settings up"
+#~ " your customizations goes as follows:"
+
+#~ msgid "customize_class_step_1"
+#~ msgstr "Select levels for your class by pressing the \"level buttons\""
+
+#~ msgid "customize_class_step_2"
+#~ msgstr ""
+#~ "\"Checkboxes\" will appear for the "
+#~ "adventures available for the chosen "
+#~ "levels"
+
+#~ msgid "customize_class_step_3"
+#~ msgstr "Select the adventures you want to make available"
+
+#~ msgid "customize_class_step_4"
+#~ msgstr "Click the name of an adventure to (de)select for all levels"
+
+#~ msgid "customize_class_step_5"
+#~ msgstr "Add personal adventures"
+
+#~ msgid "customize_class_step_6"
+#~ msgstr "Selecting an opening date for each level (you can also leave it empty)"
+
+#~ msgid "customize_class_step_7"
+#~ msgstr "Selection other settings"
+
+#~ msgid "customize_class_step_8"
+#~ msgstr "Choose \"Save\" -> You're done!"
+
+#~ msgid "customize_class_exp_2"
+#~ msgstr ""
+#~ "You can always change these settings "
+#~ "later on. For example, you can "
+#~ "make specific adventures or levels "
+#~ "available while teaching a class. This"
+#~ " way it's easy for you to "
+#~ "determine which level and adventures "
+#~ "your students will be working on. "
+#~ "If you want to make everything "
+#~ "available for your class it is "
+#~ "easiest to remove the customization all"
+#~ " together."
+
+#~ msgid "mailing_title"
+#~ msgstr "Subscribe to the Hedy newsletter"
+
+#~ msgid "surname"
+#~ msgstr "First Name"
+
+#~ msgid "lastname"
+#~ msgstr "Last Name"
+
+#~ msgid "subscribe"
+#~ msgstr "Subscribe"
+
+#~ msgid "required_field"
+#~ msgstr "Fields marked with an * are required"
+
+#~ msgid "previous_campaigns"
+#~ msgstr "View previous campaigns"
+
+#~ msgid "main_title"
+#~ msgstr "Hedy"
+
+#~ msgid "main_subtitle"
+#~ msgstr "A gradual programming language"
+
+#~ msgid "try_it"
+#~ msgstr "Try it"
 

--- a/translations/es/LC_MESSAGES/messages.po
+++ b/translations/es/LC_MESSAGES/messages.po
@@ -1,18 +1,18 @@
+
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-03-29 10:01+0200\n"
+"POT-Creation-Date: 2022-03-30 08:43+0200\n"
 "PO-Revision-Date: 2022-03-30 09:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
-"Language-Team: Spanish <https://hosted.weblate.org/projects/hedy/web-texts/"
-"es/>\n"
 "Language: es\n"
+"Language-Team: Spanish <https://hosted.weblate.org/projects/hedy/web-"
+"texts/es/>\n"
+"Plural-Forms: nplurals=2; plural=n != 1\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.12-dev\n"
 "Generated-By: Babel 2.9.1\n"
 
 #: app.py:571
@@ -20,25 +20,25 @@ msgstr ""
 msgid "program_contains_error"
 msgstr "This program contains an error, are you sure you want to share it?"
 
-#: app.py:723
+#: app.py:722
 #, fuzzy
 msgid "title_achievements"
 msgstr "Hedy - My achievements"
 
-#: app.py:740 app.py:1111 website/teacher.py:365 website/teacher.py:374
+#: app.py:739 app.py:1110 website/teacher.py:365 website/teacher.py:374
 msgid "not_teacher"
 msgstr "Parece que no eres un instructor."
 
-#: app.py:743
+#: app.py:742
 msgid "not_enrolled"
 msgstr "No se encontró tu registro para esta clase"
 
-#: app.py:775
+#: app.py:774
 #, fuzzy
 msgid "title_programs"
 msgstr "Hedy - My programs"
 
-#: app.py:785 app.py:795 app.py:799 app.py:813 app.py:1054 app.py:1357
+#: app.py:784 app.py:794 app.py:798 app.py:812 app.py:1053 app.py:1356
 #: website/admin.py:17 website/admin.py:25 website/admin.py:95
 #: website/admin.py:112 website/admin.py:130 website/auth.py:711
 #: website/auth.py:738 website/statistics.py:86
@@ -46,118 +46,118 @@ msgstr "Hedy - My programs"
 msgid "unauthorized"
 msgstr "You don't have access rights for this page"
 
-#: app.py:823
+#: app.py:822
 msgid "minutes"
 msgstr "minutos"
 
-#: app.py:826
+#: app.py:825
 msgid "hours"
 msgstr "horas"
 
-#: app.py:829
+#: app.py:828
 msgid "days"
 msgstr "días"
 
-#: app.py:832
+#: app.py:831
 #, fuzzy
 msgid "ago"
 msgstr "{time} ago"
 
-#: app.py:848 app.py:850 app.py:976
+#: app.py:847 app.py:849 app.py:975
 msgid "no_such_level"
 msgstr "No se encontró ese nivel de Hedy"
 
-#: app.py:858 app.py:865 app.py:931 app.py:937
+#: app.py:857 app.py:864 app.py:930 app.py:936
 msgid "no_such_program"
 msgstr "No se encontró el programa de Hedy"
 
-#: app.py:891
+#: app.py:890
 #, fuzzy
 msgid "level_not_translated"
 msgstr "This level is not translated in your language (yet)"
 
-#: app.py:893
+#: app.py:892
 #, fuzzy
 msgid "level_not_class"
 msgstr "You're in a class where this level has not been made available yet"
 
-#: app.py:986 website/teacher.py:432 website/teacher.py:448
+#: app.py:985 website/teacher.py:432 website/teacher.py:448
 #: website/teacher.py:477 website/teacher.py:503
 #, fuzzy
 msgid "no_such_adventure"
 msgstr "This adventure doesn't exist!"
 
-#: app.py:1005
+#: app.py:1004
 msgid "page_not_found"
 msgstr "¡No pudimos encontrar esta página!"
 
-#: app.py:1025
+#: app.py:1024
 #, fuzzy
 msgid "title_signup"
 msgstr "Hedy - Create an account"
 
-#: app.py:1032
+#: app.py:1031
 #, fuzzy
 msgid "title_login"
 msgstr "Hedy - Login"
 
-#: app.py:1039
+#: app.py:1038
 #, fuzzy
 msgid "title_recover"
 msgstr "Hedy - Recover account"
 
-#: app.py:1055
+#: app.py:1054
 #, fuzzy
 msgid "title_reset"
 msgstr "Hedy - Reset password"
 
-#: app.py:1064
+#: app.py:1063
 #, fuzzy
 msgid "title_my-profile"
 msgstr "Hedy - My account"
 
-#: app.py:1078
+#: app.py:1077
 #, fuzzy
 msgid "title_learn-more"
 msgstr "Hedy - Learn more"
 
-#: app.py:1083
+#: app.py:1082
 #, fuzzy
 msgid "title_privacy"
 msgstr "Hedy - Privacy terms"
 
-#: app.py:1090
+#: app.py:1089
 #, fuzzy
 msgid "title_landing-page"
 msgstr "Welcome to Hedy!"
 
-#: app.py:1092
+#: app.py:1091
 msgid "not_user"
 msgstr "Parece que hay que registrarse o ingresar a tu cuenta"
 
-#: app.py:1107
+#: app.py:1106
 #, fuzzy
 msgid "title_for-teacher"
 msgstr "Hedy - For teachers"
 
-#: app.py:1118
+#: app.py:1117
 #, fuzzy
 msgid "title_start"
 msgstr "Hedy - A gradual programming language"
 
-#: app.py:1171
+#: app.py:1170
 #, fuzzy
 msgid "title_explore"
 msgstr "Hedy - Explore"
 
-#: app.py:1190 app.py:1192
+#: app.py:1189 app.py:1191
 #, fuzzy
 msgid "translate_error"
 msgstr ""
-"Something went wrong while translating the code. Try running the code to see "
-"if it has an error. Code with errors can not be translated."
+"Something went wrong while translating the code. Try running the code to "
+"see if it has an error. Code with errors can not be translated."
 
-#: app.py:1301 website/auth.py:299 website/auth.py:347 website/auth.py:483
+#: app.py:1300 website/auth.py:299 website/auth.py:347 website/auth.py:483
 #: website/auth.py:509 website/auth.py:539 website/auth.py:645
 #: website/auth.py:677 website/auth.py:717 website/auth.py:744
 #: website/teacher.py:90 website/teacher.py:125 website/teacher.py:197
@@ -166,36 +166,36 @@ msgstr ""
 msgid "ajax_error"
 msgstr "Hubo un error, por favor intenta nuevamente."
 
-#: app.py:1304
+#: app.py:1303
 #, fuzzy
 msgid "image_invalid"
 msgstr "Your chosen image is invalid."
 
-#: app.py:1306
+#: app.py:1305
 #, fuzzy
 msgid "personal_text_invalid"
 msgstr "Your personal text is invalid."
 
-#: app.py:1308 app.py:1314
+#: app.py:1307 app.py:1313
 #, fuzzy
 msgid "favourite_program_invalid"
 msgstr "Your chosen favourite program is invalid."
 
-#: app.py:1326 app.py:1327
+#: app.py:1325 app.py:1326
 #, fuzzy
 msgid "public_profile_updated"
 msgstr "Public profile updated."
 
-#: app.py:1361 app.py:1385
+#: app.py:1360 app.py:1384
 #, fuzzy
 msgid "user_not_private"
 msgstr "This user doesn't exist or doesn't have a public profile"
 
-#: app.py:1394
+#: app.py:1393
 msgid "invalid_teacher_invitation_code"
 msgstr ""
-"El código de instructor es inválido. Para ser instructor, por favor mande un "
-"mensaje a hedy@felienne.com."
+"El código de instructor es inválido. Para ser instructor, por favor mande"
+" un mensaje a hedy@felienne.com."
 
 #: utils.py:203
 msgid "default_404"
@@ -213,7 +213,8 @@ msgstr "Algo salió mal..."
 #, fuzzy
 msgid "Empty Program"
 msgstr ""
-"You created an empty program. Type Hedy code in the left field and try again"
+"You created an empty program. Type Hedy code in the left field and try "
+"again"
 
 #: coursedata/error-messages.txt:2
 msgid "Wrong Level"
@@ -225,8 +226,8 @@ msgstr ""
 #: coursedata/error-messages.txt:3
 msgid "Incomplete"
 msgstr ""
-"Oops! Has olvidado algo de código! En la línea {line_number}, debes agregar "
-"texto después de {incomplete_command}."
+"Oops! Has olvidado algo de código! En la línea {line_number}, debes "
+"agregar texto después de {incomplete_command}."
 
 #: coursedata/error-messages.txt:4
 msgid "Invalid"
@@ -237,31 +238,31 @@ msgstr ""
 #: coursedata/error-messages.txt:5
 msgid "Invalid Space"
 msgstr ""
-"Oops! Has comenzado una línea con un espacio en la línea {line_number}. Los "
-"espacios confunden a las computadoras, ¿podrías quitarlos?"
+"Oops! Has comenzado una línea con un espacio en la línea {line_number}. "
+"Los espacios confunden a las computadoras, ¿podrías quitarlos?"
 
 #: coursedata/error-messages.txt:6
 #, fuzzy
 msgid "Has Blanks"
 msgstr ""
-"Your code is incomplete. It contains blanks that you have to replace with "
-"code."
+"Your code is incomplete. It contains blanks that you have to replace with"
+" code."
 
 #: coursedata/error-messages.txt:7
 #, fuzzy
 msgid "No Indentation"
 msgstr ""
 "You used too few spaces in line {line_number}. You used {leading_spaces} "
-"spaces, which is not enough. Start every new block with {indent_size} spaces "
-"more than the line before."
+"spaces, which is not enough. Start every new block with {indent_size} "
+"spaces more than the line before."
 
 #: coursedata/error-messages.txt:8
 #, fuzzy
 msgid "Unexpected Indentation"
 msgstr ""
-"You used too many spaces in line {line_number}. You used {leading_spaces} "
-"spaces, which is too much. Start every new block with {indent_size} spaces "
-"more than the line before."
+"You used too many spaces in line {line_number}. You used {leading_spaces}"
+" spaces, which is too much. Start every new block with {indent_size} "
+"spaces more than the line before."
 
 #: coursedata/error-messages.txt:9
 msgid "Parse"
@@ -273,15 +274,15 @@ msgstr ""
 #: coursedata/error-messages.txt:10
 msgid "Unquoted Text"
 msgstr ""
-"Ten cuidado! Si imprimes algo, el texto debe estar rodeado de comillas. Has "
-"olvidado agregar una comilla en alguna parte."
+"Ten cuidado! Si imprimes algo, el texto debe estar rodeado de comillas. "
+"Has olvidado agregar una comilla en alguna parte."
 
 #: coursedata/error-messages.txt:11
 #, fuzzy
 msgid "Unquoted Assignment"
 msgstr ""
-"From this level, you need to place texts to the right of the `is` between "
-"quotes. You forgot that for the text {text}."
+"From this level, you need to place texts to the right of the `is` between"
+" quotes. You forgot that for the text {text}."
 
 #: coursedata/error-messages.txt:12
 #, fuzzy
@@ -298,8 +299,8 @@ msgstr "Intentaste imprimir {name}, pero no lo instanciaste."
 #, fuzzy
 msgid "Cyclic Var Definition"
 msgstr ""
-"The name {variable} needs to be set before you can use it on the right-hand "
-"side of the is command"
+"The name {variable} needs to be set before you can use it on the right-"
+"hand side of the is command"
 
 #: coursedata/error-messages.txt:15
 #, fuzzy
@@ -312,46 +313,46 @@ msgstr ""
 #, fuzzy
 msgid "Too Big"
 msgstr ""
-"Wow! Your program has an impressive {lines_of_code} lines of code! But we "
-"can only process {max_lines} lines in this level. Make your program smaller "
-"and try again."
+"Wow! Your program has an impressive {lines_of_code} lines of code! But we"
+" can only process {max_lines} lines in this level. Make your program "
+"smaller and try again."
 
 #: coursedata/error-messages.txt:17
 #, fuzzy
 msgid "Invalid Argument Type"
 msgstr ""
-"You cannot use the command {command} with {invalid_argument} because it is "
-"{invalid_type}. Try changing {invalid_argument} to {allowed_types}."
+"You cannot use the command {command} with {invalid_argument} because it "
+"is {invalid_type}. Try changing {invalid_argument} to {allowed_types}."
 
 #: coursedata/error-messages.txt:18
 #, fuzzy
 msgid "Invalid Argument"
 msgstr ""
-"You cannot use the command {command} with {invalid_argument} . Try changing "
-"{invalid_argument} to {allowed_types}."
+"You cannot use the command {command} with {invalid_argument} . Try "
+"changing {invalid_argument} to {allowed_types}."
 
 #: coursedata/error-messages.txt:19
 #, fuzzy
 msgid "Invalid Type Combination"
 msgstr ""
-"You cannot use {invalid_argument} and {invalid_argument_2} in {operation} "
-"because one is {invalid_type} and the other is {invalid_type_2}. Try "
-"changing {invalid_argument} to {invalid_type_2} or {invalid_argument_2} to "
-"{invalid_type}."
+"You cannot use {invalid_argument} and {invalid_argument_2} in {operation}"
+" because one is {invalid_type} and the other is {invalid_type_2}. Try "
+"changing {invalid_argument} to {invalid_type_2} or {invalid_argument_2} "
+"to {invalid_type}."
 
 #: coursedata/error-messages.txt:20
 #, fuzzy
 msgid "Unsupported Float"
 msgstr ""
-"Non-integer numbers are not supported yet but they will be in a few levels. "
-"For now change {value} to an integer."
+"Non-integer numbers are not supported yet but they will be in a few "
+"levels. For now change {value} to an integer."
 
 #: coursedata/error-messages.txt:21
 #, fuzzy
 msgid "Locked Language Feature"
 msgstr ""
-"You are using {concept}! That is awesome, but {concept} is not unlocked yet! "
-"It will be unlocked in a later level."
+"You are using {concept}! That is awesome, but {concept} is not unlocked "
+"yet! It will be unlocked in a later level."
 
 #: coursedata/error-messages.txt:22
 #, fuzzy
@@ -362,15 +363,16 @@ msgstr "It looks like you forgot to use a command on line {line_number}."
 #, fuzzy
 msgid "ask_needs_var"
 msgstr ""
-"Starting in level 2, ask needs to be used with a variable. Example: name is "
-"ask What are you called?"
+"Starting in level 2, ask needs to be used with a variable. Example: name "
+"is ask What are you called?"
 
 #: coursedata/error-messages.txt:24
 #, fuzzy
 msgid "echo_out"
 msgstr ""
-"Starting in level 2 echo is no longer needed. You can repeat an answer with "
-"ask and print now. Example: name is ask What are you called? print hello name"
+"Starting in level 2 echo is no longer needed. You can repeat an answer "
+"with ask and print now. Example: name is ask What are you called? print "
+"hello name"
 
 #: coursedata/error-messages.txt:25
 msgid "space"
@@ -455,6 +457,11 @@ msgstr "a list"
 #, fuzzy
 msgid "input"
 msgstr "input from ask"
+
+#: templates/achievements.html:4
+#, fuzzy
+msgid "achievements_title"
+msgstr "achievements"
 
 #: templates/class-overview.html:16
 #, fuzzy
@@ -614,20 +621,21 @@ msgstr "Deseas unirte a la clase?"
 #: templates/class-prejoin.html:17 website/teacher.py:183
 msgid "join_prompt"
 msgstr ""
-"Debes estar registrado para unirte a una clase. ¿Deseas entrar a tu cuenta?"
+"Debes estar registrado para unirte a una clase. ¿Deseas entrar a tu "
+"cuenta?"
 
 #: templates/class-prejoin.html:17 templates/profile.html:14
 msgid "join_class"
 msgstr "Unirse a la clase"
 
-#: templates/class-stats.html:22 templates/customize-class.html:155
+#: templates/class-stats.html:22 templates/customize-class.html:150
 #, fuzzy
 msgid "back_to_class"
 msgstr "Go back to class"
 
 #: templates/code-page.html:25 templates/code-page.html:34
-#: templates/customize-class.html:28 templates/customize-class.html:64
-#: templates/customize-class.html:71 templates/customize-class.html:94
+#: templates/customize-class.html:23 templates/customize-class.html:59
+#: templates/customize-class.html:66 templates/customize-class.html:89
 #: templates/incl-adventure-tabs.html:5 templates/level-page.html:6
 #: templates/level-page.html:11 templates/quiz/startquiz.html:10
 #: templates/view-program-page.html:12 templates/view-program-page.html:28
@@ -643,21 +651,21 @@ msgstr "Create multiple accounts"
 #, fuzzy
 msgid "accounts_intro"
 msgstr ""
-"On this page you can create accounts for multiple students at the same time. "
-"It is also possible to directly add them to one of your classes. By pressing "
-"the green + on the bottom right of the page you can add extra rows. You can "
-"delete a row by pressing the corresponding red cross. Make sure no rows are "
-"empty when you press \"Create accounts\". Please keep in mind that every "
-"username and mail address needs to be unique and the password needs to be "
-"<b>at least</b> 6 characters."
+"On this page you can create accounts for multiple students at the same "
+"time. It is also possible to directly add them to one of your classes. By"
+" pressing the green + on the bottom right of the page you can add extra "
+"rows. You can delete a row by pressing the corresponding red cross. Make "
+"sure no rows are empty when you press \"Create accounts\". Please keep in"
+" mind that every username and mail address needs to be unique and the "
+"password needs to be <b>at least</b> 6 characters."
 
 #: templates/create-accounts.html:10
 #, fuzzy
 msgid "create_accounts_prompt"
 msgstr "Are you sure you want to create these accounts?"
 
-#: templates/create-accounts.html:17 templates/learn-more.html:10
-#: templates/profile.html:96 templates/recover.html:8 templates/signup.html:13
+#: templates/create-accounts.html:17 templates/profile.html:96
+#: templates/recover.html:8 templates/signup.html:13
 msgid "email"
 msgstr "Correo electrónico"
 
@@ -712,10 +720,10 @@ msgstr "Nivel"
 #, fuzzy
 msgid "adventure_exp_1"
 msgstr ""
-"Type your adventure of choice on the right-hand side. After creating your "
-"adventure you can include it in one of your classes under \"customizations"
-"\". If you want to include a command in your adventure please use code "
-"anchors like this:"
+"Type your adventure of choice on the right-hand side. After creating your"
+" adventure you can include it in one of your classes under "
+"\"customizations\". If you want to include a command in your adventure "
+"please use code anchors like this:"
 
 #: templates/customize-adventure.html:31
 #, fuzzy
@@ -729,11 +737,11 @@ msgstr ""
 msgid "adventure_exp_3"
 msgstr ""
 "You can use the \"preview\" button to view a styled version of your "
-"adventure. To view the adventure on a dedicated page, select \"view\" from "
-"the teachers page."
+"adventure. To view the adventure on a dedicated page, select \"view\" "
+"from the teachers page."
 
-#: templates/customize-adventure.html:43 templates/customize-class.html:28
-#: templates/customize-class.html:93 templates/explore.html:26
+#: templates/customize-adventure.html:43 templates/customize-class.html:23
+#: templates/customize-class.html:88 templates/explore.html:26
 #: templates/programs.html:18 templates/programs.html:48
 #: templates/view-adventure.html:6
 msgid "adventure"
@@ -763,7 +771,7 @@ msgstr "I agree that my adventure might be made publicly available on Hedy."
 msgid "preview"
 msgstr "Preview"
 
-#: templates/customize-adventure.html:51 templates/customize-class.html:150
+#: templates/customize-adventure.html:51 templates/customize-class.html:145
 #, fuzzy
 msgid "save"
 msgstr "Save"
@@ -773,128 +781,78 @@ msgstr "Save"
 msgid "delete_adventure_prompt"
 msgstr "Are you sure you want to remove this adventure?"
 
-#: templates/customize-class.html:7
-#, fuzzy
-msgid "customize_class_exp_1"
-msgstr "Customize class"
-
-#: templates/customize-class.html:10
-#, fuzzy
-msgid "customize_class_step_1"
-msgstr "Customize class"
-
-#: templates/customize-class.html:11
-#, fuzzy
-msgid "customize_class_step_2"
-msgstr "Customize class"
-
-#: templates/customize-class.html:12
-#, fuzzy
-msgid "customize_class_step_3"
-msgstr "Customize class"
-
-#: templates/customize-class.html:13
-#, fuzzy
-msgid "customize_class_step_4"
-msgstr "Customize class"
-
-#: templates/customize-class.html:14
-#, fuzzy
-msgid "customize_class_step_5"
-msgstr "Customize class"
-
-#: templates/customize-class.html:15
-#, fuzzy
-msgid "customize_class_step_6"
-msgstr "Customize class"
-
-#: templates/customize-class.html:16
-#, fuzzy
-msgid "customize_class_step_7"
-msgstr "Customize class"
-
-#: templates/customize-class.html:17
-#, fuzzy
-msgid "customize_class_step_8"
-msgstr "Customize class"
-
-#: templates/customize-class.html:20
-#, fuzzy
-msgid "customize_class_exp_2"
-msgstr "Customize class"
-
-#: templates/customize-class.html:23
+#: templates/customize-class.html:18
 #, fuzzy
 msgid "select_adventures"
 msgstr "Select adventures"
 
-#: templates/customize-class.html:59
+#: templates/customize-class.html:54
 #, fuzzy
 msgid "opening_dates"
 msgstr "Opening dates"
 
-#: templates/customize-class.html:65
+#: templates/customize-class.html:60
 #, fuzzy
 msgid "opening_date"
 msgstr "Opening date"
 
-#: templates/customize-class.html:77
+#: templates/customize-class.html:72
 #, fuzzy
 msgid "directly_available"
 msgstr "Directly open"
 
-#: templates/customize-class.html:88
+#: templates/customize-class.html:83
 #, fuzzy
 msgid "select_own_adventures"
 msgstr "Select own adventures"
 
-#: templates/customize-class.html:95 templates/customize-class.html:121
+#: templates/customize-class.html:90 templates/customize-class.html:116
 #: templates/profile.html:47 templates/profile.html:128
 #: templates/profile.html:137 templates/signup.html:26 templates/signup.html:45
 #: templates/signup.html:53
 msgid "select"
 msgstr "Seleccionar"
 
-#: templates/customize-class.html:115
+#: templates/customize-class.html:110
 #, fuzzy
 msgid "other_settings"
 msgstr "Other settings"
 
-#: templates/customize-class.html:120
+#: templates/customize-class.html:115
 #, fuzzy
 msgid "option"
 msgstr "Option"
 
-#: templates/customize-class.html:126
+#: templates/customize-class.html:121
 #, fuzzy
 msgid "mandatory_mode"
 msgstr "Mandatory developer's mode"
 
-#: templates/customize-class.html:132
+#: templates/customize-class.html:127
 #, fuzzy
 msgid "hide_cheatsheet"
 msgstr "Hide cheatsheet"
 
-#: templates/customize-class.html:138
+#: templates/customize-class.html:133
 msgid "hide_keyword_switcher"
 msgstr ""
 
-#: templates/customize-class.html:149
+#: templates/customize-class.html:144
 #, fuzzy
 msgid "reset_adventure_prompt"
 msgstr "Are you sure you want to reset all selected adventures?"
 
-#: templates/customize-class.html:149
+#: templates/customize-class.html:144
 #, fuzzy
 msgid "reset_adventures"
 msgstr "Reset selected adventures"
 
-#: templates/customize-class.html:153
+#: templates/customize-class.html:148
 #, fuzzy
 msgid "remove_customizations_prompt"
 msgstr "Are you sure you want to remove this class their customizations?"
 
-#: templates/customize-class.html:154
+#: templates/customize-class.html:149
 #, fuzzy
 msgid "remove_customization"
 msgstr "Remove customization"
@@ -912,13 +870,13 @@ msgstr "Explore programs"
 #, fuzzy
 msgid "explore_explanation"
 msgstr ""
-"On this page you can look through programs created by other Hedy users. You "
-"can filter on both a Hedy level and adventure. Click on \"View program\" to "
-"open a program and run it. Programs with a red header contain a mistake. You "
-"can still open the program, but running it will result in an error. You can "
-"of course try to fix it! If the creator has a public profile you can click "
-"their username to visit their profile. There you will find all their shared "
-"programs and much more!"
+"On this page you can look through programs created by other Hedy users. "
+"You can filter on both a Hedy level and adventure. Click on \"View "
+"program\" to open a program and run it. Programs with a red header "
+"contain a mistake. You can still open the program, but running it will "
+"result in an error. You can of course try to fix it! If the creator has a"
+" public profile you can click their username to visit their profile. "
+"There you will find all their shared programs and much more!"
 
 #: templates/explore.html:35 templates/programs.html:27
 #, fuzzy
@@ -982,8 +940,8 @@ msgstr "Create student accounts"
 #, fuzzy
 msgid "teacher_welcome"
 msgstr ""
-"Welcome to Hedy! Your are now the proud owner of a teachers account which "
-"allows you to create classes and invite students."
+"Welcome to Hedy! Your are now the proud owner of a teachers account which"
+" allows you to create classes and invite students."
 
 #: templates/incl-adventure-tabs.html:22
 #, fuzzy
@@ -1092,9 +1050,9 @@ msgstr "Welcome"
 msgid "intro_text_landing_page"
 msgstr ""
 "Welcome to the wonderful world of Hedy! Here you can learn to program in "
-"small steps, without unnecessary complicated stuff. We start easy at level "
-"1, and slowly build towards bigger and more complex programs! Choose one of "
-"the options below to get started"
+"small steps, without unnecessary complicated stuff. We start easy at "
+"level 1, and slowly build towards bigger and more complex programs! "
+"Choose one of the options below to get started"
 
 #: templates/landing-page.html:14 templates/landing-page.html:36
 #, fuzzy
@@ -1110,14 +1068,14 @@ msgstr "Start programming"
 #: templates/landing-page.html:21
 #, fuzzy
 msgid "create_class_text"
-msgstr ""
-"Group your students into classes and change the content for each class."
+msgstr "Group your students into classes and change the content for each class."
 
 #: templates/landing-page.html:28
 #, fuzzy
 msgid "read_docs_text"
 msgstr ""
-"Visit our teacher's manual for lesson plans and common mistakes by students."
+"Visit our teacher's manual for lesson plans and common mistakes by "
+"students."
 
 #: templates/landing-page.html:30
 #, fuzzy
@@ -1159,49 +1117,14 @@ msgstr "Copiar vínculo para compartir"
 #, fuzzy
 msgid "set_preferred_lang"
 msgstr ""
-"Hedy now supports preferred user languages. You can set one for your profile "
-"in \"My profile\""
+"Hedy now supports preferred user languages. You can set one for your "
+"profile in \"My profile\""
 
 #: templates/layout.html:86 templates/quiz/endquiz.html:18
 #: templates/quiz/quiz.html:29
 #, fuzzy
 msgid "achievement_earned"
 msgstr "You've earned an achievement!"
-
-#: templates/learn-more.html:7
-#, fuzzy
-msgid "mailing_title"
-msgstr "Hedy"
-
-#: templates/learn-more.html:14
-#, fuzzy
-msgid "surname"
-msgstr "Usuario"
-
-#: templates/learn-more.html:18
-#, fuzzy
-msgid "lastname"
-msgstr "Nombre"
-
-#: templates/learn-more.html:22 templates/profile.html:135
-#: templates/signup.html:52
-msgid "country"
-msgstr "País"
-
-#: templates/learn-more.html:31
-#, fuzzy
-msgid "subscribe"
-msgstr "Subscribirse al newsletter"
-
-#: templates/learn-more.html:32
-#, fuzzy
-msgid "required_field"
-msgstr "Fields marked with an * are required"
-
-#: templates/learn-more.html:35
-#, fuzzy
-msgid "previous_campaigns"
-msgstr "View previous campaigns"
 
 #: templates/level-page.html:8
 msgid "step_title"
@@ -1234,18 +1157,6 @@ msgstr "Crear cuenta"
 #: templates/login.html:33
 msgid "forgot_password"
 msgstr "¿Olvidaste tu contraseña?"
-
-#: templates/main-page.html:9
-msgid "main_title"
-msgstr "Hedy"
-
-#: templates/main-page.html:10
-msgid "main_subtitle"
-msgstr "Un lenguaje de programación gradual"
-
-#: templates/main-page.html:13
-msgid "try_it"
-msgstr "Pruébalo"
 
 #: templates/profile.html:4
 msgid "account_overview"
@@ -1310,9 +1221,9 @@ msgstr "Favourite program"
 #, fuzzy
 msgid "public_profile_info"
 msgstr ""
-"By selecting this box I make my profile visible for everyone. Be careful not "
-"to share personal information like your name or home address, because "
-"everyone will be able to see it!"
+"By selecting this box I make my profile visible for everyone. Be careful "
+"not to share personal information like your name or home address, because"
+" everyone will be able to see it!"
 
 #: templates/profile.html:59
 #, fuzzy
@@ -1377,6 +1288,10 @@ msgstr "Masculino"
 #: templates/profile.html:131 templates/signup.html:48
 msgid "other"
 msgstr "Otro"
+
+#: templates/profile.html:135 templates/signup.html:52
+msgid "country"
+msgstr "País"
 
 #: templates/profile.html:141
 msgid "update_profile"
@@ -1576,8 +1491,8 @@ msgstr "¿Ya tienes una cuenta?"
 #, fuzzy
 msgid "teacher_invitation_require_login"
 msgstr ""
-"To set up your profile as a teacher we will need you to log in. If you don't "
-"have an account, please create one."
+"To set up your profile as a teacher we will need you to log in. If you "
+"don't have an account, please create one."
 
 #: templates/view-program-page.html:13
 msgid "by"
@@ -1726,7 +1641,8 @@ msgstr "You have to agree with the privacy terms."
 #, fuzzy
 msgid "keyword_language_invalid"
 msgstr ""
-"Please select a valid keyword language (select English or your own language)."
+"Please select a valid keyword language (select English or your own "
+"language)."
 
 #: website/auth.py:371 website/auth.py:551
 msgid "year_invalid"
@@ -1802,8 +1718,8 @@ msgstr "Your token is invalid."
 #: website/auth.py:703
 msgid "password_resetted"
 msgstr ""
-"Tu contraseña ha sido cambiada exitosamente. Ya puedes entrar nuevamente a "
-"tu cuenta usando la nueva contraseña."
+"Tu contraseña ha sido cambiada exitosamente. Ya puedes entrar nuevamente "
+"a tu cuenta usando la nueva contraseña."
 
 #: website/auth.py:721
 #, fuzzy
@@ -1818,7 +1734,8 @@ msgstr "Program deleted successfully."
 #: website/programs.py:55
 msgid "save_prompt"
 msgstr ""
-"Debes estar registrado para guardar tu programa. ¿Deseas entrar a tu cuenta?"
+"Debes estar registrado para guardar tu programa. ¿Deseas entrar a tu "
+"cuenta?"
 
 #: website/programs.py:60
 #, fuzzy
@@ -2025,3 +1942,61 @@ msgstr "The adventure has been updated!"
 #, fuzzy
 msgid "adventure_empty"
 msgstr "You didn't enter an adventure name!"
+
+#~ msgid "customize_class_exp_1"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_1"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_2"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_3"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_4"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_5"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_6"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_7"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_8"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_exp_2"
+#~ msgstr "Customize class"
+
+#~ msgid "mailing_title"
+#~ msgstr "Hedy"
+
+#~ msgid "surname"
+#~ msgstr "Usuario"
+
+#~ msgid "lastname"
+#~ msgstr "Nombre"
+
+#~ msgid "subscribe"
+#~ msgstr "Subscribirse al newsletter"
+
+#~ msgid "required_field"
+#~ msgstr "Fields marked with an * are required"
+
+#~ msgid "previous_campaigns"
+#~ msgstr "View previous campaigns"
+
+#~ msgid "main_title"
+#~ msgstr "Hedy"
+
+#~ msgid "main_subtitle"
+#~ msgstr "Un lenguaje de programación gradual"
+
+#~ msgid "try_it"
+#~ msgstr "Pruébalo"
+

--- a/translations/fa/LC_MESSAGES/messages.po
+++ b/translations/fa/LC_MESSAGES/messages.po
@@ -1,52 +1,46 @@
+
 msgid ""
 msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2022-03-30 08:43+0200\n"
 "PO-Revision-Date: 2022-03-30 09:53+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
-"Language-Team: Persian <https://hosted.weblate.org/projects/hedy/web-texts/"
-"fa/>\n"
 "Language: fa\n"
+"Language-Team: Persian <https://hosted.weblate.org/projects/hedy/web-"
+"texts/fa/>\n"
+"Plural-Forms: nplurals=2; plural=n > 1\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=n > 1;\n"
-"X-Generator: Weblate 4.12-dev\n"
-
-#: templates/profile.html:4
-#, fuzzy
-msgid "account_overview"
-msgstr "Account overview"
-
-#: website/auth.py:721
-#, fuzzy
-msgid "teacher_invalid"
-msgstr "Your teacher value is invalid."
+"Generated-By: Babel 2.9.1\n"
 
 #: app.py:571
 #, fuzzy
 msgid "program_contains_error"
 msgstr "This program contains an error, are you sure you want to share it?"
 
-#: app.py:723
+#: app.py:722
 #, fuzzy
 msgid "title_achievements"
 msgstr "Hedy - My achievements"
 
-#: app.py:740 app.py:1111 website/teacher.py:365 website/teacher.py:374
+#: app.py:739 app.py:1110 website/teacher.py:365 website/teacher.py:374
 #, fuzzy
 msgid "not_teacher"
 msgstr "Looks like you are not a teacher!"
 
-#: app.py:743
+#: app.py:742
 #, fuzzy
 msgid "not_enrolled"
 msgstr "Looks like you are not in this class!"
 
-#: app.py:775
+#: app.py:774
 #, fuzzy
 msgid "title_programs"
 msgstr "Hedy - My programs"
 
-#: app.py:785 app.py:795 app.py:799 app.py:813 app.py:1054 app.py:1357
+#: app.py:784 app.py:794 app.py:798 app.py:812 app.py:1053 app.py:1356
 #: website/admin.py:17 website/admin.py:25 website/admin.py:95
 #: website/admin.py:112 website/admin.py:130 website/auth.py:711
 #: website/auth.py:738 website/statistics.py:86
@@ -54,125 +48,125 @@ msgstr "Hedy - My programs"
 msgid "unauthorized"
 msgstr "You don't have access rights for this page"
 
-#: app.py:823
+#: app.py:822
 #, fuzzy
 msgid "minutes"
 msgstr "minutes"
 
-#: app.py:826
+#: app.py:825
 #, fuzzy
 msgid "hours"
 msgstr "hours"
 
-#: app.py:829
+#: app.py:828
 #, fuzzy
 msgid "days"
 msgstr "days"
 
-#: app.py:832
+#: app.py:831
 #, fuzzy
 msgid "ago"
 msgstr "{time} ago"
 
-#: app.py:848 app.py:850 app.py:976
+#: app.py:847 app.py:849 app.py:975
 #, fuzzy
 msgid "no_such_level"
 msgstr "No such Hedy level!"
 
-#: app.py:858 app.py:865 app.py:931 app.py:937
+#: app.py:857 app.py:864 app.py:930 app.py:936
 #, fuzzy
 msgid "no_such_program"
 msgstr "No such Hedy program!"
 
-#: app.py:891
+#: app.py:890
 #, fuzzy
 msgid "level_not_translated"
 msgstr "This level is not translated in your language (yet)"
 
-#: app.py:893
+#: app.py:892
 #, fuzzy
 msgid "level_not_class"
 msgstr "You're in a class where this level has not been made available yet"
 
-#: app.py:986 website/teacher.py:432 website/teacher.py:448
+#: app.py:985 website/teacher.py:432 website/teacher.py:448
 #: website/teacher.py:477 website/teacher.py:503
 #, fuzzy
 msgid "no_such_adventure"
 msgstr "This adventure doesn't exist!"
 
-#: app.py:1005
+#: app.py:1004
 #, fuzzy
 msgid "page_not_found"
 msgstr "We could not find that page!"
 
-#: app.py:1025
+#: app.py:1024
 #, fuzzy
 msgid "title_signup"
 msgstr "Hedy - Create an account"
 
-#: app.py:1032
+#: app.py:1031
 #, fuzzy
 msgid "title_login"
 msgstr "Hedy - Login"
 
-#: app.py:1039
+#: app.py:1038
 #, fuzzy
 msgid "title_recover"
 msgstr "Hedy - Recover account"
 
-#: app.py:1055
+#: app.py:1054
 #, fuzzy
 msgid "title_reset"
 msgstr "Hedy - Reset password"
 
-#: app.py:1064
+#: app.py:1063
 #, fuzzy
 msgid "title_my-profile"
 msgstr "Hedy - My account"
 
-#: app.py:1078
+#: app.py:1077
 #, fuzzy
 msgid "title_learn-more"
 msgstr "Hedy - Learn more"
 
-#: app.py:1083
+#: app.py:1082
 #, fuzzy
 msgid "title_privacy"
 msgstr "Hedy - Privacy terms"
 
-#: app.py:1090
+#: app.py:1089
 #, fuzzy
 msgid "title_landing-page"
 msgstr "Welcome to Hedy!"
 
-#: app.py:1092
+#: app.py:1091
 #, fuzzy
 msgid "not_user"
 msgstr "Looks like you are not logged in!"
 
-#: app.py:1107
+#: app.py:1106
 #, fuzzy
 msgid "title_for-teacher"
 msgstr "Hedy - For teachers"
 
-#: app.py:1118
+#: app.py:1117
 #, fuzzy
 msgid "title_start"
 msgstr "Hedy - A gradual programming language"
 
-#: app.py:1171
+#: app.py:1170
 #, fuzzy
 msgid "title_explore"
 msgstr "Hedy - Explore"
 
-#: app.py:1190 app.py:1192
+#: app.py:1189 app.py:1191
 #, fuzzy
 msgid "translate_error"
 msgstr ""
-"Something went wrong while translating the code. Try running the code to see "
-"if it has an error. Code with errors can not be translated."
+"Something went wrong while translating the code. Try running the code to "
+"see if it has an error. Code with errors can not be translated."
 
-#: app.py:1301 website/auth.py:299 website/auth.py:347 website/auth.py:483
+#: app.py:1300 website/auth.py:299 website/auth.py:347 website/auth.py:483
 #: website/auth.py:509 website/auth.py:539 website/auth.py:645
 #: website/auth.py:677 website/auth.py:717 website/auth.py:744
 #: website/teacher.py:90 website/teacher.py:125 website/teacher.py:197
@@ -182,37 +176,37 @@ msgstr ""
 msgid "ajax_error"
 msgstr "There was an error, please try again."
 
-#: app.py:1304
+#: app.py:1303
 #, fuzzy
 msgid "image_invalid"
 msgstr "Your chosen image is invalid."
 
-#: app.py:1306
+#: app.py:1305
 #, fuzzy
 msgid "personal_text_invalid"
 msgstr "Your personal text is invalid."
 
-#: app.py:1308 app.py:1314
+#: app.py:1307 app.py:1313
 #, fuzzy
 msgid "favourite_program_invalid"
 msgstr "Your chosen favourite program is invalid."
 
-#: app.py:1326 app.py:1327
+#: app.py:1325 app.py:1326
 #, fuzzy
 msgid "public_profile_updated"
 msgstr "Public profile updated."
 
-#: app.py:1361 app.py:1385
+#: app.py:1360 app.py:1384
 #, fuzzy
 msgid "user_not_private"
 msgstr "This user doesn't exist or doesn't have a public profile"
 
-#: app.py:1394
+#: app.py:1393
 #, fuzzy
 msgid "invalid_teacher_invitation_code"
 msgstr ""
-"The teacher invitation code is invalid. To become a teacher, reach out to "
-"hedy@felienne.com."
+"The teacher invitation code is invalid. To become a teacher, reach out to"
+" hedy@felienne.com."
 
 #: utils.py:203
 #, fuzzy
@@ -233,7 +227,8 @@ msgstr "Something went wrong..."
 #, fuzzy
 msgid "Empty Program"
 msgstr ""
-"You created an empty program. Type Hedy code in the left field and try again"
+"You created an empty program. Type Hedy code in the left field and try "
+"again"
 
 #: coursedata/error-messages.txt:2
 #, fuzzy
@@ -260,53 +255,53 @@ msgstr ""
 #, fuzzy
 msgid "Invalid Space"
 msgstr ""
-"Oops! You started a line with a space on line {line_number}. Spaces confuse "
-"computers, can you remove it?"
+"Oops! You started a line with a space on line {line_number}. Spaces "
+"confuse computers, can you remove it?"
 
 #: coursedata/error-messages.txt:6
 #, fuzzy
 msgid "Has Blanks"
 msgstr ""
-"Your code is incomplete. It contains blanks that you have to replace with "
-"code."
+"Your code is incomplete. It contains blanks that you have to replace with"
+" code."
 
 #: coursedata/error-messages.txt:7
 #, fuzzy
 msgid "No Indentation"
 msgstr ""
 "You used too few spaces in line {line_number}. You used {leading_spaces} "
-"spaces, which is not enough. Start every new block with {indent_size} spaces "
-"more than the line before."
+"spaces, which is not enough. Start every new block with {indent_size} "
+"spaces more than the line before."
 
 #: coursedata/error-messages.txt:8
 #, fuzzy
 msgid "Unexpected Indentation"
 msgstr ""
-"You used too many spaces in line {line_number}. You used {leading_spaces} "
-"spaces, which is too much. Start every new block with {indent_size} spaces "
-"more than the line before."
+"You used too many spaces in line {line_number}. You used {leading_spaces}"
+" spaces, which is too much. Start every new block with {indent_size} "
+"spaces more than the line before."
 
 #: coursedata/error-messages.txt:9
 #, fuzzy
 msgid "Parse"
 msgstr ""
 "The code you entered is not valid Hedy code. There is a mistake on line "
-"{location[0]}, at position {location[1]}. You typed {character_found}, but "
-"that is not allowed."
+"{location[0]}, at position {location[1]}. You typed {character_found}, "
+"but that is not allowed."
 
 #: coursedata/error-messages.txt:10
 #, fuzzy
 msgid "Unquoted Text"
 msgstr ""
-"Be careful. If you ask or print something the text should start and finish "
-"with a quotation mark. You forgot one somewhere."
+"Be careful. If you ask or print something the text should start and "
+"finish with a quotation mark. You forgot one somewhere."
 
 #: coursedata/error-messages.txt:11
 #, fuzzy
 msgid "Unquoted Assignment"
 msgstr ""
-"From this level, you need to place texts to the right of the `is` between "
-"quotes. You forgot that for the text {text}."
+"From this level, you need to place texts to the right of the `is` between"
+" quotes. You forgot that for the text {text}."
 
 #: coursedata/error-messages.txt:12
 #, fuzzy
@@ -320,15 +315,15 @@ msgstr ""
 msgid "Var Undefined"
 msgstr ""
 "You tried to use the variable {name}, but you did not set it. It is also "
-"possible that you were trying to use the word {name} but forgot quotation "
-"marks."
+"possible that you were trying to use the word {name} but forgot quotation"
+" marks."
 
 #: coursedata/error-messages.txt:14
 #, fuzzy
 msgid "Cyclic Var Definition"
 msgstr ""
-"The name {variable} needs to be set before you can use it on the right-hand "
-"side of the is command"
+"The name {variable} needs to be set before you can use it on the right-"
+"hand side of the is command"
 
 #: coursedata/error-messages.txt:15
 #, fuzzy
@@ -341,46 +336,46 @@ msgstr ""
 #, fuzzy
 msgid "Too Big"
 msgstr ""
-"Wow! Your program has an impressive {lines_of_code} lines of code! But we "
-"can only process {max_lines} lines in this level. Make your program smaller "
-"and try again."
+"Wow! Your program has an impressive {lines_of_code} lines of code! But we"
+" can only process {max_lines} lines in this level. Make your program "
+"smaller and try again."
 
 #: coursedata/error-messages.txt:17
 #, fuzzy
 msgid "Invalid Argument Type"
 msgstr ""
-"You cannot use the command {command} with {invalid_argument} because it is "
-"{invalid_type}. Try changing {invalid_argument} to {allowed_types}."
+"You cannot use the command {command} with {invalid_argument} because it "
+"is {invalid_type}. Try changing {invalid_argument} to {allowed_types}."
 
 #: coursedata/error-messages.txt:18
 #, fuzzy
 msgid "Invalid Argument"
 msgstr ""
-"You cannot use the command {command} with {invalid_argument} . Try changing "
-"{invalid_argument} to {allowed_types}."
+"You cannot use the command {command} with {invalid_argument} . Try "
+"changing {invalid_argument} to {allowed_types}."
 
 #: coursedata/error-messages.txt:19
 #, fuzzy
 msgid "Invalid Type Combination"
 msgstr ""
-"You cannot use {invalid_argument} and {invalid_argument_2} in {operation} "
-"because one is {invalid_type} and the other is {invalid_type_2}. Try "
-"changing {invalid_argument} to {invalid_type_2} or {invalid_argument_2} to "
-"{invalid_type}."
+"You cannot use {invalid_argument} and {invalid_argument_2} in {operation}"
+" because one is {invalid_type} and the other is {invalid_type_2}. Try "
+"changing {invalid_argument} to {invalid_type_2} or {invalid_argument_2} "
+"to {invalid_type}."
 
 #: coursedata/error-messages.txt:20
 #, fuzzy
 msgid "Unsupported Float"
 msgstr ""
-"Non-integer numbers are not supported yet but they will be in a few levels. "
-"For now change {value} to an integer."
+"Non-integer numbers are not supported yet but they will be in a few "
+"levels. For now change {value} to an integer."
 
 #: coursedata/error-messages.txt:21
 #, fuzzy
 msgid "Locked Language Feature"
 msgstr ""
-"You are using {concept}! That is awesome, but {concept} is not unlocked yet! "
-"It will be unlocked in a later level."
+"You are using {concept}! That is awesome, but {concept} is not unlocked "
+"yet! It will be unlocked in a later level."
 
 #: coursedata/error-messages.txt:22
 #, fuzzy
@@ -398,9 +393,9 @@ msgstr ""
 #, fuzzy
 msgid "echo_out"
 msgstr ""
-"Starting in level 2 echo is no longer needed. You can repeat an answer with "
-"ask and print now. Example: name is ask 'What are you called?' print 'hello' "
-"name"
+"Starting in level 2 echo is no longer needed. You can repeat an answer "
+"with ask and print now. Example: name is ask 'What are you called?' print"
+" 'hello' name"
 
 #: coursedata/error-messages.txt:25
 #, fuzzy
@@ -496,6 +491,11 @@ msgstr "a list"
 #, fuzzy
 msgid "input"
 msgstr "input from ask"
+
+#: templates/achievements.html:4
+#, fuzzy
+msgid "achievements_title"
+msgstr "achievements"
 
 #: templates/class-overview.html:16
 #, fuzzy
@@ -668,22 +668,21 @@ msgstr "Do you want to join this class?"
 #: templates/class-prejoin.html:17 website/teacher.py:183
 #, fuzzy
 msgid "join_prompt"
-msgstr ""
-"You need to have an account to join a class. Would you like to login now?"
+msgstr "You need to have an account to join a class. Would you like to login now?"
 
 #: templates/class-prejoin.html:17 templates/profile.html:14
 #, fuzzy
 msgid "join_class"
 msgstr "Join class"
 
-#: templates/class-stats.html:22 templates/customize-class.html:155
+#: templates/class-stats.html:22 templates/customize-class.html:150
 #, fuzzy
 msgid "back_to_class"
 msgstr "Go back to class"
 
 #: templates/code-page.html:25 templates/code-page.html:34
-#: templates/customize-class.html:28 templates/customize-class.html:64
-#: templates/customize-class.html:71 templates/customize-class.html:94
+#: templates/customize-class.html:23 templates/customize-class.html:59
+#: templates/customize-class.html:66 templates/customize-class.html:89
 #: templates/incl-adventure-tabs.html:5 templates/level-page.html:6
 #: templates/level-page.html:11 templates/quiz/startquiz.html:10
 #: templates/view-program-page.html:12 templates/view-program-page.html:28
@@ -700,21 +699,21 @@ msgstr "Create multiple accounts"
 #, fuzzy
 msgid "accounts_intro"
 msgstr ""
-"On this page you can create accounts for multiple students at the same time. "
-"It is also possible to directly add them to one of your classes. By pressing "
-"the green + on the bottom right of the page you can add extra rows. You can "
-"delete a row by pressing the corresponding red cross. Make sure no rows are "
-"empty when you press \"Create accounts\". Please keep in mind that every "
-"username and mail address needs to be unique and the password needs to be "
-"<b>at least</b> 6 characters."
+"On this page you can create accounts for multiple students at the same "
+"time. It is also possible to directly add them to one of your classes. By"
+" pressing the green + on the bottom right of the page you can add extra "
+"rows. You can delete a row by pressing the corresponding red cross. Make "
+"sure no rows are empty when you press \"Create accounts\". Please keep in"
+" mind that every username and mail address needs to be unique and the "
+"password needs to be <b>at least</b> 6 characters."
 
 #: templates/create-accounts.html:10
 #, fuzzy
 msgid "create_accounts_prompt"
 msgstr "Are you sure you want to create these accounts?"
 
-#: templates/create-accounts.html:17 templates/learn-more.html:10
-#: templates/profile.html:96 templates/recover.html:8 templates/signup.html:13
+#: templates/create-accounts.html:17 templates/profile.html:96
+#: templates/recover.html:8 templates/signup.html:13
 #, fuzzy
 msgid "email"
 msgstr "Email"
@@ -773,10 +772,10 @@ msgstr "Level"
 #, fuzzy
 msgid "adventure_exp_1"
 msgstr ""
-"Type your adventure of choice on the right-hand side. After creating your "
-"adventure you can include it in one of your classes under \"customizations\""
-". If you want to include a command in your adventure please use code anchors "
-"like this:"
+"Type your adventure of choice on the right-hand side. After creating your"
+" adventure you can include it in one of your classes under "
+"\"customizations\". If you want to include a command in your adventure "
+"please use code anchors like this:"
 
 #: templates/customize-adventure.html:31
 #, fuzzy
@@ -790,11 +789,11 @@ msgstr ""
 msgid "adventure_exp_3"
 msgstr ""
 "You can use the \"preview\" button to view a styled version of your "
-"adventure. To view the adventure on a dedicated page, select \"view\" from "
-"the teachers page."
+"adventure. To view the adventure on a dedicated page, select \"view\" "
+"from the teachers page."
 
-#: templates/customize-adventure.html:43 templates/customize-class.html:28
-#: templates/customize-class.html:93 templates/explore.html:26
+#: templates/customize-adventure.html:43 templates/customize-class.html:23
+#: templates/customize-class.html:88 templates/explore.html:26
 #: templates/programs.html:18 templates/programs.html:48
 #: templates/view-adventure.html:6
 #, fuzzy
@@ -825,7 +824,7 @@ msgstr "I agree that my adventure might be made publicly available on Hedy."
 msgid "preview"
 msgstr "Preview"
 
-#: templates/customize-adventure.html:51 templates/customize-class.html:150
+#: templates/customize-adventure.html:51 templates/customize-class.html:145
 #, fuzzy
 msgid "save"
 msgstr "Save"
@@ -835,93 +834,32 @@ msgstr "Save"
 msgid "delete_adventure_prompt"
 msgstr "Are you sure you want to remove this adventure?"
 
-#: templates/customize-class.html:7
-#, fuzzy
-msgid "customize_class_exp_1"
-msgstr ""
-"Hi! On this page you can customize your class. By selecting levels and "
-"adventures you can choose what you student can see. You can also add you own "
-"created adventures to levels. All levels and default adventures will be "
-"selected by default. <b>Notice:</b> Not every adventure is available for "
-"every level! Settings up your customizations goes as follows:"
-
-#: templates/customize-class.html:10
-#, fuzzy
-msgid "customize_class_step_1"
-msgstr "Select levels for your class by pressing the \"level buttons\""
-
-#: templates/customize-class.html:11
-#, fuzzy
-msgid "customize_class_step_2"
-msgstr ""
-"\"Checkboxes\" will appear for the adventures available for the chosen levels"
-
-#: templates/customize-class.html:12
-#, fuzzy
-msgid "customize_class_step_3"
-msgstr "Select the adventures you want to make available"
-
-#: templates/customize-class.html:13
-#, fuzzy
-msgid "customize_class_step_4"
-msgstr "Click the name of an adventure to (de)select for all levels"
-
-#: templates/customize-class.html:14
-#, fuzzy
-msgid "customize_class_step_5"
-msgstr "Add personal adventures"
-
-#: templates/customize-class.html:15
-#, fuzzy
-msgid "customize_class_step_6"
-msgstr "Selecting an opening date for each level (you can also leave it empty)"
-
-#: templates/customize-class.html:16
-#, fuzzy
-msgid "customize_class_step_7"
-msgstr "Selection other settings"
-
-#: templates/customize-class.html:17
-#, fuzzy
-msgid "customize_class_step_8"
-msgstr "Choose \"Save\" -> You're done!"
-
-#: templates/customize-class.html:20
-#, fuzzy
-msgid "customize_class_exp_2"
-msgstr ""
-"You can always change these settings later on. For example, you can make "
-"specific adventures or levels available while teaching a class. This way "
-"it's easy for you to determine which level and adventures your students will "
-"be working on. If you want to make everything available for your class it is "
-"easiest to remove the customization all together."
-
-#: templates/customize-class.html:23
+#: templates/customize-class.html:18
 #, fuzzy
 msgid "select_adventures"
 msgstr "Select adventures"
 
-#: templates/customize-class.html:59
+#: templates/customize-class.html:54
 #, fuzzy
 msgid "opening_dates"
 msgstr "Opening dates"
 
-#: templates/customize-class.html:65
+#: templates/customize-class.html:60
 #, fuzzy
 msgid "opening_date"
 msgstr "Opening date"
 
-#: templates/customize-class.html:77
+#: templates/customize-class.html:72
 #, fuzzy
 msgid "directly_available"
 msgstr "Directly open"
 
-#: templates/customize-class.html:88
+#: templates/customize-class.html:83
 #, fuzzy
 msgid "select_own_adventures"
 msgstr "Select own adventures"
 
-#: templates/customize-class.html:95 templates/customize-class.html:121
+#: templates/customize-class.html:90 templates/customize-class.html:116
 #: templates/profile.html:47 templates/profile.html:128
 #: templates/profile.html:137 templates/signup.html:26 templates/signup.html:45
 #: templates/signup.html:53
@@ -929,42 +867,46 @@ msgstr "Select own adventures"
 msgid "select"
 msgstr "Select"
 
-#: templates/customize-class.html:115
+#: templates/customize-class.html:110
 #, fuzzy
 msgid "other_settings"
 msgstr "Other settings"
 
-#: templates/customize-class.html:120
+#: templates/customize-class.html:115
 #, fuzzy
 msgid "option"
 msgstr "Option"
 
-#: templates/customize-class.html:126
+#: templates/customize-class.html:121
 #, fuzzy
 msgid "mandatory_mode"
 msgstr "Mandatory developer's mode"
 
-#: templates/customize-class.html:132
+#: templates/customize-class.html:127
 #, fuzzy
 msgid "hide_cheatsheet"
 msgstr "Hide cheatsheet"
 
-#: templates/customize-class.html:149
+#: templates/customize-class.html:133
+msgid "hide_keyword_switcher"
+msgstr ""
+
+#: templates/customize-class.html:144
 #, fuzzy
 msgid "reset_adventure_prompt"
 msgstr "Are you sure you want to reset all selected adventures?"
 
-#: templates/customize-class.html:149
+#: templates/customize-class.html:144
 #, fuzzy
 msgid "reset_adventures"
 msgstr "Reset selected adventures"
 
-#: templates/customize-class.html:153
+#: templates/customize-class.html:148
 #, fuzzy
 msgid "remove_customizations_prompt"
 msgstr "Are you sure you want to remove this class their customizations?"
 
-#: templates/customize-class.html:154
+#: templates/customize-class.html:149
 #, fuzzy
 msgid "remove_customization"
 msgstr "Remove customization"
@@ -983,13 +925,13 @@ msgstr "Explore programs"
 #, fuzzy
 msgid "explore_explanation"
 msgstr ""
-"On this page you can look through programs created by other Hedy users. You "
-"can filter on both a Hedy level and adventure. Click on \"View program\" to "
-"open a program and run it. Programs with a red header contain a mistake. You "
-"can still open the program, but running it will result in an error. You can "
-"of course try to fix it! If the creator has a public profile you can click "
-"their username to visit their profile. There you will find all their shared "
-"programs and much more!"
+"On this page you can look through programs created by other Hedy users. "
+"You can filter on both a Hedy level and adventure. Click on \"View "
+"program\" to open a program and run it. Programs with a red header "
+"contain a mistake. You can still open the program, but running it will "
+"result in an error. You can of course try to fix it! If the creator has a"
+" public profile you can click their username to visit their profile. "
+"There you will find all their shared programs and much more!"
 
 #: templates/explore.html:35 templates/programs.html:27
 #, fuzzy
@@ -1056,8 +998,8 @@ msgstr "Create student accounts"
 #, fuzzy
 msgid "teacher_welcome"
 msgstr ""
-"Welcome to Hedy! Your are now the proud owner of a teachers account which "
-"allows you to create classes and invite students."
+"Welcome to Hedy! Your are now the proud owner of a teachers account which"
+" allows you to create classes and invite students."
 
 #: templates/incl-adventure-tabs.html:22
 #, fuzzy
@@ -1070,6 +1012,10 @@ msgstr ""
 #, fuzzy
 msgid "go_to_quiz"
 msgstr "Go to quiz"
+
+#: templates/incl-editor-and-output.html:95
+msgid "variables"
+msgstr ""
 
 #: templates/incl-editor-and-output.html:111
 #, fuzzy
@@ -1179,9 +1125,9 @@ msgstr "Welcome"
 msgid "intro_text_landing_page"
 msgstr ""
 "Welcome to the wonderful world of Hedy! Here you can learn to program in "
-"small steps, without unnecessary complicated stuff. We start easy at level "
-"1, and slowly build towards bigger and more complex programs! Choose one of "
-"the options below to get started"
+"small steps, without unnecessary complicated stuff. We start easy at "
+"level 1, and slowly build towards bigger and more complex programs! "
+"Choose one of the options below to get started"
 
 #: templates/landing-page.html:14 templates/landing-page.html:36
 #, fuzzy
@@ -1203,7 +1149,8 @@ msgstr "Group your students into classes and change the content for each class."
 #, fuzzy
 msgid "read_docs_text"
 msgstr ""
-"Visit our teacher's manual for lesson plans and common mistakes by students."
+"Visit our teacher's manual for lesson plans and common mistakes by "
+"students."
 
 #: templates/landing-page.html:30
 #, fuzzy
@@ -1250,50 +1197,14 @@ msgstr "Copy link to share"
 #, fuzzy
 msgid "set_preferred_lang"
 msgstr ""
-"Hedy now supports preferred user languages. You can set one for your profile "
-"in \"My profile\""
+"Hedy now supports preferred user languages. You can set one for your "
+"profile in \"My profile\""
 
 #: templates/layout.html:86 templates/quiz/endquiz.html:18
 #: templates/quiz/quiz.html:29
 #, fuzzy
 msgid "achievement_earned"
 msgstr "You've earned an achievement!"
-
-#: templates/learn-more.html:7
-#, fuzzy
-msgid "mailing_title"
-msgstr "Subscribe to the Hedy newsletter"
-
-#: templates/learn-more.html:14
-#, fuzzy
-msgid "surname"
-msgstr "First Name"
-
-#: templates/learn-more.html:18
-#, fuzzy
-msgid "lastname"
-msgstr "Last Name"
-
-#: templates/learn-more.html:22 templates/profile.html:135
-#: templates/signup.html:52
-#, fuzzy
-msgid "country"
-msgstr "Country"
-
-#: templates/learn-more.html:31
-#, fuzzy
-msgid "subscribe"
-msgstr "Subscribe"
-
-#: templates/learn-more.html:32
-#, fuzzy
-msgid "required_field"
-msgstr "Fields marked with an * are required"
-
-#: templates/learn-more.html:35
-#, fuzzy
-msgid "previous_campaigns"
-msgstr "View previous campaigns"
 
 #: templates/level-page.html:8
 #, fuzzy
@@ -1335,15 +1246,10 @@ msgstr "Create account"
 msgid "forgot_password"
 msgstr "Forgot your password?"
 
-#: templates/main-page.html:9
+#: templates/profile.html:4
 #, fuzzy
-msgid "main_title"
-msgstr "Hedy"
-
-#: templates/main-page.html:10
-#, fuzzy
-msgid "main_subtitle"
-msgstr "A gradual programming language"
+msgid "account_overview"
+msgstr "Account overview"
 
 #: templates/profile.html:6 templates/profile.html:8
 #, fuzzy
@@ -1404,9 +1310,9 @@ msgstr "Favourite program"
 #, fuzzy
 msgid "public_profile_info"
 msgstr ""
-"By selecting this box I make my profile visible for everyone. Be careful not "
-"to share personal information like your name or home address, because "
-"everyone will be able to see it!"
+"By selecting this box I make my profile visible for everyone. Be careful "
+"not to share personal information like your name or home address, because"
+" everyone will be able to see it!"
 
 #: templates/profile.html:59
 #, fuzzy
@@ -1477,6 +1383,11 @@ msgstr "Male"
 #, fuzzy
 msgid "other"
 msgstr "Other"
+
+#: templates/profile.html:135 templates/signup.html:52
+#, fuzzy
+msgid "country"
+msgstr "Country"
 
 #: templates/profile.html:141
 #, fuzzy
@@ -1704,8 +1615,8 @@ msgstr "Already have an account?"
 #, fuzzy
 msgid "teacher_invitation_require_login"
 msgstr ""
-"To set up your profile as a teacher we will need you to log in. If you don't "
-"have an account, please create one."
+"To set up your profile as a teacher we will need you to log in. If you "
+"don't have an account, please create one."
 
 #: templates/view-program-page.html:13
 #, fuzzy
@@ -1765,6 +1676,11 @@ msgstr "Quiz results"
 #: templates/quiz/quiz-result-overview.html:45
 #, fuzzy
 msgid "correct"
+msgstr "Correct"
+
+#: templates/quiz/quiz-result-overview.html:62
+#, fuzzy
+msgid "incorrect"
 msgstr "Correct"
 
 #: templates/quiz/quiz-result-overview.html:91
@@ -1871,7 +1787,8 @@ msgstr "You have to agree with the privacy terms."
 #, fuzzy
 msgid "keyword_language_invalid"
 msgstr ""
-"Please select a valid keyword language (select English or your own language)."
+"Please select a valid keyword language (select English or your own "
+"language)."
 
 #: website/auth.py:371 website/auth.py:551
 #, fuzzy
@@ -1955,8 +1872,13 @@ msgstr "Your token is invalid."
 #, fuzzy
 msgid "password_resetted"
 msgstr ""
-"Your password has been successfully reset. You are being redirected to the "
-"login page."
+"Your password has been successfully reset. You are being redirected to "
+"the login page."
+
+#: website/auth.py:721
+#, fuzzy
+msgid "teacher_invalid"
+msgstr "Your teacher value is invalid."
 
 #: website/programs.py:41
 #, fuzzy
@@ -1967,8 +1889,8 @@ msgstr "Program deleted successfully."
 #, fuzzy
 msgid "save_prompt"
 msgstr ""
-"You need to have an account to save your program. Would you like to login "
-"now?"
+"You need to have an account to save your program. Would you like to login"
+" now?"
 
 #: website/programs.py:60
 #, fuzzy
@@ -1997,6 +1919,11 @@ msgstr "Program shared successfully."
 msgid "unshare_success_detail"
 msgstr "Program unshared successfully."
 
+#: website/programs.py:202
+#, fuzzy
+msgid "favourite_success"
+msgstr "Your program is set as favourite."
+
 #: website/statistics.py:37 website/teacher.py:28 website/teacher.py:36
 #: website/teacher.py:211 website/teacher.py:235 website/teacher.py:247
 #: website/teacher.py:314 website/teacher.py:353
@@ -2004,17 +1931,17 @@ msgstr "Program unshared successfully."
 msgid "retrieve_class_error"
 msgstr "Only teachers can retrieve classes"
 
-#: website/programs.py:202
-#, fuzzy
-msgid "favourite_success"
-msgstr "Your program is set as favourite."
-
 #: website/statistics.py:41 website/teacher.py:39 website/teacher.py:133
 #: website/teacher.py:152 website/teacher.py:214 website/teacher.py:238
 #: website/teacher.py:250 website/teacher.py:317 website/teacher.py:356
 #, fuzzy
 msgid "no_such_class"
 msgstr "No such Hedy class"
+
+#: website/statistics.py:45
+#, fuzzy
+msgid "title_class statistics"
+msgstr "My statistics"
 
 #: website/teacher.py:76
 #, fuzzy
@@ -2176,3 +2103,82 @@ msgstr "The adventure has been updated!"
 #, fuzzy
 msgid "adventure_empty"
 msgstr "You didn't enter an adventure name!"
+
+#~ msgid "customize_class_exp_1"
+#~ msgstr ""
+#~ "Hi! On this page you can customize"
+#~ " your class. By selecting levels and"
+#~ " adventures you can choose what you"
+#~ " student can see. You can also "
+#~ "add you own created adventures to "
+#~ "levels. All levels and default "
+#~ "adventures will be selected by default."
+#~ " <b>Notice:</b> Not every adventure is "
+#~ "available for every level! Settings up"
+#~ " your customizations goes as follows:"
+
+#~ msgid "customize_class_step_1"
+#~ msgstr "Select levels for your class by pressing the \"level buttons\""
+
+#~ msgid "customize_class_step_2"
+#~ msgstr ""
+#~ "\"Checkboxes\" will appear for the "
+#~ "adventures available for the chosen "
+#~ "levels"
+
+#~ msgid "customize_class_step_3"
+#~ msgstr "Select the adventures you want to make available"
+
+#~ msgid "customize_class_step_4"
+#~ msgstr "Click the name of an adventure to (de)select for all levels"
+
+#~ msgid "customize_class_step_5"
+#~ msgstr "Add personal adventures"
+
+#~ msgid "customize_class_step_6"
+#~ msgstr "Selecting an opening date for each level (you can also leave it empty)"
+
+#~ msgid "customize_class_step_7"
+#~ msgstr "Selection other settings"
+
+#~ msgid "customize_class_step_8"
+#~ msgstr "Choose \"Save\" -> You're done!"
+
+#~ msgid "customize_class_exp_2"
+#~ msgstr ""
+#~ "You can always change these settings "
+#~ "later on. For example, you can "
+#~ "make specific adventures or levels "
+#~ "available while teaching a class. This"
+#~ " way it's easy for you to "
+#~ "determine which level and adventures "
+#~ "your students will be working on. "
+#~ "If you want to make everything "
+#~ "available for your class it is "
+#~ "easiest to remove the customization all"
+#~ " together."
+
+#~ msgid "mailing_title"
+#~ msgstr "Subscribe to the Hedy newsletter"
+
+#~ msgid "surname"
+#~ msgstr "First Name"
+
+#~ msgid "lastname"
+#~ msgstr "Last Name"
+
+#~ msgid "subscribe"
+#~ msgstr "Subscribe"
+
+#~ msgid "required_field"
+#~ msgstr "Fields marked with an * are required"
+
+#~ msgid "previous_campaigns"
+#~ msgstr "View previous campaigns"
+
+#~ msgid "main_title"
+#~ msgstr "Hedy"
+
+#~ msgid "main_subtitle"
+#~ msgstr "A gradual programming language"
+

--- a/translations/fr/LC_MESSAGES/messages.po
+++ b/translations/fr/LC_MESSAGES/messages.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-03-29 10:01+0200\n"
+"POT-Creation-Date: 2022-03-30 08:43+0200\n"
 "PO-Revision-Date: 2022-03-23 11:48+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: fr\n"
@@ -20,27 +20,27 @@ msgstr ""
 msgid "program_contains_error"
 msgstr "This program contains an error, are you sure you want to share it?"
 
-#: app.py:723
+#: app.py:722
 #, fuzzy
 msgid "title_achievements"
 msgstr "Hedy - My achievements"
 
-#: app.py:740 app.py:1111 website/teacher.py:365 website/teacher.py:374
+#: app.py:739 app.py:1110 website/teacher.py:365 website/teacher.py:374
 #, fuzzy
 msgid "not_teacher"
 msgstr "Looks like you are not a teacher!"
 
-#: app.py:743
+#: app.py:742
 #, fuzzy
 msgid "not_enrolled"
 msgstr "Looks like you are not in this class!"
 
-#: app.py:775
+#: app.py:774
 #, fuzzy
 msgid "title_programs"
 msgstr "Hedy - My programs"
 
-#: app.py:785 app.py:795 app.py:799 app.py:813 app.py:1054 app.py:1357
+#: app.py:784 app.py:794 app.py:798 app.py:812 app.py:1053 app.py:1356
 #: website/admin.py:17 website/admin.py:25 website/admin.py:95
 #: website/admin.py:112 website/admin.py:130 website/auth.py:711
 #: website/auth.py:738 website/statistics.py:86
@@ -48,122 +48,122 @@ msgstr "Hedy - My programs"
 msgid "unauthorized"
 msgstr "You don't have access rights for this page"
 
-#: app.py:823
+#: app.py:822
 msgid "minutes"
 msgstr "minutes"
 
-#: app.py:826
+#: app.py:825
 msgid "hours"
 msgstr "heures"
 
-#: app.py:829
+#: app.py:828
 msgid "days"
 msgstr "jours"
 
-#: app.py:832
+#: app.py:831
 #, fuzzy
 msgid "ago"
 msgstr "{time} ago"
 
-#: app.py:848 app.py:850 app.py:976
+#: app.py:847 app.py:849 app.py:975
 #, fuzzy
 msgid "no_such_level"
 msgstr "No such Hedy level!"
 
-#: app.py:858 app.py:865 app.py:931 app.py:937
+#: app.py:857 app.py:864 app.py:930 app.py:936
 #, fuzzy
 msgid "no_such_program"
 msgstr "No such Hedy program!"
 
-#: app.py:891
+#: app.py:890
 #, fuzzy
 msgid "level_not_translated"
 msgstr "This level is not translated in your language (yet)"
 
-#: app.py:893
+#: app.py:892
 #, fuzzy
 msgid "level_not_class"
 msgstr "You're in a class where this level has not been made available yet"
 
-#: app.py:986 website/teacher.py:432 website/teacher.py:448
+#: app.py:985 website/teacher.py:432 website/teacher.py:448
 #: website/teacher.py:477 website/teacher.py:503
 #, fuzzy
 msgid "no_such_adventure"
 msgstr "This adventure doesn't exist!"
 
-#: app.py:1005
+#: app.py:1004
 #, fuzzy
 msgid "page_not_found"
 msgstr "We could not find that page!"
 
-#: app.py:1025
+#: app.py:1024
 #, fuzzy
 msgid "title_signup"
 msgstr "Hedy - Create an account"
 
-#: app.py:1032
+#: app.py:1031
 #, fuzzy
 msgid "title_login"
 msgstr "Hedy - Login"
 
-#: app.py:1039
+#: app.py:1038
 #, fuzzy
 msgid "title_recover"
 msgstr "Hedy - Recover account"
 
-#: app.py:1055
+#: app.py:1054
 #, fuzzy
 msgid "title_reset"
 msgstr "Hedy - Reset password"
 
-#: app.py:1064
+#: app.py:1063
 #, fuzzy
 msgid "title_my-profile"
 msgstr "Hedy - My account"
 
-#: app.py:1078
+#: app.py:1077
 #, fuzzy
 msgid "title_learn-more"
 msgstr "Hedy - Learn more"
 
-#: app.py:1083
+#: app.py:1082
 #, fuzzy
 msgid "title_privacy"
 msgstr "Hedy - Privacy terms"
 
-#: app.py:1090
+#: app.py:1089
 #, fuzzy
 msgid "title_landing-page"
 msgstr "Welcome to Hedy!"
 
-#: app.py:1092
+#: app.py:1091
 #, fuzzy
 msgid "not_user"
 msgstr "Looks like you are not logged in!"
 
-#: app.py:1107
+#: app.py:1106
 #, fuzzy
 msgid "title_for-teacher"
 msgstr "Hedy - For teachers"
 
-#: app.py:1118
+#: app.py:1117
 #, fuzzy
 msgid "title_start"
 msgstr "Hedy - A gradual programming language"
 
-#: app.py:1171
+#: app.py:1170
 #, fuzzy
 msgid "title_explore"
 msgstr "Hedy - Explore"
 
-#: app.py:1190 app.py:1192
+#: app.py:1189 app.py:1191
 #, fuzzy
 msgid "translate_error"
 msgstr ""
 "Something went wrong while translating the code. Try running the code to "
 "see if it has an error. Code with errors can not be translated."
 
-#: app.py:1301 website/auth.py:299 website/auth.py:347 website/auth.py:483
+#: app.py:1300 website/auth.py:299 website/auth.py:347 website/auth.py:483
 #: website/auth.py:509 website/auth.py:539 website/auth.py:645
 #: website/auth.py:677 website/auth.py:717 website/auth.py:744
 #: website/teacher.py:90 website/teacher.py:125 website/teacher.py:197
@@ -172,32 +172,32 @@ msgstr ""
 msgid "ajax_error"
 msgstr "Une erreur est survenue, merci de réessayer."
 
-#: app.py:1304
+#: app.py:1303
 #, fuzzy
 msgid "image_invalid"
 msgstr "Your chosen image is invalid."
 
-#: app.py:1306
+#: app.py:1305
 #, fuzzy
 msgid "personal_text_invalid"
 msgstr "Your personal text is invalid."
 
-#: app.py:1308 app.py:1314
+#: app.py:1307 app.py:1313
 #, fuzzy
 msgid "favourite_program_invalid"
 msgstr "Your chosen favourite program is invalid."
 
-#: app.py:1326 app.py:1327
+#: app.py:1325 app.py:1326
 #, fuzzy
 msgid "public_profile_updated"
 msgstr "Public profile updated."
 
-#: app.py:1361 app.py:1385
+#: app.py:1360 app.py:1384
 #, fuzzy
 msgid "user_not_private"
 msgstr "This user doesn't exist or doesn't have a public profile"
 
-#: app.py:1394
+#: app.py:1393
 #, fuzzy
 msgid "invalid_teacher_invitation_code"
 msgstr ""
@@ -372,16 +372,16 @@ msgstr "It looks like you forgot to use a command on line {line_number}."
 #, fuzzy
 msgid "ask_needs_var"
 msgstr ""
-"Starting in level 2, ask needs to be used with a variable. "
-"Example: name is ask What are you called?"
+"Starting in level 2, ask needs to be used with a variable. Example: name "
+"is ask What are you called?"
 
 #: coursedata/error-messages.txt:24
 #, fuzzy
 msgid "echo_out"
 msgstr ""
 "Starting in level 2 echo is no longer needed. You can repeat an answer "
-"with ask and print now. Example: name is ask What are you called? print"
-" hello name"
+"with ask and print now. Example: name is ask What are you called? print "
+"hello name"
 
 #: coursedata/error-messages.txt:25
 msgid "space"
@@ -466,6 +466,11 @@ msgstr "a list"
 #, fuzzy
 msgid "input"
 msgstr "input from ask"
+
+#: templates/achievements.html:4
+#, fuzzy
+msgid "achievements_title"
+msgstr "achievements"
 
 #: templates/class-overview.html:16
 #, fuzzy
@@ -629,14 +634,14 @@ msgstr ""
 msgid "join_class"
 msgstr "Rejoignez le cours"
 
-#: templates/class-stats.html:22 templates/customize-class.html:155
+#: templates/class-stats.html:22 templates/customize-class.html:150
 #, fuzzy
 msgid "back_to_class"
 msgstr "Go back to class"
 
 #: templates/code-page.html:25 templates/code-page.html:34
-#: templates/customize-class.html:28 templates/customize-class.html:64
-#: templates/customize-class.html:71 templates/customize-class.html:94
+#: templates/customize-class.html:23 templates/customize-class.html:59
+#: templates/customize-class.html:66 templates/customize-class.html:89
 #: templates/incl-adventure-tabs.html:5 templates/level-page.html:6
 #: templates/level-page.html:11 templates/quiz/startquiz.html:10
 #: templates/view-program-page.html:12 templates/view-program-page.html:28
@@ -665,8 +670,8 @@ msgstr ""
 msgid "create_accounts_prompt"
 msgstr "Are you sure you want to create these accounts?"
 
-#: templates/create-accounts.html:17 templates/learn-more.html:10
-#: templates/profile.html:96 templates/recover.html:8 templates/signup.html:13
+#: templates/create-accounts.html:17 templates/profile.html:96
+#: templates/recover.html:8 templates/signup.html:13
 msgid "email"
 msgstr "Adresse email"
 
@@ -742,8 +747,8 @@ msgstr ""
 "adventure. To view the adventure on a dedicated page, select \"view\" "
 "from the teachers page."
 
-#: templates/customize-adventure.html:43 templates/customize-class.html:28
-#: templates/customize-class.html:93 templates/explore.html:26
+#: templates/customize-adventure.html:43 templates/customize-class.html:23
+#: templates/customize-class.html:88 templates/explore.html:26
 #: templates/programs.html:18 templates/programs.html:48
 #: templates/view-adventure.html:6
 msgid "adventure"
@@ -773,7 +778,7 @@ msgstr "I agree that my adventure might be made publicly available on Hedy."
 msgid "preview"
 msgstr "Preview"
 
-#: templates/customize-adventure.html:51 templates/customize-class.html:150
+#: templates/customize-adventure.html:51 templates/customize-class.html:145
 #, fuzzy
 msgid "save"
 msgstr "Save"
@@ -783,119 +788,78 @@ msgstr "Save"
 msgid "delete_adventure_prompt"
 msgstr "Are you sure you want to remove this adventure?"
 
-#: templates/customize-class.html:7
-msgid "customize_class_exp_1"
-msgstr "Salut ! Sur cette page, vous pouvez personnaliser votre classe. En sélectionnant les niveaux et les aventures, vous pouvez choisir ce que vos élèves pourront voir. Vous pouvez également ajouter vos propres aventures créées. <b>Remarque :</b> Toutes les aventures ne sont pas disponibles pour tous les niveaux ! La configuration de vos personnalisations se déroule comme suit :"
-
-#: templates/customize-class.html:10
-msgid "customize_class_step_1"
-msgstr "Sélectionnez les niveaux de votre classe en appuyant sur la touche \"level buttons\""
-
-#: templates/customize-class.html:11
-msgid "customize_class_step_2"
-msgstr "Les \"Checkboxes\" apparaitront pour les aventures disponibles pour les niveaux choisis"
-
-#: templates/customize-class.html:12
-msgid "customize_class_step_3"
-msgstr "Sélectionnez les aventures que vous voulez rendre disponibles"
-
-#: templates/customize-class.html:13
-msgid "customize_class_step_4"
-msgstr "Cliquez sur le nom d'une aventure pour la (dé)sélectionner pour tous les niveaux."
-
-#: templates/customize-class.html:14
-msgid "customize_class_step_5"
-msgstr "Ajouter des aventures personnelles"
-
-#: templates/customize-class.html:15
-msgid "customize_class_step_6"
-msgstr "Choisissez \"Sauvez\" -> Vous avez terminé !"
-
-#: templates/customize-class.html:16
-msgid "customize_class_step_7"
-msgstr "Selection other settings"
-
-#: templates/customize-class.html:17
-#, fuzzy
-msgid "customize_class_step_8"
-msgstr "Customize class"
-
-#: templates/customize-class.html:20
-msgid "customize_class_exp_2"
-msgstr "Vous pouvez toujours modifier ces paramètres par la suite. Par exemple, vous pouvez rendre des aventures ou des niveaux spécifiques disponibles durant le cours. De cette façon, il est facile pour vous de déterminer sur quel niveau et quelles aventures vos élèves vont travailler. Si vous voulez que tout soit disponible, le plus simple est de supprimer complètement la personnalisation."
-
-#: templates/customize-class.html:23
+#: templates/customize-class.html:18
 #, fuzzy
 msgid "select_adventures"
 msgstr "Select adventures"
 
-#: templates/customize-class.html:59
+#: templates/customize-class.html:54
 #, fuzzy
 msgid "opening_dates"
 msgstr "Opening dates"
 
-#: templates/customize-class.html:65
+#: templates/customize-class.html:60
 #, fuzzy
 msgid "opening_date"
 msgstr "Opening date"
 
-#: templates/customize-class.html:77
+#: templates/customize-class.html:72
 #, fuzzy
 msgid "directly_available"
 msgstr "Directly open"
 
-#: templates/customize-class.html:88
+#: templates/customize-class.html:83
 #, fuzzy
 msgid "select_own_adventures"
 msgstr "Select own adventures"
 
-#: templates/customize-class.html:95 templates/customize-class.html:121
+#: templates/customize-class.html:90 templates/customize-class.html:116
 #: templates/profile.html:47 templates/profile.html:128
 #: templates/profile.html:137 templates/signup.html:26 templates/signup.html:45
 #: templates/signup.html:53
 msgid "select"
 msgstr "Sélectionner"
 
-#: templates/customize-class.html:115
+#: templates/customize-class.html:110
 #, fuzzy
 msgid "other_settings"
 msgstr "Other settings"
 
-#: templates/customize-class.html:120
+#: templates/customize-class.html:115
 #, fuzzy
 msgid "option"
 msgstr "Option"
 
-#: templates/customize-class.html:126
+#: templates/customize-class.html:121
 #, fuzzy
 msgid "mandatory_mode"
 msgstr "Mandatory developer's mode"
 
-#: templates/customize-class.html:132
+#: templates/customize-class.html:127
 #, fuzzy
 msgid "hide_cheatsheet"
 msgstr "Hide cheatsheet"
 
-#: templates/customize-class.html:138
+#: templates/customize-class.html:133
 msgid "hide_keyword_switcher"
 msgstr ""
 
-#: templates/customize-class.html:149
+#: templates/customize-class.html:144
 #, fuzzy
 msgid "reset_adventure_prompt"
 msgstr "Are you sure you want to reset all selected adventures?"
 
-#: templates/customize-class.html:149
+#: templates/customize-class.html:144
 #, fuzzy
 msgid "reset_adventures"
 msgstr "Reset selected adventures"
 
-#: templates/customize-class.html:153
+#: templates/customize-class.html:148
 #, fuzzy
 msgid "remove_customizations_prompt"
 msgstr "Are you sure you want to remove this class their customizations?"
 
-#: templates/customize-class.html:154
+#: templates/customize-class.html:149
 #, fuzzy
 msgid "remove_customization"
 msgstr "Remove customization"
@@ -1170,35 +1134,6 @@ msgstr ""
 msgid "achievement_earned"
 msgstr "You've earned an achievement!"
 
-#: templates/learn-more.html:7
-msgid "mailing_title"
-msgstr "Abonne-toi à la newsletter Hedy"
-
-#: templates/learn-more.html:14
-msgid "surname"
-msgstr "Prénom"
-
-#: templates/learn-more.html:18
-msgid "lastname"
-msgstr "Nom"
-
-#: templates/learn-more.html:22 templates/profile.html:135
-#: templates/signup.html:52
-msgid "country"
-msgstr "Pays"
-
-#: templates/learn-more.html:31
-msgid "subscribe"
-msgstr "S'abonner"
-
-#: templates/learn-more.html:32
-msgid "required_field"
-msgstr "* champs requis"
-
-#: templates/learn-more.html:35
-msgid "previous_campaigns"
-msgstr "Voir les précédentes nouvelles"
-
 #: templates/level-page.html:8
 msgid "step_title"
 msgstr "Devoir"
@@ -1230,18 +1165,6 @@ msgstr "Créer un compte"
 #: templates/login.html:33
 msgid "forgot_password"
 msgstr "Mot de passe oublié ?"
-
-#: templates/main-page.html:9
-msgid "main_title"
-msgstr "Hedy"
-
-#: templates/main-page.html:10
-msgid "main_subtitle"
-msgstr "Un langage de programmation progressif"
-
-#: templates/main-page.html:13
-msgid "try_it"
-msgstr "Essayer"
 
 #: templates/profile.html:4
 #, fuzzy
@@ -1374,6 +1297,10 @@ msgstr "Homme"
 #: templates/profile.html:131 templates/signup.html:48
 msgid "other"
 msgstr "Autre"
+
+#: templates/profile.html:135 templates/signup.html:52
+msgid "country"
+msgstr "Pays"
 
 #: templates/profile.html:141
 msgid "update_profile"
@@ -2036,4 +1963,92 @@ msgstr "You didn't enter an adventure name!"
 
 #~ msgid "required"
 #~ msgstr ""
+
+#~ msgid "customize_class_exp_1"
+#~ msgstr ""
+#~ "Salut ! Sur cette page, vous "
+#~ "pouvez personnaliser votre classe. En "
+#~ "sélectionnant les niveaux et les "
+#~ "aventures, vous pouvez choisir ce que"
+#~ " vos élèves pourront voir. Vous "
+#~ "pouvez également ajouter vos propres "
+#~ "aventures créées. <b>Remarque :</b> Toutes "
+#~ "les aventures ne sont pas disponibles"
+#~ " pour tous les niveaux ! La "
+#~ "configuration de vos personnalisations se "
+#~ "déroule comme suit :"
+
+#~ msgid "customize_class_step_1"
+#~ msgstr ""
+#~ "Sélectionnez les niveaux de votre classe"
+#~ " en appuyant sur la touche \"level"
+#~ " buttons\""
+
+#~ msgid "customize_class_step_2"
+#~ msgstr ""
+#~ "Les \"Checkboxes\" apparaitront pour les "
+#~ "aventures disponibles pour les niveaux "
+#~ "choisis"
+
+#~ msgid "customize_class_step_3"
+#~ msgstr "Sélectionnez les aventures que vous voulez rendre disponibles"
+
+#~ msgid "customize_class_step_4"
+#~ msgstr ""
+#~ "Cliquez sur le nom d'une aventure "
+#~ "pour la (dé)sélectionner pour tous les"
+#~ " niveaux."
+
+#~ msgid "customize_class_step_5"
+#~ msgstr "Ajouter des aventures personnelles"
+
+#~ msgid "customize_class_step_6"
+#~ msgstr "Choisissez \"Sauvez\" -> Vous avez terminé !"
+
+#~ msgid "customize_class_step_7"
+#~ msgstr "Selection other settings"
+
+#~ msgid "customize_class_step_8"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_exp_2"
+#~ msgstr ""
+#~ "Vous pouvez toujours modifier ces "
+#~ "paramètres par la suite. Par exemple,"
+#~ " vous pouvez rendre des aventures ou"
+#~ " des niveaux spécifiques disponibles durant"
+#~ " le cours. De cette façon, il "
+#~ "est facile pour vous de déterminer "
+#~ "sur quel niveau et quelles aventures "
+#~ "vos élèves vont travailler. Si vous "
+#~ "voulez que tout soit disponible, le "
+#~ "plus simple est de supprimer "
+#~ "complètement la personnalisation."
+
+#~ msgid "mailing_title"
+#~ msgstr "Abonne-toi à la newsletter Hedy"
+
+#~ msgid "surname"
+#~ msgstr "Prénom"
+
+#~ msgid "lastname"
+#~ msgstr "Nom"
+
+#~ msgid "subscribe"
+#~ msgstr "S'abonner"
+
+#~ msgid "required_field"
+#~ msgstr "* champs requis"
+
+#~ msgid "previous_campaigns"
+#~ msgstr "Voir les précédentes nouvelles"
+
+#~ msgid "main_title"
+#~ msgstr "Hedy"
+
+#~ msgid "main_subtitle"
+#~ msgstr "Un langage de programmation progressif"
+
+#~ msgid "try_it"
+#~ msgstr "Essayer"
 

--- a/translations/fy/LC_MESSAGES/messages.po
+++ b/translations/fy/LC_MESSAGES/messages.po
@@ -1,18 +1,18 @@
+
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-03-29 10:01+0200\n"
+"POT-Creation-Date: 2022-03-30 08:43+0200\n"
 "PO-Revision-Date: 2022-03-30 09:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
-"Language-Team: Frisian <https://hosted.weblate.org/projects/hedy/web-texts/"
-"fy/>\n"
 "Language: fy\n"
+"Language-Team: Frisian <https://hosted.weblate.org/projects/hedy/web-"
+"texts/fy/>\n"
+"Plural-Forms: nplurals=2; plural=n != 1\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.12-dev\n"
 "Generated-By: Babel 2.9.1\n"
 
 #: app.py:571
@@ -20,27 +20,27 @@ msgstr ""
 msgid "program_contains_error"
 msgstr "This program contains an error, are you sure you want to share it?"
 
-#: app.py:723
+#: app.py:722
 #, fuzzy
 msgid "title_achievements"
 msgstr "Hedy - My achievements"
 
-#: app.py:740 app.py:1111 website/teacher.py:365 website/teacher.py:374
+#: app.py:739 app.py:1110 website/teacher.py:365 website/teacher.py:374
 #, fuzzy
 msgid "not_teacher"
 msgstr "Looks like you are not a teacher!"
 
-#: app.py:743
+#: app.py:742
 #, fuzzy
 msgid "not_enrolled"
 msgstr "Looks like you are not in this class!"
 
-#: app.py:775
+#: app.py:774
 #, fuzzy
 msgid "title_programs"
 msgstr "Hedy - My programs"
 
-#: app.py:785 app.py:795 app.py:799 app.py:813 app.py:1054 app.py:1357
+#: app.py:784 app.py:794 app.py:798 app.py:812 app.py:1053 app.py:1356
 #: website/admin.py:17 website/admin.py:25 website/admin.py:95
 #: website/admin.py:112 website/admin.py:130 website/auth.py:711
 #: website/auth.py:738 website/statistics.py:86
@@ -48,122 +48,122 @@ msgstr "Hedy - My programs"
 msgid "unauthorized"
 msgstr "You don't have access rights for this page"
 
-#: app.py:823
+#: app.py:822
 msgid "minutes"
 msgstr "minuten"
 
-#: app.py:826
+#: app.py:825
 msgid "hours"
 msgstr "oeren"
 
-#: app.py:829
+#: app.py:828
 msgid "days"
 msgstr "dagen"
 
-#: app.py:832
+#: app.py:831
 #, fuzzy
 msgid "ago"
 msgstr "{time} ago"
 
-#: app.py:848 app.py:850 app.py:976
+#: app.py:847 app.py:849 app.py:975
 #, fuzzy
 msgid "no_such_level"
 msgstr "No such Hedy level!"
 
-#: app.py:858 app.py:865 app.py:931 app.py:937
+#: app.py:857 app.py:864 app.py:930 app.py:936
 #, fuzzy
 msgid "no_such_program"
 msgstr "No such Hedy program!"
 
-#: app.py:891
+#: app.py:890
 #, fuzzy
 msgid "level_not_translated"
 msgstr "This level is not translated in your language (yet)"
 
-#: app.py:893
+#: app.py:892
 #, fuzzy
 msgid "level_not_class"
 msgstr "You're in a class where this level has not been made available yet"
 
-#: app.py:986 website/teacher.py:432 website/teacher.py:448
+#: app.py:985 website/teacher.py:432 website/teacher.py:448
 #: website/teacher.py:477 website/teacher.py:503
 #, fuzzy
 msgid "no_such_adventure"
 msgstr "This adventure doesn't exist!"
 
-#: app.py:1005
+#: app.py:1004
 #, fuzzy
 msgid "page_not_found"
 msgstr "We could not find that page!"
 
-#: app.py:1025
+#: app.py:1024
 #, fuzzy
 msgid "title_signup"
 msgstr "Hedy - Create an account"
 
-#: app.py:1032
+#: app.py:1031
 #, fuzzy
 msgid "title_login"
 msgstr "Hedy - Login"
 
-#: app.py:1039
+#: app.py:1038
 #, fuzzy
 msgid "title_recover"
 msgstr "Hedy - Recover account"
 
-#: app.py:1055
+#: app.py:1054
 #, fuzzy
 msgid "title_reset"
 msgstr "Hedy - Reset password"
 
-#: app.py:1064
+#: app.py:1063
 #, fuzzy
 msgid "title_my-profile"
 msgstr "Hedy - My account"
 
-#: app.py:1078
+#: app.py:1077
 #, fuzzy
 msgid "title_learn-more"
 msgstr "Hedy - Learn more"
 
-#: app.py:1083
+#: app.py:1082
 #, fuzzy
 msgid "title_privacy"
 msgstr "Hedy - Privacy terms"
 
-#: app.py:1090
+#: app.py:1089
 #, fuzzy
 msgid "title_landing-page"
 msgstr "Welcome to Hedy!"
 
-#: app.py:1092
+#: app.py:1091
 #, fuzzy
 msgid "not_user"
 msgstr "Looks like you are not logged in!"
 
-#: app.py:1107
+#: app.py:1106
 #, fuzzy
 msgid "title_for-teacher"
 msgstr "Hedy - For teachers"
 
-#: app.py:1118
+#: app.py:1117
 #, fuzzy
 msgid "title_start"
 msgstr "Hedy - A gradual programming language"
 
-#: app.py:1171
+#: app.py:1170
 #, fuzzy
 msgid "title_explore"
 msgstr "Hedy - Explore"
 
-#: app.py:1190 app.py:1192
+#: app.py:1189 app.py:1191
 #, fuzzy
 msgid "translate_error"
 msgstr ""
-"Something went wrong while translating the code. Try running the code to see "
-"if it has an error. Code with errors can not be translated."
+"Something went wrong while translating the code. Try running the code to "
+"see if it has an error. Code with errors can not be translated."
 
-#: app.py:1301 website/auth.py:299 website/auth.py:347 website/auth.py:483
+#: app.py:1300 website/auth.py:299 website/auth.py:347 website/auth.py:483
 #: website/auth.py:509 website/auth.py:539 website/auth.py:645
 #: website/auth.py:677 website/auth.py:717 website/auth.py:744
 #: website/teacher.py:90 website/teacher.py:125 website/teacher.py:197
@@ -172,37 +172,37 @@ msgstr ""
 msgid "ajax_error"
 msgstr "Der gong wat mis, besykje it nochris."
 
-#: app.py:1304
+#: app.py:1303
 #, fuzzy
 msgid "image_invalid"
 msgstr "Your chosen image is invalid."
 
-#: app.py:1306
+#: app.py:1305
 #, fuzzy
 msgid "personal_text_invalid"
 msgstr "Your personal text is invalid."
 
-#: app.py:1308 app.py:1314
+#: app.py:1307 app.py:1313
 #, fuzzy
 msgid "favourite_program_invalid"
 msgstr "Your chosen favourite program is invalid."
 
-#: app.py:1326 app.py:1327
+#: app.py:1325 app.py:1326
 #, fuzzy
 msgid "public_profile_updated"
 msgstr "Public profile updated."
 
-#: app.py:1361 app.py:1385
+#: app.py:1360 app.py:1384
 #, fuzzy
 msgid "user_not_private"
 msgstr "This user doesn't exist or doesn't have a public profile"
 
-#: app.py:1394
+#: app.py:1393
 #, fuzzy
 msgid "invalid_teacher_invitation_code"
 msgstr ""
-"The teacher invitation code is invalid. To become a teacher, reach out to "
-"hedy@felienne.com."
+"The teacher invitation code is invalid. To become a teacher, reach out to"
+" hedy@felienne.com."
 
 #: utils.py:203
 #, fuzzy
@@ -222,20 +222,20 @@ msgstr "Something went wrong..."
 #: coursedata/error-messages.txt:1
 msgid "Empty Program"
 msgstr ""
-"Hast in leech programma makke. Skreau koade yn it linkerfjild en besykje it "
-"openij."
+"Hast in leech programma makke. Skreau koade yn it linkerfjild en besykje "
+"it openij."
 
 #: coursedata/error-messages.txt:2
 msgid "Wrong Level"
 msgstr ""
-"Dat wie bêste koade hear, mar net op in goeie level. Hast koade skreaun foar "
-"level {working_level} op level {original_level}."
+"Dat wie bêste koade hear, mar net op in goeie level. Hast koade skreaun "
+"foar level {working_level} op level {original_level}."
 
 #: coursedata/error-messages.txt:3
 msgid "Incomplete"
 msgstr ""
-"Tink derom, bist wat koade fergetten. Op rigel {line_number} moat der efter "
-"{incomplete_command} noch tekst komme."
+"Tink derom, bist wat koade fergetten. Op rigel {line_number} moat der "
+"efter {incomplete_command} noch tekst komme."
 
 #: coursedata/error-messages.txt:4
 msgid "Invalid"
@@ -246,36 +246,36 @@ msgstr ""
 #: coursedata/error-messages.txt:5
 msgid "Invalid Space"
 msgstr ""
-"Heden! Rigel {line_number} begjint mei ien spaasje. Computers kinne net sa "
-"goed oer spaasjes, kinst him fuorthelje?"
+"Heden! Rigel {line_number} begjint mei ien spaasje. Computers kinne net "
+"sa goed oer spaasjes, kinst him fuorthelje?"
 
 #: coursedata/error-messages.txt:6
 msgid "Has Blanks"
 msgstr ""
-"Tink der om! Dyn koade is noch net ôf. Der stiet noch leech streepke yn, dêr "
-"moat de goede koade noch stean."
+"Tink der om! Dyn koade is noch net ôf. Der stiet noch leech streepke yn, "
+"dêr moat de goede koade noch stean."
 
 #: coursedata/error-messages.txt:7
 #, fuzzy
 msgid "No Indentation"
 msgstr ""
 "You used too few spaces in line {line_number}. You used {leading_spaces} "
-"spaces, which is not enough. Start every new block with {indent_size} spaces "
-"more than the line before."
+"spaces, which is not enough. Start every new block with {indent_size} "
+"spaces more than the line before."
 
 #: coursedata/error-messages.txt:8
 msgid "Unexpected Indentation"
 msgstr ""
 "Hast tefolle spaasjes foar rigel {line_number} brûkt. Der stean "
-"{leading_spaces} spaasjes, mar dat binne tefolle. Begjin in blok hieltiid "
-"mei {indent_size} spaasjes."
+"{leading_spaces} spaasjes, mar dat binne tefolle. Begjin in blok hieltiid"
+" mei {indent_size} spaasjes."
 
 #: coursedata/error-messages.txt:9
 msgid "Parse"
 msgstr ""
-"De koade dysto skreaun hast is gjin jildige Hedy-koade. Der sit in flater op "
-"rigel {location[0]}, op posysje {location[1]}. Do hast  {character_found} "
-"typt, mar dat mei op dy plak net."
+"De koade dysto skreaun hast is gjin jildige Hedy-koade. Der sit in flater"
+" op rigel {location[0]}, op posysje {location[1]}. Do hast  "
+"{character_found} typt, mar dat mei op dy plak net."
 
 #: coursedata/error-messages.txt:10
 msgid "Unquoted Text"
@@ -287,8 +287,8 @@ msgstr ""
 #, fuzzy
 msgid "Unquoted Assignment"
 msgstr ""
-"From this level, you need to place texts to the right of the `is` between "
-"quotes. You forgot that for the text {text}."
+"From this level, you need to place texts to the right of the `is` between"
+" quotes. You forgot that for the text {text}."
 
 #: coursedata/error-messages.txt:12
 #, fuzzy
@@ -300,66 +300,66 @@ msgstr ""
 #: coursedata/error-messages.txt:13
 msgid "Var Undefined"
 msgstr ""
-"Do besykest de fariabele {name} te printen, mar dy hast gjin wearde jûn. It "
-"kin ek wêze datst it wurd {name} printen woest en oanhellingtekens fergetten "
-"bist."
+"Do besykest de fariabele {name} te printen, mar dy hast gjin wearde jûn. "
+"It kin ek wêze datst it wurd {name} printen woest en oanhellingtekens "
+"fergetten bist."
 
 #: coursedata/error-messages.txt:14
 #, fuzzy
 msgid "Cyclic Var Definition"
 msgstr ""
-"The name {variable} needs to be set before you can use it on the right-hand "
-"side of the is command"
+"The name {variable} needs to be set before you can use it on the right-"
+"hand side of the is command"
 
 #: coursedata/error-messages.txt:15
 msgid "Lonely Echo"
 msgstr ""
-"Brûkst in `echo` foar in `ask`, as een `echo` sûnder `ask`. Freegje earst "
-"mei in `ask` om ynfier earst dy werhellest mei in `echo`."
+"Brûkst in `echo` foar in `ask`, as een `echo` sûnder `ask`. Freegje earst"
+" mei in `ask` om ynfier earst dy werhellest mei in `echo`."
 
 #: coursedata/error-messages.txt:16
 msgid "Too Big"
 msgstr ""
-"Krammele! Dyn programme is wol {lines_of_code} rigels lang! Mar... Hedy kin "
-"mar {max_lines} rigels oan yn dit level. Meitsje dyn programma wat lytser en "
-"besykje it nochris."
+"Krammele! Dyn programme is wol {lines_of_code} rigels lang! Mar... Hedy "
+"kin mar {max_lines} rigels oan yn dit level. Meitsje dyn programma wat "
+"lytser en besykje it nochris."
 
 #: coursedata/error-messages.txt:17
 #, fuzzy
 msgid "Invalid Argument Type"
 msgstr ""
-"You cannot use the command {command} with {invalid_argument} because it is "
-"{invalid_type}. Try changing {invalid_argument} to {allowed_types}."
+"You cannot use the command {command} with {invalid_argument} because it "
+"is {invalid_type}. Try changing {invalid_argument} to {allowed_types}."
 
 #: coursedata/error-messages.txt:18
 #, fuzzy
 msgid "Invalid Argument"
 msgstr ""
-"You cannot use the command {command} with {invalid_argument} . Try changing "
-"{invalid_argument} to {allowed_types}."
+"You cannot use the command {command} with {invalid_argument} . Try "
+"changing {invalid_argument} to {allowed_types}."
 
 #: coursedata/error-messages.txt:19
 #, fuzzy
 msgid "Invalid Type Combination"
 msgstr ""
-"You cannot use {invalid_argument} and {invalid_argument_2} in {operation} "
-"because one is {invalid_type} and the other is {invalid_type_2}. Try "
-"changing {invalid_argument} to {invalid_type_2} or {invalid_argument_2} to "
-"{invalid_type}."
+"You cannot use {invalid_argument} and {invalid_argument_2} in {operation}"
+" because one is {invalid_type} and the other is {invalid_type_2}. Try "
+"changing {invalid_argument} to {invalid_type_2} or {invalid_argument_2} "
+"to {invalid_type}."
 
 #: coursedata/error-messages.txt:20
 #, fuzzy
 msgid "Unsupported Float"
 msgstr ""
-"Non-integer numbers are not supported yet but they will be in a few levels. "
-"For now change {value} to an integer."
+"Non-integer numbers are not supported yet but they will be in a few "
+"levels. For now change {value} to an integer."
 
 #: coursedata/error-messages.txt:21
 #, fuzzy
 msgid "Locked Language Feature"
 msgstr ""
-"You are using {concept}! That is awesome, but {concept} is not unlocked yet! "
-"It will be unlocked in a later level."
+"You are using {concept}! That is awesome, but {concept} is not unlocked "
+"yet! It will be unlocked in a later level."
 
 #: coursedata/error-messages.txt:22
 #, fuzzy
@@ -370,15 +370,16 @@ msgstr "It looks like you forgot to use a command on line {line_number}."
 #, fuzzy
 msgid "ask_needs_var"
 msgstr ""
-"Starting in level 2, ask needs to be used with a variable. Example: name is "
-"ask What are you called?"
+"Starting in level 2, ask needs to be used with a variable. Example: name "
+"is ask What are you called?"
 
 #: coursedata/error-messages.txt:24
 #, fuzzy
 msgid "echo_out"
 msgstr ""
-"Starting in level 2 echo is no longer needed. You can repeat an answer with "
-"ask and print now. Example: name is ask What are you called? print hello name"
+"Starting in level 2 echo is no longer needed. You can repeat an answer "
+"with ask and print now. Example: name is ask What are you called? print "
+"hello name"
 
 #: coursedata/error-messages.txt:25
 msgid "space"
@@ -463,6 +464,11 @@ msgstr "a list"
 #, fuzzy
 msgid "input"
 msgstr "input from ask"
+
+#: templates/achievements.html:4
+#, fuzzy
+msgid "achievements_title"
+msgstr "achievements"
 
 #: templates/class-overview.html:16
 #, fuzzy
@@ -618,21 +624,22 @@ msgstr "Wolst oan dizze klas meidwaan?"
 #: templates/class-prejoin.html:17 website/teacher.py:183
 msgid "join_prompt"
 msgstr ""
-"Hast in akkount nedich om oan in klas meidwaan te kinnen. Wolst no ynlogge?"
+"Hast in akkount nedich om oan in klas meidwaan te kinnen. Wolst no "
+"ynlogge?"
 
 #: templates/class-prejoin.html:17 templates/profile.html:14
 #, fuzzy
 msgid "join_class"
 msgstr "Join class"
 
-#: templates/class-stats.html:22 templates/customize-class.html:155
+#: templates/class-stats.html:22 templates/customize-class.html:150
 #, fuzzy
 msgid "back_to_class"
 msgstr "Go back to class"
 
 #: templates/code-page.html:25 templates/code-page.html:34
-#: templates/customize-class.html:28 templates/customize-class.html:64
-#: templates/customize-class.html:71 templates/customize-class.html:94
+#: templates/customize-class.html:23 templates/customize-class.html:59
+#: templates/customize-class.html:66 templates/customize-class.html:89
 #: templates/incl-adventure-tabs.html:5 templates/level-page.html:6
 #: templates/level-page.html:11 templates/quiz/startquiz.html:10
 #: templates/view-program-page.html:12 templates/view-program-page.html:28
@@ -649,21 +656,21 @@ msgstr "Create multiple accounts"
 #, fuzzy
 msgid "accounts_intro"
 msgstr ""
-"On this page you can create accounts for multiple students at the same time. "
-"It is also possible to directly add them to one of your classes. By pressing "
-"the green + on the bottom right of the page you can add extra rows. You can "
-"delete a row by pressing the corresponding red cross. Make sure no rows are "
-"empty when you press \"Create accounts\". Please keep in mind that every "
-"username and mail address needs to be unique and the password needs to be "
-"<b>at least</b> 6 characters."
+"On this page you can create accounts for multiple students at the same "
+"time. It is also possible to directly add them to one of your classes. By"
+" pressing the green + on the bottom right of the page you can add extra "
+"rows. You can delete a row by pressing the corresponding red cross. Make "
+"sure no rows are empty when you press \"Create accounts\". Please keep in"
+" mind that every username and mail address needs to be unique and the "
+"password needs to be <b>at least</b> 6 characters."
 
 #: templates/create-accounts.html:10
 #, fuzzy
 msgid "create_accounts_prompt"
 msgstr "Are you sure you want to create these accounts?"
 
-#: templates/create-accounts.html:17 templates/learn-more.html:10
-#: templates/profile.html:96 templates/recover.html:8 templates/signup.html:13
+#: templates/create-accounts.html:17 templates/profile.html:96
+#: templates/recover.html:8 templates/signup.html:13
 msgid "email"
 msgstr "Email"
 
@@ -718,10 +725,10 @@ msgstr "Level"
 #, fuzzy
 msgid "adventure_exp_1"
 msgstr ""
-"Type your adventure of choice on the right-hand side. After creating your "
-"adventure you can include it in one of your classes under \"customizations"
-"\". If you want to include a command in your adventure please use code "
-"anchors like this:"
+"Type your adventure of choice on the right-hand side. After creating your"
+" adventure you can include it in one of your classes under "
+"\"customizations\". If you want to include a command in your adventure "
+"please use code anchors like this:"
 
 #: templates/customize-adventure.html:31
 #, fuzzy
@@ -735,11 +742,11 @@ msgstr ""
 msgid "adventure_exp_3"
 msgstr ""
 "You can use the \"preview\" button to view a styled version of your "
-"adventure. To view the adventure on a dedicated page, select \"view\" from "
-"the teachers page."
+"adventure. To view the adventure on a dedicated page, select \"view\" "
+"from the teachers page."
 
-#: templates/customize-adventure.html:43 templates/customize-class.html:28
-#: templates/customize-class.html:93 templates/explore.html:26
+#: templates/customize-adventure.html:43 templates/customize-class.html:23
+#: templates/customize-class.html:88 templates/explore.html:26
 #: templates/programs.html:18 templates/programs.html:48
 #: templates/view-adventure.html:6
 msgid "adventure"
@@ -769,7 +776,7 @@ msgstr "I agree that my adventure might be made publicly available on Hedy."
 msgid "preview"
 msgstr "Preview"
 
-#: templates/customize-adventure.html:51 templates/customize-class.html:150
+#: templates/customize-adventure.html:51 templates/customize-class.html:145
 #, fuzzy
 msgid "save"
 msgstr "Save"
@@ -779,128 +786,78 @@ msgstr "Save"
 msgid "delete_adventure_prompt"
 msgstr "Are you sure you want to remove this adventure?"
 
-#: templates/customize-class.html:7
-#, fuzzy
-msgid "customize_class_exp_1"
-msgstr "Customize class"
-
-#: templates/customize-class.html:10
-#, fuzzy
-msgid "customize_class_step_1"
-msgstr "Customize class"
-
-#: templates/customize-class.html:11
-#, fuzzy
-msgid "customize_class_step_2"
-msgstr "Customize class"
-
-#: templates/customize-class.html:12
-#, fuzzy
-msgid "customize_class_step_3"
-msgstr "Customize class"
-
-#: templates/customize-class.html:13
-#, fuzzy
-msgid "customize_class_step_4"
-msgstr "Customize class"
-
-#: templates/customize-class.html:14
-#, fuzzy
-msgid "customize_class_step_5"
-msgstr "Customize class"
-
-#: templates/customize-class.html:15
-#, fuzzy
-msgid "customize_class_step_6"
-msgstr "Customize class"
-
-#: templates/customize-class.html:16
-#, fuzzy
-msgid "customize_class_step_7"
-msgstr "Customize class"
-
-#: templates/customize-class.html:17
-#, fuzzy
-msgid "customize_class_step_8"
-msgstr "Customize class"
-
-#: templates/customize-class.html:20
-#, fuzzy
-msgid "customize_class_exp_2"
-msgstr "Customize class"
-
-#: templates/customize-class.html:23
+#: templates/customize-class.html:18
 #, fuzzy
 msgid "select_adventures"
 msgstr "Select adventures"
 
-#: templates/customize-class.html:59
+#: templates/customize-class.html:54
 #, fuzzy
 msgid "opening_dates"
 msgstr "Opening dates"
 
-#: templates/customize-class.html:65
+#: templates/customize-class.html:60
 #, fuzzy
 msgid "opening_date"
 msgstr "Opening date"
 
-#: templates/customize-class.html:77
+#: templates/customize-class.html:72
 #, fuzzy
 msgid "directly_available"
 msgstr "Directly open"
 
-#: templates/customize-class.html:88
+#: templates/customize-class.html:83
 #, fuzzy
 msgid "select_own_adventures"
 msgstr "Select own adventures"
 
-#: templates/customize-class.html:95 templates/customize-class.html:121
+#: templates/customize-class.html:90 templates/customize-class.html:116
 #: templates/profile.html:47 templates/profile.html:128
 #: templates/profile.html:137 templates/signup.html:26 templates/signup.html:45
 #: templates/signup.html:53
 msgid "select"
 msgstr "Kies"
 
-#: templates/customize-class.html:115
+#: templates/customize-class.html:110
 #, fuzzy
 msgid "other_settings"
 msgstr "Other settings"
 
-#: templates/customize-class.html:120
+#: templates/customize-class.html:115
 #, fuzzy
 msgid "option"
 msgstr "Option"
 
-#: templates/customize-class.html:126
+#: templates/customize-class.html:121
 #, fuzzy
 msgid "mandatory_mode"
 msgstr "Mandatory developer's mode"
 
-#: templates/customize-class.html:132
+#: templates/customize-class.html:127
 #, fuzzy
 msgid "hide_cheatsheet"
 msgstr "Hide cheatsheet"
 
-#: templates/customize-class.html:138
+#: templates/customize-class.html:133
 msgid "hide_keyword_switcher"
 msgstr ""
 
-#: templates/customize-class.html:149
+#: templates/customize-class.html:144
 #, fuzzy
 msgid "reset_adventure_prompt"
 msgstr "Are you sure you want to reset all selected adventures?"
 
-#: templates/customize-class.html:149
+#: templates/customize-class.html:144
 #, fuzzy
 msgid "reset_adventures"
 msgstr "Reset selected adventures"
 
-#: templates/customize-class.html:153
+#: templates/customize-class.html:148
 #, fuzzy
 msgid "remove_customizations_prompt"
 msgstr "Are you sure you want to remove this class their customizations?"
 
-#: templates/customize-class.html:154
+#: templates/customize-class.html:149
 #, fuzzy
 msgid "remove_customization"
 msgstr "Remove customization"
@@ -919,13 +876,13 @@ msgstr "Explore programs"
 #, fuzzy
 msgid "explore_explanation"
 msgstr ""
-"On this page you can look through programs created by other Hedy users. You "
-"can filter on both a Hedy level and adventure. Click on \"View program\" to "
-"open a program and run it. Programs with a red header contain a mistake. You "
-"can still open the program, but running it will result in an error. You can "
-"of course try to fix it! If the creator has a public profile you can click "
-"their username to visit their profile. There you will find all their shared "
-"programs and much more!"
+"On this page you can look through programs created by other Hedy users. "
+"You can filter on both a Hedy level and adventure. Click on \"View "
+"program\" to open a program and run it. Programs with a red header "
+"contain a mistake. You can still open the program, but running it will "
+"result in an error. You can of course try to fix it! If the creator has a"
+" public profile you can click their username to visit their profile. "
+"There you will find all their shared programs and much more!"
 
 #: templates/explore.html:35 templates/programs.html:27
 #, fuzzy
@@ -989,8 +946,8 @@ msgstr "Create student accounts"
 #, fuzzy
 msgid "teacher_welcome"
 msgstr ""
-"Welcome to Hedy! Your are now the proud owner of a teachers account which "
-"allows you to create classes and invite students."
+"Welcome to Hedy! Your are now the proud owner of a teachers account which"
+" allows you to create classes and invite students."
 
 #: templates/incl-adventure-tabs.html:22
 #, fuzzy
@@ -1101,9 +1058,9 @@ msgstr "Welcome"
 msgid "intro_text_landing_page"
 msgstr ""
 "Welcome to the wonderful world of Hedy! Here you can learn to program in "
-"small steps, without unnecessary complicated stuff. We start easy at level "
-"1, and slowly build towards bigger and more complex programs! Choose one of "
-"the options below to get started"
+"small steps, without unnecessary complicated stuff. We start easy at "
+"level 1, and slowly build towards bigger and more complex programs! "
+"Choose one of the options below to get started"
 
 #: templates/landing-page.html:14 templates/landing-page.html:36
 #, fuzzy
@@ -1119,14 +1076,14 @@ msgstr "Start programming"
 #: templates/landing-page.html:21
 #, fuzzy
 msgid "create_class_text"
-msgstr ""
-"Group your students into classes and change the content for each class."
+msgstr "Group your students into classes and change the content for each class."
 
 #: templates/landing-page.html:28
 #, fuzzy
 msgid "read_docs_text"
 msgstr ""
-"Visit our teacher's manual for lesson plans and common mistakes by students."
+"Visit our teacher's manual for lesson plans and common mistakes by "
+"students."
 
 #: templates/landing-page.html:30
 #, fuzzy
@@ -1168,49 +1125,14 @@ msgstr "Diellink kopiëare"
 #, fuzzy
 msgid "set_preferred_lang"
 msgstr ""
-"Hedy now supports preferred user languages. You can set one for your profile "
-"in \"My profile\""
+"Hedy now supports preferred user languages. You can set one for your "
+"profile in \"My profile\""
 
 #: templates/layout.html:86 templates/quiz/endquiz.html:18
 #: templates/quiz/quiz.html:29
 #, fuzzy
 msgid "achievement_earned"
 msgstr "You've earned an achievement!"
-
-#: templates/learn-more.html:7
-#, fuzzy
-msgid "mailing_title"
-msgstr "Title"
-
-#: templates/learn-more.html:14
-#, fuzzy
-msgid "surname"
-msgstr "Brûkersnamme"
-
-#: templates/learn-more.html:18
-#, fuzzy
-msgid "lastname"
-msgstr "Namme"
-
-#: templates/learn-more.html:22 templates/profile.html:135
-#: templates/signup.html:52
-msgid "country"
-msgstr "Lân wêrst wennest"
-
-#: templates/learn-more.html:31
-#, fuzzy
-msgid "subscribe"
-msgstr "Ynskreaue foar de nijsbrief"
-
-#: templates/learn-more.html:32
-#, fuzzy
-msgid "required_field"
-msgstr "Fields marked with an * are required"
-
-#: templates/learn-more.html:35
-#, fuzzy
-msgid "previous_campaigns"
-msgstr "View previous campaigns"
 
 #: templates/level-page.html:8
 msgid "step_title"
@@ -1243,21 +1165,6 @@ msgstr "Meitsje in akkount"
 #: templates/login.html:33
 msgid "forgot_password"
 msgstr "Bist dyn wachtwurd fergetten?"
-
-#: templates/main-page.html:9
-#, fuzzy
-msgid "main_title"
-msgstr "Title"
-
-#: templates/main-page.html:10
-#, fuzzy
-msgid "main_subtitle"
-msgstr "programs submitted"
-
-#: templates/main-page.html:13
-#, fuzzy
-msgid "try_it"
-msgstr "Besykje"
 
 #: templates/profile.html:4
 #, fuzzy
@@ -1323,9 +1230,9 @@ msgstr "Favourite program"
 #, fuzzy
 msgid "public_profile_info"
 msgstr ""
-"By selecting this box I make my profile visible for everyone. Be careful not "
-"to share personal information like your name or home address, because "
-"everyone will be able to see it!"
+"By selecting this box I make my profile visible for everyone. Be careful "
+"not to share personal information like your name or home address, because"
+" everyone will be able to see it!"
 
 #: templates/profile.html:59
 #, fuzzy
@@ -1390,6 +1297,10 @@ msgstr "Jonge"
 #: templates/profile.html:131 templates/signup.html:48
 msgid "other"
 msgstr "Oars"
+
+#: templates/profile.html:135 templates/signup.html:52
+msgid "country"
+msgstr "Lân wêrst wennest"
 
 #: templates/profile.html:141
 msgid "update_profile"
@@ -1589,8 +1500,8 @@ msgstr "Hast al in akkount?"
 #, fuzzy
 msgid "teacher_invitation_require_login"
 msgstr ""
-"To set up your profile as a teacher we will need you to log in. If you don't "
-"have an account, please create one."
+"To set up your profile as a teacher we will need you to log in. If you "
+"don't have an account, please create one."
 
 #: templates/view-program-page.html:13
 msgid "by"
@@ -1750,7 +1661,8 @@ msgstr "You have to agree with the privacy terms."
 #, fuzzy
 msgid "keyword_language_invalid"
 msgstr ""
-"Please select a valid keyword language (select English or your own language)."
+"Please select a valid keyword language (select English or your own "
+"language)."
 
 #: website/auth.py:371 website/auth.py:551
 msgid "year_invalid"
@@ -1815,8 +1727,8 @@ msgstr "Profile updated, page will be re-loaded."
 #: website/auth.py:670
 msgid "sent_password_recovery"
 msgstr ""
-"Do krijst sa in emailtsje wêrt yn útlein wurdt hoest in nij wachtwurd kieze "
-"kinst."
+"Do krijst sa in emailtsje wêrt yn útlein wurdt hoest in nij wachtwurd "
+"kieze kinst."
 
 #: website/auth.py:681 website/auth.py:691
 #, fuzzy
@@ -1840,7 +1752,8 @@ msgstr "Program deleted successfully."
 #: website/programs.py:55
 msgid "save_prompt"
 msgstr ""
-"Do hast in akkount nedich om dyn programma's te bewarjen. Wolst no ynlogge?"
+"Do hast in akkount nedich om dyn programma's te bewarjen. Wolst no "
+"ynlogge?"
 
 #: website/programs.py:60
 #, fuzzy
@@ -2050,3 +1963,61 @@ msgstr "The adventure has been updated!"
 #, fuzzy
 msgid "adventure_empty"
 msgstr "You didn't enter an adventure name!"
+
+#~ msgid "customize_class_exp_1"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_1"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_2"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_3"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_4"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_5"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_6"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_7"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_8"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_exp_2"
+#~ msgstr "Customize class"
+
+#~ msgid "mailing_title"
+#~ msgstr "Title"
+
+#~ msgid "surname"
+#~ msgstr "Brûkersnamme"
+
+#~ msgid "lastname"
+#~ msgstr "Namme"
+
+#~ msgid "subscribe"
+#~ msgstr "Ynskreaue foar de nijsbrief"
+
+#~ msgid "required_field"
+#~ msgstr "Fields marked with an * are required"
+
+#~ msgid "previous_campaigns"
+#~ msgstr "View previous campaigns"
+
+#~ msgid "main_title"
+#~ msgstr "Title"
+
+#~ msgid "main_subtitle"
+#~ msgstr "programs submitted"
+
+#~ msgid "try_it"
+#~ msgstr "Besykje"
+

--- a/translations/hi/LC_MESSAGES/messages.po
+++ b/translations/hi/LC_MESSAGES/messages.po
@@ -1,18 +1,18 @@
+
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-03-29 10:01+0200\n"
+"POT-Creation-Date: 2022-03-30 08:43+0200\n"
 "PO-Revision-Date: 2022-03-30 09:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
-"Language-Team: Hindi <https://hosted.weblate.org/projects/hedy/web-texts/hi/"
-">\n"
 "Language: hi\n"
+"Language-Team: Hindi <https://hosted.weblate.org/projects/hedy/web-"
+"texts/hi/>\n"
+"Plural-Forms: nplurals=2; plural=n != 1\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.12-dev\n"
 "Generated-By: Babel 2.9.1\n"
 
 #: app.py:571
@@ -20,25 +20,25 @@ msgstr ""
 msgid "program_contains_error"
 msgstr "This program contains an error, are you sure you want to share it?"
 
-#: app.py:723
+#: app.py:722
 #, fuzzy
 msgid "title_achievements"
 msgstr "Hedy - My achievements"
 
-#: app.py:740 app.py:1111 website/teacher.py:365 website/teacher.py:374
+#: app.py:739 app.py:1110 website/teacher.py:365 website/teacher.py:374
 msgid "not_teacher"
 msgstr "लगता है आप शिक्षक नहीं हैं!"
 
-#: app.py:743
+#: app.py:742
 msgid "not_enrolled"
 msgstr "ऐसा लगता है कि आप इस कक्षा में नहीं हैं!"
 
-#: app.py:775
+#: app.py:774
 #, fuzzy
 msgid "title_programs"
 msgstr "Hedy - My programs"
 
-#: app.py:785 app.py:795 app.py:799 app.py:813 app.py:1054 app.py:1357
+#: app.py:784 app.py:794 app.py:798 app.py:812 app.py:1053 app.py:1356
 #: website/admin.py:17 website/admin.py:25 website/admin.py:95
 #: website/admin.py:112 website/admin.py:130 website/auth.py:711
 #: website/auth.py:738 website/statistics.py:86
@@ -46,118 +46,118 @@ msgstr "Hedy - My programs"
 msgid "unauthorized"
 msgstr "You don't have access rights for this page"
 
-#: app.py:823
+#: app.py:822
 msgid "minutes"
 msgstr "मिनट "
 
-#: app.py:826
+#: app.py:825
 msgid "hours"
 msgstr "घंटे"
 
-#: app.py:829
+#: app.py:828
 msgid "days"
 msgstr "दिन"
 
-#: app.py:832
+#: app.py:831
 #, fuzzy
 msgid "ago"
 msgstr "{time} ago"
 
-#: app.py:848 app.py:850 app.py:976
+#: app.py:847 app.py:849 app.py:975
 msgid "no_such_level"
 msgstr "ऐसा कोई हेडी स्तर नहीं!"
 
-#: app.py:858 app.py:865 app.py:931 app.py:937
+#: app.py:857 app.py:864 app.py:930 app.py:936
 msgid "no_such_program"
 msgstr "ऐसा कोई हेडी प्रोग्राम नहीं!"
 
-#: app.py:891
+#: app.py:890
 #, fuzzy
 msgid "level_not_translated"
 msgstr "This level is not translated in your language (yet)"
 
-#: app.py:893
+#: app.py:892
 #, fuzzy
 msgid "level_not_class"
 msgstr "You're in a class where this level has not been made available yet"
 
-#: app.py:986 website/teacher.py:432 website/teacher.py:448
+#: app.py:985 website/teacher.py:432 website/teacher.py:448
 #: website/teacher.py:477 website/teacher.py:503
 #, fuzzy
 msgid "no_such_adventure"
 msgstr "This adventure doesn't exist!"
 
-#: app.py:1005
+#: app.py:1004
 msgid "page_not_found"
 msgstr "हमें वह पृष्ठ नहीं मिला!"
 
-#: app.py:1025
+#: app.py:1024
 #, fuzzy
 msgid "title_signup"
 msgstr "Hedy - Create an account"
 
-#: app.py:1032
+#: app.py:1031
 #, fuzzy
 msgid "title_login"
 msgstr "Hedy - Login"
 
-#: app.py:1039
+#: app.py:1038
 #, fuzzy
 msgid "title_recover"
 msgstr "Hedy - Recover account"
 
-#: app.py:1055
+#: app.py:1054
 #, fuzzy
 msgid "title_reset"
 msgstr "Hedy - Reset password"
 
-#: app.py:1064
+#: app.py:1063
 #, fuzzy
 msgid "title_my-profile"
 msgstr "Hedy - My account"
 
-#: app.py:1078
+#: app.py:1077
 #, fuzzy
 msgid "title_learn-more"
 msgstr "Hedy - Learn more"
 
-#: app.py:1083
+#: app.py:1082
 #, fuzzy
 msgid "title_privacy"
 msgstr "Hedy - Privacy terms"
 
-#: app.py:1090
+#: app.py:1089
 #, fuzzy
 msgid "title_landing-page"
 msgstr "Welcome to Hedy!"
 
-#: app.py:1092
+#: app.py:1091
 msgid "not_user"
 msgstr "ऐसा लगता है कि आप लॉग इन नहीं हैं!"
 
-#: app.py:1107
+#: app.py:1106
 #, fuzzy
 msgid "title_for-teacher"
 msgstr "Hedy - For teachers"
 
-#: app.py:1118
+#: app.py:1117
 #, fuzzy
 msgid "title_start"
 msgstr "Hedy - A gradual programming language"
 
-#: app.py:1171
+#: app.py:1170
 #, fuzzy
 msgid "title_explore"
 msgstr "Hedy - Explore"
 
-#: app.py:1190 app.py:1192
+#: app.py:1189 app.py:1191
 #, fuzzy
 msgid "translate_error"
 msgstr ""
-"Something went wrong while translating the code. Try running the code to see "
-"if it has an error. Code with errors can not be translated."
+"Something went wrong while translating the code. Try running the code to "
+"see if it has an error. Code with errors can not be translated."
 
-#: app.py:1301 website/auth.py:299 website/auth.py:347 website/auth.py:483
+#: app.py:1300 website/auth.py:299 website/auth.py:347 website/auth.py:483
 #: website/auth.py:509 website/auth.py:539 website/auth.py:645
 #: website/auth.py:677 website/auth.py:717 website/auth.py:744
 #: website/teacher.py:90 website/teacher.py:125 website/teacher.py:197
@@ -166,29 +166,31 @@ msgstr ""
 msgid "ajax_error"
 msgstr "एक त्रुटि थी, कृपया पुनः प्रयास करें।"
 
-#: app.py:1304
+#: app.py:1303
 msgid "image_invalid"
 msgstr "आपकी फोटो अमान्य है"
 
-#: app.py:1306
+#: app.py:1305
 msgid "personal_text_invalid"
 msgstr "आपका व्यक्तिगत पाठ अमान्य है"
 
-#: app.py:1308 app.py:1314
+#: app.py:1307 app.py:1313
 msgid "favourite_program_invalid"
 msgstr "आपका पसंदीदा प्रोग्राम अमान्य है"
 
-#: app.py:1326 app.py:1327
+#: app.py:1325 app.py:1326
 msgid "public_profile_updated"
 msgstr "सार्वजनिक प्रोफ़ाइल अद्यतन की गई।"
 
-#: app.py:1361 app.py:1385
+#: app.py:1360 app.py:1384
 msgid "user_not_private"
 msgstr "यह उपयोगकर्ता मौजूद नहीं है या उसकी कोई सार्वजनिक प्रोफ़ाइल नहीं है"
 
-#: app.py:1394
+#: app.py:1393
 msgid "invalid_teacher_invitation_code"
-msgstr "िक्षक आमंत्रण कोड अमान्य है| शिक्षक बनने के लिए, hedy@felienne.com पर संपर्क करें|"
+msgstr ""
+"िक्षक आमंत्रण कोड अमान्य है| शिक्षक बनने के लिए, hedy@felienne.com पर "
+"संपर्क करें|"
 
 #: utils.py:203
 msgid "default_404"
@@ -205,19 +207,20 @@ msgstr "कुछ गलत हो गया…"
 #: coursedata/error-messages.txt:1
 msgid "Empty Program"
 msgstr ""
-"आपने एक खाली प्रोग्राम बनाया है। बाएं क्षेत्र में हेडी कोड टाइप करें और पुनः प्रयास करें"
+"आपने एक खाली प्रोग्राम बनाया है। बाएं क्षेत्र में हेडी कोड टाइप करें और "
+"पुनः प्रयास करें"
 
 #: coursedata/error-messages.txt:2
 msgid "Wrong Level"
 msgstr ""
-"वह सही हैडी कोड था, लेकिन सही स्तर पर नहीं। आपने {offending_keyword}  स्तर  "
-"{working_level} के लिए लिखा है। युक्ति: {tip}"
+"वह सही हैडी कोड था, लेकिन सही स्तर पर नहीं। आपने {offending_keyword}  "
+"स्तर  {working_level} के लिए लिखा है। युक्ति: {tip}"
 
 #: coursedata/error-messages.txt:3
 msgid "Incomplete"
 msgstr ""
-"उफ़! आप थोड़ा सा कोड भूल गए! लाइन {line_number} पर, आपको {incomplete_command} के "
-"पीछे टेक्स्ट डालना होगा|"
+"उफ़! आप थोड़ा सा कोड भूल गए! लाइन {line_number} पर, आपको "
+"{incomplete_command} के पीछे टेक्स्ट डालना होगा|"
 
 #: coursedata/error-messages.txt:4
 msgid "Invalid"
@@ -228,8 +231,8 @@ msgstr ""
 #: coursedata/error-messages.txt:5
 msgid "Invalid Space"
 msgstr ""
-"ओह! आपने {line_number} लाइन पर रिक्त स्थान के साथ एक लाइन शुरू की है। रिक्त स्थान "
-"कंप्यूटर को भ्रमित करते हैं, क्या आप इसे हटा सकते हैं?"
+"ओह! आपने {line_number} लाइन पर रिक्त स्थान के साथ एक लाइन शुरू की है। "
+"रिक्त स्थान कंप्यूटर को भ्रमित करते हैं, क्या आप इसे हटा सकते हैं?"
 
 #: coursedata/error-messages.txt:6
 msgid "Has Blanks"
@@ -239,34 +242,36 @@ msgstr "आपका कोड अधूरा है। इसमें रि�
 msgid "No Indentation"
 msgstr ""
 "आपने लाइन {line_number} में बहुत कम रिक्त स्थान का उपयोग किया है। आपने "
-"{leading_spaces} रिक्त स्थान का उपयोग किया है, जो पर्याप्त नहीं है। प्रत्येक नए ब्लॉक "
-"को {indent_size} रिक्त स्थान के साथ शुरू करें जो पहले की पंक्ति से अधिक है।"
+"{leading_spaces} रिक्त स्थान का उपयोग किया है, जो पर्याप्त नहीं है। "
+"प्रत्येक नए ब्लॉक को {indent_size} रिक्त स्थान के साथ शुरू करें जो पहले "
+"की पंक्ति से अधिक है।"
 
 #: coursedata/error-messages.txt:8
 msgid "Unexpected Indentation"
 msgstr ""
 "आपने लाइन {line_number} में बहुत अधिक रिक्त स्थान का उपयोग किया है। आपने "
-"{leading_spaces} स्पेस का इस्तेमाल किया, जो बहुत अधिक है। प्रत्येक नए ब्लॉक को पहले की "
-"पंक्ति से अधिक {indent_size} रिक्त स्थान के साथ प्रारंभ करें।"
+"{leading_spaces} स्पेस का इस्तेमाल किया, जो बहुत अधिक है। प्रत्येक नए "
+"ब्लॉक को पहले की पंक्ति से अधिक {indent_size} रिक्त स्थान के साथ प्रारंभ "
+"करें।"
 
 #: coursedata/error-messages.txt:9
 msgid "Parse"
 msgstr ""
-"आपके द्वारा दर्ज किया गया कोड मान्य Hedy कोड नहीं है। लाइन {location[0]}, स्थिति "
-"{location[1]} पर एक गलती है। आपने {character_found} टाइप किया, लेकिन इसकी अनुमति "
-"नहीं है|"
+"आपके द्वारा दर्ज किया गया कोड मान्य Hedy कोड नहीं है। लाइन {location[0]},"
+" स्थिति {location[1]} पर एक गलती है। आपने {character_found} टाइप किया, "
+"लेकिन इसकी अनुमति नहीं है|"
 
 #: coursedata/error-messages.txt:10
 msgid "Unquoted Text"
 msgstr ""
-"सावधान रहे। यदि आप कुछ पूछते या प्रिंट करते हैं, तो पाठ एक उद्धरण चिह्न के साथ शुरू और "
-"समाप्त होना चाहिए। आप एक को कहीं भूल गए।"
+"सावधान रहे। यदि आप कुछ पूछते या प्रिंट करते हैं, तो पाठ एक उद्धरण चिह्न "
+"के साथ शुरू और समाप्त होना चाहिए। आप एक को कहीं भूल गए।"
 
 #: coursedata/error-messages.txt:11
 msgid "Unquoted Assignment"
 msgstr ""
-"इस स्तर से, आपको टेक्स्ट को उद्धरणों के बीच `is` के दाईं ओर रखना होगा। आप इसे {text} "
-"टेक्स्ट के लिए भूल गए।"
+"इस स्तर से, आपको टेक्स्ट को उद्धरणों के बीच `is` के दाईं ओर रखना होगा। आप"
+" इसे {text} टेक्स्ट के लिए भूल गए।"
 
 #: coursedata/error-messages.txt:12
 #, fuzzy
@@ -278,32 +283,35 @@ msgstr ""
 #: coursedata/error-messages.txt:13
 msgid "Var Undefined"
 msgstr ""
-"आपने वेरिएबल {name} का उपयोग करने का प्रयास किया, लेकिन आपने इसे सेट नहीं किया। यह भी "
-"संभव है कि आप {name} शब्द का उपयोग करने की कोशिश कर रहे थे लेकिन उद्धरण चिह्नों को भूल "
-"गए।"
+"आपने वेरिएबल {name} का उपयोग करने का प्रयास किया, लेकिन आपने इसे सेट नहीं"
+" किया। यह भी संभव है कि आप {name} शब्द का उपयोग करने की कोशिश कर रहे थे "
+"लेकिन उद्धरण चिह्नों को भूल गए।"
 
 #: coursedata/error-messages.txt:14
 msgid "Cyclic Var Definition"
-msgstr "नाम {variable} को is कमांड के दाईं ओर उपयोग करने से पहले सेट करने की आवश्यकता है"
+msgstr ""
+"नाम {variable} को is कमांड के दाईं ओर उपयोग करने से पहले सेट करने की "
+"आवश्यकता है"
 
 #: coursedata/error-messages.txt:15
 msgid "Lonely Echo"
 msgstr ""
-"आपने ask से पहले एक echo का उपयोग किया, या बिना ask के एक echo का उपयोग किया। "
-"पहले इनपुट के लिए ask, फिर echo का उपयोग करें।"
+"आपने ask से पहले एक echo का उपयोग किया, या बिना ask के एक echo का उपयोग "
+"किया। पहले इनपुट के लिए ask, फिर echo का उपयोग करें।"
 
 #: coursedata/error-messages.txt:16
 msgid "Too Big"
 msgstr ""
-"वाह! आपके प्रोग्राम में कोड की प्रभावशाली {lines_of_code} पंक्तियाँ हैं! लेकिन हम इस स्तर "
-"पर केवल {max_lines} पंक्तियों को संसाधित कर सकते हैं। अपने प्रोग्राम को छोटा करें और पुनः "
-"प्रयास करें।"
+"वाह! आपके प्रोग्राम में कोड की प्रभावशाली {lines_of_code} पंक्तियाँ हैं! "
+"लेकिन हम इस स्तर पर केवल {max_lines} पंक्तियों को संसाधित कर सकते हैं। "
+"अपने प्रोग्राम को छोटा करें और पुनः प्रयास करें।"
 
 #: coursedata/error-messages.txt:17
 msgid "Invalid Argument Type"
 msgstr ""
-"आप {invalid_argument} के साथ {command} कमांड का उपयोग नहीं कर सकते क्योंकि यह "
-"{invalid_type} है। {invalid_argument} को {allowed_types} में बदलने का प्रयास करें।"
+"आप {invalid_argument} के साथ {command} कमांड का उपयोग नहीं कर सकते "
+"क्योंकि यह {invalid_type} है। {invalid_argument} को {allowed_types} में "
+"बदलने का प्रयास करें।"
 
 #: coursedata/error-messages.txt:18
 msgid "Invalid Argument"
@@ -314,22 +322,22 @@ msgstr ""
 #: coursedata/error-messages.txt:19
 msgid "Invalid Type Combination"
 msgstr ""
-"आप {command} में {invalid_argument} और {invalid_argument_2} का उपयोग नहीं कर "
-"सकते क्योंकि एक {invalid_type} है और दूसरा {invalid_type_2} है। {invalid_argument} "
-"को {invalid_type_2} या {invalid_argument_2} को {invalid_type} में बदलने की "
-"कोशिश करें।"
+"आप {command} में {invalid_argument} और {invalid_argument_2} का उपयोग नहीं"
+" कर सकते क्योंकि एक {invalid_type} है और दूसरा {invalid_type_2} है। "
+"{invalid_argument} को {invalid_type_2} या {invalid_argument_2} को "
+"{invalid_type} में बदलने की कोशिश करें।"
 
 #: coursedata/error-messages.txt:20
 msgid "Unsupported Float"
 msgstr ""
-"गैर-पूर्णांक संख्याएं अभी तक समर्थित नहीं हैं लेकिन वे कुछ स्तरों में होंगी। अभी के लिए {value} "
-"को एक पूर्णांक में बदलें।"
+"गैर-पूर्णांक संख्याएं अभी तक समर्थित नहीं हैं लेकिन वे कुछ स्तरों में "
+"होंगी। अभी के लिए {value} को एक पूर्णांक में बदलें।"
 
 #: coursedata/error-messages.txt:21
 msgid "Locked Language Feature"
 msgstr ""
-"आप {concept} का उपयोग कर रहे हैं! यह बहुत बढ़िया है, लेकिन {concept} अभी तक खुला नहीं "
-"है! इसे बाद के स्तर पर अनलॉक किया जाएगा।"
+"आप {concept} का उपयोग कर रहे हैं! यह बहुत बढ़िया है, लेकिन {concept} अभी "
+"तक खुला नहीं है! इसे बाद के स्तर पर अनलॉक किया जाएगा।"
 
 #: coursedata/error-messages.txt:22
 msgid "Missing Command"
@@ -338,15 +346,15 @@ msgstr "ऐसा लगता है कि आप {line_number} लाइन �
 #: coursedata/error-messages.txt:23
 msgid "ask_needs_var"
 msgstr ""
-"स्तर 2 से शुरू होकर, ask को एक variable के साथ उपयोग करने की आवश्यकता है। उदाहरण: "
-"name is ask आपको क्या कहा जाता है?"
+"स्तर 2 से शुरू होकर, ask को एक variable के साथ उपयोग करने की आवश्यकता है।"
+" उदाहरण: name is ask आपको क्या कहा जाता है?"
 
 #: coursedata/error-messages.txt:24
 msgid "echo_out"
 msgstr ""
-"स्तर 2  में शुरू करने पर  अब echo की आवश्यकता नहीं है। आप एक उत्तर को ask के साथ दोहरा "
-"सकते हैं और अभी प्रिंट कर सकते हैं। उदाहरण: name is ask आपको क्या कहा जाता है? print "
-"हैलो name"
+"स्तर 2  में शुरू करने पर  अब echo की आवश्यकता नहीं है। आप एक उत्तर को ask"
+" के साथ दोहरा सकते हैं और अभी प्रिंट कर सकते हैं। उदाहरण: name is ask "
+"आपको क्या कहा जाता है? print हैलो name"
 
 #: coursedata/error-messages.txt:25
 msgid "space"
@@ -423,6 +431,11 @@ msgstr "एक सूची"
 #: coursedata/error-messages.txt:43
 msgid "input"
 msgstr "ask से input"
+
+#: templates/achievements.html:4
+#, fuzzy
+msgid "achievements_title"
+msgstr "उपलब्धियां"
 
 #: templates/class-overview.html:16
 msgid "visible_columns"
@@ -564,20 +577,20 @@ msgstr "क्या आप इस कक्षा में शामिल ह
 #: templates/class-prejoin.html:17 website/teacher.py:183
 msgid "join_prompt"
 msgstr ""
-"कक्षा में शामिल होने के लिए आपके पास एक खाता होना चाहिए। क्या आप अभी लॉग इन करना "
-"चाहेंगे?"
+"कक्षा में शामिल होने के लिए आपके पास एक खाता होना चाहिए। क्या आप अभी लॉग "
+"इन करना चाहेंगे?"
 
 #: templates/class-prejoin.html:17 templates/profile.html:14
 msgid "join_class"
 msgstr "कक्षा में शामिल हों"
 
-#: templates/class-stats.html:22 templates/customize-class.html:155
+#: templates/class-stats.html:22 templates/customize-class.html:150
 msgid "back_to_class"
 msgstr "कक्षा में वापस जाएं"
 
 #: templates/code-page.html:25 templates/code-page.html:34
-#: templates/customize-class.html:28 templates/customize-class.html:64
-#: templates/customize-class.html:71 templates/customize-class.html:94
+#: templates/customize-class.html:23 templates/customize-class.html:59
+#: templates/customize-class.html:66 templates/customize-class.html:89
 #: templates/incl-adventure-tabs.html:5 templates/level-page.html:6
 #: templates/level-page.html:11 templates/quiz/startquiz.html:10
 #: templates/view-program-page.html:12 templates/view-program-page.html:28
@@ -593,21 +606,21 @@ msgstr "Create multiple accounts"
 #, fuzzy
 msgid "accounts_intro"
 msgstr ""
-"On this page you can create accounts for multiple students at the same time. "
-"It is also possible to directly add them to one of your classes. By pressing "
-"the green + on the bottom right of the page you can add extra rows. You can "
-"delete a row by pressing the corresponding red cross. Make sure no rows are "
-"empty when you press \"Create accounts\". Please keep in mind that every "
-"username and mail address needs to be unique and the password needs to be "
-"<b>at least</b> 6 characters."
+"On this page you can create accounts for multiple students at the same "
+"time. It is also possible to directly add them to one of your classes. By"
+" pressing the green + on the bottom right of the page you can add extra "
+"rows. You can delete a row by pressing the corresponding red cross. Make "
+"sure no rows are empty when you press \"Create accounts\". Please keep in"
+" mind that every username and mail address needs to be unique and the "
+"password needs to be <b>at least</b> 6 characters."
 
 #: templates/create-accounts.html:10
 #, fuzzy
 msgid "create_accounts_prompt"
 msgstr "Are you sure you want to create these accounts?"
 
-#: templates/create-accounts.html:17 templates/learn-more.html:10
-#: templates/profile.html:96 templates/recover.html:8 templates/signup.html:13
+#: templates/create-accounts.html:17 templates/profile.html:96
+#: templates/recover.html:8 templates/signup.html:13
 msgid "email"
 msgstr "ईमेल"
 
@@ -658,24 +671,26 @@ msgstr "स्तर"
 #: templates/customize-adventure.html:25
 msgid "adventure_exp_1"
 msgstr ""
-"अपनी पसंद के साहसिक कार्य को दाईं ओर टाइप करें। अपने साहसिक कार्य को बनाने के बाद आप "
-"इसे \"कस्टमाइज़ेशन\" के अंतर्गत अपनी किसी एक कक्षा में शामिल कर सकते हैं। यदि आप अपने "
-"साहसिक कार्य में एक कमांड शामिल करना चाहते हैं तो कृपया इस तरह कोड एंकर का उपयोग करें:"
+"अपनी पसंद के साहसिक कार्य को दाईं ओर टाइप करें। अपने साहसिक कार्य को "
+"बनाने के बाद आप इसे \"कस्टमाइज़ेशन\" के अंतर्गत अपनी किसी एक कक्षा में "
+"शामिल कर सकते हैं। यदि आप अपने साहसिक कार्य में एक कमांड शामिल करना चाहते"
+" हैं तो कृपया इस तरह कोड एंकर का उपयोग करें:"
 
 #: templates/customize-adventure.html:31
 msgid "adventure_exp_2"
 msgstr ""
-"यदि आप वास्तविक कोड स्निपेट दिखाना चाहते हैं, उदाहरण के लिए छात्र को कोड का टेम्प्लेट या "
-"उदाहरण देना। कृपया इस तरह प्री एंकर का उपयोग करें:"
+"यदि आप वास्तविक कोड स्निपेट दिखाना चाहते हैं, उदाहरण के लिए छात्र को कोड "
+"का टेम्प्लेट या उदाहरण देना। कृपया इस तरह प्री एंकर का उपयोग करें:"
 
 #: templates/customize-adventure.html:39
 msgid "adventure_exp_3"
 msgstr ""
-"आप अपने रोमांच का स्टाइल संस्करण देखने के लिए \"पूर्वावलोकन\" बटन का उपयोग कर सकते हैं। "
-"रोमांच को एक समर्पित पृष्ठ पर देखने के लिए, शिक्षक पृष्ठ से \"दृश्य\" चुनें।"
+"आप अपने रोमांच का स्टाइल संस्करण देखने के लिए \"पूर्वावलोकन\" बटन का "
+"उपयोग कर सकते हैं। रोमांच को एक समर्पित पृष्ठ पर देखने के लिए, शिक्षक "
+"पृष्ठ से \"दृश्य\" चुनें।"
 
-#: templates/customize-adventure.html:43 templates/customize-class.html:28
-#: templates/customize-class.html:93 templates/explore.html:26
+#: templates/customize-adventure.html:43 templates/customize-class.html:23
+#: templates/customize-class.html:88 templates/explore.html:26
 #: templates/programs.html:18 templates/programs.html:48
 #: templates/view-adventure.html:6
 msgid "adventure"
@@ -697,13 +712,15 @@ msgstr ""
 
 #: templates/customize-adventure.html:47
 msgid "adventure_terms"
-msgstr "मैं सहमत हूं कि मेरे रोमांच को हेडी पर सार्वजनिक रूप से उपलब्ध कराया जा सकता है।"
+msgstr ""
+"मैं सहमत हूं कि मेरे रोमांच को हेडी पर सार्वजनिक रूप से उपलब्ध कराया जा "
+"सकता है।"
 
 #: templates/customize-adventure.html:50
 msgid "preview"
 msgstr "पूर्वावलोकन"
 
-#: templates/customize-adventure.html:51 templates/customize-class.html:150
+#: templates/customize-adventure.html:51 templates/customize-class.html:145
 msgid "save"
 msgstr "सहेजें"
 
@@ -711,123 +728,73 @@ msgstr "सहेजें"
 msgid "delete_adventure_prompt"
 msgstr "क्या आप वाकई इस adventure को हटाना चाहते हैं?"
 
-#: templates/customize-class.html:7
-#, fuzzy
-msgid "customize_class_exp_1"
-msgstr "कक्षा को अनुकूलित करें"
-
-#: templates/customize-class.html:10
-#, fuzzy
-msgid "customize_class_step_1"
-msgstr "कक्षा को अनुकूलित करें"
-
-#: templates/customize-class.html:11
-#, fuzzy
-msgid "customize_class_step_2"
-msgstr "कक्षा को अनुकूलित करें"
-
-#: templates/customize-class.html:12
-#, fuzzy
-msgid "customize_class_step_3"
-msgstr "कक्षा को अनुकूलित करें"
-
-#: templates/customize-class.html:13
-#, fuzzy
-msgid "customize_class_step_4"
-msgstr "कक्षा को अनुकूलित करें"
-
-#: templates/customize-class.html:14
-#, fuzzy
-msgid "customize_class_step_5"
-msgstr "कक्षा को अनुकूलित करें"
-
-#: templates/customize-class.html:15
-#, fuzzy
-msgid "customize_class_step_6"
-msgstr "कक्षा को अनुकूलित करें"
-
-#: templates/customize-class.html:16
-#, fuzzy
-msgid "customize_class_step_7"
-msgstr "कक्षा को अनुकूलित करें"
-
-#: templates/customize-class.html:17
-#, fuzzy
-msgid "customize_class_step_8"
-msgstr "कक्षा को अनुकूलित करें"
-
-#: templates/customize-class.html:20
-#, fuzzy
-msgid "customize_class_exp_2"
-msgstr "कक्षा को अनुकूलित करें"
-
-#: templates/customize-class.html:23
+#: templates/customize-class.html:18
 msgid "select_adventures"
 msgstr "adventures का चयन करें"
 
-#: templates/customize-class.html:59
+#: templates/customize-class.html:54
 #, fuzzy
 msgid "opening_dates"
 msgstr "Opening dates"
 
-#: templates/customize-class.html:65
+#: templates/customize-class.html:60
 #, fuzzy
 msgid "opening_date"
 msgstr "Opening date"
 
-#: templates/customize-class.html:77
+#: templates/customize-class.html:72
 #, fuzzy
 msgid "directly_available"
 msgstr "Directly open"
 
-#: templates/customize-class.html:88
+#: templates/customize-class.html:83
 msgid "select_own_adventures"
 msgstr "खुद के adventures चुनें"
 
-#: templates/customize-class.html:95 templates/customize-class.html:121
+#: templates/customize-class.html:90 templates/customize-class.html:116
 #: templates/profile.html:47 templates/profile.html:128
 #: templates/profile.html:137 templates/signup.html:26 templates/signup.html:45
 #: templates/signup.html:53
 msgid "select"
 msgstr "चुनें"
 
-#: templates/customize-class.html:115
+#: templates/customize-class.html:110
 #, fuzzy
 msgid "other_settings"
 msgstr "Other settings"
 
-#: templates/customize-class.html:120
+#: templates/customize-class.html:115
 #, fuzzy
 msgid "option"
 msgstr "Option"
 
-#: templates/customize-class.html:126
+#: templates/customize-class.html:121
 #, fuzzy
 msgid "mandatory_mode"
 msgstr "Mandatory developer's mode"
 
-#: templates/customize-class.html:132
+#: templates/customize-class.html:127
 #, fuzzy
 msgid "hide_cheatsheet"
 msgstr "Hide cheatsheet"
 
-#: templates/customize-class.html:138
+#: templates/customize-class.html:133
 msgid "hide_keyword_switcher"
 msgstr ""
 
-#: templates/customize-class.html:149
+#: templates/customize-class.html:144
 msgid "reset_adventure_prompt"
 msgstr "क्या आप वाकई सभी चयनित adventures को रीसेट करना चाहते हैं?"
 
-#: templates/customize-class.html:149
+#: templates/customize-class.html:144
 msgid "reset_adventures"
 msgstr "चयनित adventures रीसेट करें"
 
-#: templates/customize-class.html:153
+#: templates/customize-class.html:148
 msgid "remove_customizations_prompt"
 msgstr "क्या आप वाकई इस वर्ग के अनुकूलन को हटाना चाहते हैं?"
 
-#: templates/customize-class.html:154
+#: templates/customize-class.html:149
 msgid "remove_customization"
 msgstr "अनुकूलन निकालें"
 
@@ -843,13 +810,13 @@ msgstr "्रोग्राम्स का अन्वेषण करें
 #, fuzzy
 msgid "explore_explanation"
 msgstr ""
-"On this page you can look through programs created by other Hedy users. You "
-"can filter on both a Hedy level and adventure. Click on \"View program\" to "
-"open a program and run it. Programs with a red header contain a mistake. You "
-"can still open the program, but running it will result in an error. You can "
-"of course try to fix it! If the creator has a public profile you can click "
-"their username to visit their profile. There you will find all their shared "
-"programs and much more!"
+"On this page you can look through programs created by other Hedy users. "
+"You can filter on both a Hedy level and adventure. Click on \"View "
+"program\" to open a program and run it. Programs with a red header "
+"contain a mistake. You can still open the program, but running it will "
+"result in an error. You can of course try to fix it! If the creator has a"
+" public profile you can click their username to visit their profile. "
+"There you will find all their shared programs and much more!"
 
 #: templates/explore.html:35 templates/programs.html:27
 #, fuzzy
@@ -905,8 +872,8 @@ msgstr "Create student accounts"
 #: templates/for-teachers.html:113
 msgid "teacher_welcome"
 msgstr ""
-"हेडी में आपका स्वागत है! अब आप एक शिक्षक खाते के गर्वित स्वामी हैं जो आपको कक्षाएं बनाने और "
-"छात्रों को आमंत्रित करने की अनुमति देता है।"
+"हेडी में आपका स्वागत है! अब आप एक शिक्षक खाते के गर्वित स्वामी हैं जो "
+"आपको कक्षाएं बनाने और छात्रों को आमंत्रित करने की अनुमति देता है।"
 
 #: templates/incl-adventure-tabs.html:22
 #, fuzzy
@@ -1013,9 +980,10 @@ msgstr "स्वागत"
 #: templates/landing-page.html:7
 msgid "intro_text_landing_page"
 msgstr ""
-"हेडी की अद्भुत दुनिया में आपका स्वागत है! यहां आप अनावश्यक जटिल सामग्री के बिना, छोटे "
-"चरणों में प्रोग्राम करना सीख सकते हैं। हम स्तर 1 पर आसान शुरुआत करते हैं, और धीरे-धीरे बड़े और "
-"अधिक जटिल प्रोग्राम्स की ओर बढ़ते हैं! आरंभ करने के लिए नीचे दिए गए विकल्पों में से एक चुनें।"
+"हेडी की अद्भुत दुनिया में आपका स्वागत है! यहां आप अनावश्यक जटिल सामग्री "
+"के बिना, छोटे चरणों में प्रोग्राम करना सीख सकते हैं। हम स्तर 1 पर आसान "
+"शुरुआत करते हैं, और धीरे-धीरे बड़े और अधिक जटिल प्रोग्राम्स की ओर बढ़ते "
+"हैं! आरंभ करने के लिए नीचे दिए गए विकल्पों में से एक चुनें।"
 
 #: templates/landing-page.html:14 templates/landing-page.html:36
 #, fuzzy
@@ -1029,11 +997,15 @@ msgstr "प्रोग्रामिंग शुरू करें"
 
 #: templates/landing-page.html:21
 msgid "create_class_text"
-msgstr "अपने छात्रों को कक्षाओं में समूहित करें और प्रत्येक कक्षा के लिए सामग्री बदलें"
+msgstr ""
+"अपने छात्रों को कक्षाओं में समूहित करें और प्रत्येक कक्षा के लिए सामग्री "
+"बदलें"
 
 #: templates/landing-page.html:28
 msgid "read_docs_text"
-msgstr "पाठ योजनाओं और छात्रों द्वारा सामान्य गलतियों के लिए हमारे शिक्षक के मैनुअल पर जाएँ"
+msgstr ""
+"पाठ योजनाओं और छात्रों द्वारा सामान्य गलतियों के लिए हमारे शिक्षक के "
+"मैनुअल पर जाएँ"
 
 #: templates/landing-page.html:30
 msgid "read_docs"
@@ -1071,48 +1043,13 @@ msgstr "शेयर करने के लिए लिंक कॉपी क
 #: templates/layout.html:78
 msgid "set_preferred_lang"
 msgstr ""
-"हेडी अब पसंदीदा उपयोगकर्ता भाषाओं का समर्थन करता है। आप \"मेरी प्रोफ़ाइल\" में अपनी "
-"प्रोफ़ाइल के लिए एक सेट कर सकते हैं"
+"हेडी अब पसंदीदा उपयोगकर्ता भाषाओं का समर्थन करता है। आप \"मेरी "
+"प्रोफ़ाइल\" में अपनी प्रोफ़ाइल के लिए एक सेट कर सकते हैं"
 
 #: templates/layout.html:86 templates/quiz/endquiz.html:18
 #: templates/quiz/quiz.html:29
 msgid "achievement_earned"
 msgstr "आपने एक उपलब्धि अर्जित की है!"
-
-#: templates/learn-more.html:7
-#, fuzzy
-msgid "mailing_title"
-msgstr "शीर्षक"
-
-#: templates/learn-more.html:14
-#, fuzzy
-msgid "surname"
-msgstr "उपयोगकर्ता नाम"
-
-#: templates/learn-more.html:18
-#, fuzzy
-msgid "lastname"
-msgstr "नाम"
-
-#: templates/learn-more.html:22 templates/profile.html:135
-#: templates/signup.html:52
-msgid "country"
-msgstr "देश"
-
-#: templates/learn-more.html:31
-#, fuzzy
-msgid "subscribe"
-msgstr "समाचार पत्रिका की सदस्यता लें"
-
-#: templates/learn-more.html:32
-#, fuzzy
-msgid "required_field"
-msgstr "Fields marked with an * are required"
-
-#: templates/learn-more.html:35
-#, fuzzy
-msgid "previous_campaigns"
-msgstr "View previous campaigns"
 
 #: templates/level-page.html:8
 msgid "step_title"
@@ -1145,21 +1082,6 @@ msgstr "खाता बनाएं"
 #: templates/login.html:33
 msgid "forgot_password"
 msgstr "आपका सांकेतिक शब्द भूल गए?"
-
-#: templates/main-page.html:9
-#, fuzzy
-msgid "main_title"
-msgstr "शीर्षक"
-
-#: templates/main-page.html:10
-#, fuzzy
-msgid "main_subtitle"
-msgstr "्रस्तुत प्रोग्राम "
-
-#: templates/main-page.html:13
-#, fuzzy
-msgid "try_it"
-msgstr "कोशिश करें"
 
 #: templates/profile.html:4
 msgid "account_overview"
@@ -1212,9 +1134,9 @@ msgstr "पसंदीदा प्रोग्राम "
 #: templates/profile.html:56
 msgid "public_profile_info"
 msgstr ""
-"इस बॉक्स को चुनकर मैं अपनी प्रोफ़ाइल को सभी के लिए दृश्यमान बनाता हूं। अपना नाम या घर "
-"का पता जैसी व्यक्तिगत जानकारी साझा न करने के लिए सावधान रहें, क्योंकि हर कोई इसे देख "
-"सकेगा!"
+"इस बॉक्स को चुनकर मैं अपनी प्रोफ़ाइल को सभी के लिए दृश्यमान बनाता हूं। "
+"अपना नाम या घर का पता जैसी व्यक्तिगत जानकारी साझा न करने के लिए सावधान "
+"रहें, क्योंकि हर कोई इसे देख सकेगा!"
 
 #: templates/profile.html:59
 msgid "update_public"
@@ -1272,6 +1194,10 @@ msgstr "पुरुष"
 #: templates/profile.html:131 templates/signup.html:48
 msgid "other"
 msgstr "अन्य"
+
+#: templates/profile.html:135 templates/signup.html:52
+msgid "country"
+msgstr "देश"
 
 #: templates/profile.html:141
 msgid "update_profile"
@@ -1427,7 +1353,9 @@ msgstr "एक और पाठ भाषा"
 
 #: templates/signup.html:88
 msgid "request_teacher"
-msgstr "मैं एक शिक्षक हूं और मैं एक शिक्षक के खाते के लिए आवेदन करना चाहता/चाहती हूं"
+msgstr ""
+"मैं एक शिक्षक हूं और मैं एक शिक्षक के खाते के लिए आवेदन करना चाहता/चाहती "
+"हूं"
 
 #: templates/signup.html:91
 msgid "subscribe_newsletter"
@@ -1457,8 +1385,8 @@ msgstr "पहले से ही एक खाता है?"
 #: templates/teacher-invitation.html:5
 msgid "teacher_invitation_require_login"
 msgstr ""
-"एक शिक्षक के रूप में आपकी प्रोफ़ाइल सेट करने के लिए हमें आपको लॉग इन करने की आवश्यकता "
-"होगी। यदि आपके पास कोई खाता नहीं है, तो कृपया एक बनाएं।"
+"एक शिक्षक के रूप में आपकी प्रोफ़ाइल सेट करने के लिए हमें आपको लॉग इन करने"
+" की आवश्यकता होगी। यदि आपके पास कोई खाता नहीं है, तो कृपया एक बनाएं।"
 
 #: templates/view-program-page.html:13
 msgid "by"
@@ -1604,7 +1532,8 @@ msgstr "You have to agree with the privacy terms."
 #, fuzzy
 msgid "keyword_language_invalid"
 msgstr ""
-"Please select a valid keyword language (select English or your own language)."
+"Please select a valid keyword language (select English or your own "
+"language)."
 
 #: website/auth.py:371 website/auth.py:551
 msgid "year_invalid"
@@ -1664,8 +1593,8 @@ msgstr "Profile updated, page will be re-loaded."
 #: website/auth.py:670
 msgid "sent_password_recovery"
 msgstr ""
-"आपको जल्द ही अपना सांकेतिक शब्द फिर से कायम करने के निर्देशों के साथ एक ईमेल प्राप्त होना "
-"चाहिए|"
+"आपको जल्द ही अपना सांकेतिक शब्द फिर से कायम करने के निर्देशों के साथ एक "
+"ईमेल प्राप्त होना चाहिए|"
 
 #: website/auth.py:681 website/auth.py:691
 msgid "token_invalid"
@@ -1686,21 +1615,21 @@ msgstr "प्रोग्राम सफलतापूर्वक हटा�
 #: website/programs.py:55
 msgid "save_prompt"
 msgstr ""
-"अपने प्रोग्राम को सहेजने के लिए आपके पास एक खाता होना चाहिए। क्या आप अभी लॉग इन करना "
-"चाहेंगे?"
+"अपने प्रोग्राम को सहेजने के लिए आपके पास एक खाता होना चाहिए। क्या आप अभी "
+"लॉग इन करना चाहेंगे?"
 
 #: website/programs.py:60
 msgid "overwrite_warning"
 msgstr ""
-"आपके पास पहले से ही इस नाम का एक प्रोग्राम है, इस प्रोग्राम को सहेजने से पुराना प्रोग्राम "
-"अधिलेखित हो जाएगा। क्या आपको यकीन है?"
+"आपके पास पहले से ही इस नाम का एक प्रोग्राम है, इस प्रोग्राम को सहेजने से "
+"पुराना प्रोग्राम अधिलेखित हो जाएगा। क्या आपको यकीन है?"
 
 #: website/programs.py:87
 #, fuzzy
 msgid "save_parse_warning"
 msgstr ""
-"आपके पास पहले से ही इस नाम का एक प्रोग्राम है, इस प्रोग्राम को सहेजने से पुराना प्रोग्राम "
-"अधिलेखित हो जाएगा। क्या आपको यकीन है?"
+"आपके पास पहले से ही इस नाम का एक प्रोग्राम है, इस प्रोग्राम को सहेजने से "
+"पुराना प्रोग्राम अधिलेखित हो जाएगा। क्या आपको यकीन है?"
 
 #: website/programs.py:131 website/programs.py:132
 msgid "save_success_detail"
@@ -1883,3 +1812,61 @@ msgstr "आपने एक adventure नाम दर्ज नहीं कि
 
 #~ msgid "ago-2"
 #~ msgstr "पहले"
+
+#~ msgid "customize_class_exp_1"
+#~ msgstr "कक्षा को अनुकूलित करें"
+
+#~ msgid "customize_class_step_1"
+#~ msgstr "कक्षा को अनुकूलित करें"
+
+#~ msgid "customize_class_step_2"
+#~ msgstr "कक्षा को अनुकूलित करें"
+
+#~ msgid "customize_class_step_3"
+#~ msgstr "कक्षा को अनुकूलित करें"
+
+#~ msgid "customize_class_step_4"
+#~ msgstr "कक्षा को अनुकूलित करें"
+
+#~ msgid "customize_class_step_5"
+#~ msgstr "कक्षा को अनुकूलित करें"
+
+#~ msgid "customize_class_step_6"
+#~ msgstr "कक्षा को अनुकूलित करें"
+
+#~ msgid "customize_class_step_7"
+#~ msgstr "कक्षा को अनुकूलित करें"
+
+#~ msgid "customize_class_step_8"
+#~ msgstr "कक्षा को अनुकूलित करें"
+
+#~ msgid "customize_class_exp_2"
+#~ msgstr "कक्षा को अनुकूलित करें"
+
+#~ msgid "mailing_title"
+#~ msgstr "शीर्षक"
+
+#~ msgid "surname"
+#~ msgstr "उपयोगकर्ता नाम"
+
+#~ msgid "lastname"
+#~ msgstr "नाम"
+
+#~ msgid "subscribe"
+#~ msgstr "समाचार पत्रिका की सदस्यता लें"
+
+#~ msgid "required_field"
+#~ msgstr "Fields marked with an * are required"
+
+#~ msgid "previous_campaigns"
+#~ msgstr "View previous campaigns"
+
+#~ msgid "main_title"
+#~ msgstr "शीर्षक"
+
+#~ msgid "main_subtitle"
+#~ msgstr "्रस्तुत प्रोग्राम "
+
+#~ msgid "try_it"
+#~ msgstr "कोशिश करें"
+

--- a/translations/hu/LC_MESSAGES/messages.po
+++ b/translations/hu/LC_MESSAGES/messages.po
@@ -1,18 +1,18 @@
+
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-03-29 10:01+0200\n"
+"POT-Creation-Date: 2022-03-30 08:43+0200\n"
 "PO-Revision-Date: 2022-03-30 09:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
-"Language-Team: Hungarian <https://hosted.weblate.org/projects/hedy/web-texts/"
-"hu/>\n"
 "Language: hu\n"
+"Language-Team: Hungarian <https://hosted.weblate.org/projects/hedy/web-"
+"texts/hu/>\n"
+"Plural-Forms: nplurals=1; plural=0\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: Weblate 4.12-dev\n"
 "Generated-By: Babel 2.9.1\n"
 
 #: app.py:571
@@ -20,27 +20,27 @@ msgstr ""
 msgid "program_contains_error"
 msgstr "This program contains an error, are you sure you want to share it?"
 
-#: app.py:723
+#: app.py:722
 #, fuzzy
 msgid "title_achievements"
 msgstr "Hedy - My achievements"
 
-#: app.py:740 app.py:1111 website/teacher.py:365 website/teacher.py:374
+#: app.py:739 app.py:1110 website/teacher.py:365 website/teacher.py:374
 #, fuzzy
 msgid "not_teacher"
 msgstr "Looks like you are not a teacher!"
 
-#: app.py:743
+#: app.py:742
 #, fuzzy
 msgid "not_enrolled"
 msgstr "Looks like you are not in this class!"
 
-#: app.py:775
+#: app.py:774
 #, fuzzy
 msgid "title_programs"
 msgstr "Hedy - My programs"
 
-#: app.py:785 app.py:795 app.py:799 app.py:813 app.py:1054 app.py:1357
+#: app.py:784 app.py:794 app.py:798 app.py:812 app.py:1053 app.py:1356
 #: website/admin.py:17 website/admin.py:25 website/admin.py:95
 #: website/admin.py:112 website/admin.py:130 website/auth.py:711
 #: website/auth.py:738 website/statistics.py:86
@@ -48,122 +48,122 @@ msgstr "Hedy - My programs"
 msgid "unauthorized"
 msgstr "You don't have access rights for this page"
 
-#: app.py:823
+#: app.py:822
 msgid "minutes"
 msgstr "percek"
 
-#: app.py:826
+#: app.py:825
 msgid "hours"
 msgstr "órák"
 
-#: app.py:829
+#: app.py:828
 msgid "days"
 msgstr "napok"
 
-#: app.py:832
+#: app.py:831
 #, fuzzy
 msgid "ago"
 msgstr "{time} ago"
 
-#: app.py:848 app.py:850 app.py:976
+#: app.py:847 app.py:849 app.py:975
 #, fuzzy
 msgid "no_such_level"
 msgstr "No such Hedy level!"
 
-#: app.py:858 app.py:865 app.py:931 app.py:937
+#: app.py:857 app.py:864 app.py:930 app.py:936
 #, fuzzy
 msgid "no_such_program"
 msgstr "No such Hedy program!"
 
-#: app.py:891
+#: app.py:890
 #, fuzzy
 msgid "level_not_translated"
 msgstr "This level is not translated in your language (yet)"
 
-#: app.py:893
+#: app.py:892
 #, fuzzy
 msgid "level_not_class"
 msgstr "You're in a class where this level has not been made available yet"
 
-#: app.py:986 website/teacher.py:432 website/teacher.py:448
+#: app.py:985 website/teacher.py:432 website/teacher.py:448
 #: website/teacher.py:477 website/teacher.py:503
 #, fuzzy
 msgid "no_such_adventure"
 msgstr "This adventure doesn't exist!"
 
-#: app.py:1005
+#: app.py:1004
 #, fuzzy
 msgid "page_not_found"
 msgstr "We could not find that page!"
 
-#: app.py:1025
+#: app.py:1024
 #, fuzzy
 msgid "title_signup"
 msgstr "Hedy - Create an account"
 
-#: app.py:1032
+#: app.py:1031
 #, fuzzy
 msgid "title_login"
 msgstr "Hedy - Login"
 
-#: app.py:1039
+#: app.py:1038
 #, fuzzy
 msgid "title_recover"
 msgstr "Hedy - Recover account"
 
-#: app.py:1055
+#: app.py:1054
 #, fuzzy
 msgid "title_reset"
 msgstr "Hedy - Reset password"
 
-#: app.py:1064
+#: app.py:1063
 #, fuzzy
 msgid "title_my-profile"
 msgstr "Hedy - My account"
 
-#: app.py:1078
+#: app.py:1077
 #, fuzzy
 msgid "title_learn-more"
 msgstr "Hedy - Learn more"
 
-#: app.py:1083
+#: app.py:1082
 #, fuzzy
 msgid "title_privacy"
 msgstr "Hedy - Privacy terms"
 
-#: app.py:1090
+#: app.py:1089
 #, fuzzy
 msgid "title_landing-page"
 msgstr "Welcome to Hedy!"
 
-#: app.py:1092
+#: app.py:1091
 #, fuzzy
 msgid "not_user"
 msgstr "Looks like you are not logged in!"
 
-#: app.py:1107
+#: app.py:1106
 #, fuzzy
 msgid "title_for-teacher"
 msgstr "Hedy - For teachers"
 
-#: app.py:1118
+#: app.py:1117
 #, fuzzy
 msgid "title_start"
 msgstr "Hedy - A gradual programming language"
 
-#: app.py:1171
+#: app.py:1170
 #, fuzzy
 msgid "title_explore"
 msgstr "Hedy - Explore"
 
-#: app.py:1190 app.py:1192
+#: app.py:1189 app.py:1191
 #, fuzzy
 msgid "translate_error"
 msgstr ""
-"Something went wrong while translating the code. Try running the code to see "
-"if it has an error. Code with errors can not be translated."
+"Something went wrong while translating the code. Try running the code to "
+"see if it has an error. Code with errors can not be translated."
 
-#: app.py:1301 website/auth.py:299 website/auth.py:347 website/auth.py:483
+#: app.py:1300 website/auth.py:299 website/auth.py:347 website/auth.py:483
 #: website/auth.py:509 website/auth.py:539 website/auth.py:645
 #: website/auth.py:677 website/auth.py:717 website/auth.py:744
 #: website/teacher.py:90 website/teacher.py:125 website/teacher.py:197
@@ -172,37 +172,37 @@ msgstr ""
 msgid "ajax_error"
 msgstr "Hiba történt, próbálkozz újra."
 
-#: app.py:1304
+#: app.py:1303
 #, fuzzy
 msgid "image_invalid"
 msgstr "Your chosen image is invalid."
 
-#: app.py:1306
+#: app.py:1305
 #, fuzzy
 msgid "personal_text_invalid"
 msgstr "Your personal text is invalid."
 
-#: app.py:1308 app.py:1314
+#: app.py:1307 app.py:1313
 #, fuzzy
 msgid "favourite_program_invalid"
 msgstr "Your chosen favourite program is invalid."
 
-#: app.py:1326 app.py:1327
+#: app.py:1325 app.py:1326
 #, fuzzy
 msgid "public_profile_updated"
 msgstr "Public profile updated."
 
-#: app.py:1361 app.py:1385
+#: app.py:1360 app.py:1384
 #, fuzzy
 msgid "user_not_private"
 msgstr "This user doesn't exist or doesn't have a public profile"
 
-#: app.py:1394
+#: app.py:1393
 #, fuzzy
 msgid "invalid_teacher_invitation_code"
 msgstr ""
-"The teacher invitation code is invalid. To become a teacher, reach out to "
-"hedy@felienne.com."
+"The teacher invitation code is invalid. To become a teacher, reach out to"
+" hedy@felienne.com."
 
 #: utils.py:203
 #, fuzzy
@@ -223,13 +223,14 @@ msgstr "Something went wrong..."
 #, fuzzy
 msgid "Empty Program"
 msgstr ""
-"You created an empty program. Type Hedy code in the left field and try again"
+"You created an empty program. Type Hedy code in the left field and try "
+"again"
 
 #: coursedata/error-messages.txt:2
 msgid "Wrong Level"
 msgstr ""
-"Ez helyes Hedy-kód volt, de nem a megfelelő szinten. A {working_level} szint "
-"kódját írtad {original_level} szinten."
+"Ez helyes Hedy-kód volt, de nem a megfelelő szinten. A {working_level} "
+"szint kódját írtad {original_level} szinten."
 
 #: coursedata/error-messages.txt:3
 msgid "Incomplete"
@@ -260,16 +261,16 @@ msgstr ""
 msgid "No Indentation"
 msgstr ""
 "You used too few spaces in line {line_number}. You used {leading_spaces} "
-"spaces, which is not enough. Start every new block with {indent_size} spaces "
-"more than the line before."
+"spaces, which is not enough. Start every new block with {indent_size} "
+"spaces more than the line before."
 
 #: coursedata/error-messages.txt:8
 #, fuzzy
 msgid "Unexpected Indentation"
 msgstr ""
-"You used too many spaces in line {line_number}. You used {leading_spaces} "
-"spaces, which is too much. Start every new block with {indent_size} spaces "
-"more than the line before."
+"You used too many spaces in line {line_number}. You used {leading_spaces}"
+" spaces, which is too much. Start every new block with {indent_size} "
+"spaces more than the line before."
 
 #: coursedata/error-messages.txt:9
 msgid "Parse"
@@ -288,8 +289,8 @@ msgstr ""
 #, fuzzy
 msgid "Unquoted Assignment"
 msgstr ""
-"From this level, you need to place texts to the right of the `is` between "
-"quotes. You forgot that for the text {text}."
+"From this level, you need to place texts to the right of the `is` between"
+" quotes. You forgot that for the text {text}."
 
 #: coursedata/error-messages.txt:12
 #, fuzzy
@@ -306,58 +307,58 @@ msgstr "Ki akartad íratni: {name}, de nem adtál neki értéket."
 #, fuzzy
 msgid "Cyclic Var Definition"
 msgstr ""
-"The name {variable} needs to be set before you can use it on the right-hand "
-"side of the is command"
+"The name {variable} needs to be set before you can use it on the right-"
+"hand side of the is command"
 
 #: coursedata/error-messages.txt:15
 msgid "Lonely Echo"
 msgstr ""
-"Echo -t használtál kérdezés előtt, vagy echo-t kérdés nélkül. Először az ask "
-"utasítással kérj be adatot, majd használd az echo -t."
+"Echo -t használtál kérdezés előtt, vagy echo-t kérdés nélkül. Először az "
+"ask utasítással kérj be adatot, majd használd az echo -t."
 
 #: coursedata/error-messages.txt:16
 msgid "Too Big"
 msgstr ""
-"Azta! A program lenyűgöző {lines_of_code} kódsorral rendelkezik! De ezen a "
-"szinten csak {max_lines} sort dolgozhatunk fel. Csökkentsd a programot, és "
-"próbáld újra."
+"Azta! A program lenyűgöző {lines_of_code} kódsorral rendelkezik! De ezen "
+"a szinten csak {max_lines} sort dolgozhatunk fel. Csökkentsd a programot,"
+" és próbáld újra."
 
 #: coursedata/error-messages.txt:17
 #, fuzzy
 msgid "Invalid Argument Type"
 msgstr ""
-"You cannot use the command {command} with {invalid_argument} because it is "
-"{invalid_type}. Try changing {invalid_argument} to {allowed_types}."
+"You cannot use the command {command} with {invalid_argument} because it "
+"is {invalid_type}. Try changing {invalid_argument} to {allowed_types}."
 
 #: coursedata/error-messages.txt:18
 #, fuzzy
 msgid "Invalid Argument"
 msgstr ""
-"You cannot use the command {command} with {invalid_argument} . Try changing "
-"{invalid_argument} to {allowed_types}."
+"You cannot use the command {command} with {invalid_argument} . Try "
+"changing {invalid_argument} to {allowed_types}."
 
 #: coursedata/error-messages.txt:19
 #, fuzzy
 msgid "Invalid Type Combination"
 msgstr ""
-"You cannot use {invalid_argument} and {invalid_argument_2} in {operation} "
-"because one is {invalid_type} and the other is {invalid_type_2}. Try "
-"changing {invalid_argument} to {invalid_type_2} or {invalid_argument_2} to "
-"{invalid_type}."
+"You cannot use {invalid_argument} and {invalid_argument_2} in {operation}"
+" because one is {invalid_type} and the other is {invalid_type_2}. Try "
+"changing {invalid_argument} to {invalid_type_2} or {invalid_argument_2} "
+"to {invalid_type}."
 
 #: coursedata/error-messages.txt:20
 #, fuzzy
 msgid "Unsupported Float"
 msgstr ""
-"Non-integer numbers are not supported yet but they will be in a few levels. "
-"For now change {value} to an integer."
+"Non-integer numbers are not supported yet but they will be in a few "
+"levels. For now change {value} to an integer."
 
 #: coursedata/error-messages.txt:21
 #, fuzzy
 msgid "Locked Language Feature"
 msgstr ""
-"You are using {concept}! That is awesome, but {concept} is not unlocked yet! "
-"It will be unlocked in a later level."
+"You are using {concept}! That is awesome, but {concept} is not unlocked "
+"yet! It will be unlocked in a later level."
 
 #: coursedata/error-messages.txt:22
 #, fuzzy
@@ -368,15 +369,16 @@ msgstr "It looks like you forgot to use a command on line {line_number}."
 #, fuzzy
 msgid "ask_needs_var"
 msgstr ""
-"Starting in level 2, ask needs to be used with a variable. Example: name is "
-"ask What are you called?"
+"Starting in level 2, ask needs to be used with a variable. Example: name "
+"is ask What are you called?"
 
 #: coursedata/error-messages.txt:24
 #, fuzzy
 msgid "echo_out"
 msgstr ""
-"Starting in level 2 echo is no longer needed. You can repeat an answer with "
-"ask and print now. Example: name is ask What are you called? print hello name"
+"Starting in level 2 echo is no longer needed. You can repeat an answer "
+"with ask and print now. Example: name is ask What are you called? print "
+"hello name"
 
 #: coursedata/error-messages.txt:25
 msgid "space"
@@ -461,6 +463,11 @@ msgstr "a list"
 #, fuzzy
 msgid "input"
 msgstr "input from ask"
+
+#: templates/achievements.html:4
+#, fuzzy
+msgid "achievements_title"
+msgstr "achievements"
 
 #: templates/class-overview.html:16
 #, fuzzy
@@ -616,21 +623,21 @@ msgstr "Ehhez az osztályhoz akarsz csatlakozni?"
 #: templates/class-prejoin.html:17 website/teacher.py:183
 msgid "join_prompt"
 msgstr ""
-"Ahhoz, hogy részt vehess egy kurzuson, rendelkezned kell fiókkal. Szeretnél "
-"most bejelentkezni?"
+"Ahhoz, hogy részt vehess egy kurzuson, rendelkezned kell fiókkal. "
+"Szeretnél most bejelentkezni?"
 
 #: templates/class-prejoin.html:17 templates/profile.html:14
 msgid "join_class"
 msgstr "Belépés az osztályba"
 
-#: templates/class-stats.html:22 templates/customize-class.html:155
+#: templates/class-stats.html:22 templates/customize-class.html:150
 #, fuzzy
 msgid "back_to_class"
 msgstr "Go back to class"
 
 #: templates/code-page.html:25 templates/code-page.html:34
-#: templates/customize-class.html:28 templates/customize-class.html:64
-#: templates/customize-class.html:71 templates/customize-class.html:94
+#: templates/customize-class.html:23 templates/customize-class.html:59
+#: templates/customize-class.html:66 templates/customize-class.html:89
 #: templates/incl-adventure-tabs.html:5 templates/level-page.html:6
 #: templates/level-page.html:11 templates/quiz/startquiz.html:10
 #: templates/view-program-page.html:12 templates/view-program-page.html:28
@@ -646,21 +653,21 @@ msgstr "Create multiple accounts"
 #, fuzzy
 msgid "accounts_intro"
 msgstr ""
-"On this page you can create accounts for multiple students at the same time. "
-"It is also possible to directly add them to one of your classes. By pressing "
-"the green + on the bottom right of the page you can add extra rows. You can "
-"delete a row by pressing the corresponding red cross. Make sure no rows are "
-"empty when you press \"Create accounts\". Please keep in mind that every "
-"username and mail address needs to be unique and the password needs to be "
-"<b>at least</b> 6 characters."
+"On this page you can create accounts for multiple students at the same "
+"time. It is also possible to directly add them to one of your classes. By"
+" pressing the green + on the bottom right of the page you can add extra "
+"rows. You can delete a row by pressing the corresponding red cross. Make "
+"sure no rows are empty when you press \"Create accounts\". Please keep in"
+" mind that every username and mail address needs to be unique and the "
+"password needs to be <b>at least</b> 6 characters."
 
 #: templates/create-accounts.html:10
 #, fuzzy
 msgid "create_accounts_prompt"
 msgstr "Are you sure you want to create these accounts?"
 
-#: templates/create-accounts.html:17 templates/learn-more.html:10
-#: templates/profile.html:96 templates/recover.html:8 templates/signup.html:13
+#: templates/create-accounts.html:17 templates/profile.html:96
+#: templates/recover.html:8 templates/signup.html:13
 msgid "email"
 msgstr "Email"
 
@@ -715,10 +722,10 @@ msgstr "Szint"
 #, fuzzy
 msgid "adventure_exp_1"
 msgstr ""
-"Type your adventure of choice on the right-hand side. After creating your "
-"adventure you can include it in one of your classes under \"customizations"
-"\". If you want to include a command in your adventure please use code "
-"anchors like this:"
+"Type your adventure of choice on the right-hand side. After creating your"
+" adventure you can include it in one of your classes under "
+"\"customizations\". If you want to include a command in your adventure "
+"please use code anchors like this:"
 
 #: templates/customize-adventure.html:31
 #, fuzzy
@@ -732,11 +739,11 @@ msgstr ""
 msgid "adventure_exp_3"
 msgstr ""
 "You can use the \"preview\" button to view a styled version of your "
-"adventure. To view the adventure on a dedicated page, select \"view\" from "
-"the teachers page."
+"adventure. To view the adventure on a dedicated page, select \"view\" "
+"from the teachers page."
 
-#: templates/customize-adventure.html:43 templates/customize-class.html:28
-#: templates/customize-class.html:93 templates/explore.html:26
+#: templates/customize-adventure.html:43 templates/customize-class.html:23
+#: templates/customize-class.html:88 templates/explore.html:26
 #: templates/programs.html:18 templates/programs.html:48
 #: templates/view-adventure.html:6
 msgid "adventure"
@@ -766,7 +773,7 @@ msgstr "I agree that my adventure might be made publicly available on Hedy."
 msgid "preview"
 msgstr "Preview"
 
-#: templates/customize-adventure.html:51 templates/customize-class.html:150
+#: templates/customize-adventure.html:51 templates/customize-class.html:145
 #, fuzzy
 msgid "save"
 msgstr "Save"
@@ -776,128 +783,78 @@ msgstr "Save"
 msgid "delete_adventure_prompt"
 msgstr "Are you sure you want to remove this adventure?"
 
-#: templates/customize-class.html:7
-#, fuzzy
-msgid "customize_class_exp_1"
-msgstr "Customize class"
-
-#: templates/customize-class.html:10
-#, fuzzy
-msgid "customize_class_step_1"
-msgstr "Customize class"
-
-#: templates/customize-class.html:11
-#, fuzzy
-msgid "customize_class_step_2"
-msgstr "Customize class"
-
-#: templates/customize-class.html:12
-#, fuzzy
-msgid "customize_class_step_3"
-msgstr "Customize class"
-
-#: templates/customize-class.html:13
-#, fuzzy
-msgid "customize_class_step_4"
-msgstr "Customize class"
-
-#: templates/customize-class.html:14
-#, fuzzy
-msgid "customize_class_step_5"
-msgstr "Customize class"
-
-#: templates/customize-class.html:15
-#, fuzzy
-msgid "customize_class_step_6"
-msgstr "Customize class"
-
-#: templates/customize-class.html:16
-#, fuzzy
-msgid "customize_class_step_7"
-msgstr "Customize class"
-
-#: templates/customize-class.html:17
-#, fuzzy
-msgid "customize_class_step_8"
-msgstr "Customize class"
-
-#: templates/customize-class.html:20
-#, fuzzy
-msgid "customize_class_exp_2"
-msgstr "Customize class"
-
-#: templates/customize-class.html:23
+#: templates/customize-class.html:18
 #, fuzzy
 msgid "select_adventures"
 msgstr "Select adventures"
 
-#: templates/customize-class.html:59
+#: templates/customize-class.html:54
 #, fuzzy
 msgid "opening_dates"
 msgstr "Opening dates"
 
-#: templates/customize-class.html:65
+#: templates/customize-class.html:60
 #, fuzzy
 msgid "opening_date"
 msgstr "Opening date"
 
-#: templates/customize-class.html:77
+#: templates/customize-class.html:72
 #, fuzzy
 msgid "directly_available"
 msgstr "Directly open"
 
-#: templates/customize-class.html:88
+#: templates/customize-class.html:83
 #, fuzzy
 msgid "select_own_adventures"
 msgstr "Select own adventures"
 
-#: templates/customize-class.html:95 templates/customize-class.html:121
+#: templates/customize-class.html:90 templates/customize-class.html:116
 #: templates/profile.html:47 templates/profile.html:128
 #: templates/profile.html:137 templates/signup.html:26 templates/signup.html:45
 #: templates/signup.html:53
 msgid "select"
 msgstr "Választ"
 
-#: templates/customize-class.html:115
+#: templates/customize-class.html:110
 #, fuzzy
 msgid "other_settings"
 msgstr "Other settings"
 
-#: templates/customize-class.html:120
+#: templates/customize-class.html:115
 #, fuzzy
 msgid "option"
 msgstr "Option"
 
-#: templates/customize-class.html:126
+#: templates/customize-class.html:121
 #, fuzzy
 msgid "mandatory_mode"
 msgstr "Mandatory developer's mode"
 
-#: templates/customize-class.html:132
+#: templates/customize-class.html:127
 #, fuzzy
 msgid "hide_cheatsheet"
 msgstr "Hide cheatsheet"
 
-#: templates/customize-class.html:138
+#: templates/customize-class.html:133
 msgid "hide_keyword_switcher"
 msgstr ""
 
-#: templates/customize-class.html:149
+#: templates/customize-class.html:144
 #, fuzzy
 msgid "reset_adventure_prompt"
 msgstr "Are you sure you want to reset all selected adventures?"
 
-#: templates/customize-class.html:149
+#: templates/customize-class.html:144
 #, fuzzy
 msgid "reset_adventures"
 msgstr "Reset selected adventures"
 
-#: templates/customize-class.html:153
+#: templates/customize-class.html:148
 #, fuzzy
 msgid "remove_customizations_prompt"
 msgstr "Are you sure you want to remove this class their customizations?"
 
-#: templates/customize-class.html:154
+#: templates/customize-class.html:149
 #, fuzzy
 msgid "remove_customization"
 msgstr "Remove customization"
@@ -916,13 +873,13 @@ msgstr "Explore programs"
 #, fuzzy
 msgid "explore_explanation"
 msgstr ""
-"On this page you can look through programs created by other Hedy users. You "
-"can filter on both a Hedy level and adventure. Click on \"View program\" to "
-"open a program and run it. Programs with a red header contain a mistake. You "
-"can still open the program, but running it will result in an error. You can "
-"of course try to fix it! If the creator has a public profile you can click "
-"their username to visit their profile. There you will find all their shared "
-"programs and much more!"
+"On this page you can look through programs created by other Hedy users. "
+"You can filter on both a Hedy level and adventure. Click on \"View "
+"program\" to open a program and run it. Programs with a red header "
+"contain a mistake. You can still open the program, but running it will "
+"result in an error. You can of course try to fix it! If the creator has a"
+" public profile you can click their username to visit their profile. "
+"There you will find all their shared programs and much more!"
 
 #: templates/explore.html:35 templates/programs.html:27
 #, fuzzy
@@ -986,8 +943,8 @@ msgstr "Create student accounts"
 #, fuzzy
 msgid "teacher_welcome"
 msgstr ""
-"Welcome to Hedy! Your are now the proud owner of a teachers account which "
-"allows you to create classes and invite students."
+"Welcome to Hedy! Your are now the proud owner of a teachers account which"
+" allows you to create classes and invite students."
 
 #: templates/incl-adventure-tabs.html:22
 #, fuzzy
@@ -1100,9 +1057,9 @@ msgstr "Welcome"
 msgid "intro_text_landing_page"
 msgstr ""
 "Welcome to the wonderful world of Hedy! Here you can learn to program in "
-"small steps, without unnecessary complicated stuff. We start easy at level "
-"1, and slowly build towards bigger and more complex programs! Choose one of "
-"the options below to get started"
+"small steps, without unnecessary complicated stuff. We start easy at "
+"level 1, and slowly build towards bigger and more complex programs! "
+"Choose one of the options below to get started"
 
 #: templates/landing-page.html:14 templates/landing-page.html:36
 #, fuzzy
@@ -1118,14 +1075,14 @@ msgstr "Start programming"
 #: templates/landing-page.html:21
 #, fuzzy
 msgid "create_class_text"
-msgstr ""
-"Group your students into classes and change the content for each class."
+msgstr "Group your students into classes and change the content for each class."
 
 #: templates/landing-page.html:28
 #, fuzzy
 msgid "read_docs_text"
 msgstr ""
-"Visit our teacher's manual for lesson plans and common mistakes by students."
+"Visit our teacher's manual for lesson plans and common mistakes by "
+"students."
 
 #: templates/landing-page.html:30
 #, fuzzy
@@ -1167,49 +1124,14 @@ msgstr "Link másolása a megosztáshoz"
 #, fuzzy
 msgid "set_preferred_lang"
 msgstr ""
-"Hedy now supports preferred user languages. You can set one for your profile "
-"in \"My profile\""
+"Hedy now supports preferred user languages. You can set one for your "
+"profile in \"My profile\""
 
 #: templates/layout.html:86 templates/quiz/endquiz.html:18
 #: templates/quiz/quiz.html:29
 #, fuzzy
 msgid "achievement_earned"
 msgstr "You've earned an achievement!"
-
-#: templates/learn-more.html:7
-#, fuzzy
-msgid "mailing_title"
-msgstr "Hedy"
-
-#: templates/learn-more.html:14
-#, fuzzy
-msgid "surname"
-msgstr "Felhasználónév"
-
-#: templates/learn-more.html:18
-#, fuzzy
-msgid "lastname"
-msgstr "Név"
-
-#: templates/learn-more.html:22 templates/profile.html:135
-#: templates/signup.html:52
-msgid "country"
-msgstr "Ország"
-
-#: templates/learn-more.html:31
-#, fuzzy
-msgid "subscribe"
-msgstr "Iratkozz fel a hírlevélre "
-
-#: templates/learn-more.html:32
-#, fuzzy
-msgid "required_field"
-msgstr "Fields marked with an * are required"
-
-#: templates/learn-more.html:35
-#, fuzzy
-msgid "previous_campaigns"
-msgstr "View previous campaigns"
 
 #: templates/level-page.html:8
 msgid "step_title"
@@ -1242,18 +1164,6 @@ msgstr "Készíts fiókot"
 #: templates/login.html:33
 msgid "forgot_password"
 msgstr "Elfelejtetted a jelszavad?"
-
-#: templates/main-page.html:9
-msgid "main_title"
-msgstr "Hedy"
-
-#: templates/main-page.html:10
-msgid "main_subtitle"
-msgstr "A fokozatos programozási nyelv"
-
-#: templates/main-page.html:13
-msgid "try_it"
-msgstr "Try it"
 
 #: templates/profile.html:4
 #, fuzzy
@@ -1319,9 +1229,9 @@ msgstr "Favourite program"
 #, fuzzy
 msgid "public_profile_info"
 msgstr ""
-"By selecting this box I make my profile visible for everyone. Be careful not "
-"to share personal information like your name or home address, because "
-"everyone will be able to see it!"
+"By selecting this box I make my profile visible for everyone. Be careful "
+"not to share personal information like your name or home address, because"
+" everyone will be able to see it!"
 
 #: templates/profile.html:59
 #, fuzzy
@@ -1386,6 +1296,10 @@ msgstr "Férfi"
 #: templates/profile.html:131 templates/signup.html:48
 msgid "other"
 msgstr "Más"
+
+#: templates/profile.html:135 templates/signup.html:52
+msgid "country"
+msgstr "Ország"
 
 #: templates/profile.html:141
 msgid "update_profile"
@@ -1586,8 +1500,8 @@ msgstr "Már van fiókod?"
 #, fuzzy
 msgid "teacher_invitation_require_login"
 msgstr ""
-"To set up your profile as a teacher we will need you to log in. If you don't "
-"have an account, please create one."
+"To set up your profile as a teacher we will need you to log in. If you "
+"don't have an account, please create one."
 
 #: templates/view-program-page.html:13
 #, fuzzy
@@ -1750,7 +1664,8 @@ msgstr "You have to agree with the privacy terms."
 #, fuzzy
 msgid "keyword_language_invalid"
 msgstr ""
-"Please select a valid keyword language (select English or your own language)."
+"Please select a valid keyword language (select English or your own "
+"language)."
 
 #: website/auth.py:371 website/auth.py:551
 msgid "year_invalid"
@@ -1840,7 +1755,8 @@ msgstr "Program deleted successfully."
 #: website/programs.py:55
 msgid "save_prompt"
 msgstr ""
-"A program mentéséhez fiókkal kell rendelkezned. Szeretnél most bejelentkezni?"
+"A program mentéséhez fiókkal kell rendelkezned. Szeretnél most "
+"bejelentkezni?"
 
 #: website/programs.py:60
 #, fuzzy
@@ -2050,3 +1966,61 @@ msgstr "The adventure has been updated!"
 #, fuzzy
 msgid "adventure_empty"
 msgstr "You didn't enter an adventure name!"
+
+#~ msgid "customize_class_exp_1"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_1"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_2"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_3"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_4"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_5"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_6"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_7"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_8"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_exp_2"
+#~ msgstr "Customize class"
+
+#~ msgid "mailing_title"
+#~ msgstr "Hedy"
+
+#~ msgid "surname"
+#~ msgstr "Felhasználónév"
+
+#~ msgid "lastname"
+#~ msgstr "Név"
+
+#~ msgid "subscribe"
+#~ msgstr "Iratkozz fel a hírlevélre "
+
+#~ msgid "required_field"
+#~ msgstr "Fields marked with an * are required"
+
+#~ msgid "previous_campaigns"
+#~ msgstr "View previous campaigns"
+
+#~ msgid "main_title"
+#~ msgstr "Hedy"
+
+#~ msgid "main_subtitle"
+#~ msgstr "A fokozatos programozási nyelv"
+
+#~ msgid "try_it"
+#~ msgstr "Try it"
+

--- a/translations/id/LC_MESSAGES/messages.po
+++ b/translations/id/LC_MESSAGES/messages.po
@@ -1,18 +1,18 @@
+
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-03-29 10:01+0200\n"
+"POT-Creation-Date: 2022-03-30 08:43+0200\n"
 "PO-Revision-Date: 2022-03-30 09:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
+"Language: id\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/hedy/web-"
 "texts/id/>\n"
-"Language: id\n"
+"Plural-Forms: nplurals=2; plural=n != 1\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.12-dev\n"
 "Generated-By: Babel 2.9.1\n"
 
 #: app.py:571
@@ -20,27 +20,27 @@ msgstr ""
 msgid "program_contains_error"
 msgstr "This program contains an error, are you sure you want to share it?"
 
-#: app.py:723
+#: app.py:722
 #, fuzzy
 msgid "title_achievements"
 msgstr "Hedy - My achievements"
 
-#: app.py:740 app.py:1111 website/teacher.py:365 website/teacher.py:374
+#: app.py:739 app.py:1110 website/teacher.py:365 website/teacher.py:374
 #, fuzzy
 msgid "not_teacher"
 msgstr "Looks like you are not a teacher!"
 
-#: app.py:743
+#: app.py:742
 #, fuzzy
 msgid "not_enrolled"
 msgstr "Looks like you are not in this class!"
 
-#: app.py:775
+#: app.py:774
 #, fuzzy
 msgid "title_programs"
 msgstr "Hedy - My programs"
 
-#: app.py:785 app.py:795 app.py:799 app.py:813 app.py:1054 app.py:1357
+#: app.py:784 app.py:794 app.py:798 app.py:812 app.py:1053 app.py:1356
 #: website/admin.py:17 website/admin.py:25 website/admin.py:95
 #: website/admin.py:112 website/admin.py:130 website/auth.py:711
 #: website/auth.py:738 website/statistics.py:86
@@ -48,122 +48,122 @@ msgstr "Hedy - My programs"
 msgid "unauthorized"
 msgstr "You don't have access rights for this page"
 
-#: app.py:823
+#: app.py:822
 msgid "minutes"
 msgstr "menit"
 
-#: app.py:826
+#: app.py:825
 msgid "hours"
 msgstr "jam"
 
-#: app.py:829
+#: app.py:828
 msgid "days"
 msgstr "hari"
 
-#: app.py:832
+#: app.py:831
 #, fuzzy
 msgid "ago"
 msgstr "{time} ago"
 
-#: app.py:848 app.py:850 app.py:976
+#: app.py:847 app.py:849 app.py:975
 #, fuzzy
 msgid "no_such_level"
 msgstr "No such Hedy level!"
 
-#: app.py:858 app.py:865 app.py:931 app.py:937
+#: app.py:857 app.py:864 app.py:930 app.py:936
 #, fuzzy
 msgid "no_such_program"
 msgstr "No such Hedy program!"
 
-#: app.py:891
+#: app.py:890
 #, fuzzy
 msgid "level_not_translated"
 msgstr "This level is not translated in your language (yet)"
 
-#: app.py:893
+#: app.py:892
 #, fuzzy
 msgid "level_not_class"
 msgstr "You're in a class where this level has not been made available yet"
 
-#: app.py:986 website/teacher.py:432 website/teacher.py:448
+#: app.py:985 website/teacher.py:432 website/teacher.py:448
 #: website/teacher.py:477 website/teacher.py:503
 #, fuzzy
 msgid "no_such_adventure"
 msgstr "This adventure doesn't exist!"
 
-#: app.py:1005
+#: app.py:1004
 #, fuzzy
 msgid "page_not_found"
 msgstr "We could not find that page!"
 
-#: app.py:1025
+#: app.py:1024
 #, fuzzy
 msgid "title_signup"
 msgstr "Hedy - Create an account"
 
-#: app.py:1032
+#: app.py:1031
 #, fuzzy
 msgid "title_login"
 msgstr "Hedy - Login"
 
-#: app.py:1039
+#: app.py:1038
 #, fuzzy
 msgid "title_recover"
 msgstr "Hedy - Recover account"
 
-#: app.py:1055
+#: app.py:1054
 #, fuzzy
 msgid "title_reset"
 msgstr "Hedy - Reset password"
 
-#: app.py:1064
+#: app.py:1063
 #, fuzzy
 msgid "title_my-profile"
 msgstr "Hedy - My account"
 
-#: app.py:1078
+#: app.py:1077
 #, fuzzy
 msgid "title_learn-more"
 msgstr "Hedy - Learn more"
 
-#: app.py:1083
+#: app.py:1082
 #, fuzzy
 msgid "title_privacy"
 msgstr "Hedy - Privacy terms"
 
-#: app.py:1090
+#: app.py:1089
 #, fuzzy
 msgid "title_landing-page"
 msgstr "Welcome to Hedy!"
 
-#: app.py:1092
+#: app.py:1091
 #, fuzzy
 msgid "not_user"
 msgstr "Looks like you are not logged in!"
 
-#: app.py:1107
+#: app.py:1106
 #, fuzzy
 msgid "title_for-teacher"
 msgstr "Hedy - For teachers"
 
-#: app.py:1118
+#: app.py:1117
 #, fuzzy
 msgid "title_start"
 msgstr "Hedy - A gradual programming language"
 
-#: app.py:1171
+#: app.py:1170
 #, fuzzy
 msgid "title_explore"
 msgstr "Hedy - Explore"
 
-#: app.py:1190 app.py:1192
+#: app.py:1189 app.py:1191
 #, fuzzy
 msgid "translate_error"
 msgstr ""
-"Something went wrong while translating the code. Try running the code to see "
-"if it has an error. Code with errors can not be translated."
+"Something went wrong while translating the code. Try running the code to "
+"see if it has an error. Code with errors can not be translated."
 
-#: app.py:1301 website/auth.py:299 website/auth.py:347 website/auth.py:483
+#: app.py:1300 website/auth.py:299 website/auth.py:347 website/auth.py:483
 #: website/auth.py:509 website/auth.py:539 website/auth.py:645
 #: website/auth.py:677 website/auth.py:717 website/auth.py:744
 #: website/teacher.py:90 website/teacher.py:125 website/teacher.py:197
@@ -172,37 +172,37 @@ msgstr ""
 msgid "ajax_error"
 msgstr "Ditemukan sebuah error. Silakan coba lagi."
 
-#: app.py:1304
+#: app.py:1303
 #, fuzzy
 msgid "image_invalid"
 msgstr "Your chosen image is invalid."
 
-#: app.py:1306
+#: app.py:1305
 #, fuzzy
 msgid "personal_text_invalid"
 msgstr "Your personal text is invalid."
 
-#: app.py:1308 app.py:1314
+#: app.py:1307 app.py:1313
 #, fuzzy
 msgid "favourite_program_invalid"
 msgstr "Your chosen favourite program is invalid."
 
-#: app.py:1326 app.py:1327
+#: app.py:1325 app.py:1326
 #, fuzzy
 msgid "public_profile_updated"
 msgstr "Public profile updated."
 
-#: app.py:1361 app.py:1385
+#: app.py:1360 app.py:1384
 #, fuzzy
 msgid "user_not_private"
 msgstr "This user doesn't exist or doesn't have a public profile"
 
-#: app.py:1394
+#: app.py:1393
 #, fuzzy
 msgid "invalid_teacher_invitation_code"
 msgstr ""
-"The teacher invitation code is invalid. To become a teacher, reach out to "
-"hedy@felienne.com."
+"The teacher invitation code is invalid. To become a teacher, reach out to"
+" hedy@felienne.com."
 
 #: utils.py:203
 #, fuzzy
@@ -223,7 +223,8 @@ msgstr "Something went wrong..."
 #, fuzzy
 msgid "Empty Program"
 msgstr ""
-"You created an empty program. Type Hedy code in the left field and try again"
+"You created an empty program. Type Hedy code in the left field and try "
+"again"
 
 #: coursedata/error-messages.txt:2
 msgid "Wrong Level"
@@ -246,51 +247,51 @@ msgstr ""
 #: coursedata/error-messages.txt:5
 msgid "Invalid Space"
 msgstr ""
-"Ups! kamu memulai baris dengan sebuah spasi pada baris {line_number}. Spasi "
-"membingungkan komputer, dapatkah kamu membuangnya?"
+"Ups! kamu memulai baris dengan sebuah spasi pada baris {line_number}. "
+"Spasi membingungkan komputer, dapatkah kamu membuangnya?"
 
 #: coursedata/error-messages.txt:6
 msgid "Has Blanks"
 msgstr ""
-"Kode kamu tidak lengkap. Itu memiliki beberapa bagian kosong yang harus kamu "
-"isi dengan kode."
+"Kode kamu tidak lengkap. Itu memiliki beberapa bagian kosong yang harus "
+"kamu isi dengan kode."
 
 #: coursedata/error-messages.txt:7
 #, fuzzy
 msgid "No Indentation"
 msgstr ""
 "You used too few spaces in line {line_number}. You used {leading_spaces} "
-"spaces, which is not enough. Start every new block with {indent_size} spaces "
-"more than the line before."
+"spaces, which is not enough. Start every new block with {indent_size} "
+"spaces more than the line before."
 
 #: coursedata/error-messages.txt:8
 #, fuzzy
 msgid "Unexpected Indentation"
 msgstr ""
-"You used too many spaces in line {line_number}. You used {leading_spaces} "
-"spaces, which is too much. Start every new block with {indent_size} spaces "
-"more than the line before."
+"You used too many spaces in line {line_number}. You used {leading_spaces}"
+" spaces, which is too much. Start every new block with {indent_size} "
+"spaces more than the line before."
 
 #: coursedata/error-messages.txt:9
 msgid "Parse"
 msgstr ""
-"Kode yang kamu masukan bukan kode Hedy yang valid. Ada kesalahan pada baris "
-"{location[0]}, pada posisi {location[1]}. Kamu menuliskan {character_found}, "
-"tapi itu tidak diperbolehkan."
+"Kode yang kamu masukan bukan kode Hedy yang valid. Ada kesalahan pada "
+"baris {location[0]}, pada posisi {location[1]}. Kamu menuliskan "
+"{character_found}, tapi itu tidak diperbolehkan."
 
 #: coursedata/error-messages.txt:10
 msgid "Unquoted Text"
 msgstr ""
-"Berhati-hatilah. Jika kamu meminta masukan atau menampilkan sesuatu, teksnya "
-"harus diawali dan diakhiri dengan kutip satu. Kamu melupakan salah satu "
-"tanda kutip."
+"Berhati-hatilah. Jika kamu meminta masukan atau menampilkan sesuatu, "
+"teksnya harus diawali dan diakhiri dengan kutip satu. Kamu melupakan "
+"salah satu tanda kutip."
 
 #: coursedata/error-messages.txt:11
 #, fuzzy
 msgid "Unquoted Assignment"
 msgstr ""
-"From this level, you need to place texts to the right of the `is` between "
-"quotes. You forgot that for the text {text}."
+"From this level, you need to place texts to the right of the `is` between"
+" quotes. You forgot that for the text {text}."
 
 #: coursedata/error-messages.txt:12
 #, fuzzy
@@ -302,16 +303,16 @@ msgstr ""
 #: coursedata/error-messages.txt:13
 msgid "Var Undefined"
 msgstr ""
-"Kamu mencoba untuk menampilkan variabel {name}, tapi kamu belum mengisinya "
-"dengan nilai. Ada kemungkinan bahwa kamu sedang mencoba untuk menampilkan "
-"kata {name} tapi melupakan tanda kutip."
+"Kamu mencoba untuk menampilkan variabel {name}, tapi kamu belum "
+"mengisinya dengan nilai. Ada kemungkinan bahwa kamu sedang mencoba untuk "
+"menampilkan kata {name} tapi melupakan tanda kutip."
 
 #: coursedata/error-messages.txt:14
 #, fuzzy
 msgid "Cyclic Var Definition"
 msgstr ""
-"The name {variable} needs to be set before you can use it on the right-hand "
-"side of the is command"
+"The name {variable} needs to be set before you can use it on the right-"
+"hand side of the is command"
 
 #: coursedata/error-messages.txt:15
 msgid "Lonely Echo"
@@ -323,46 +324,46 @@ msgstr ""
 #, fuzzy
 msgid "Too Big"
 msgstr ""
-"Wow! Your program has an impressive {lines_of_code} lines of code! But we "
-"can only process {max_lines} lines in this level. Make your program smaller "
-"and try again."
+"Wow! Your program has an impressive {lines_of_code} lines of code! But we"
+" can only process {max_lines} lines in this level. Make your program "
+"smaller and try again."
 
 #: coursedata/error-messages.txt:17
 #, fuzzy
 msgid "Invalid Argument Type"
 msgstr ""
-"You cannot use the command {command} with {invalid_argument} because it is "
-"{invalid_type}. Try changing {invalid_argument} to {allowed_types}."
+"You cannot use the command {command} with {invalid_argument} because it "
+"is {invalid_type}. Try changing {invalid_argument} to {allowed_types}."
 
 #: coursedata/error-messages.txt:18
 #, fuzzy
 msgid "Invalid Argument"
 msgstr ""
-"You cannot use the command {command} with {invalid_argument} . Try changing "
-"{invalid_argument} to {allowed_types}."
+"You cannot use the command {command} with {invalid_argument} . Try "
+"changing {invalid_argument} to {allowed_types}."
 
 #: coursedata/error-messages.txt:19
 #, fuzzy
 msgid "Invalid Type Combination"
 msgstr ""
-"You cannot use {invalid_argument} and {invalid_argument_2} in {operation} "
-"because one is {invalid_type} and the other is {invalid_type_2}. Try "
-"changing {invalid_argument} to {invalid_type_2} or {invalid_argument_2} to "
-"{invalid_type}."
+"You cannot use {invalid_argument} and {invalid_argument_2} in {operation}"
+" because one is {invalid_type} and the other is {invalid_type_2}. Try "
+"changing {invalid_argument} to {invalid_type_2} or {invalid_argument_2} "
+"to {invalid_type}."
 
 #: coursedata/error-messages.txt:20
 #, fuzzy
 msgid "Unsupported Float"
 msgstr ""
-"Non-integer numbers are not supported yet but they will be in a few levels. "
-"For now change {value} to an integer."
+"Non-integer numbers are not supported yet but they will be in a few "
+"levels. For now change {value} to an integer."
 
 #: coursedata/error-messages.txt:21
 #, fuzzy
 msgid "Locked Language Feature"
 msgstr ""
-"You are using {concept}! That is awesome, but {concept} is not unlocked yet! "
-"It will be unlocked in a later level."
+"You are using {concept}! That is awesome, but {concept} is not unlocked "
+"yet! It will be unlocked in a later level."
 
 #: coursedata/error-messages.txt:22
 #, fuzzy
@@ -373,15 +374,16 @@ msgstr "It looks like you forgot to use a command on line {line_number}."
 #, fuzzy
 msgid "ask_needs_var"
 msgstr ""
-"Starting in level 2, ask needs to be used with a variable. Example: name is "
-"ask What are you called?"
+"Starting in level 2, ask needs to be used with a variable. Example: name "
+"is ask What are you called?"
 
 #: coursedata/error-messages.txt:24
 #, fuzzy
 msgid "echo_out"
 msgstr ""
-"Starting in level 2 echo is no longer needed. You can repeat an answer with "
-"ask and print now. Example: name is ask What are you called? print hello name"
+"Starting in level 2 echo is no longer needed. You can repeat an answer "
+"with ask and print now. Example: name is ask What are you called? print "
+"hello name"
 
 #: coursedata/error-messages.txt:25
 msgid "space"
@@ -466,6 +468,11 @@ msgstr "a list"
 #, fuzzy
 msgid "input"
 msgstr "input from ask"
+
+#: templates/achievements.html:4
+#, fuzzy
+msgid "achievements_title"
+msgstr "achievements"
 
 #: templates/class-overview.html:16
 #, fuzzy
@@ -629,14 +636,14 @@ msgstr ""
 msgid "join_class"
 msgstr "Gabung kelas"
 
-#: templates/class-stats.html:22 templates/customize-class.html:155
+#: templates/class-stats.html:22 templates/customize-class.html:150
 #, fuzzy
 msgid "back_to_class"
 msgstr "Go back to class"
 
 #: templates/code-page.html:25 templates/code-page.html:34
-#: templates/customize-class.html:28 templates/customize-class.html:64
-#: templates/customize-class.html:71 templates/customize-class.html:94
+#: templates/customize-class.html:23 templates/customize-class.html:59
+#: templates/customize-class.html:66 templates/customize-class.html:89
 #: templates/incl-adventure-tabs.html:5 templates/level-page.html:6
 #: templates/level-page.html:11 templates/quiz/startquiz.html:10
 #: templates/view-program-page.html:12 templates/view-program-page.html:28
@@ -652,21 +659,21 @@ msgstr "Create multiple accounts"
 #, fuzzy
 msgid "accounts_intro"
 msgstr ""
-"On this page you can create accounts for multiple students at the same time. "
-"It is also possible to directly add them to one of your classes. By pressing "
-"the green + on the bottom right of the page you can add extra rows. You can "
-"delete a row by pressing the corresponding red cross. Make sure no rows are "
-"empty when you press \"Create accounts\". Please keep in mind that every "
-"username and mail address needs to be unique and the password needs to be "
-"<b>at least</b> 6 characters."
+"On this page you can create accounts for multiple students at the same "
+"time. It is also possible to directly add them to one of your classes. By"
+" pressing the green + on the bottom right of the page you can add extra "
+"rows. You can delete a row by pressing the corresponding red cross. Make "
+"sure no rows are empty when you press \"Create accounts\". Please keep in"
+" mind that every username and mail address needs to be unique and the "
+"password needs to be <b>at least</b> 6 characters."
 
 #: templates/create-accounts.html:10
 #, fuzzy
 msgid "create_accounts_prompt"
 msgstr "Are you sure you want to create these accounts?"
 
-#: templates/create-accounts.html:17 templates/learn-more.html:10
-#: templates/profile.html:96 templates/recover.html:8 templates/signup.html:13
+#: templates/create-accounts.html:17 templates/profile.html:96
+#: templates/recover.html:8 templates/signup.html:13
 msgid "email"
 msgstr "Email"
 
@@ -721,10 +728,10 @@ msgstr "Level"
 #, fuzzy
 msgid "adventure_exp_1"
 msgstr ""
-"Type your adventure of choice on the right-hand side. After creating your "
-"adventure you can include it in one of your classes under \"customizations"
-"\". If you want to include a command in your adventure please use code "
-"anchors like this:"
+"Type your adventure of choice on the right-hand side. After creating your"
+" adventure you can include it in one of your classes under "
+"\"customizations\". If you want to include a command in your adventure "
+"please use code anchors like this:"
 
 #: templates/customize-adventure.html:31
 #, fuzzy
@@ -738,11 +745,11 @@ msgstr ""
 msgid "adventure_exp_3"
 msgstr ""
 "You can use the \"preview\" button to view a styled version of your "
-"adventure. To view the adventure on a dedicated page, select \"view\" from "
-"the teachers page."
+"adventure. To view the adventure on a dedicated page, select \"view\" "
+"from the teachers page."
 
-#: templates/customize-adventure.html:43 templates/customize-class.html:28
-#: templates/customize-class.html:93 templates/explore.html:26
+#: templates/customize-adventure.html:43 templates/customize-class.html:23
+#: templates/customize-class.html:88 templates/explore.html:26
 #: templates/programs.html:18 templates/programs.html:48
 #: templates/view-adventure.html:6
 msgid "adventure"
@@ -772,7 +779,7 @@ msgstr "I agree that my adventure might be made publicly available on Hedy."
 msgid "preview"
 msgstr "Preview"
 
-#: templates/customize-adventure.html:51 templates/customize-class.html:150
+#: templates/customize-adventure.html:51 templates/customize-class.html:145
 #, fuzzy
 msgid "save"
 msgstr "Save"
@@ -782,128 +789,78 @@ msgstr "Save"
 msgid "delete_adventure_prompt"
 msgstr "Are you sure you want to remove this adventure?"
 
-#: templates/customize-class.html:7
-#, fuzzy
-msgid "customize_class_exp_1"
-msgstr "Customize class"
-
-#: templates/customize-class.html:10
-#, fuzzy
-msgid "customize_class_step_1"
-msgstr "Customize class"
-
-#: templates/customize-class.html:11
-#, fuzzy
-msgid "customize_class_step_2"
-msgstr "Customize class"
-
-#: templates/customize-class.html:12
-#, fuzzy
-msgid "customize_class_step_3"
-msgstr "Customize class"
-
-#: templates/customize-class.html:13
-#, fuzzy
-msgid "customize_class_step_4"
-msgstr "Customize class"
-
-#: templates/customize-class.html:14
-#, fuzzy
-msgid "customize_class_step_5"
-msgstr "Customize class"
-
-#: templates/customize-class.html:15
-#, fuzzy
-msgid "customize_class_step_6"
-msgstr "Customize class"
-
-#: templates/customize-class.html:16
-#, fuzzy
-msgid "customize_class_step_7"
-msgstr "Customize class"
-
-#: templates/customize-class.html:17
-#, fuzzy
-msgid "customize_class_step_8"
-msgstr "Customize class"
-
-#: templates/customize-class.html:20
-#, fuzzy
-msgid "customize_class_exp_2"
-msgstr "Customize class"
-
-#: templates/customize-class.html:23
+#: templates/customize-class.html:18
 #, fuzzy
 msgid "select_adventures"
 msgstr "Select adventures"
 
-#: templates/customize-class.html:59
+#: templates/customize-class.html:54
 #, fuzzy
 msgid "opening_dates"
 msgstr "Opening dates"
 
-#: templates/customize-class.html:65
+#: templates/customize-class.html:60
 #, fuzzy
 msgid "opening_date"
 msgstr "Opening date"
 
-#: templates/customize-class.html:77
+#: templates/customize-class.html:72
 #, fuzzy
 msgid "directly_available"
 msgstr "Directly open"
 
-#: templates/customize-class.html:88
+#: templates/customize-class.html:83
 #, fuzzy
 msgid "select_own_adventures"
 msgstr "Select own adventures"
 
-#: templates/customize-class.html:95 templates/customize-class.html:121
+#: templates/customize-class.html:90 templates/customize-class.html:116
 #: templates/profile.html:47 templates/profile.html:128
 #: templates/profile.html:137 templates/signup.html:26 templates/signup.html:45
 #: templates/signup.html:53
 msgid "select"
 msgstr "Pilih"
 
-#: templates/customize-class.html:115
+#: templates/customize-class.html:110
 #, fuzzy
 msgid "other_settings"
 msgstr "Other settings"
 
-#: templates/customize-class.html:120
+#: templates/customize-class.html:115
 #, fuzzy
 msgid "option"
 msgstr "Option"
 
-#: templates/customize-class.html:126
+#: templates/customize-class.html:121
 #, fuzzy
 msgid "mandatory_mode"
 msgstr "Mandatory developer's mode"
 
-#: templates/customize-class.html:132
+#: templates/customize-class.html:127
 #, fuzzy
 msgid "hide_cheatsheet"
 msgstr "Hide cheatsheet"
 
-#: templates/customize-class.html:138
+#: templates/customize-class.html:133
 msgid "hide_keyword_switcher"
 msgstr ""
 
-#: templates/customize-class.html:149
+#: templates/customize-class.html:144
 #, fuzzy
 msgid "reset_adventure_prompt"
 msgstr "Are you sure you want to reset all selected adventures?"
 
-#: templates/customize-class.html:149
+#: templates/customize-class.html:144
 #, fuzzy
 msgid "reset_adventures"
 msgstr "Reset selected adventures"
 
-#: templates/customize-class.html:153
+#: templates/customize-class.html:148
 #, fuzzy
 msgid "remove_customizations_prompt"
 msgstr "Are you sure you want to remove this class their customizations?"
 
-#: templates/customize-class.html:154
+#: templates/customize-class.html:149
 #, fuzzy
 msgid "remove_customization"
 msgstr "Remove customization"
@@ -922,13 +879,13 @@ msgstr "Explore programs"
 #, fuzzy
 msgid "explore_explanation"
 msgstr ""
-"On this page you can look through programs created by other Hedy users. You "
-"can filter on both a Hedy level and adventure. Click on \"View program\" to "
-"open a program and run it. Programs with a red header contain a mistake. You "
-"can still open the program, but running it will result in an error. You can "
-"of course try to fix it! If the creator has a public profile you can click "
-"their username to visit their profile. There you will find all their shared "
-"programs and much more!"
+"On this page you can look through programs created by other Hedy users. "
+"You can filter on both a Hedy level and adventure. Click on \"View "
+"program\" to open a program and run it. Programs with a red header "
+"contain a mistake. You can still open the program, but running it will "
+"result in an error. You can of course try to fix it! If the creator has a"
+" public profile you can click their username to visit their profile. "
+"There you will find all their shared programs and much more!"
 
 #: templates/explore.html:35 templates/programs.html:27
 #, fuzzy
@@ -992,8 +949,8 @@ msgstr "Create student accounts"
 #, fuzzy
 msgid "teacher_welcome"
 msgstr ""
-"Welcome to Hedy! Your are now the proud owner of a teachers account which "
-"allows you to create classes and invite students."
+"Welcome to Hedy! Your are now the proud owner of a teachers account which"
+" allows you to create classes and invite students."
 
 #: templates/incl-adventure-tabs.html:22
 #, fuzzy
@@ -1107,9 +1064,9 @@ msgstr "Welcome"
 msgid "intro_text_landing_page"
 msgstr ""
 "Welcome to the wonderful world of Hedy! Here you can learn to program in "
-"small steps, without unnecessary complicated stuff. We start easy at level "
-"1, and slowly build towards bigger and more complex programs! Choose one of "
-"the options below to get started"
+"small steps, without unnecessary complicated stuff. We start easy at "
+"level 1, and slowly build towards bigger and more complex programs! "
+"Choose one of the options below to get started"
 
 #: templates/landing-page.html:14 templates/landing-page.html:36
 #, fuzzy
@@ -1125,14 +1082,14 @@ msgstr "Start programming"
 #: templates/landing-page.html:21
 #, fuzzy
 msgid "create_class_text"
-msgstr ""
-"Group your students into classes and change the content for each class."
+msgstr "Group your students into classes and change the content for each class."
 
 #: templates/landing-page.html:28
 #, fuzzy
 msgid "read_docs_text"
 msgstr ""
-"Visit our teacher's manual for lesson plans and common mistakes by students."
+"Visit our teacher's manual for lesson plans and common mistakes by "
+"students."
 
 #: templates/landing-page.html:30
 #, fuzzy
@@ -1174,45 +1131,14 @@ msgstr "Salin tautan untuk berbagi"
 #, fuzzy
 msgid "set_preferred_lang"
 msgstr ""
-"Hedy now supports preferred user languages. You can set one for your profile "
-"in \"My profile\""
+"Hedy now supports preferred user languages. You can set one for your "
+"profile in \"My profile\""
 
 #: templates/layout.html:86 templates/quiz/endquiz.html:18
 #: templates/quiz/quiz.html:29
 #, fuzzy
 msgid "achievement_earned"
 msgstr "You've earned an achievement!"
-
-#: templates/learn-more.html:7
-msgid "mailing_title"
-msgstr "Berlangganan ke buletin Hedy"
-
-#: templates/learn-more.html:14
-msgid "surname"
-msgstr "Nama Depan"
-
-#: templates/learn-more.html:18
-msgid "lastname"
-msgstr "Nama Belakang"
-
-#: templates/learn-more.html:22 templates/profile.html:135
-#: templates/signup.html:52
-msgid "country"
-msgstr "Negara"
-
-#: templates/learn-more.html:31
-#, fuzzy
-msgid "subscribe"
-msgstr "Berlangganan"
-
-#: templates/learn-more.html:32
-#, fuzzy
-msgid "required_field"
-msgstr "Fields marked with an * are required"
-
-#: templates/learn-more.html:35
-msgid "previous_campaigns"
-msgstr "Lihat kampanye-kampanye sebelumnya"
 
 #: templates/level-page.html:8
 msgid "step_title"
@@ -1245,18 +1171,6 @@ msgstr "Membuat akun"
 #: templates/login.html:33
 msgid "forgot_password"
 msgstr "Lupa passowrd kamu?"
-
-#: templates/main-page.html:9
-msgid "main_title"
-msgstr "Hedy"
-
-#: templates/main-page.html:10
-msgid "main_subtitle"
-msgstr "Sebuah bahasa pemrograman bertahap"
-
-#: templates/main-page.html:13
-msgid "try_it"
-msgstr "Coba"
 
 #: templates/profile.html:4
 #, fuzzy
@@ -1322,9 +1236,9 @@ msgstr "Favourite program"
 #, fuzzy
 msgid "public_profile_info"
 msgstr ""
-"By selecting this box I make my profile visible for everyone. Be careful not "
-"to share personal information like your name or home address, because "
-"everyone will be able to see it!"
+"By selecting this box I make my profile visible for everyone. Be careful "
+"not to share personal information like your name or home address, because"
+" everyone will be able to see it!"
 
 #: templates/profile.html:59
 #, fuzzy
@@ -1389,6 +1303,10 @@ msgstr "Laki-laki"
 #: templates/profile.html:131 templates/signup.html:48
 msgid "other"
 msgstr "Lainnya"
+
+#: templates/profile.html:135 templates/signup.html:52
+msgid "country"
+msgstr "Negara"
 
 #: templates/profile.html:141
 msgid "update_profile"
@@ -1588,8 +1506,8 @@ msgstr "Sudah memiliki akun?"
 #, fuzzy
 msgid "teacher_invitation_require_login"
 msgstr ""
-"To set up your profile as a teacher we will need you to log in. If you don't "
-"have an account, please create one."
+"To set up your profile as a teacher we will need you to log in. If you "
+"don't have an account, please create one."
 
 #: templates/view-program-page.html:13
 msgid "by"
@@ -1752,7 +1670,8 @@ msgstr "You have to agree with the privacy terms."
 #, fuzzy
 msgid "keyword_language_invalid"
 msgstr ""
-"Please select a valid keyword language (select English or your own language)."
+"Please select a valid keyword language (select English or your own "
+"language)."
 
 #: website/auth.py:371 website/auth.py:551
 msgid "year_invalid"
@@ -1818,8 +1737,8 @@ msgstr "Profile updated, page will be re-loaded."
 #: website/auth.py:670
 msgid "sent_password_recovery"
 msgstr ""
-"Kamu harusnya akan segera menerima email dengan instruksi terkait bagaimana "
-"memulihkan password kamu."
+"Kamu harusnya akan segera menerima email dengan instruksi terkait "
+"bagaimana memulihkan password kamu."
 
 #: website/auth.py:681 website/auth.py:691
 #, fuzzy
@@ -2060,3 +1979,61 @@ msgstr "You didn't enter an adventure name!"
 
 #~ msgid "ago-2"
 #~ msgstr "lalu"
+
+#~ msgid "customize_class_exp_1"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_1"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_2"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_3"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_4"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_5"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_6"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_7"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_8"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_exp_2"
+#~ msgstr "Customize class"
+
+#~ msgid "mailing_title"
+#~ msgstr "Berlangganan ke buletin Hedy"
+
+#~ msgid "surname"
+#~ msgstr "Nama Depan"
+
+#~ msgid "lastname"
+#~ msgstr "Nama Belakang"
+
+#~ msgid "subscribe"
+#~ msgstr "Berlangganan"
+
+#~ msgid "required_field"
+#~ msgstr "Fields marked with an * are required"
+
+#~ msgid "previous_campaigns"
+#~ msgstr "Lihat kampanye-kampanye sebelumnya"
+
+#~ msgid "main_title"
+#~ msgstr "Hedy"
+
+#~ msgid "main_subtitle"
+#~ msgstr "Sebuah bahasa pemrograman bertahap"
+
+#~ msgid "try_it"
+#~ msgstr "Coba"
+

--- a/translations/it/LC_MESSAGES/messages.po
+++ b/translations/it/LC_MESSAGES/messages.po
@@ -1,18 +1,18 @@
+
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-03-29 10:01+0200\n"
+"POT-Creation-Date: 2022-03-30 08:43+0200\n"
 "PO-Revision-Date: 2022-03-30 09:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
-"Language-Team: Italian <https://hosted.weblate.org/projects/hedy/web-texts/"
-"it/>\n"
 "Language: it\n"
+"Language-Team: Italian <https://hosted.weblate.org/projects/hedy/web-"
+"texts/it/>\n"
+"Plural-Forms: nplurals=2; plural=n != 1\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.12-dev\n"
 "Generated-By: Babel 2.9.1\n"
 
 #: app.py:571
@@ -20,27 +20,27 @@ msgstr ""
 msgid "program_contains_error"
 msgstr "This program contains an error, are you sure you want to share it?"
 
-#: app.py:723
+#: app.py:722
 #, fuzzy
 msgid "title_achievements"
 msgstr "Hedy - My achievements"
 
-#: app.py:740 app.py:1111 website/teacher.py:365 website/teacher.py:374
+#: app.py:739 app.py:1110 website/teacher.py:365 website/teacher.py:374
 #, fuzzy
 msgid "not_teacher"
 msgstr "Looks like you are not a teacher!"
 
-#: app.py:743
+#: app.py:742
 #, fuzzy
 msgid "not_enrolled"
 msgstr "Looks like you are not in this class!"
 
-#: app.py:775
+#: app.py:774
 #, fuzzy
 msgid "title_programs"
 msgstr "Hedy - My programs"
 
-#: app.py:785 app.py:795 app.py:799 app.py:813 app.py:1054 app.py:1357
+#: app.py:784 app.py:794 app.py:798 app.py:812 app.py:1053 app.py:1356
 #: website/admin.py:17 website/admin.py:25 website/admin.py:95
 #: website/admin.py:112 website/admin.py:130 website/auth.py:711
 #: website/auth.py:738 website/statistics.py:86
@@ -48,122 +48,122 @@ msgstr "Hedy - My programs"
 msgid "unauthorized"
 msgstr "You don't have access rights for this page"
 
-#: app.py:823
+#: app.py:822
 msgid "minutes"
 msgstr "minuti"
 
-#: app.py:826
+#: app.py:825
 msgid "hours"
 msgstr "ore"
 
-#: app.py:829
+#: app.py:828
 msgid "days"
 msgstr "giorni"
 
-#: app.py:832
+#: app.py:831
 #, fuzzy
 msgid "ago"
 msgstr "{time} ago"
 
-#: app.py:848 app.py:850 app.py:976
+#: app.py:847 app.py:849 app.py:975
 #, fuzzy
 msgid "no_such_level"
 msgstr "No such Hedy level!"
 
-#: app.py:858 app.py:865 app.py:931 app.py:937
+#: app.py:857 app.py:864 app.py:930 app.py:936
 #, fuzzy
 msgid "no_such_program"
 msgstr "No such Hedy program!"
 
-#: app.py:891
+#: app.py:890
 #, fuzzy
 msgid "level_not_translated"
 msgstr "This level is not translated in your language (yet)"
 
-#: app.py:893
+#: app.py:892
 #, fuzzy
 msgid "level_not_class"
 msgstr "You're in a class where this level has not been made available yet"
 
-#: app.py:986 website/teacher.py:432 website/teacher.py:448
+#: app.py:985 website/teacher.py:432 website/teacher.py:448
 #: website/teacher.py:477 website/teacher.py:503
 #, fuzzy
 msgid "no_such_adventure"
 msgstr "This adventure doesn't exist!"
 
-#: app.py:1005
+#: app.py:1004
 #, fuzzy
 msgid "page_not_found"
 msgstr "We could not find that page!"
 
-#: app.py:1025
+#: app.py:1024
 #, fuzzy
 msgid "title_signup"
 msgstr "Hedy - Create an account"
 
-#: app.py:1032
+#: app.py:1031
 #, fuzzy
 msgid "title_login"
 msgstr "Hedy - Login"
 
-#: app.py:1039
+#: app.py:1038
 #, fuzzy
 msgid "title_recover"
 msgstr "Hedy - Recover account"
 
-#: app.py:1055
+#: app.py:1054
 #, fuzzy
 msgid "title_reset"
 msgstr "Hedy - Reset password"
 
-#: app.py:1064
+#: app.py:1063
 #, fuzzy
 msgid "title_my-profile"
 msgstr "Hedy - My account"
 
-#: app.py:1078
+#: app.py:1077
 #, fuzzy
 msgid "title_learn-more"
 msgstr "Hedy - Learn more"
 
-#: app.py:1083
+#: app.py:1082
 #, fuzzy
 msgid "title_privacy"
 msgstr "Hedy - Privacy terms"
 
-#: app.py:1090
+#: app.py:1089
 #, fuzzy
 msgid "title_landing-page"
 msgstr "Welcome to Hedy!"
 
-#: app.py:1092
+#: app.py:1091
 #, fuzzy
 msgid "not_user"
 msgstr "Looks like you are not logged in!"
 
-#: app.py:1107
+#: app.py:1106
 #, fuzzy
 msgid "title_for-teacher"
 msgstr "Hedy - For teachers"
 
-#: app.py:1118
+#: app.py:1117
 #, fuzzy
 msgid "title_start"
 msgstr "Hedy - A gradual programming language"
 
-#: app.py:1171
+#: app.py:1170
 #, fuzzy
 msgid "title_explore"
 msgstr "Hedy - Explore"
 
-#: app.py:1190 app.py:1192
+#: app.py:1189 app.py:1191
 #, fuzzy
 msgid "translate_error"
 msgstr ""
-"Something went wrong while translating the code. Try running the code to see "
-"if it has an error. Code with errors can not be translated."
+"Something went wrong while translating the code. Try running the code to "
+"see if it has an error. Code with errors can not be translated."
 
-#: app.py:1301 website/auth.py:299 website/auth.py:347 website/auth.py:483
+#: app.py:1300 website/auth.py:299 website/auth.py:347 website/auth.py:483
 #: website/auth.py:509 website/auth.py:539 website/auth.py:645
 #: website/auth.py:677 website/auth.py:717 website/auth.py:744
 #: website/teacher.py:90 website/teacher.py:125 website/teacher.py:197
@@ -172,37 +172,37 @@ msgstr ""
 msgid "ajax_error"
 msgstr "C'è stato un problema, per favore riprova."
 
-#: app.py:1304
+#: app.py:1303
 #, fuzzy
 msgid "image_invalid"
 msgstr "Your chosen image is invalid."
 
-#: app.py:1306
+#: app.py:1305
 #, fuzzy
 msgid "personal_text_invalid"
 msgstr "Your personal text is invalid."
 
-#: app.py:1308 app.py:1314
+#: app.py:1307 app.py:1313
 #, fuzzy
 msgid "favourite_program_invalid"
 msgstr "Your chosen favourite program is invalid."
 
-#: app.py:1326 app.py:1327
+#: app.py:1325 app.py:1326
 #, fuzzy
 msgid "public_profile_updated"
 msgstr "Public profile updated."
 
-#: app.py:1361 app.py:1385
+#: app.py:1360 app.py:1384
 #, fuzzy
 msgid "user_not_private"
 msgstr "This user doesn't exist or doesn't have a public profile"
 
-#: app.py:1394
+#: app.py:1393
 #, fuzzy
 msgid "invalid_teacher_invitation_code"
 msgstr ""
-"The teacher invitation code is invalid. To become a teacher, reach out to "
-"hedy@felienne.com."
+"The teacher invitation code is invalid. To become a teacher, reach out to"
+" hedy@felienne.com."
 
 #: utils.py:203
 #, fuzzy
@@ -223,13 +223,14 @@ msgstr "Something went wrong..."
 #, fuzzy
 msgid "Empty Program"
 msgstr ""
-"You created an empty program. Type Hedy code in the left field and try again"
+"You created an empty program. Type Hedy code in the left field and try "
+"again"
 
 #: coursedata/error-messages.txt:2
 msgid "Wrong Level"
 msgstr ""
-"Questo è il codice Hedy corretto ma non al livello giusto. Hai scritto un "
-"codice per il livello {working_level} al livello {original_level}."
+"Questo è il codice Hedy corretto ma non al livello giusto. Hai scritto un"
+" codice per il livello {working_level} al livello {original_level}."
 
 #: coursedata/error-messages.txt:3
 msgid "Incomplete"
@@ -240,8 +241,8 @@ msgstr ""
 #: coursedata/error-messages.txt:4
 msgid "Invalid"
 msgstr ""
-"{invalid_command} non è un commando Hedy per il livello {level}. Intendevi "
-"{guessed_command}?"
+"{invalid_command} non è un commando Hedy per il livello {level}. "
+"Intendevi {guessed_command}?"
 
 #: coursedata/error-messages.txt:5
 msgid "Invalid Space"
@@ -253,44 +254,44 @@ msgstr ""
 #, fuzzy
 msgid "Has Blanks"
 msgstr ""
-"Your code is incomplete. It contains blanks that you have to replace with "
-"code."
+"Your code is incomplete. It contains blanks that you have to replace with"
+" code."
 
 #: coursedata/error-messages.txt:7
 #, fuzzy
 msgid "No Indentation"
 msgstr ""
 "You used too few spaces in line {line_number}. You used {leading_spaces} "
-"spaces, which is not enough. Start every new block with {indent_size} spaces "
-"more than the line before."
+"spaces, which is not enough. Start every new block with {indent_size} "
+"spaces more than the line before."
 
 #: coursedata/error-messages.txt:8
 #, fuzzy
 msgid "Unexpected Indentation"
 msgstr ""
-"You used too many spaces in line {line_number}. You used {leading_spaces} "
-"spaces, which is too much. Start every new block with {indent_size} spaces "
-"more than the line before."
+"You used too many spaces in line {line_number}. You used {leading_spaces}"
+" spaces, which is too much. Start every new block with {indent_size} "
+"spaces more than the line before."
 
 #: coursedata/error-messages.txt:9
 msgid "Parse"
 msgstr ""
-"Il codice che hai scritto non è un codice Hedy valido. C'è un errore alla "
-"linea {location[0]}, alla posizione {location[1]}. Hai scritto "
+"Il codice che hai scritto non è un codice Hedy valido. C'è un errore alla"
+" linea {location[0]}, alla posizione {location[1]}. Hai scritto "
 "{character_found} ma questo non è permesso."
 
 #: coursedata/error-messages.txt:10
 msgid "Unquoted Text"
 msgstr ""
-"Stai attento. Se stampi qualcosa, il testo dovrebbe iniziare e finire con "
-"virgolette. Ne hai dimenticato una da qualche parte."
+"Stai attento. Se stampi qualcosa, il testo dovrebbe iniziare e finire con"
+" virgolette. Ne hai dimenticato una da qualche parte."
 
 #: coursedata/error-messages.txt:11
 #, fuzzy
 msgid "Unquoted Assignment"
 msgstr ""
-"From this level, you need to place texts to the right of the `is` between "
-"quotes. You forgot that for the text {text}."
+"From this level, you need to place texts to the right of the `is` between"
+" quotes. You forgot that for the text {text}."
 
 #: coursedata/error-messages.txt:12
 #, fuzzy
@@ -307,8 +308,8 @@ msgstr "Hai provato a scrivere {name} ma non l'hai inizializzato."
 #, fuzzy
 msgid "Cyclic Var Definition"
 msgstr ""
-"The name {variable} needs to be set before you can use it on the right-hand "
-"side of the is command"
+"The name {variable} needs to be set before you can use it on the right-"
+"hand side of the is command"
 
 #: coursedata/error-messages.txt:15
 #, fuzzy
@@ -321,46 +322,46 @@ msgstr ""
 #, fuzzy
 msgid "Too Big"
 msgstr ""
-"Wow! Your program has an impressive {lines_of_code} lines of code! But we "
-"can only process {max_lines} lines in this level. Make your program smaller "
-"and try again."
+"Wow! Your program has an impressive {lines_of_code} lines of code! But we"
+" can only process {max_lines} lines in this level. Make your program "
+"smaller and try again."
 
 #: coursedata/error-messages.txt:17
 #, fuzzy
 msgid "Invalid Argument Type"
 msgstr ""
-"You cannot use the command {command} with {invalid_argument} because it is "
-"{invalid_type}. Try changing {invalid_argument} to {allowed_types}."
+"You cannot use the command {command} with {invalid_argument} because it "
+"is {invalid_type}. Try changing {invalid_argument} to {allowed_types}."
 
 #: coursedata/error-messages.txt:18
 #, fuzzy
 msgid "Invalid Argument"
 msgstr ""
-"You cannot use the command {command} with {invalid_argument} . Try changing "
-"{invalid_argument} to {allowed_types}."
+"You cannot use the command {command} with {invalid_argument} . Try "
+"changing {invalid_argument} to {allowed_types}."
 
 #: coursedata/error-messages.txt:19
 #, fuzzy
 msgid "Invalid Type Combination"
 msgstr ""
-"You cannot use {invalid_argument} and {invalid_argument_2} in {operation} "
-"because one is {invalid_type} and the other is {invalid_type_2}. Try "
-"changing {invalid_argument} to {invalid_type_2} or {invalid_argument_2} to "
-"{invalid_type}."
+"You cannot use {invalid_argument} and {invalid_argument_2} in {operation}"
+" because one is {invalid_type} and the other is {invalid_type_2}. Try "
+"changing {invalid_argument} to {invalid_type_2} or {invalid_argument_2} "
+"to {invalid_type}."
 
 #: coursedata/error-messages.txt:20
 #, fuzzy
 msgid "Unsupported Float"
 msgstr ""
-"Non-integer numbers are not supported yet but they will be in a few levels. "
-"For now change {value} to an integer."
+"Non-integer numbers are not supported yet but they will be in a few "
+"levels. For now change {value} to an integer."
 
 #: coursedata/error-messages.txt:21
 #, fuzzy
 msgid "Locked Language Feature"
 msgstr ""
-"You are using {concept}! That is awesome, but {concept} is not unlocked yet! "
-"It will be unlocked in a later level."
+"You are using {concept}! That is awesome, but {concept} is not unlocked "
+"yet! It will be unlocked in a later level."
 
 #: coursedata/error-messages.txt:22
 #, fuzzy
@@ -371,15 +372,16 @@ msgstr "It looks like you forgot to use a command on line {line_number}."
 #, fuzzy
 msgid "ask_needs_var"
 msgstr ""
-"Starting in level 2, ask needs to be used with a variable. Example: name is "
-"ask What are you called?"
+"Starting in level 2, ask needs to be used with a variable. Example: name "
+"is ask What are you called?"
 
 #: coursedata/error-messages.txt:24
 #, fuzzy
 msgid "echo_out"
 msgstr ""
-"Starting in level 2 echo is no longer needed. You can repeat an answer with "
-"ask and print now. Example: name is ask What are you called? print hello name"
+"Starting in level 2 echo is no longer needed. You can repeat an answer "
+"with ask and print now. Example: name is ask What are you called? print "
+"hello name"
 
 #: coursedata/error-messages.txt:25
 msgid "space"
@@ -464,6 +466,11 @@ msgstr "a list"
 #, fuzzy
 msgid "input"
 msgstr "input from ask"
+
+#: templates/achievements.html:4
+#, fuzzy
+msgid "achievements_title"
+msgstr "achievements"
 
 #: templates/class-overview.html:16
 #, fuzzy
@@ -634,22 +641,21 @@ msgstr "Do you want to join this class?"
 #: templates/class-prejoin.html:17 website/teacher.py:183
 #, fuzzy
 msgid "join_prompt"
-msgstr ""
-"You need to have an account to join a class. Would you like to login now?"
+msgstr "You need to have an account to join a class. Would you like to login now?"
 
 #: templates/class-prejoin.html:17 templates/profile.html:14
 #, fuzzy
 msgid "join_class"
 msgstr "Join class"
 
-#: templates/class-stats.html:22 templates/customize-class.html:155
+#: templates/class-stats.html:22 templates/customize-class.html:150
 #, fuzzy
 msgid "back_to_class"
 msgstr "Go back to class"
 
 #: templates/code-page.html:25 templates/code-page.html:34
-#: templates/customize-class.html:28 templates/customize-class.html:64
-#: templates/customize-class.html:71 templates/customize-class.html:94
+#: templates/customize-class.html:23 templates/customize-class.html:59
+#: templates/customize-class.html:66 templates/customize-class.html:89
 #: templates/incl-adventure-tabs.html:5 templates/level-page.html:6
 #: templates/level-page.html:11 templates/quiz/startquiz.html:10
 #: templates/view-program-page.html:12 templates/view-program-page.html:28
@@ -665,21 +671,21 @@ msgstr "Create multiple accounts"
 #, fuzzy
 msgid "accounts_intro"
 msgstr ""
-"On this page you can create accounts for multiple students at the same time. "
-"It is also possible to directly add them to one of your classes. By pressing "
-"the green + on the bottom right of the page you can add extra rows. You can "
-"delete a row by pressing the corresponding red cross. Make sure no rows are "
-"empty when you press \"Create accounts\". Please keep in mind that every "
-"username and mail address needs to be unique and the password needs to be "
-"<b>at least</b> 6 characters."
+"On this page you can create accounts for multiple students at the same "
+"time. It is also possible to directly add them to one of your classes. By"
+" pressing the green + on the bottom right of the page you can add extra "
+"rows. You can delete a row by pressing the corresponding red cross. Make "
+"sure no rows are empty when you press \"Create accounts\". Please keep in"
+" mind that every username and mail address needs to be unique and the "
+"password needs to be <b>at least</b> 6 characters."
 
 #: templates/create-accounts.html:10
 #, fuzzy
 msgid "create_accounts_prompt"
 msgstr "Are you sure you want to create these accounts?"
 
-#: templates/create-accounts.html:17 templates/learn-more.html:10
-#: templates/profile.html:96 templates/recover.html:8 templates/signup.html:13
+#: templates/create-accounts.html:17 templates/profile.html:96
+#: templates/recover.html:8 templates/signup.html:13
 msgid "email"
 msgstr "Email"
 
@@ -735,10 +741,10 @@ msgstr "Livello"
 #, fuzzy
 msgid "adventure_exp_1"
 msgstr ""
-"Type your adventure of choice on the right-hand side. After creating your "
-"adventure you can include it in one of your classes under \"customizations"
-"\". If you want to include a command in your adventure please use code "
-"anchors like this:"
+"Type your adventure of choice on the right-hand side. After creating your"
+" adventure you can include it in one of your classes under "
+"\"customizations\". If you want to include a command in your adventure "
+"please use code anchors like this:"
 
 #: templates/customize-adventure.html:31
 #, fuzzy
@@ -752,11 +758,11 @@ msgstr ""
 msgid "adventure_exp_3"
 msgstr ""
 "You can use the \"preview\" button to view a styled version of your "
-"adventure. To view the adventure on a dedicated page, select \"view\" from "
-"the teachers page."
+"adventure. To view the adventure on a dedicated page, select \"view\" "
+"from the teachers page."
 
-#: templates/customize-adventure.html:43 templates/customize-class.html:28
-#: templates/customize-class.html:93 templates/explore.html:26
+#: templates/customize-adventure.html:43 templates/customize-class.html:23
+#: templates/customize-class.html:88 templates/explore.html:26
 #: templates/programs.html:18 templates/programs.html:48
 #: templates/view-adventure.html:6
 #, fuzzy
@@ -787,7 +793,7 @@ msgstr "I agree that my adventure might be made publicly available on Hedy."
 msgid "preview"
 msgstr "Preview"
 
-#: templates/customize-adventure.html:51 templates/customize-class.html:150
+#: templates/customize-adventure.html:51 templates/customize-class.html:145
 #, fuzzy
 msgid "save"
 msgstr "Save"
@@ -797,128 +803,78 @@ msgstr "Save"
 msgid "delete_adventure_prompt"
 msgstr "Are you sure you want to remove this adventure?"
 
-#: templates/customize-class.html:7
-#, fuzzy
-msgid "customize_class_exp_1"
-msgstr "Customize class"
-
-#: templates/customize-class.html:10
-#, fuzzy
-msgid "customize_class_step_1"
-msgstr "Customize class"
-
-#: templates/customize-class.html:11
-#, fuzzy
-msgid "customize_class_step_2"
-msgstr "Customize class"
-
-#: templates/customize-class.html:12
-#, fuzzy
-msgid "customize_class_step_3"
-msgstr "Customize class"
-
-#: templates/customize-class.html:13
-#, fuzzy
-msgid "customize_class_step_4"
-msgstr "Customize class"
-
-#: templates/customize-class.html:14
-#, fuzzy
-msgid "customize_class_step_5"
-msgstr "Customize class"
-
-#: templates/customize-class.html:15
-#, fuzzy
-msgid "customize_class_step_6"
-msgstr "Customize class"
-
-#: templates/customize-class.html:16
-#, fuzzy
-msgid "customize_class_step_7"
-msgstr "Customize class"
-
-#: templates/customize-class.html:17
-#, fuzzy
-msgid "customize_class_step_8"
-msgstr "Customize class"
-
-#: templates/customize-class.html:20
-#, fuzzy
-msgid "customize_class_exp_2"
-msgstr "Customize class"
-
-#: templates/customize-class.html:23
+#: templates/customize-class.html:18
 #, fuzzy
 msgid "select_adventures"
 msgstr "Select adventures"
 
-#: templates/customize-class.html:59
+#: templates/customize-class.html:54
 #, fuzzy
 msgid "opening_dates"
 msgstr "Opening dates"
 
-#: templates/customize-class.html:65
+#: templates/customize-class.html:60
 #, fuzzy
 msgid "opening_date"
 msgstr "Opening date"
 
-#: templates/customize-class.html:77
+#: templates/customize-class.html:72
 #, fuzzy
 msgid "directly_available"
 msgstr "Directly open"
 
-#: templates/customize-class.html:88
+#: templates/customize-class.html:83
 #, fuzzy
 msgid "select_own_adventures"
 msgstr "Select own adventures"
 
-#: templates/customize-class.html:95 templates/customize-class.html:121
+#: templates/customize-class.html:90 templates/customize-class.html:116
 #: templates/profile.html:47 templates/profile.html:128
 #: templates/profile.html:137 templates/signup.html:26 templates/signup.html:45
 #: templates/signup.html:53
 msgid "select"
 msgstr "Seleziona"
 
-#: templates/customize-class.html:115
+#: templates/customize-class.html:110
 #, fuzzy
 msgid "other_settings"
 msgstr "Other settings"
 
-#: templates/customize-class.html:120
+#: templates/customize-class.html:115
 #, fuzzy
 msgid "option"
 msgstr "Option"
 
-#: templates/customize-class.html:126
+#: templates/customize-class.html:121
 #, fuzzy
 msgid "mandatory_mode"
 msgstr "Mandatory developer's mode"
 
-#: templates/customize-class.html:132
+#: templates/customize-class.html:127
 #, fuzzy
 msgid "hide_cheatsheet"
 msgstr "Hide cheatsheet"
 
-#: templates/customize-class.html:138
+#: templates/customize-class.html:133
 msgid "hide_keyword_switcher"
 msgstr ""
 
-#: templates/customize-class.html:149
+#: templates/customize-class.html:144
 #, fuzzy
 msgid "reset_adventure_prompt"
 msgstr "Are you sure you want to reset all selected adventures?"
 
-#: templates/customize-class.html:149
+#: templates/customize-class.html:144
 #, fuzzy
 msgid "reset_adventures"
 msgstr "Reset selected adventures"
 
-#: templates/customize-class.html:153
+#: templates/customize-class.html:148
 #, fuzzy
 msgid "remove_customizations_prompt"
 msgstr "Are you sure you want to remove this class their customizations?"
 
-#: templates/customize-class.html:154
+#: templates/customize-class.html:149
 #, fuzzy
 msgid "remove_customization"
 msgstr "Remove customization"
@@ -937,13 +893,13 @@ msgstr "Explore programs"
 #, fuzzy
 msgid "explore_explanation"
 msgstr ""
-"On this page you can look through programs created by other Hedy users. You "
-"can filter on both a Hedy level and adventure. Click on \"View program\" to "
-"open a program and run it. Programs with a red header contain a mistake. You "
-"can still open the program, but running it will result in an error. You can "
-"of course try to fix it! If the creator has a public profile you can click "
-"their username to visit their profile. There you will find all their shared "
-"programs and much more!"
+"On this page you can look through programs created by other Hedy users. "
+"You can filter on both a Hedy level and adventure. Click on \"View "
+"program\" to open a program and run it. Programs with a red header "
+"contain a mistake. You can still open the program, but running it will "
+"result in an error. You can of course try to fix it! If the creator has a"
+" public profile you can click their username to visit their profile. "
+"There you will find all their shared programs and much more!"
 
 #: templates/explore.html:35 templates/programs.html:27
 #, fuzzy
@@ -1010,8 +966,8 @@ msgstr "Create student accounts"
 #, fuzzy
 msgid "teacher_welcome"
 msgstr ""
-"Welcome to Hedy! Your are now the proud owner of a teachers account which "
-"allows you to create classes and invite students."
+"Welcome to Hedy! Your are now the proud owner of a teachers account which"
+" allows you to create classes and invite students."
 
 #: templates/incl-adventure-tabs.html:22
 #, fuzzy
@@ -1127,9 +1083,9 @@ msgstr "Welcome"
 msgid "intro_text_landing_page"
 msgstr ""
 "Welcome to the wonderful world of Hedy! Here you can learn to program in "
-"small steps, without unnecessary complicated stuff. We start easy at level "
-"1, and slowly build towards bigger and more complex programs! Choose one of "
-"the options below to get started"
+"small steps, without unnecessary complicated stuff. We start easy at "
+"level 1, and slowly build towards bigger and more complex programs! "
+"Choose one of the options below to get started"
 
 #: templates/landing-page.html:14 templates/landing-page.html:36
 #, fuzzy
@@ -1145,14 +1101,14 @@ msgstr "Start programming"
 #: templates/landing-page.html:21
 #, fuzzy
 msgid "create_class_text"
-msgstr ""
-"Group your students into classes and change the content for each class."
+msgstr "Group your students into classes and change the content for each class."
 
 #: templates/landing-page.html:28
 #, fuzzy
 msgid "read_docs_text"
 msgstr ""
-"Visit our teacher's manual for lesson plans and common mistakes by students."
+"Visit our teacher's manual for lesson plans and common mistakes by "
+"students."
 
 #: templates/landing-page.html:30
 #, fuzzy
@@ -1199,49 +1155,14 @@ msgstr "Copy link to share"
 #, fuzzy
 msgid "set_preferred_lang"
 msgstr ""
-"Hedy now supports preferred user languages. You can set one for your profile "
-"in \"My profile\""
+"Hedy now supports preferred user languages. You can set one for your "
+"profile in \"My profile\""
 
 #: templates/layout.html:86 templates/quiz/endquiz.html:18
 #: templates/quiz/quiz.html:29
 #, fuzzy
 msgid "achievement_earned"
 msgstr "You've earned an achievement!"
-
-#: templates/learn-more.html:7
-#, fuzzy
-msgid "mailing_title"
-msgstr "Title"
-
-#: templates/learn-more.html:14
-#, fuzzy
-msgid "surname"
-msgstr "Nome utente"
-
-#: templates/learn-more.html:18
-#, fuzzy
-msgid "lastname"
-msgstr "Name"
-
-#: templates/learn-more.html:22 templates/profile.html:135
-#: templates/signup.html:52
-msgid "country"
-msgstr "Paese"
-
-#: templates/learn-more.html:31
-#, fuzzy
-msgid "subscribe"
-msgstr "Iscriviti alla newsletter"
-
-#: templates/learn-more.html:32
-#, fuzzy
-msgid "required_field"
-msgstr "Fields marked with an * are required"
-
-#: templates/learn-more.html:35
-#, fuzzy
-msgid "previous_campaigns"
-msgstr "View previous campaigns"
 
 #: templates/level-page.html:8
 msgid "step_title"
@@ -1275,21 +1196,6 @@ msgstr "Crea account"
 #: templates/login.html:33
 msgid "forgot_password"
 msgstr "Dimenticato la tua password?"
-
-#: templates/main-page.html:9
-#, fuzzy
-msgid "main_title"
-msgstr "Title"
-
-#: templates/main-page.html:10
-#, fuzzy
-msgid "main_subtitle"
-msgstr "programs submitted"
-
-#: templates/main-page.html:13
-#, fuzzy
-msgid "try_it"
-msgstr "Provar"
 
 #: templates/profile.html:4
 #, fuzzy
@@ -1355,9 +1261,9 @@ msgstr "Favourite program"
 #, fuzzy
 msgid "public_profile_info"
 msgstr ""
-"By selecting this box I make my profile visible for everyone. Be careful not "
-"to share personal information like your name or home address, because "
-"everyone will be able to see it!"
+"By selecting this box I make my profile visible for everyone. Be careful "
+"not to share personal information like your name or home address, because"
+" everyone will be able to see it!"
 
 #: templates/profile.html:59
 #, fuzzy
@@ -1422,6 +1328,10 @@ msgstr "Maschio"
 #: templates/profile.html:131 templates/signup.html:48
 msgid "other"
 msgstr "Altro"
+
+#: templates/profile.html:135 templates/signup.html:52
+msgid "country"
+msgstr "Paese"
 
 #: templates/profile.html:141
 msgid "update_profile"
@@ -1630,8 +1540,8 @@ msgstr "Hai già account?"
 #, fuzzy
 msgid "teacher_invitation_require_login"
 msgstr ""
-"To set up your profile as a teacher we will need you to log in. If you don't "
-"have an account, please create one."
+"To set up your profile as a teacher we will need you to log in. If you "
+"don't have an account, please create one."
 
 #: templates/view-program-page.html:13
 #, fuzzy
@@ -1795,7 +1705,8 @@ msgstr "You have to agree with the privacy terms."
 #, fuzzy
 msgid "keyword_language_invalid"
 msgstr ""
-"Please select a valid keyword language (select English or your own language)."
+"Please select a valid keyword language (select English or your own "
+"language)."
 
 #: website/auth.py:371 website/auth.py:551
 msgid "year_invalid"
@@ -2100,3 +2011,61 @@ msgstr "The adventure has been updated!"
 #, fuzzy
 msgid "adventure_empty"
 msgstr "You didn't enter an adventure name!"
+
+#~ msgid "customize_class_exp_1"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_1"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_2"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_3"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_4"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_5"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_6"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_7"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_8"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_exp_2"
+#~ msgstr "Customize class"
+
+#~ msgid "mailing_title"
+#~ msgstr "Title"
+
+#~ msgid "surname"
+#~ msgstr "Nome utente"
+
+#~ msgid "lastname"
+#~ msgstr "Name"
+
+#~ msgid "subscribe"
+#~ msgstr "Iscriviti alla newsletter"
+
+#~ msgid "required_field"
+#~ msgstr "Fields marked with an * are required"
+
+#~ msgid "previous_campaigns"
+#~ msgstr "View previous campaigns"
+
+#~ msgid "main_title"
+#~ msgstr "Title"
+
+#~ msgid "main_subtitle"
+#~ msgstr "programs submitted"
+
+#~ msgid "try_it"
+#~ msgstr "Provar"
+

--- a/translations/nb_NO/LC_MESSAGES/messages.po
+++ b/translations/nb_NO/LC_MESSAGES/messages.po
@@ -1,10 +1,11 @@
 
 msgid ""
 msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2022-03-30 08:43+0200\n"
 "PO-Revision-Date: 2022-03-28 12:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
-"Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/hedy/"
-"web-texts/nb_NO/>\n"
 "Language: nb_NO\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/hedy"
 "/web-texts/nb_NO/>\n"
@@ -18,125 +19,125 @@ msgstr ""
 msgid "program_contains_error"
 msgstr "Dette programmet inneholder en feil, er du sikker på at du vil dele det?"
 
-#: app.py:723
+#: app.py:722
 msgid "title_achievements"
 msgstr "Hedy - Mine prestasjoner"
 
-#: app.py:740 app.py:1111 website/teacher.py:365 website/teacher.py:374
+#: app.py:739 app.py:1110 website/teacher.py:365 website/teacher.py:374
 msgid "not_teacher"
 msgstr "Ser ut til at du ikke er en lærer!"
 
-#: app.py:743
+#: app.py:742
 msgid "not_enrolled"
 msgstr "Det ser ut som at du ikke er medlem i denne klassen!"
 
-#: app.py:775
+#: app.py:774
 msgid "title_programs"
 msgstr "Hedy - Mine programmer"
 
-#: app.py:785 app.py:795 app.py:799 app.py:813 app.py:1054 app.py:1357
+#: app.py:784 app.py:794 app.py:798 app.py:812 app.py:1053 app.py:1356
 #: website/admin.py:17 website/admin.py:25 website/admin.py:95
 #: website/admin.py:112 website/admin.py:130 website/auth.py:711
 #: website/auth.py:738 website/statistics.py:86
 msgid "unauthorized"
 msgstr "Du har ikke rettigheter til å se denne siden"
 
-#: app.py:823
+#: app.py:822
 msgid "minutes"
 msgstr "minutter"
 
-#: app.py:826
+#: app.py:825
 msgid "hours"
 msgstr "timer"
 
-#: app.py:829
+#: app.py:828
 msgid "days"
 msgstr "dager"
 
-#: app.py:832
+#: app.py:831
 msgid "ago"
 msgstr "{time} siden"
 
-#: app.py:848 app.py:850 app.py:976
+#: app.py:847 app.py:849 app.py:975
 msgid "no_such_level"
 msgstr "Dette Hedy nivået fins ikke!"
 
-#: app.py:858 app.py:865 app.py:931 app.py:937
+#: app.py:857 app.py:864 app.py:930 app.py:936
 msgid "no_such_program"
 msgstr "Dette Hedy programmet fins ikke!"
 
-#: app.py:891
+#: app.py:890
 msgid "level_not_translated"
 msgstr "Dette nivået er ikke oversatt til ditt språk (foreløpig!)"
 
-#: app.py:893
+#: app.py:892
 msgid "level_not_class"
 msgstr "Klassen din har ikke tilgang til dette nivået enda"
 
-#: app.py:986 website/teacher.py:432 website/teacher.py:448
+#: app.py:985 website/teacher.py:432 website/teacher.py:448
 #: website/teacher.py:477 website/teacher.py:503
 msgid "no_such_adventure"
 msgstr "Dette eventyret eksisterer ikke!"
 
-#: app.py:1005
+#: app.py:1004
 msgid "page_not_found"
 msgstr "Vi klarte ikke å finne den siden!"
 
-#: app.py:1025
+#: app.py:1024
 msgid "title_signup"
 msgstr "Hedy - Opprett konto"
 
-#: app.py:1032
+#: app.py:1031
 msgid "title_login"
 msgstr "Hedy - Logg inn"
 
-#: app.py:1039
+#: app.py:1038
 msgid "title_recover"
 msgstr "Hedy - Gjennopprett konto"
 
-#: app.py:1055
+#: app.py:1054
 msgid "title_reset"
 msgstr "Hedy - Tilbakestill passord"
 
-#: app.py:1064
+#: app.py:1063
 msgid "title_my-profile"
 msgstr "Hedy - Min konto"
 
-#: app.py:1078
+#: app.py:1077
 msgid "title_learn-more"
 msgstr "Hedy - Lær mer"
 
-#: app.py:1083
+#: app.py:1082
 msgid "title_privacy"
 msgstr "Hedy - Personvernsvilkår"
 
-#: app.py:1090
+#: app.py:1089
 msgid "title_landing-page"
 msgstr "Velkommen til Hedy!"
 
-#: app.py:1092
+#: app.py:1091
 msgid "not_user"
 msgstr "Ser ut til at du ikke er logget inn!"
 
-#: app.py:1107
+#: app.py:1106
 msgid "title_for-teacher"
 msgstr "Hedy - For lærere"
 
-#: app.py:1118
+#: app.py:1117
 msgid "title_start"
 msgstr "Hedy - Et gradvis programmeringsspråk"
 
-#: app.py:1171
+#: app.py:1170
 msgid "title_explore"
 msgstr "Hedy - Utforsk"
 
-#: app.py:1190 app.py:1192
+#: app.py:1189 app.py:1191
 msgid "translate_error"
 msgstr ""
 "Noe gikk galt når vi prøvde å oversette koden. Prøv å kjøre koden for å "
 "se om den inneholder en feil. Kode med feil i kan ikke oversettes."
 
-#: app.py:1301 website/auth.py:299 website/auth.py:347 website/auth.py:483
+#: app.py:1300 website/auth.py:299 website/auth.py:347 website/auth.py:483
 #: website/auth.py:509 website/auth.py:539 website/auth.py:645
 #: website/auth.py:677 website/auth.py:717 website/auth.py:744
 #: website/teacher.py:90 website/teacher.py:125 website/teacher.py:197
@@ -145,29 +146,29 @@ msgstr ""
 msgid "ajax_error"
 msgstr "Det skjedde noe feil, vennligst prøv igjen."
 
-#: app.py:1304
+#: app.py:1303
 msgid "image_invalid"
 msgstr "Bildet du valgte er ugyldig."
 
-#: app.py:1306
+#: app.py:1305
 msgid "personal_text_invalid"
 msgstr "Din personlige tekst er ugyldig."
 
-#: app.py:1308 app.py:1314
+#: app.py:1307 app.py:1313
 msgid "favourite_program_invalid"
 msgstr "Ditt valgte favorittprogram er ugyldig."
 
-#: app.py:1326 app.py:1327
+#: app.py:1325 app.py:1326
 msgid "public_profile_updated"
 msgstr "Din offentlige profil ble oppdatert."
 
-#: app.py:1361 app.py:1385
+#: app.py:1360 app.py:1384
 msgid "user_not_private"
 msgstr ""
 "Denne brukeren eksisterer ikke, eller så har de ikke opprettet en "
 "offentlig profil"
 
-#: app.py:1394
+#: app.py:1393
 msgid "invalid_teacher_invitation_code"
 msgstr ""
 "Invitasjonskoden til å bli lærer er ugyldig. For å bli en Hedy-lærer, ta "
@@ -410,6 +411,11 @@ msgstr "en liste"
 msgid "input"
 msgstr "inndata fra spør-kommandoen"
 
+#: templates/achievements.html:4
+#, fuzzy
+msgid "achievements_title"
+msgstr "prestasjoner"
+
 #: templates/class-overview.html:16
 msgid "visible_columns"
 msgstr "Synlige kolonner"
@@ -554,13 +560,13 @@ msgstr "Du trenger en konto for å bli med i klassen. Vil du logge inn nå?"
 msgid "join_class"
 msgstr "Bli med i klassen"
 
-#: templates/class-stats.html:22 templates/customize-class.html:155
+#: templates/class-stats.html:22 templates/customize-class.html:150
 msgid "back_to_class"
 msgstr "Gå tilbake til klassen"
 
 #: templates/code-page.html:25 templates/code-page.html:34
-#: templates/customize-class.html:28 templates/customize-class.html:64
-#: templates/customize-class.html:71 templates/customize-class.html:94
+#: templates/customize-class.html:23 templates/customize-class.html:59
+#: templates/customize-class.html:66 templates/customize-class.html:89
 #: templates/incl-adventure-tabs.html:5 templates/level-page.html:6
 #: templates/level-page.html:11 templates/quiz/startquiz.html:10
 #: templates/view-program-page.html:12 templates/view-program-page.html:28
@@ -586,8 +592,8 @@ msgstr ""
 msgid "create_accounts_prompt"
 msgstr "Er du sikker på at du vil opprette disse kontoene?"
 
-#: templates/create-accounts.html:17 templates/learn-more.html:10
-#: templates/profile.html:96 templates/recover.html:8 templates/signup.html:13
+#: templates/create-accounts.html:17 templates/profile.html:96
+#: templates/recover.html:8 templates/signup.html:13
 msgid "email"
 msgstr "E-post"
 
@@ -653,8 +659,8 @@ msgstr ""
 "eventyret ditt. For å se eventyret på en egen side, velg \"vis\" fra "
 "lærersiden."
 
-#: templates/customize-adventure.html:43 templates/customize-class.html:28
-#: templates/customize-class.html:93 templates/explore.html:26
+#: templates/customize-adventure.html:43 templates/customize-class.html:23
+#: templates/customize-class.html:88 templates/explore.html:26
 #: templates/programs.html:18 templates/programs.html:48
 #: templates/view-adventure.html:6
 msgid "adventure"
@@ -681,7 +687,7 @@ msgstr "Jeg tillater at eventyret mitt kan offentliggjøres på Hedy."
 msgid "preview"
 msgstr "Forhåndsvis"
 
-#: templates/customize-adventure.html:51 templates/customize-class.html:150
+#: templates/customize-adventure.html:51 templates/customize-class.html:145
 msgid "save"
 msgstr "Lagre"
 
@@ -689,106 +695,66 @@ msgstr "Lagre"
 msgid "delete_adventure_prompt"
 msgstr "Er du sikker på at du vil fjerne dette eventyret?"
 
-#: templates/customize-class.html:7
-msgid "customize_class_exp_1"
-msgstr "Hei! På denne siden kan du tilpasse innstillingene for klassen din. Du kan velge hva elevene dine skal kunne se ved å velge nivåer og eventyr.\nSom standard vil alle nivåer og standardeventyr vil være valgt. Du kan også legge til dine egne eventyr til nivåer. <b>Merk:</b> Det er ikke alle eventyr som er tilgjengelig for alle nivåer.\nFor å tilpasse innstillingene kan du gjøre slik:"
-
-#: templates/customize-class.html:10
-msgid "customize_class_step_1"
-msgstr "Velg nivåer for klassen din ved å trykke på \"Nivå knappenene\""
-
-#: templates/customize-class.html:11
-msgid "customize_class_step_2"
-msgstr "\"Avkrysningsbokser\" vil dukke opp for eventyrene som er tilgjengelig for de valgte nivåene"
-
-#: templates/customize-class.html:12
-msgid "customize_class_step_3"
-msgstr "Velg hvilke eventyr du ønsker at skal være tilgjengelig"
-
-#: templates/customize-class.html:13
-msgid "customize_class_step_4"
-msgstr "Trykk på navnet til et eventyr for å legge til eller fjerne det for alle nivåer"
-
-#: templates/customize-class.html:14
-msgid "customize_class_step_5"
-msgstr "Legg til dine egne eventyr"
-
-#: templates/customize-class.html:15
-msgid "customize_class_step_6"
-msgstr "Velg en dato for når hvert nivå skal gjøres tilgjengelig (du kan også la feltene være tomme)"
-
-#: templates/customize-class.html:16
-msgid "customize_class_step_7"
-msgstr "Velg resten av innstillingene"
-
-#: templates/customize-class.html:17
-msgid "customize_class_step_8"
-msgstr "Trykk \"Lagre\" -> Så er du ferdig!"
-
-#: templates/customize-class.html:20
-msgid "customize_class_exp_2"
-msgstr "Du kan alltids komme tilbake senere og endre disse innstillingene. Du kan for eksempel gjøre spesifikke evntyr og nivåer tilgjengelig når du underviser en klasse.\nPå denne måten er det lett for deg å bestemme hvilke nivåer og eventyr elevene dine skal jobbe med.\nHvis du har lyst til å gjøre alt tilgjengelig for klassen din, er det lettest å bare fjerne alle tilpasningene du har gjort."
-
-#: templates/customize-class.html:23
+#: templates/customize-class.html:18
 msgid "select_adventures"
 msgstr "Velg eventyr"
 
-#: templates/customize-class.html:59
+#: templates/customize-class.html:54
 msgid "opening_dates"
 msgstr "Dato for tilgjengeliggjøring"
 
-#: templates/customize-class.html:65
+#: templates/customize-class.html:60
 msgid "opening_date"
 msgstr "Dato for tilgjengeliggjøring"
 
-#: templates/customize-class.html:77
+#: templates/customize-class.html:72
 msgid "directly_available"
 msgstr "Åpne på direkten"
 
-#: templates/customize-class.html:88
+#: templates/customize-class.html:83
 msgid "select_own_adventures"
 msgstr "Velg egne eventyr"
 
-#: templates/customize-class.html:95 templates/customize-class.html:121
+#: templates/customize-class.html:90 templates/customize-class.html:116
 #: templates/profile.html:47 templates/profile.html:128
 #: templates/profile.html:137 templates/signup.html:26 templates/signup.html:45
 #: templates/signup.html:53
 msgid "select"
 msgstr "Velg"
 
-#: templates/customize-class.html:115
+#: templates/customize-class.html:110
 msgid "other_settings"
 msgstr "Andre innstillinger"
 
-#: templates/customize-class.html:120
+#: templates/customize-class.html:115
 msgid "option"
 msgstr "Valg"
 
-#: templates/customize-class.html:126
+#: templates/customize-class.html:121
 msgid "mandatory_mode"
 msgstr "Obligatorisk utviklermodus"
 
-#: templates/customize-class.html:132
+#: templates/customize-class.html:127
 msgid "hide_cheatsheet"
 msgstr "Skjul hjelpeark"
 
-#: templates/customize-class.html:138
+#: templates/customize-class.html:133
 msgid "hide_keyword_switcher"
 msgstr "hide keyboard switcher"
 
-#: templates/customize-class.html:149
+#: templates/customize-class.html:144
 msgid "reset_adventure_prompt"
 msgstr "Er du sikker på at du vil tilbakestille alle valgte eventyr?"
 
-#: templates/customize-class.html:149
+#: templates/customize-class.html:144
 msgid "reset_adventures"
 msgstr "Tilbakestill valgte eventyr"
 
-#: templates/customize-class.html:153
+#: templates/customize-class.html:148
 msgid "remove_customizations_prompt"
 msgstr "Er du sikker på at du vil fjerne tilpasningene for denne klassen?"
 
-#: templates/customize-class.html:154
+#: templates/customize-class.html:149
 msgid "remove_customization"
 msgstr "Fjern tilpasninger"
 
@@ -1036,35 +1002,6 @@ msgstr ""
 msgid "achievement_earned"
 msgstr "Du oppnådde en prestasjon!"
 
-#: templates/learn-more.html:7
-msgid "mailing_title"
-msgstr "Abonner på nyhetsbrevet fra Hedy"
-
-#: templates/learn-more.html:14
-msgid "surname"
-msgstr "Fornavn"
-
-#: templates/learn-more.html:18
-msgid "lastname"
-msgstr "Etternavn"
-
-#: templates/learn-more.html:22 templates/profile.html:135
-#: templates/signup.html:52
-msgid "country"
-msgstr "Land"
-
-#: templates/learn-more.html:31
-msgid "subscribe"
-msgstr "Abonner"
-
-#: templates/learn-more.html:32
-msgid "required_field"
-msgstr "Felter merket med en * er påkrevd"
-
-#: templates/learn-more.html:35
-msgid "previous_campaigns"
-msgstr "Se tidligere kampanjer"
-
 #: templates/level-page.html:8
 msgid "step_title"
 msgstr "Oppgave"
@@ -1096,18 +1033,6 @@ msgstr "Opprett konto"
 #: templates/login.html:33
 msgid "forgot_password"
 msgstr "Glemt passord?"
-
-#: templates/main-page.html:9
-msgid "main_title"
-msgstr "Hedy"
-
-#: templates/main-page.html:10
-msgid "main_subtitle"
-msgstr "Et gradvis programmeringsspråk"
-
-#: templates/main-page.html:13
-msgid "try_it"
-msgstr "Prøv det"
 
 #: templates/profile.html:4
 msgid "account_overview"
@@ -1219,6 +1144,10 @@ msgstr "Gutt"
 #: templates/profile.html:131 templates/signup.html:48
 msgid "other"
 msgstr "Annet"
+
+#: templates/profile.html:135 templates/signup.html:52
+msgid "country"
+msgstr "Land"
 
 #: templates/profile.html:141
 msgid "update_profile"
@@ -1794,11 +1723,94 @@ msgstr "Eventyret har blitt oppdatert!"
 msgid "adventure_empty"
 msgstr "Du skrev ikke noe navn på eventyret!"
 
-#: templates/customize-class.html:133
-#: templates/customize-class.html:133
-msgid "hide_keyword_switcher"
-msgstr "hide keyboard switcher"
+#~ msgid "customize_class_exp_1"
+#~ msgstr ""
+#~ "Hei! På denne siden kan du "
+#~ "tilpasse innstillingene for klassen din. "
+#~ "Du kan velge hva elevene dine skal"
+#~ " kunne se ved å velge nivåer og"
+#~ " eventyr.\n"
+#~ "Som standard vil alle nivåer og "
+#~ "standardeventyr vil være valgt. Du kan"
+#~ " også legge til dine egne eventyr "
+#~ "til nivåer. <b>Merk:</b> Det er ikke "
+#~ "alle eventyr som er tilgjengelig for "
+#~ "alle nivåer.\n"
+#~ "For å tilpasse innstillingene kan du gjøre slik:"
 
-#: templates/explore.html:35 templates/programs.html:27
-msgid "search_button"
-msgstr "Søk"
+#~ msgid "customize_class_step_1"
+#~ msgstr "Velg nivåer for klassen din ved å trykke på \"Nivå knappenene\""
+
+#~ msgid "customize_class_step_2"
+#~ msgstr ""
+#~ "\"Avkrysningsbokser\" vil dukke opp for "
+#~ "eventyrene som er tilgjengelig for de"
+#~ " valgte nivåene"
+
+#~ msgid "customize_class_step_3"
+#~ msgstr "Velg hvilke eventyr du ønsker at skal være tilgjengelig"
+
+#~ msgid "customize_class_step_4"
+#~ msgstr ""
+#~ "Trykk på navnet til et eventyr for"
+#~ " å legge til eller fjerne det "
+#~ "for alle nivåer"
+
+#~ msgid "customize_class_step_5"
+#~ msgstr "Legg til dine egne eventyr"
+
+#~ msgid "customize_class_step_6"
+#~ msgstr ""
+#~ "Velg en dato for når hvert nivå"
+#~ " skal gjøres tilgjengelig (du kan "
+#~ "også la feltene være tomme)"
+
+#~ msgid "customize_class_step_7"
+#~ msgstr "Velg resten av innstillingene"
+
+#~ msgid "customize_class_step_8"
+#~ msgstr "Trykk \"Lagre\" -> Så er du ferdig!"
+
+#~ msgid "customize_class_exp_2"
+#~ msgstr ""
+#~ "Du kan alltids komme tilbake senere "
+#~ "og endre disse innstillingene. Du kan"
+#~ " for eksempel gjøre spesifikke evntyr "
+#~ "og nivåer tilgjengelig når du underviser"
+#~ " en klasse.\n"
+#~ "På denne måten er det lett for "
+#~ "deg å bestemme hvilke nivåer og "
+#~ "eventyr elevene dine skal jobbe med."
+#~ "\n"
+#~ "Hvis du har lyst til å gjøre "
+#~ "alt tilgjengelig for klassen din, er "
+#~ "det lettest å bare fjerne alle "
+#~ "tilpasningene du har gjort."
+
+#~ msgid "mailing_title"
+#~ msgstr "Abonner på nyhetsbrevet fra Hedy"
+
+#~ msgid "surname"
+#~ msgstr "Fornavn"
+
+#~ msgid "lastname"
+#~ msgstr "Etternavn"
+
+#~ msgid "subscribe"
+#~ msgstr "Abonner"
+
+#~ msgid "required_field"
+#~ msgstr "Felter merket med en * er påkrevd"
+
+#~ msgid "previous_campaigns"
+#~ msgstr "Se tidligere kampanjer"
+
+#~ msgid "main_title"
+#~ msgstr "Hedy"
+
+#~ msgid "main_subtitle"
+#~ msgstr "Et gradvis programmeringsspråk"
+
+#~ msgid "try_it"
+#~ msgstr "Prøv det"
+

--- a/translations/nl/LC_MESSAGES/messages.po
+++ b/translations/nl/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-03-29 10:01+0200\n"
+"POT-Creation-Date: 2022-03-30 08:43+0200\n"
 "PO-Revision-Date: 2022-02-25 13:01+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: nl\n"
@@ -22,126 +22,126 @@ msgstr ""
 msgid "program_contains_error"
 msgstr "Dit programma bevat een foutje, weet je zeker dat je hem wilt delen?"
 
-#: app.py:723
+#: app.py:722
 msgid "title_achievements"
 msgstr "Hedy - Mijn badges"
 
-#: app.py:740 app.py:1111 website/teacher.py:365 website/teacher.py:374
+#: app.py:739 app.py:1110 website/teacher.py:365 website/teacher.py:374
 msgid "not_teacher"
 msgstr "Jij bent geen leraar!"
 
-#: app.py:743
+#: app.py:742
 msgid "not_enrolled"
 msgstr "Jij zit niet in deze klas!"
 
-#: app.py:775
+#: app.py:774
 msgid "title_programs"
 msgstr "Hedy - Mijn programma's"
 
-#: app.py:785 app.py:795 app.py:799 app.py:813 app.py:1054 app.py:1357
+#: app.py:784 app.py:794 app.py:798 app.py:812 app.py:1053 app.py:1356
 #: website/admin.py:17 website/admin.py:25 website/admin.py:95
 #: website/admin.py:112 website/admin.py:130 website/auth.py:711
 #: website/auth.py:738 website/statistics.py:86
 msgid "unauthorized"
 msgstr "Jij hebt geen rechten voor deze pagina"
 
-#: app.py:823
+#: app.py:822
 msgid "minutes"
 msgstr "minuten"
 
-#: app.py:826
+#: app.py:825
 msgid "hours"
 msgstr "uur"
 
-#: app.py:829
+#: app.py:828
 msgid "days"
 msgstr "dagen"
 
-#: app.py:832
+#: app.py:831
 msgid "ago"
 msgstr "{time} geleden"
 
-#: app.py:848 app.py:850 app.py:976
+#: app.py:847 app.py:849 app.py:975
 msgid "no_such_level"
 msgstr "Dit level bestaat niet!"
 
-#: app.py:858 app.py:865 app.py:931 app.py:937
+#: app.py:857 app.py:864 app.py:930 app.py:936
 msgid "no_such_program"
 msgstr "Dit programma bestaat niet!"
 
-#: app.py:891
+#: app.py:890
 msgid "level_not_translated"
 msgstr "Dit level is (nog) niet vertaald in jouw taal"
 
-#: app.py:893
+#: app.py:892
 msgid "level_not_class"
 msgstr "Je zit in een klas waar dit level nog niet beschikbaar is gemaakt"
 
-#: app.py:986 website/teacher.py:432 website/teacher.py:448
+#: app.py:985 website/teacher.py:432 website/teacher.py:448
 #: website/teacher.py:477 website/teacher.py:503
 msgid "no_such_adventure"
 msgstr "Dit avontuur bestaat niet!"
 
-#: app.py:1005
+#: app.py:1004
 msgid "page_not_found"
 msgstr "We konden deze pagina niet vinden!"
 
-#: app.py:1025
+#: app.py:1024
 msgid "title_signup"
 msgstr "Hedy - Account aanmaken"
 
-#: app.py:1032
+#: app.py:1031
 msgid "title_login"
 msgstr "Hedy - Inloggen"
 
-#: app.py:1039
+#: app.py:1038
 msgid "title_recover"
 msgstr "Hedy - Account herstellen"
 
-#: app.py:1055
+#: app.py:1054
 msgid "title_reset"
 msgstr "Hedy - Wachtwoord resetten"
 
-#: app.py:1064
+#: app.py:1063
 msgid "title_my-profile"
 msgstr "Hedy - Mijn account"
 
-#: app.py:1078
+#: app.py:1077
 msgid "title_learn-more"
 msgstr "Hedy - Meer info"
 
-#: app.py:1083
+#: app.py:1082
 msgid "title_privacy"
 msgstr "Hedy - Privacyverklaring"
 
-#: app.py:1090
+#: app.py:1089
 msgid "title_landing-page"
 msgstr "Welkom bij Hedy!"
 
-#: app.py:1092
+#: app.py:1091
 msgid "not_user"
 msgstr "Jij bent niet ingelogd!"
 
-#: app.py:1107
+#: app.py:1106
 msgid "title_for-teacher"
 msgstr "Hedy - Voor leerkrachten"
 
-#: app.py:1118
+#: app.py:1117
 msgid "title_start"
 msgstr "Hedy - Een graduele programmeertaal"
 
-#: app.py:1171
+#: app.py:1170
 msgid "title_explore"
 msgstr "Hedy - Ontdekken"
 
-#: app.py:1190 app.py:1192
+#: app.py:1189 app.py:1191
 msgid "translate_error"
 msgstr ""
 "Er is iets misgegaan met het vertalen van de code. Probeer je code te "
 "runnen om te kijken of er misschien een foutje in zit. Code met foutjes "
 "kan niet vertaald worden."
 
-#: app.py:1301 website/auth.py:299 website/auth.py:347 website/auth.py:483
+#: app.py:1300 website/auth.py:299 website/auth.py:347 website/auth.py:483
 #: website/auth.py:509 website/auth.py:539 website/auth.py:645
 #: website/auth.py:677 website/auth.py:717 website/auth.py:744
 #: website/teacher.py:90 website/teacher.py:125 website/teacher.py:197
@@ -150,27 +150,27 @@ msgstr ""
 msgid "ajax_error"
 msgstr "Er is een fout opgetreden, probeer het nog eens."
 
-#: app.py:1304
+#: app.py:1303
 msgid "image_invalid"
 msgstr "Jouw gekozen profielfoto is ongeldig."
 
-#: app.py:1306
+#: app.py:1305
 msgid "personal_text_invalid"
 msgstr "Jouw persoonlijke tekst is ongeldig."
 
-#: app.py:1308 app.py:1314
+#: app.py:1307 app.py:1313
 msgid "favourite_program_invalid"
 msgstr "Jouw gekozen favoriete programma is ongeldig."
 
-#: app.py:1326 app.py:1327
+#: app.py:1325 app.py:1326
 msgid "public_profile_updated"
 msgstr "Je openbare profiel is aangepast."
 
-#: app.py:1361 app.py:1385
+#: app.py:1360 app.py:1384
 msgid "user_not_private"
 msgstr "Deze gebruiker bestaat niet of heeft geen openbaar profiel"
 
-#: app.py:1394
+#: app.py:1393
 msgid "invalid_teacher_invitation_code"
 msgstr ""
 "Deze leerkrachtenuitnodigingscode is niet geldig. Als je een nieuwe "
@@ -330,15 +330,15 @@ msgstr ""
 #: coursedata/error-messages.txt:23
 msgid "ask_needs_var"
 msgstr ""
-"Vanaf level 2 hoort ask met een variabele ervoor. "
-"Bijv: naam is ask Hoe heet jij?"
+"Vanaf level 2 hoort ask met een variabele ervoor. Bijv: naam is ask Hoe "
+"heet jij?"
 
 #: coursedata/error-messages.txt:24
 msgid "echo_out"
 msgstr ""
 "Vanaf level 2 heb je geen echo meer nodig! Je kunt een variabele "
-"gebruiken om iets te herhalen. Voorbeeld: naam is ask Hoe heet jij? "
-"print hallo naam"
+"gebruiken om iets te herhalen. Voorbeeld: naam is ask Hoe heet jij? print"
+" hallo naam"
 
 #: coursedata/error-messages.txt:25
 msgid "space"
@@ -415,6 +415,10 @@ msgstr "een lijstje"
 #: coursedata/error-messages.txt:43
 msgid "input"
 msgstr "invoer van een ask"
+
+#: templates/achievements.html:4
+msgid "achievements_title"
+msgstr "Hedy achievements"
 
 #: templates/class-overview.html:16
 msgid "visible_columns"
@@ -562,13 +566,13 @@ msgstr ""
 msgid "join_class"
 msgstr "Inschrijven voor klas"
 
-#: templates/class-stats.html:22 templates/customize-class.html:155
+#: templates/class-stats.html:22 templates/customize-class.html:150
 msgid "back_to_class"
 msgstr "Ga terug naar klas"
 
 #: templates/code-page.html:25 templates/code-page.html:34
-#: templates/customize-class.html:28 templates/customize-class.html:64
-#: templates/customize-class.html:71 templates/customize-class.html:94
+#: templates/customize-class.html:23 templates/customize-class.html:59
+#: templates/customize-class.html:66 templates/customize-class.html:89
 #: templates/incl-adventure-tabs.html:5 templates/level-page.html:6
 #: templates/level-page.html:11 templates/quiz/startquiz.html:10
 #: templates/view-program-page.html:12 templates/view-program-page.html:28
@@ -594,8 +598,8 @@ msgstr ""
 msgid "create_accounts_prompt"
 msgstr "Weet je zeker dat je deze accounts wilt aanmaken?"
 
-#: templates/create-accounts.html:17 templates/learn-more.html:10
-#: templates/profile.html:96 templates/recover.html:8 templates/signup.html:13
+#: templates/create-accounts.html:17 templates/profile.html:96
+#: templates/recover.html:8 templates/signup.html:13
 msgid "email"
 msgstr "Email"
 
@@ -661,8 +665,8 @@ msgstr ""
 "avontuur te zien. Om jouw avontuur op een speciale pagina te zien kies je"
 " \"bekijk\" op de lerarenpagina."
 
-#: templates/customize-adventure.html:43 templates/customize-class.html:28
-#: templates/customize-class.html:93 templates/explore.html:26
+#: templates/customize-adventure.html:43 templates/customize-class.html:23
+#: templates/customize-class.html:88 templates/explore.html:26
 #: templates/programs.html:18 templates/programs.html:48
 #: templates/view-adventure.html:6
 msgid "adventure"
@@ -689,7 +693,7 @@ msgstr "Ik ga ermee akkoord dat mijn avontuur mogelijk beschikbaar komt op Hedy.
 msgid "preview"
 msgstr "Voorbeeld"
 
-#: templates/customize-adventure.html:51 templates/customize-class.html:150
+#: templates/customize-adventure.html:51 templates/customize-class.html:145
 msgid "save"
 msgstr "Opslaan"
 
@@ -697,106 +701,66 @@ msgstr "Opslaan"
 msgid "delete_adventure_prompt"
 msgstr "Weet je zeker dat je dit avontuur wilt verwijderen?"
 
-#: templates/customize-class.html:7
-msgid "customize_class_exp_1"
-msgstr "Hoi! Hier kun je jouw klas personaliseren. Door het selecteren van levels en avonturen kun je kiezen wat jouw leerlingen kunnen zien. Ook kun je jouw zelfgemaakte avonturen aan levels toevoegen. Alle levels en standaard avonturen zijn aan het begin geselecteerd. <b>Let op:</b> Niet elk avontuur is voor elk level beschikbaar! Het instellen gaat als volgt:"
-
-#: templates/customize-class.html:10
-msgid "customize_class_step_1"
-msgstr "Selecteer de levels voor jouw klas door op een \"level knop\" te drukken"
-
-#: templates/customize-class.html:11
-msgid "customize_class_step_2"
-msgstr "Er verschijnen \"selectievinkjes\" voor de beschikbare avonturen voor deze levels"
-
-#: templates/customize-class.html:12
-msgid "customize_class_step_3"
-msgstr "Selecteer de avonturen die je beschikbaar wilt maken"
-
-#: templates/customize-class.html:13
-msgid "customize_class_step_4"
-msgstr "Klik op de naam van een avontuur om deze voor alle levels te (de)selecteren"
-
-#: templates/customize-class.html:14
-msgid "customize_class_step_5"
-msgstr "Voeg eventueel persoonlijke avonturen toe"
-
-#: templates/customize-class.html:15
-msgid "customize_class_step_6"
-msgstr "Selecteer een openingsdatum per level (leeg laten mag ook)"
-
-#: templates/customize-class.html:16
-msgid "customize_class_step_7"
-msgstr "Kies andere instellingen"
-
-#: templates/customize-class.html:17
-msgid "customize_class_step_8"
-msgstr "Kies \"Opslaan\" -> je bent helemaal klaar!"
-
-#: templates/customize-class.html:20
-msgid "customize_class_exp_2"
-msgstr "Je kunt deze instellingen altijd op een later moment wijzigen. Zo kun je bijvoorbeeld tijdens het les geven nieuwe avonturen of levels beschikbaar maken. Hierdoor is het voor leerlingen (en voor de leraar!) makkelijker om te kiezen waar aan gewerkt kan worden en wat er geleerd wordt. Als je alles beschikbaar wilt maken voor jouw klas kun je het beste de \"personalisatie\" verwijderen, doe dit met de \"verwijder\" knop beneden in het scherm."
-
-#: templates/customize-class.html:23
+#: templates/customize-class.html:18
 msgid "select_adventures"
 msgstr "Avonturen selecteren"
 
-#: templates/customize-class.html:59
+#: templates/customize-class.html:54
 msgid "opening_dates"
 msgstr "Openingsdata"
 
-#: templates/customize-class.html:65
+#: templates/customize-class.html:60
 msgid "opening_date"
 msgstr "Openingsdatum"
 
-#: templates/customize-class.html:77
+#: templates/customize-class.html:72
 msgid "directly_available"
 msgstr "Gelijk open"
 
-#: templates/customize-class.html:88
+#: templates/customize-class.html:83
 msgid "select_own_adventures"
 msgstr "Eigen avonturen selecteren"
 
-#: templates/customize-class.html:95 templates/customize-class.html:121
+#: templates/customize-class.html:90 templates/customize-class.html:116
 #: templates/profile.html:47 templates/profile.html:128
 #: templates/profile.html:137 templates/signup.html:26 templates/signup.html:45
 #: templates/signup.html:53
 msgid "select"
 msgstr "Kies"
 
-#: templates/customize-class.html:115
+#: templates/customize-class.html:110
 msgid "other_settings"
 msgstr "Andere instellingen"
 
-#: templates/customize-class.html:120
+#: templates/customize-class.html:115
 msgid "option"
 msgstr "Optie"
 
-#: templates/customize-class.html:126
+#: templates/customize-class.html:121
 msgid "mandatory_mode"
 msgstr "Verplichte programmeursmodus"
 
-#: templates/customize-class.html:132
+#: templates/customize-class.html:127
 msgid "hide_cheatsheet"
 msgstr "Verberg spiekbriefje"
 
-#: templates/customize-class.html:138
+#: templates/customize-class.html:133
 msgid "hide_keyword_switcher"
 msgstr "Verberg commando-taal switcher"
 
-#: templates/customize-class.html:149
+#: templates/customize-class.html:144
 msgid "reset_adventure_prompt"
 msgstr "Weet je zeker dat je alle geselecteerde avonturen wilt wissen?"
 
-#: templates/customize-class.html:149
+#: templates/customize-class.html:144
 msgid "reset_adventures"
 msgstr "Wis gekozen avonturen"
 
-#: templates/customize-class.html:153
+#: templates/customize-class.html:148
 msgid "remove_customizations_prompt"
 msgstr "Weet je zeker dat je de personalisatie van deze klas wilt verwijderen?"
 
-#: templates/customize-class.html:154
+#: templates/customize-class.html:149
 msgid "remove_customization"
 msgstr "Verwijder Personalisatie"
 
@@ -1042,35 +1006,6 @@ msgstr ""
 msgid "achievement_earned"
 msgstr "Je hebt een badge verdiend!"
 
-#: templates/learn-more.html:7
-msgid "mailing_title"
-msgstr "Schrijf je in voor de Hedy nieuwsbrief"
-
-#: templates/learn-more.html:14
-msgid "surname"
-msgstr "Voornaam"
-
-#: templates/learn-more.html:18
-msgid "lastname"
-msgstr "Achternaam"
-
-#: templates/learn-more.html:22 templates/profile.html:135
-#: templates/signup.html:52
-msgid "country"
-msgstr "Land waarin je woont"
-
-#: templates/learn-more.html:31
-msgid "subscribe"
-msgstr "Schrijf je in"
-
-#: templates/learn-more.html:32
-msgid "required_field"
-msgstr "Velden met een * zijn verplicht"
-
-#: templates/learn-more.html:35
-msgid "previous_campaigns"
-msgstr "Bekijk het nieuwsbrief archief"
-
 #: templates/level-page.html:8
 msgid "step_title"
 msgstr "Opdracht"
@@ -1102,18 +1037,6 @@ msgstr "Maak een account"
 #: templates/login.html:33
 msgid "forgot_password"
 msgstr "Wachtwoord vergeten?"
-
-#: templates/main-page.html:9
-msgid "main_title"
-msgstr "Hedy"
-
-#: templates/main-page.html:10
-msgid "main_subtitle"
-msgstr "Een graduele programmeertaal"
-
-#: templates/main-page.html:13
-msgid "try_it"
-msgstr "Probeer het uit"
 
 #: templates/profile.html:4
 msgid "account_overview"
@@ -1225,6 +1148,10 @@ msgstr "Jongen"
 #: templates/profile.html:131 templates/signup.html:48
 msgid "other"
 msgstr "Anders"
+
+#: templates/profile.html:135 templates/signup.html:52
+msgid "country"
+msgstr "Land waarin je woont"
 
 #: templates/profile.html:141
 msgid "update_profile"
@@ -1803,4 +1730,92 @@ msgstr "Je hebt geen avonturen naam ingevuld!"
 
 #~ msgid "required"
 #~ msgstr ""
+
+#~ msgid "customize_class_exp_1"
+#~ msgstr ""
+#~ "Hoi! Hier kun je jouw klas "
+#~ "personaliseren. Door het selecteren van "
+#~ "levels en avonturen kun je kiezen "
+#~ "wat jouw leerlingen kunnen zien. Ook "
+#~ "kun je jouw zelfgemaakte avonturen aan"
+#~ " levels toevoegen. Alle levels en "
+#~ "standaard avonturen zijn aan het begin"
+#~ " geselecteerd. <b>Let op:</b> Niet elk "
+#~ "avontuur is voor elk level beschikbaar!"
+#~ " Het instellen gaat als volgt:"
+
+#~ msgid "customize_class_step_1"
+#~ msgstr ""
+#~ "Selecteer de levels voor jouw klas "
+#~ "door op een \"level knop\" te "
+#~ "drukken"
+
+#~ msgid "customize_class_step_2"
+#~ msgstr ""
+#~ "Er verschijnen \"selectievinkjes\" voor de "
+#~ "beschikbare avonturen voor deze levels"
+
+#~ msgid "customize_class_step_3"
+#~ msgstr "Selecteer de avonturen die je beschikbaar wilt maken"
+
+#~ msgid "customize_class_step_4"
+#~ msgstr ""
+#~ "Klik op de naam van een avontuur"
+#~ " om deze voor alle levels te "
+#~ "(de)selecteren"
+
+#~ msgid "customize_class_step_5"
+#~ msgstr "Voeg eventueel persoonlijke avonturen toe"
+
+#~ msgid "customize_class_step_6"
+#~ msgstr "Selecteer een openingsdatum per level (leeg laten mag ook)"
+
+#~ msgid "customize_class_step_7"
+#~ msgstr "Kies andere instellingen"
+
+#~ msgid "customize_class_step_8"
+#~ msgstr "Kies \"Opslaan\" -> je bent helemaal klaar!"
+
+#~ msgid "customize_class_exp_2"
+#~ msgstr ""
+#~ "Je kunt deze instellingen altijd op "
+#~ "een later moment wijzigen. Zo kun "
+#~ "je bijvoorbeeld tijdens het les geven"
+#~ " nieuwe avonturen of levels beschikbaar "
+#~ "maken. Hierdoor is het voor leerlingen"
+#~ " (en voor de leraar!) makkelijker om"
+#~ " te kiezen waar aan gewerkt kan "
+#~ "worden en wat er geleerd wordt. "
+#~ "Als je alles beschikbaar wilt maken "
+#~ "voor jouw klas kun je het beste"
+#~ " de \"personalisatie\" verwijderen, doe dit"
+#~ " met de \"verwijder\" knop beneden in"
+#~ " het scherm."
+
+#~ msgid "mailing_title"
+#~ msgstr "Schrijf je in voor de Hedy nieuwsbrief"
+
+#~ msgid "surname"
+#~ msgstr "Voornaam"
+
+#~ msgid "lastname"
+#~ msgstr "Achternaam"
+
+#~ msgid "subscribe"
+#~ msgstr "Schrijf je in"
+
+#~ msgid "required_field"
+#~ msgstr "Velden met een * zijn verplicht"
+
+#~ msgid "previous_campaigns"
+#~ msgstr "Bekijk het nieuwsbrief archief"
+
+#~ msgid "main_title"
+#~ msgstr "Hedy"
+
+#~ msgid "main_subtitle"
+#~ msgstr "Een graduele programmeertaal"
+
+#~ msgid "try_it"
+#~ msgstr "Probeer het uit"
 

--- a/translations/pl/LC_MESSAGES/messages.po
+++ b/translations/pl/LC_MESSAGES/messages.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-03-29 10:01+0200\n"
+"POT-Creation-Date: 2022-03-30 08:43+0200\n"
 "PO-Revision-Date: 2022-03-28 12:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: pl\n"
@@ -21,25 +21,25 @@ msgstr ""
 msgid "program_contains_error"
 msgstr "This program contains an error, are you sure you want to share it?"
 
-#: app.py:723
+#: app.py:722
 msgid "title_achievements"
 msgstr "Hedy - Moje osiągnięcia"
 
-#: app.py:740 app.py:1111 website/teacher.py:365 website/teacher.py:374
+#: app.py:739 app.py:1110 website/teacher.py:365 website/teacher.py:374
 #, fuzzy
 msgid "not_teacher"
 msgstr "Looks like you are not a teacher!"
 
-#: app.py:743
+#: app.py:742
 #, fuzzy
 msgid "not_enrolled"
 msgstr "Looks like you are not in this class!"
 
-#: app.py:775
+#: app.py:774
 msgid "title_programs"
 msgstr "Hedy - Moje programy"
 
-#: app.py:785 app.py:795 app.py:799 app.py:813 app.py:1054 app.py:1357
+#: app.py:784 app.py:794 app.py:798 app.py:812 app.py:1053 app.py:1356
 #: website/admin.py:17 website/admin.py:25 website/admin.py:95
 #: website/admin.py:112 website/admin.py:130 website/auth.py:711
 #: website/auth.py:738 website/statistics.py:86
@@ -47,108 +47,108 @@ msgstr "Hedy - Moje programy"
 msgid "unauthorized"
 msgstr "You don't have access rights for this page"
 
-#: app.py:823
+#: app.py:822
 msgid "minutes"
 msgstr "minut"
 
-#: app.py:826
+#: app.py:825
 msgid "hours"
 msgstr "godzin"
 
-#: app.py:829
+#: app.py:828
 msgid "days"
 msgstr "dni"
 
-#: app.py:832
+#: app.py:831
 msgid "ago"
 msgstr "{time} temu"
 
-#: app.py:848 app.py:850 app.py:976
+#: app.py:847 app.py:849 app.py:975
 msgid "no_such_level"
 msgstr "Nie ma takiego poziomu Hedy!"
 
-#: app.py:858 app.py:865 app.py:931 app.py:937
+#: app.py:857 app.py:864 app.py:930 app.py:936
 msgid "no_such_program"
 msgstr "Nie ma takiego programu Hedy!"
 
-#: app.py:891
+#: app.py:890
 msgid "level_not_translated"
 msgstr "Ten poziom nie jest (jeszcze) przetłumaczony na twój język"
 
-#: app.py:893
+#: app.py:892
 #, fuzzy
 msgid "level_not_class"
 msgstr "You're in a class where this level has not been made available yet"
 
-#: app.py:986 website/teacher.py:432 website/teacher.py:448
+#: app.py:985 website/teacher.py:432 website/teacher.py:448
 #: website/teacher.py:477 website/teacher.py:503
 msgid "no_such_adventure"
 msgstr "Ta przygoda nie istnieje!"
 
-#: app.py:1005
+#: app.py:1004
 msgid "page_not_found"
 msgstr "Nie możemy odnaleźć tej strony!"
 
-#: app.py:1025
+#: app.py:1024
 msgid "title_signup"
 msgstr "Hedy - Utwórz konto"
 
-#: app.py:1032
+#: app.py:1031
 msgid "title_login"
 msgstr "Hedy - Logowanie"
 
-#: app.py:1039
+#: app.py:1038
 msgid "title_recover"
 msgstr "Hedy - Odzyskaj konto"
 
-#: app.py:1055
+#: app.py:1054
 msgid "title_reset"
 msgstr "Hedy - Zresetuj hasło"
 
-#: app.py:1064
+#: app.py:1063
 msgid "title_my-profile"
 msgstr "Hedy - Moje konto"
 
-#: app.py:1078
+#: app.py:1077
 msgid "title_learn-more"
 msgstr "Hedy - Dowiedz się więcej"
 
-#: app.py:1083
+#: app.py:1082
 #, fuzzy
 msgid "title_privacy"
 msgstr "Hedy - Privacy terms"
 
-#: app.py:1090
+#: app.py:1089
 #, fuzzy
 msgid "title_landing-page"
 msgstr "Welcome to Hedy!"
 
-#: app.py:1092
+#: app.py:1091
 #, fuzzy
 msgid "not_user"
 msgstr "Looks like you are not logged in!"
 
-#: app.py:1107
+#: app.py:1106
 msgid "title_for-teacher"
 msgstr "Hedy - Dla nauczycieli"
 
-#: app.py:1118
+#: app.py:1117
 msgid "title_start"
 msgstr "Hedy - Stopniowany język programowania"
 
-#: app.py:1171
+#: app.py:1170
 #, fuzzy
 msgid "title_explore"
 msgstr "Hedy - Explore"
 
-#: app.py:1190 app.py:1192
+#: app.py:1189 app.py:1191
 #, fuzzy
 msgid "translate_error"
 msgstr ""
 "Something went wrong while translating the code. Try running the code to "
 "see if it has an error. Code with errors can not be translated."
 
-#: app.py:1301 website/auth.py:299 website/auth.py:347 website/auth.py:483
+#: app.py:1300 website/auth.py:299 website/auth.py:347 website/auth.py:483
 #: website/auth.py:509 website/auth.py:539 website/auth.py:645
 #: website/auth.py:677 website/auth.py:717 website/auth.py:744
 #: website/teacher.py:90 website/teacher.py:125 website/teacher.py:197
@@ -157,32 +157,32 @@ msgstr ""
 msgid "ajax_error"
 msgstr "Wystąpił błąd, proszę spróbować ponownie."
 
-#: app.py:1304
+#: app.py:1303
 #, fuzzy
 msgid "image_invalid"
 msgstr "Your chosen image is invalid."
 
-#: app.py:1306
+#: app.py:1305
 #, fuzzy
 msgid "personal_text_invalid"
 msgstr "Your personal text is invalid."
 
-#: app.py:1308 app.py:1314
+#: app.py:1307 app.py:1313
 #, fuzzy
 msgid "favourite_program_invalid"
 msgstr "Your chosen favourite program is invalid."
 
-#: app.py:1326 app.py:1327
+#: app.py:1325 app.py:1326
 #, fuzzy
 msgid "public_profile_updated"
 msgstr "Public profile updated."
 
-#: app.py:1361 app.py:1385
+#: app.py:1360 app.py:1384
 #, fuzzy
 msgid "user_not_private"
 msgstr "This user doesn't exist or doesn't have a public profile"
 
-#: app.py:1394
+#: app.py:1393
 #, fuzzy
 msgid "invalid_teacher_invitation_code"
 msgstr ""
@@ -366,16 +366,16 @@ msgstr "It looks like you forgot to use a command on line {line_number}."
 #, fuzzy
 msgid "ask_needs_var"
 msgstr ""
-"Starting in level 2, ask needs to be used with a variable. "
-"Example: name is ask What are you called?"
+"Starting in level 2, ask needs to be used with a variable. Example: name "
+"is ask What are you called?"
 
 #: coursedata/error-messages.txt:24
 #, fuzzy
 msgid "echo_out"
 msgstr ""
 "Starting in level 2 echo is no longer needed. You can repeat an answer "
-"with ask and print now. Example: name is ask What are you called? print"
-" hello name"
+"with ask and print now. Example: name is ask What are you called? print "
+"hello name"
 
 #: coursedata/error-messages.txt:25
 msgid "space"
@@ -455,6 +455,11 @@ msgstr "lista"
 #, fuzzy
 msgid "input"
 msgstr "input from ask"
+
+#: templates/achievements.html:4
+#, fuzzy
+msgid "achievements_title"
+msgstr "osiągnięcia"
 
 #: templates/class-overview.html:16
 msgid "visible_columns"
@@ -616,13 +621,13 @@ msgstr "You need to have an account to join a class. Would you like to login now
 msgid "join_class"
 msgstr "Dołącz do klasy"
 
-#: templates/class-stats.html:22 templates/customize-class.html:155
+#: templates/class-stats.html:22 templates/customize-class.html:150
 msgid "back_to_class"
 msgstr "Powróć do klasy"
 
 #: templates/code-page.html:25 templates/code-page.html:34
-#: templates/customize-class.html:28 templates/customize-class.html:64
-#: templates/customize-class.html:71 templates/customize-class.html:94
+#: templates/customize-class.html:23 templates/customize-class.html:59
+#: templates/customize-class.html:66 templates/customize-class.html:89
 #: templates/incl-adventure-tabs.html:5 templates/level-page.html:6
 #: templates/level-page.html:11 templates/quiz/startquiz.html:10
 #: templates/view-program-page.html:12 templates/view-program-page.html:28
@@ -650,8 +655,8 @@ msgstr ""
 msgid "create_accounts_prompt"
 msgstr "Are you sure you want to create these accounts?"
 
-#: templates/create-accounts.html:17 templates/learn-more.html:10
-#: templates/profile.html:96 templates/recover.html:8 templates/signup.html:13
+#: templates/create-accounts.html:17 templates/profile.html:96
+#: templates/recover.html:8 templates/signup.html:13
 msgid "email"
 msgstr "Email"
 
@@ -725,8 +730,8 @@ msgstr ""
 "adventure. To view the adventure on a dedicated page, select \"view\" "
 "from the teachers page."
 
-#: templates/customize-adventure.html:43 templates/customize-class.html:28
-#: templates/customize-class.html:93 templates/explore.html:26
+#: templates/customize-adventure.html:43 templates/customize-class.html:23
+#: templates/customize-class.html:88 templates/explore.html:26
 #: templates/programs.html:18 templates/programs.html:48
 #: templates/view-adventure.html:6
 msgid "adventure"
@@ -755,7 +760,7 @@ msgstr "I agree that my adventure might be made publicly available on Hedy."
 msgid "preview"
 msgstr "Podgląd"
 
-#: templates/customize-adventure.html:51 templates/customize-class.html:150
+#: templates/customize-adventure.html:51 templates/customize-class.html:145
 msgid "save"
 msgstr "Zapisz"
 
@@ -764,123 +769,74 @@ msgstr "Zapisz"
 msgid "delete_adventure_prompt"
 msgstr "Are you sure you want to remove this adventure?"
 
-#: templates/customize-class.html:7
-#, fuzzy
-msgid "customize_class_exp_1"
-msgstr "Customize class"
-
-#: templates/customize-class.html:10
-#, fuzzy
-msgid "customize_class_step_1"
-msgstr "Customize class"
-
-#: templates/customize-class.html:11
-#, fuzzy
-msgid "customize_class_step_2"
-msgstr "Customize class"
-
-#: templates/customize-class.html:12
-#, fuzzy
-msgid "customize_class_step_3"
-msgstr "Customize class"
-
-#: templates/customize-class.html:13
-#, fuzzy
-msgid "customize_class_step_4"
-msgstr "Customize class"
-
-#: templates/customize-class.html:14
-#, fuzzy
-msgid "customize_class_step_5"
-msgstr "Customize class"
-
-#: templates/customize-class.html:15
-#, fuzzy
-msgid "customize_class_step_6"
-msgstr "Customize class"
-
-#: templates/customize-class.html:16
-#, fuzzy
-msgid "customize_class_step_7"
-msgstr "Customize class"
-
-#: templates/customize-class.html:17
-msgid "customize_class_step_8"
-msgstr "Wybierz \"Zapisz\" -> I gotowe!"
-
-#: templates/customize-class.html:20
-#, fuzzy
-msgid "customize_class_exp_2"
-msgstr "Customize class"
-
-#: templates/customize-class.html:23
+#: templates/customize-class.html:18
 msgid "select_adventures"
 msgstr "Wybierz przygody"
 
-#: templates/customize-class.html:59
+#: templates/customize-class.html:54
 #, fuzzy
 msgid "opening_dates"
 msgstr "Opening dates"
 
-#: templates/customize-class.html:65
+#: templates/customize-class.html:60
 #, fuzzy
 msgid "opening_date"
 msgstr "Opening date"
 
-#: templates/customize-class.html:77
+#: templates/customize-class.html:72
 #, fuzzy
 msgid "directly_available"
 msgstr "Directly open"
 
-#: templates/customize-class.html:88
+#: templates/customize-class.html:83
 msgid "select_own_adventures"
 msgstr "Wybierz własne przygody"
 
-#: templates/customize-class.html:95 templates/customize-class.html:121
+#: templates/customize-class.html:90 templates/customize-class.html:116
 #: templates/profile.html:47 templates/profile.html:128
 #: templates/profile.html:137 templates/signup.html:26 templates/signup.html:45
 #: templates/signup.html:53
 msgid "select"
 msgstr "Wybierz"
 
-#: templates/customize-class.html:115
+#: templates/customize-class.html:110
 msgid "other_settings"
 msgstr "Inne ustawienia"
 
-#: templates/customize-class.html:120
+#: templates/customize-class.html:115
 msgid "option"
 msgstr "Opcja"
 
-#: templates/customize-class.html:126
+#: templates/customize-class.html:121
 msgid "mandatory_mode"
 msgstr "Obowiązkowy tryb deweloperski"
 
-#: templates/customize-class.html:132
+#: templates/customize-class.html:127
 #, fuzzy
 msgid "hide_cheatsheet"
 msgstr "Hide cheatsheet"
 
-#: templates/customize-class.html:138
+#: templates/customize-class.html:133
 #, fuzzy
 msgid "hide_keyword_switcher"
 msgstr "Hide keyword switcher"
 
-#: templates/customize-class.html:149
+#: templates/customize-class.html:144
 #, fuzzy
 msgid "reset_adventure_prompt"
 msgstr "Are you sure you want to reset all selected adventures?"
 
-#: templates/customize-class.html:149
+#: templates/customize-class.html:144
 #, fuzzy
 msgid "reset_adventures"
 msgstr "Reset selected adventures"
 
-#: templates/customize-class.html:153
+#: templates/customize-class.html:148
 #, fuzzy
 msgid "remove_customizations_prompt"
 msgstr "Are you sure you want to remove this class their customizations?"
 
-#: templates/customize-class.html:154
+#: templates/customize-class.html:149
 #, fuzzy
 msgid "remove_customization"
 msgstr "Remove customization"
@@ -1148,38 +1104,6 @@ msgstr ""
 msgid "achievement_earned"
 msgstr "You've earned an achievement!"
 
-#: templates/learn-more.html:7
-#, fuzzy
-msgid "mailing_title"
-msgstr "Hedy"
-
-#: templates/learn-more.html:14
-#, fuzzy
-msgid "surname"
-msgstr "Imię"
-
-#: templates/learn-more.html:18
-msgid "lastname"
-msgstr "Nazwisko"
-
-#: templates/learn-more.html:22 templates/profile.html:135
-#: templates/signup.html:52
-msgid "country"
-msgstr "Kraj"
-
-#: templates/learn-more.html:31
-#, fuzzy
-msgid "subscribe"
-msgstr "Subscribe to the newsletter"
-
-#: templates/learn-more.html:32
-msgid "required_field"
-msgstr "Pola oznaczone * są wymagane"
-
-#: templates/learn-more.html:35
-msgid "previous_campaigns"
-msgstr "Wyświetl poprzednie kampanie"
-
 #: templates/level-page.html:8
 #, fuzzy
 msgid "step_title"
@@ -1215,18 +1139,6 @@ msgstr "Utwórz konto"
 #, fuzzy
 msgid "forgot_password"
 msgstr "Forgot your password?"
-
-#: templates/main-page.html:9
-msgid "main_title"
-msgstr "Hedy"
-
-#: templates/main-page.html:10
-msgid "main_subtitle"
-msgstr "Stopniowany język programowania"
-
-#: templates/main-page.html:13
-msgid "try_it"
-msgstr "Wypróbuj"
 
 #: templates/profile.html:4
 #, fuzzy
@@ -1345,6 +1257,10 @@ msgstr "Męska"
 #: templates/profile.html:131 templates/signup.html:48
 msgid "other"
 msgstr "Inna"
+
+#: templates/profile.html:135 templates/signup.html:52
+msgid "country"
+msgstr "Kraj"
 
 #: templates/profile.html:141
 msgid "update_profile"
@@ -2004,4 +1920,61 @@ msgstr "You didn't enter an adventure name!"
 
 #~ msgid "required"
 #~ msgstr ""
+
+#~ msgid "customize_class_exp_1"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_1"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_2"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_3"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_4"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_5"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_6"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_7"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_8"
+#~ msgstr "Wybierz \"Zapisz\" -> I gotowe!"
+
+#~ msgid "customize_class_exp_2"
+#~ msgstr "Customize class"
+
+#~ msgid "mailing_title"
+#~ msgstr "Hedy"
+
+#~ msgid "surname"
+#~ msgstr "Imię"
+
+#~ msgid "lastname"
+#~ msgstr "Nazwisko"
+
+#~ msgid "subscribe"
+#~ msgstr "Subscribe to the newsletter"
+
+#~ msgid "required_field"
+#~ msgstr "Pola oznaczone * są wymagane"
+
+#~ msgid "previous_campaigns"
+#~ msgstr "Wyświetl poprzednie kampanie"
+
+#~ msgid "main_title"
+#~ msgstr "Hedy"
+
+#~ msgid "main_subtitle"
+#~ msgstr "Stopniowany język programowania"
+
+#~ msgid "try_it"
+#~ msgstr "Wypróbuj"
 

--- a/translations/pt_BR/LC_MESSAGES/messages.po
+++ b/translations/pt_BR/LC_MESSAGES/messages.po
@@ -1,18 +1,18 @@
+
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-03-29 10:01+0200\n"
+"POT-Creation-Date: 2022-03-30 08:43+0200\n"
 "PO-Revision-Date: 2022-03-30 09:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
-"Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/hedy/"
-"web-texts/pt_BR/>\n"
 "Language: pt_BR\n"
+"Language-Team: Portuguese (Brazil) "
+"<https://hosted.weblate.org/projects/hedy/web-texts/pt_BR/>\n"
+"Plural-Forms: nplurals=2; plural=n > 1\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=n > 1;\n"
-"X-Generator: Weblate 4.12-dev\n"
 "Generated-By: Babel 2.9.1\n"
 
 #: app.py:571
@@ -20,27 +20,27 @@ msgstr ""
 msgid "program_contains_error"
 msgstr "This program contains an error, are you sure you want to share it?"
 
-#: app.py:723
+#: app.py:722
 #, fuzzy
 msgid "title_achievements"
 msgstr "Hedy - My achievements"
 
-#: app.py:740 app.py:1111 website/teacher.py:365 website/teacher.py:374
+#: app.py:739 app.py:1110 website/teacher.py:365 website/teacher.py:374
 #, fuzzy
 msgid "not_teacher"
 msgstr "Looks like you are not a teacher!"
 
-#: app.py:743
+#: app.py:742
 #, fuzzy
 msgid "not_enrolled"
 msgstr "Looks like you are not in this class!"
 
-#: app.py:775
+#: app.py:774
 #, fuzzy
 msgid "title_programs"
 msgstr "Hedy - My programs"
 
-#: app.py:785 app.py:795 app.py:799 app.py:813 app.py:1054 app.py:1357
+#: app.py:784 app.py:794 app.py:798 app.py:812 app.py:1053 app.py:1356
 #: website/admin.py:17 website/admin.py:25 website/admin.py:95
 #: website/admin.py:112 website/admin.py:130 website/auth.py:711
 #: website/auth.py:738 website/statistics.py:86
@@ -48,122 +48,122 @@ msgstr "Hedy - My programs"
 msgid "unauthorized"
 msgstr "You don't have access rights for this page"
 
-#: app.py:823
+#: app.py:822
 msgid "minutes"
 msgstr "minutos"
 
-#: app.py:826
+#: app.py:825
 msgid "hours"
 msgstr "horas"
 
-#: app.py:829
+#: app.py:828
 msgid "days"
 msgstr "dias"
 
-#: app.py:832
+#: app.py:831
 #, fuzzy
 msgid "ago"
 msgstr "{time} ago"
 
-#: app.py:848 app.py:850 app.py:976
+#: app.py:847 app.py:849 app.py:975
 #, fuzzy
 msgid "no_such_level"
 msgstr "No such Hedy level!"
 
-#: app.py:858 app.py:865 app.py:931 app.py:937
+#: app.py:857 app.py:864 app.py:930 app.py:936
 #, fuzzy
 msgid "no_such_program"
 msgstr "No such Hedy program!"
 
-#: app.py:891
+#: app.py:890
 #, fuzzy
 msgid "level_not_translated"
 msgstr "This level is not translated in your language (yet)"
 
-#: app.py:893
+#: app.py:892
 #, fuzzy
 msgid "level_not_class"
 msgstr "You're in a class where this level has not been made available yet"
 
-#: app.py:986 website/teacher.py:432 website/teacher.py:448
+#: app.py:985 website/teacher.py:432 website/teacher.py:448
 #: website/teacher.py:477 website/teacher.py:503
 #, fuzzy
 msgid "no_such_adventure"
 msgstr "This adventure doesn't exist!"
 
-#: app.py:1005
+#: app.py:1004
 #, fuzzy
 msgid "page_not_found"
 msgstr "We could not find that page!"
 
-#: app.py:1025
+#: app.py:1024
 #, fuzzy
 msgid "title_signup"
 msgstr "Hedy - Create an account"
 
-#: app.py:1032
+#: app.py:1031
 #, fuzzy
 msgid "title_login"
 msgstr "Hedy - Login"
 
-#: app.py:1039
+#: app.py:1038
 #, fuzzy
 msgid "title_recover"
 msgstr "Hedy - Recover account"
 
-#: app.py:1055
+#: app.py:1054
 #, fuzzy
 msgid "title_reset"
 msgstr "Hedy - Reset password"
 
-#: app.py:1064
+#: app.py:1063
 #, fuzzy
 msgid "title_my-profile"
 msgstr "Hedy - My account"
 
-#: app.py:1078
+#: app.py:1077
 #, fuzzy
 msgid "title_learn-more"
 msgstr "Hedy - Learn more"
 
-#: app.py:1083
+#: app.py:1082
 #, fuzzy
 msgid "title_privacy"
 msgstr "Hedy - Privacy terms"
 
-#: app.py:1090
+#: app.py:1089
 #, fuzzy
 msgid "title_landing-page"
 msgstr "Welcome to Hedy!"
 
-#: app.py:1092
+#: app.py:1091
 #, fuzzy
 msgid "not_user"
 msgstr "Looks like you are not logged in!"
 
-#: app.py:1107
+#: app.py:1106
 #, fuzzy
 msgid "title_for-teacher"
 msgstr "Hedy - For teachers"
 
-#: app.py:1118
+#: app.py:1117
 #, fuzzy
 msgid "title_start"
 msgstr "Hedy - A gradual programming language"
 
-#: app.py:1171
+#: app.py:1170
 #, fuzzy
 msgid "title_explore"
 msgstr "Hedy - Explore"
 
-#: app.py:1190 app.py:1192
+#: app.py:1189 app.py:1191
 #, fuzzy
 msgid "translate_error"
 msgstr ""
-"Something went wrong while translating the code. Try running the code to see "
-"if it has an error. Code with errors can not be translated."
+"Something went wrong while translating the code. Try running the code to "
+"see if it has an error. Code with errors can not be translated."
 
-#: app.py:1301 website/auth.py:299 website/auth.py:347 website/auth.py:483
+#: app.py:1300 website/auth.py:299 website/auth.py:347 website/auth.py:483
 #: website/auth.py:509 website/auth.py:539 website/auth.py:645
 #: website/auth.py:677 website/auth.py:717 website/auth.py:744
 #: website/teacher.py:90 website/teacher.py:125 website/teacher.py:197
@@ -172,37 +172,37 @@ msgstr ""
 msgid "ajax_error"
 msgstr "Ocorreu um erro, por favor, tente novamente."
 
-#: app.py:1304
+#: app.py:1303
 #, fuzzy
 msgid "image_invalid"
 msgstr "Your chosen image is invalid."
 
-#: app.py:1306
+#: app.py:1305
 #, fuzzy
 msgid "personal_text_invalid"
 msgstr "Your personal text is invalid."
 
-#: app.py:1308 app.py:1314
+#: app.py:1307 app.py:1313
 #, fuzzy
 msgid "favourite_program_invalid"
 msgstr "Your chosen favourite program is invalid."
 
-#: app.py:1326 app.py:1327
+#: app.py:1325 app.py:1326
 #, fuzzy
 msgid "public_profile_updated"
 msgstr "Public profile updated."
 
-#: app.py:1361 app.py:1385
+#: app.py:1360 app.py:1384
 #, fuzzy
 msgid "user_not_private"
 msgstr "This user doesn't exist or doesn't have a public profile"
 
-#: app.py:1394
+#: app.py:1393
 #, fuzzy
 msgid "invalid_teacher_invitation_code"
 msgstr ""
-"The teacher invitation code is invalid. To become a teacher, reach out to "
-"hedy@felienne.com."
+"The teacher invitation code is invalid. To become a teacher, reach out to"
+" hedy@felienne.com."
 
 #: utils.py:203
 #, fuzzy
@@ -223,61 +223,62 @@ msgstr "Something went wrong..."
 #, fuzzy
 msgid "Empty Program"
 msgstr ""
-"You created an empty program. Type Hedy code in the left field and try again"
+"You created an empty program. Type Hedy code in the left field and try "
+"again"
 
 #: coursedata/error-messages.txt:2
 msgid "Wrong Level"
 msgstr ""
-"Este era um código Hedy correto, mas não para o nível correto. Você escreveu "
-"para o nível {working_level} no nível {original_level}."
+"Este era um código Hedy correto, mas não para o nível correto. Você "
+"escreveu para o nível {working_level} no nível {original_level}."
 
 #: coursedata/error-messages.txt:3
 msgid "Incomplete"
 msgstr ""
-"Opa! Você esqueceu um pedaço do código! Na linha {line_number}, você precisa "
-"entrar com texto após {incomplete_command}."
+"Opa! Você esqueceu um pedaço do código! Na linha {line_number}, você "
+"precisa entrar com texto após {incomplete_command}."
 
 #: coursedata/error-messages.txt:4
 msgid "Invalid"
 msgstr ""
-"{invalid_command} não é um commando Hedy do nível {level}. Você quis dizer "
-"{guessed_command}?"
+"{invalid_command} não é um commando Hedy do nível {level}. Você quis "
+"dizer {guessed_command}?"
 
 #: coursedata/error-messages.txt:5
 msgid "Invalid Space"
 msgstr ""
-"Opa! Você começou uma linha com um espaço na linha {line_number}. Espaços "
-"confundem os computadores, você poderia removê-lo?"
+"Opa! Você começou uma linha com um espaço na linha {line_number}. Espaços"
+" confundem os computadores, você poderia removê-lo?"
 
 #: coursedata/error-messages.txt:6
 #, fuzzy
 msgid "Has Blanks"
 msgstr ""
-"Your code is incomplete. It contains blanks that you have to replace with "
-"code."
+"Your code is incomplete. It contains blanks that you have to replace with"
+" code."
 
 #: coursedata/error-messages.txt:7
 #, fuzzy
 msgid "No Indentation"
 msgstr ""
 "You used too few spaces in line {line_number}. You used {leading_spaces} "
-"spaces, which is not enough. Start every new block with {indent_size} spaces "
-"more than the line before."
+"spaces, which is not enough. Start every new block with {indent_size} "
+"spaces more than the line before."
 
 #: coursedata/error-messages.txt:8
 #, fuzzy
 msgid "Unexpected Indentation"
 msgstr ""
-"You used too many spaces in line {line_number}. You used {leading_spaces} "
-"spaces, which is too much. Start every new block with {indent_size} spaces "
-"more than the line before."
+"You used too many spaces in line {line_number}. You used {leading_spaces}"
+" spaces, which is too much. Start every new block with {indent_size} "
+"spaces more than the line before."
 
 #: coursedata/error-messages.txt:9
 msgid "Parse"
 msgstr ""
 "O código que você enviou não é um código Hedy válido. O erro é na linha "
-"{location[0]}, posição {location[1]}. Você escreveu {character_found}, mas "
-"isso não é permitido."
+"{location[0]}, posição {location[1]}. Você escreveu {character_found}, "
+"mas isso não é permitido."
 
 #: coursedata/error-messages.txt:10
 msgid "Unquoted Text"
@@ -289,8 +290,8 @@ msgstr ""
 #, fuzzy
 msgid "Unquoted Assignment"
 msgstr ""
-"From this level, you need to place texts to the right of the `is` between "
-"quotes. You forgot that for the text {text}."
+"From this level, you need to place texts to the right of the `is` between"
+" quotes. You forgot that for the text {text}."
 
 #: coursedata/error-messages.txt:12
 #, fuzzy
@@ -307,8 +308,8 @@ msgstr "Você tentou printar {name}, mas você não o instanciou."
 #, fuzzy
 msgid "Cyclic Var Definition"
 msgstr ""
-"The name {variable} needs to be set before you can use it on the right-hand "
-"side of the is command"
+"The name {variable} needs to be set before you can use it on the right-"
+"hand side of the is command"
 
 #: coursedata/error-messages.txt:15
 #, fuzzy
@@ -321,46 +322,46 @@ msgstr ""
 #, fuzzy
 msgid "Too Big"
 msgstr ""
-"Wow! Your program has an impressive {lines_of_code} lines of code! But we "
-"can only process {max_lines} lines in this level. Make your program smaller "
-"and try again."
+"Wow! Your program has an impressive {lines_of_code} lines of code! But we"
+" can only process {max_lines} lines in this level. Make your program "
+"smaller and try again."
 
 #: coursedata/error-messages.txt:17
 #, fuzzy
 msgid "Invalid Argument Type"
 msgstr ""
-"You cannot use the command {command} with {invalid_argument} because it is "
-"{invalid_type}. Try changing {invalid_argument} to {allowed_types}."
+"You cannot use the command {command} with {invalid_argument} because it "
+"is {invalid_type}. Try changing {invalid_argument} to {allowed_types}."
 
 #: coursedata/error-messages.txt:18
 #, fuzzy
 msgid "Invalid Argument"
 msgstr ""
-"You cannot use the command {command} with {invalid_argument} . Try changing "
-"{invalid_argument} to {allowed_types}."
+"You cannot use the command {command} with {invalid_argument} . Try "
+"changing {invalid_argument} to {allowed_types}."
 
 #: coursedata/error-messages.txt:19
 #, fuzzy
 msgid "Invalid Type Combination"
 msgstr ""
-"You cannot use {invalid_argument} and {invalid_argument_2} in {operation} "
-"because one is {invalid_type} and the other is {invalid_type_2}. Try "
-"changing {invalid_argument} to {invalid_type_2} or {invalid_argument_2} to "
-"{invalid_type}."
+"You cannot use {invalid_argument} and {invalid_argument_2} in {operation}"
+" because one is {invalid_type} and the other is {invalid_type_2}. Try "
+"changing {invalid_argument} to {invalid_type_2} or {invalid_argument_2} "
+"to {invalid_type}."
 
 #: coursedata/error-messages.txt:20
 #, fuzzy
 msgid "Unsupported Float"
 msgstr ""
-"Non-integer numbers are not supported yet but they will be in a few levels. "
-"For now change {value} to an integer."
+"Non-integer numbers are not supported yet but they will be in a few "
+"levels. For now change {value} to an integer."
 
 #: coursedata/error-messages.txt:21
 #, fuzzy
 msgid "Locked Language Feature"
 msgstr ""
-"You are using {concept}! That is awesome, but {concept} is not unlocked yet! "
-"It will be unlocked in a later level."
+"You are using {concept}! That is awesome, but {concept} is not unlocked "
+"yet! It will be unlocked in a later level."
 
 #: coursedata/error-messages.txt:22
 #, fuzzy
@@ -371,15 +372,16 @@ msgstr "It looks like you forgot to use a command on line {line_number}."
 #, fuzzy
 msgid "ask_needs_var"
 msgstr ""
-"Starting in level 2, ask needs to be used with a variable. Example: name is "
-"ask What are you called?"
+"Starting in level 2, ask needs to be used with a variable. Example: name "
+"is ask What are you called?"
 
 #: coursedata/error-messages.txt:24
 #, fuzzy
 msgid "echo_out"
 msgstr ""
-"Starting in level 2 echo is no longer needed. You can repeat an answer with "
-"ask and print now. Example: name is ask What are you called? print hello name"
+"Starting in level 2 echo is no longer needed. You can repeat an answer "
+"with ask and print now. Example: name is ask What are you called? print "
+"hello name"
 
 #: coursedata/error-messages.txt:25
 msgid "space"
@@ -464,6 +466,11 @@ msgstr "a list"
 #, fuzzy
 msgid "input"
 msgstr "input from ask"
+
+#: templates/achievements.html:4
+#, fuzzy
+msgid "achievements_title"
+msgstr "achievements"
 
 #: templates/class-overview.html:16
 #, fuzzy
@@ -627,14 +634,14 @@ msgstr ""
 msgid "join_class"
 msgstr "Entrar na turma"
 
-#: templates/class-stats.html:22 templates/customize-class.html:155
+#: templates/class-stats.html:22 templates/customize-class.html:150
 #, fuzzy
 msgid "back_to_class"
 msgstr "Go back to class"
 
 #: templates/code-page.html:25 templates/code-page.html:34
-#: templates/customize-class.html:28 templates/customize-class.html:64
-#: templates/customize-class.html:71 templates/customize-class.html:94
+#: templates/customize-class.html:23 templates/customize-class.html:59
+#: templates/customize-class.html:66 templates/customize-class.html:89
 #: templates/incl-adventure-tabs.html:5 templates/level-page.html:6
 #: templates/level-page.html:11 templates/quiz/startquiz.html:10
 #: templates/view-program-page.html:12 templates/view-program-page.html:28
@@ -650,21 +657,21 @@ msgstr "Create multiple accounts"
 #, fuzzy
 msgid "accounts_intro"
 msgstr ""
-"On this page you can create accounts for multiple students at the same time. "
-"It is also possible to directly add them to one of your classes. By pressing "
-"the green + on the bottom right of the page you can add extra rows. You can "
-"delete a row by pressing the corresponding red cross. Make sure no rows are "
-"empty when you press \"Create accounts\". Please keep in mind that every "
-"username and mail address needs to be unique and the password needs to be "
-"<b>at least</b> 6 characters."
+"On this page you can create accounts for multiple students at the same "
+"time. It is also possible to directly add them to one of your classes. By"
+" pressing the green + on the bottom right of the page you can add extra "
+"rows. You can delete a row by pressing the corresponding red cross. Make "
+"sure no rows are empty when you press \"Create accounts\". Please keep in"
+" mind that every username and mail address needs to be unique and the "
+"password needs to be <b>at least</b> 6 characters."
 
 #: templates/create-accounts.html:10
 #, fuzzy
 msgid "create_accounts_prompt"
 msgstr "Are you sure you want to create these accounts?"
 
-#: templates/create-accounts.html:17 templates/learn-more.html:10
-#: templates/profile.html:96 templates/recover.html:8 templates/signup.html:13
+#: templates/create-accounts.html:17 templates/profile.html:96
+#: templates/recover.html:8 templates/signup.html:13
 msgid "email"
 msgstr "Email"
 
@@ -720,10 +727,10 @@ msgstr "Nível"
 #, fuzzy
 msgid "adventure_exp_1"
 msgstr ""
-"Type your adventure of choice on the right-hand side. After creating your "
-"adventure you can include it in one of your classes under \"customizations"
-"\". If you want to include a command in your adventure please use code "
-"anchors like this:"
+"Type your adventure of choice on the right-hand side. After creating your"
+" adventure you can include it in one of your classes under "
+"\"customizations\". If you want to include a command in your adventure "
+"please use code anchors like this:"
 
 #: templates/customize-adventure.html:31
 #, fuzzy
@@ -737,11 +744,11 @@ msgstr ""
 msgid "adventure_exp_3"
 msgstr ""
 "You can use the \"preview\" button to view a styled version of your "
-"adventure. To view the adventure on a dedicated page, select \"view\" from "
-"the teachers page."
+"adventure. To view the adventure on a dedicated page, select \"view\" "
+"from the teachers page."
 
-#: templates/customize-adventure.html:43 templates/customize-class.html:28
-#: templates/customize-class.html:93 templates/explore.html:26
+#: templates/customize-adventure.html:43 templates/customize-class.html:23
+#: templates/customize-class.html:88 templates/explore.html:26
 #: templates/programs.html:18 templates/programs.html:48
 #: templates/view-adventure.html:6
 msgid "adventure"
@@ -771,7 +778,7 @@ msgstr "I agree that my adventure might be made publicly available on Hedy."
 msgid "preview"
 msgstr "Preview"
 
-#: templates/customize-adventure.html:51 templates/customize-class.html:150
+#: templates/customize-adventure.html:51 templates/customize-class.html:145
 #, fuzzy
 msgid "save"
 msgstr "Save"
@@ -781,128 +788,78 @@ msgstr "Save"
 msgid "delete_adventure_prompt"
 msgstr "Are you sure you want to remove this adventure?"
 
-#: templates/customize-class.html:7
-#, fuzzy
-msgid "customize_class_exp_1"
-msgstr "Customize class"
-
-#: templates/customize-class.html:10
-#, fuzzy
-msgid "customize_class_step_1"
-msgstr "Customize class"
-
-#: templates/customize-class.html:11
-#, fuzzy
-msgid "customize_class_step_2"
-msgstr "Customize class"
-
-#: templates/customize-class.html:12
-#, fuzzy
-msgid "customize_class_step_3"
-msgstr "Customize class"
-
-#: templates/customize-class.html:13
-#, fuzzy
-msgid "customize_class_step_4"
-msgstr "Customize class"
-
-#: templates/customize-class.html:14
-#, fuzzy
-msgid "customize_class_step_5"
-msgstr "Customize class"
-
-#: templates/customize-class.html:15
-#, fuzzy
-msgid "customize_class_step_6"
-msgstr "Customize class"
-
-#: templates/customize-class.html:16
-#, fuzzy
-msgid "customize_class_step_7"
-msgstr "Customize class"
-
-#: templates/customize-class.html:17
-#, fuzzy
-msgid "customize_class_step_8"
-msgstr "Customize class"
-
-#: templates/customize-class.html:20
-#, fuzzy
-msgid "customize_class_exp_2"
-msgstr "Customize class"
-
-#: templates/customize-class.html:23
+#: templates/customize-class.html:18
 #, fuzzy
 msgid "select_adventures"
 msgstr "Select adventures"
 
-#: templates/customize-class.html:59
+#: templates/customize-class.html:54
 #, fuzzy
 msgid "opening_dates"
 msgstr "Opening dates"
 
-#: templates/customize-class.html:65
+#: templates/customize-class.html:60
 #, fuzzy
 msgid "opening_date"
 msgstr "Opening date"
 
-#: templates/customize-class.html:77
+#: templates/customize-class.html:72
 #, fuzzy
 msgid "directly_available"
 msgstr "Directly open"
 
-#: templates/customize-class.html:88
+#: templates/customize-class.html:83
 #, fuzzy
 msgid "select_own_adventures"
 msgstr "Select own adventures"
 
-#: templates/customize-class.html:95 templates/customize-class.html:121
+#: templates/customize-class.html:90 templates/customize-class.html:116
 #: templates/profile.html:47 templates/profile.html:128
 #: templates/profile.html:137 templates/signup.html:26 templates/signup.html:45
 #: templates/signup.html:53
 msgid "select"
 msgstr "Selecione"
 
-#: templates/customize-class.html:115
+#: templates/customize-class.html:110
 #, fuzzy
 msgid "other_settings"
 msgstr "Other settings"
 
-#: templates/customize-class.html:120
+#: templates/customize-class.html:115
 #, fuzzy
 msgid "option"
 msgstr "Option"
 
-#: templates/customize-class.html:126
+#: templates/customize-class.html:121
 #, fuzzy
 msgid "mandatory_mode"
 msgstr "Mandatory developer's mode"
 
-#: templates/customize-class.html:132
+#: templates/customize-class.html:127
 #, fuzzy
 msgid "hide_cheatsheet"
 msgstr "Hide cheatsheet"
 
-#: templates/customize-class.html:138
+#: templates/customize-class.html:133
 msgid "hide_keyword_switcher"
 msgstr ""
 
-#: templates/customize-class.html:149
+#: templates/customize-class.html:144
 #, fuzzy
 msgid "reset_adventure_prompt"
 msgstr "Are you sure you want to reset all selected adventures?"
 
-#: templates/customize-class.html:149
+#: templates/customize-class.html:144
 #, fuzzy
 msgid "reset_adventures"
 msgstr "Reset selected adventures"
 
-#: templates/customize-class.html:153
+#: templates/customize-class.html:148
 #, fuzzy
 msgid "remove_customizations_prompt"
 msgstr "Are you sure you want to remove this class their customizations?"
 
-#: templates/customize-class.html:154
+#: templates/customize-class.html:149
 #, fuzzy
 msgid "remove_customization"
 msgstr "Remove customization"
@@ -921,13 +878,13 @@ msgstr "Explore programs"
 #, fuzzy
 msgid "explore_explanation"
 msgstr ""
-"On this page you can look through programs created by other Hedy users. You "
-"can filter on both a Hedy level and adventure. Click on \"View program\" to "
-"open a program and run it. Programs with a red header contain a mistake. You "
-"can still open the program, but running it will result in an error. You can "
-"of course try to fix it! If the creator has a public profile you can click "
-"their username to visit their profile. There you will find all their shared "
-"programs and much more!"
+"On this page you can look through programs created by other Hedy users. "
+"You can filter on both a Hedy level and adventure. Click on \"View "
+"program\" to open a program and run it. Programs with a red header "
+"contain a mistake. You can still open the program, but running it will "
+"result in an error. You can of course try to fix it! If the creator has a"
+" public profile you can click their username to visit their profile. "
+"There you will find all their shared programs and much more!"
 
 #: templates/explore.html:35 templates/programs.html:27
 #, fuzzy
@@ -991,8 +948,8 @@ msgstr "Create student accounts"
 #, fuzzy
 msgid "teacher_welcome"
 msgstr ""
-"Welcome to Hedy! Your are now the proud owner of a teachers account which "
-"allows you to create classes and invite students."
+"Welcome to Hedy! Your are now the proud owner of a teachers account which"
+" allows you to create classes and invite students."
 
 #: templates/incl-adventure-tabs.html:22
 #, fuzzy
@@ -1102,9 +1059,9 @@ msgstr "Welcome"
 msgid "intro_text_landing_page"
 msgstr ""
 "Welcome to the wonderful world of Hedy! Here you can learn to program in "
-"small steps, without unnecessary complicated stuff. We start easy at level "
-"1, and slowly build towards bigger and more complex programs! Choose one of "
-"the options below to get started"
+"small steps, without unnecessary complicated stuff. We start easy at "
+"level 1, and slowly build towards bigger and more complex programs! "
+"Choose one of the options below to get started"
 
 #: templates/landing-page.html:14 templates/landing-page.html:36
 #, fuzzy
@@ -1120,14 +1077,14 @@ msgstr "Start programming"
 #: templates/landing-page.html:21
 #, fuzzy
 msgid "create_class_text"
-msgstr ""
-"Group your students into classes and change the content for each class."
+msgstr "Group your students into classes and change the content for each class."
 
 #: templates/landing-page.html:28
 #, fuzzy
 msgid "read_docs_text"
 msgstr ""
-"Visit our teacher's manual for lesson plans and common mistakes by students."
+"Visit our teacher's manual for lesson plans and common mistakes by "
+"students."
 
 #: templates/landing-page.html:30
 #, fuzzy
@@ -1169,49 +1126,14 @@ msgstr "Copiar link para compartilhar"
 #, fuzzy
 msgid "set_preferred_lang"
 msgstr ""
-"Hedy now supports preferred user languages. You can set one for your profile "
-"in \"My profile\""
+"Hedy now supports preferred user languages. You can set one for your "
+"profile in \"My profile\""
 
 #: templates/layout.html:86 templates/quiz/endquiz.html:18
 #: templates/quiz/quiz.html:29
 #, fuzzy
 msgid "achievement_earned"
 msgstr "You've earned an achievement!"
-
-#: templates/learn-more.html:7
-#, fuzzy
-msgid "mailing_title"
-msgstr "Hedy"
-
-#: templates/learn-more.html:14
-#, fuzzy
-msgid "surname"
-msgstr "Usuário"
-
-#: templates/learn-more.html:18
-#, fuzzy
-msgid "lastname"
-msgstr "Name"
-
-#: templates/learn-more.html:22 templates/profile.html:135
-#: templates/signup.html:52
-msgid "country"
-msgstr "País"
-
-#: templates/learn-more.html:31
-#, fuzzy
-msgid "subscribe"
-msgstr "Assinar a newsletter"
-
-#: templates/learn-more.html:32
-#, fuzzy
-msgid "required_field"
-msgstr "Fields marked with an * are required"
-
-#: templates/learn-more.html:35
-#, fuzzy
-msgid "previous_campaigns"
-msgstr "View previous campaigns"
 
 #: templates/level-page.html:8
 msgid "step_title"
@@ -1244,18 +1166,6 @@ msgstr "Crie uma conta"
 #: templates/login.html:33
 msgid "forgot_password"
 msgstr "Esqueceu sua senha?"
-
-#: templates/main-page.html:9
-msgid "main_title"
-msgstr "Hedy"
-
-#: templates/main-page.html:10
-msgid "main_subtitle"
-msgstr "Uma linguagem de programação gradual"
-
-#: templates/main-page.html:13
-msgid "try_it"
-msgstr "Experimente aqui"
 
 #: templates/profile.html:4
 #, fuzzy
@@ -1321,9 +1231,9 @@ msgstr "Favourite program"
 #, fuzzy
 msgid "public_profile_info"
 msgstr ""
-"By selecting this box I make my profile visible for everyone. Be careful not "
-"to share personal information like your name or home address, because "
-"everyone will be able to see it!"
+"By selecting this box I make my profile visible for everyone. Be careful "
+"not to share personal information like your name or home address, because"
+" everyone will be able to see it!"
 
 #: templates/profile.html:59
 #, fuzzy
@@ -1388,6 +1298,10 @@ msgstr "Masculino"
 #: templates/profile.html:131 templates/signup.html:48
 msgid "other"
 msgstr "Outro"
+
+#: templates/profile.html:135 templates/signup.html:52
+msgid "country"
+msgstr "País"
 
 #: templates/profile.html:141
 msgid "update_profile"
@@ -1587,8 +1501,8 @@ msgstr "Você já tem uma conta?"
 #, fuzzy
 msgid "teacher_invitation_require_login"
 msgstr ""
-"To set up your profile as a teacher we will need you to log in. If you don't "
-"have an account, please create one."
+"To set up your profile as a teacher we will need you to log in. If you "
+"don't have an account, please create one."
 
 #: templates/view-program-page.html:13
 msgid "by"
@@ -1751,7 +1665,8 @@ msgstr "You have to agree with the privacy terms."
 #, fuzzy
 msgid "keyword_language_invalid"
 msgstr ""
-"Please select a valid keyword language (select English or your own language)."
+"Please select a valid keyword language (select English or your own "
+"language)."
 
 #: website/auth.py:371 website/auth.py:551
 msgid "year_invalid"
@@ -1816,8 +1731,8 @@ msgstr "Profile updated, page will be re-loaded."
 #: website/auth.py:670
 msgid "sent_password_recovery"
 msgstr ""
-"Em breve, você receberá um e-mail com instruções sobre como redefinir sua "
-"senha."
+"Em breve, você receberá um e-mail com instruções sobre como redefinir sua"
+" senha."
 
 #: website/auth.py:681 website/auth.py:691
 #, fuzzy
@@ -1841,8 +1756,8 @@ msgstr "Program deleted successfully."
 #: website/programs.py:55
 msgid "save_prompt"
 msgstr ""
-"Você precisa ter uma conta para salvar seu programa. Você gostaria de fazer "
-"o login agora?"
+"Você precisa ter uma conta para salvar seu programa. Você gostaria de "
+"fazer o login agora?"
 
 #: website/programs.py:60
 #, fuzzy
@@ -2052,3 +1967,61 @@ msgstr "The adventure has been updated!"
 #, fuzzy
 msgid "adventure_empty"
 msgstr "You didn't enter an adventure name!"
+
+#~ msgid "customize_class_exp_1"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_1"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_2"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_3"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_4"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_5"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_6"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_7"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_8"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_exp_2"
+#~ msgstr "Customize class"
+
+#~ msgid "mailing_title"
+#~ msgstr "Hedy"
+
+#~ msgid "surname"
+#~ msgstr "Usuário"
+
+#~ msgid "lastname"
+#~ msgstr "Name"
+
+#~ msgid "subscribe"
+#~ msgstr "Assinar a newsletter"
+
+#~ msgid "required_field"
+#~ msgstr "Fields marked with an * are required"
+
+#~ msgid "previous_campaigns"
+#~ msgstr "View previous campaigns"
+
+#~ msgid "main_title"
+#~ msgstr "Hedy"
+
+#~ msgid "main_subtitle"
+#~ msgstr "Uma linguagem de programação gradual"
+
+#~ msgid "try_it"
+#~ msgstr "Experimente aqui"
+

--- a/translations/pt_PT/LC_MESSAGES/messages.po
+++ b/translations/pt_PT/LC_MESSAGES/messages.po
@@ -1,18 +1,18 @@
+
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-03-29 10:01+0200\n"
+"POT-Creation-Date: 2022-03-30 08:43+0200\n"
 "PO-Revision-Date: 2022-03-30 09:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
-"Language-Team: Portuguese (Portugal) <https://hosted.weblate.org/projects/"
-"hedy/web-texts/pt_PT/>\n"
 "Language: pt_PT\n"
+"Language-Team: Portuguese (Portugal) "
+"<https://hosted.weblate.org/projects/hedy/web-texts/pt_PT/>\n"
+"Plural-Forms: nplurals=2; plural=n != 1\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.12-dev\n"
 "Generated-By: Babel 2.9.1\n"
 
 #: app.py:571
@@ -20,27 +20,27 @@ msgstr ""
 msgid "program_contains_error"
 msgstr "This program contains an error, are you sure you want to share it?"
 
-#: app.py:723
+#: app.py:722
 #, fuzzy
 msgid "title_achievements"
 msgstr "Hedy - My achievements"
 
-#: app.py:740 app.py:1111 website/teacher.py:365 website/teacher.py:374
+#: app.py:739 app.py:1110 website/teacher.py:365 website/teacher.py:374
 #, fuzzy
 msgid "not_teacher"
 msgstr "Looks like you are not a teacher!"
 
-#: app.py:743
+#: app.py:742
 #, fuzzy
 msgid "not_enrolled"
 msgstr "Looks like you are not in this class!"
 
-#: app.py:775
+#: app.py:774
 #, fuzzy
 msgid "title_programs"
 msgstr "Hedy - My programs"
 
-#: app.py:785 app.py:795 app.py:799 app.py:813 app.py:1054 app.py:1357
+#: app.py:784 app.py:794 app.py:798 app.py:812 app.py:1053 app.py:1356
 #: website/admin.py:17 website/admin.py:25 website/admin.py:95
 #: website/admin.py:112 website/admin.py:130 website/auth.py:711
 #: website/auth.py:738 website/statistics.py:86
@@ -48,122 +48,122 @@ msgstr "Hedy - My programs"
 msgid "unauthorized"
 msgstr "You don't have access rights for this page"
 
-#: app.py:823
+#: app.py:822
 msgid "minutes"
 msgstr "minutos"
 
-#: app.py:826
+#: app.py:825
 msgid "hours"
 msgstr "horas"
 
-#: app.py:829
+#: app.py:828
 msgid "days"
 msgstr "dias"
 
-#: app.py:832
+#: app.py:831
 #, fuzzy
 msgid "ago"
 msgstr "{time} ago"
 
-#: app.py:848 app.py:850 app.py:976
+#: app.py:847 app.py:849 app.py:975
 #, fuzzy
 msgid "no_such_level"
 msgstr "No such Hedy level!"
 
-#: app.py:858 app.py:865 app.py:931 app.py:937
+#: app.py:857 app.py:864 app.py:930 app.py:936
 #, fuzzy
 msgid "no_such_program"
 msgstr "No such Hedy program!"
 
-#: app.py:891
+#: app.py:890
 #, fuzzy
 msgid "level_not_translated"
 msgstr "This level is not translated in your language (yet)"
 
-#: app.py:893
+#: app.py:892
 #, fuzzy
 msgid "level_not_class"
 msgstr "You're in a class where this level has not been made available yet"
 
-#: app.py:986 website/teacher.py:432 website/teacher.py:448
+#: app.py:985 website/teacher.py:432 website/teacher.py:448
 #: website/teacher.py:477 website/teacher.py:503
 #, fuzzy
 msgid "no_such_adventure"
 msgstr "This adventure doesn't exist!"
 
-#: app.py:1005
+#: app.py:1004
 #, fuzzy
 msgid "page_not_found"
 msgstr "We could not find that page!"
 
-#: app.py:1025
+#: app.py:1024
 #, fuzzy
 msgid "title_signup"
 msgstr "Hedy - Create an account"
 
-#: app.py:1032
+#: app.py:1031
 #, fuzzy
 msgid "title_login"
 msgstr "Hedy - Login"
 
-#: app.py:1039
+#: app.py:1038
 #, fuzzy
 msgid "title_recover"
 msgstr "Hedy - Recover account"
 
-#: app.py:1055
+#: app.py:1054
 #, fuzzy
 msgid "title_reset"
 msgstr "Hedy - Reset password"
 
-#: app.py:1064
+#: app.py:1063
 #, fuzzy
 msgid "title_my-profile"
 msgstr "Hedy - My account"
 
-#: app.py:1078
+#: app.py:1077
 #, fuzzy
 msgid "title_learn-more"
 msgstr "Hedy - Learn more"
 
-#: app.py:1083
+#: app.py:1082
 #, fuzzy
 msgid "title_privacy"
 msgstr "Hedy - Privacy terms"
 
-#: app.py:1090
+#: app.py:1089
 #, fuzzy
 msgid "title_landing-page"
 msgstr "Welcome to Hedy!"
 
-#: app.py:1092
+#: app.py:1091
 #, fuzzy
 msgid "not_user"
 msgstr "Looks like you are not logged in!"
 
-#: app.py:1107
+#: app.py:1106
 #, fuzzy
 msgid "title_for-teacher"
 msgstr "Hedy - For teachers"
 
-#: app.py:1118
+#: app.py:1117
 #, fuzzy
 msgid "title_start"
 msgstr "Hedy - A gradual programming language"
 
-#: app.py:1171
+#: app.py:1170
 #, fuzzy
 msgid "title_explore"
 msgstr "Hedy - Explore"
 
-#: app.py:1190 app.py:1192
+#: app.py:1189 app.py:1191
 #, fuzzy
 msgid "translate_error"
 msgstr ""
-"Something went wrong while translating the code. Try running the code to see "
-"if it has an error. Code with errors can not be translated."
+"Something went wrong while translating the code. Try running the code to "
+"see if it has an error. Code with errors can not be translated."
 
-#: app.py:1301 website/auth.py:299 website/auth.py:347 website/auth.py:483
+#: app.py:1300 website/auth.py:299 website/auth.py:347 website/auth.py:483
 #: website/auth.py:509 website/auth.py:539 website/auth.py:645
 #: website/auth.py:677 website/auth.py:717 website/auth.py:744
 #: website/teacher.py:90 website/teacher.py:125 website/teacher.py:197
@@ -172,37 +172,37 @@ msgstr ""
 msgid "ajax_error"
 msgstr "Ocorreu um erro, por favor tenta novamente."
 
-#: app.py:1304
+#: app.py:1303
 #, fuzzy
 msgid "image_invalid"
 msgstr "Your chosen image is invalid."
 
-#: app.py:1306
+#: app.py:1305
 #, fuzzy
 msgid "personal_text_invalid"
 msgstr "Your personal text is invalid."
 
-#: app.py:1308 app.py:1314
+#: app.py:1307 app.py:1313
 #, fuzzy
 msgid "favourite_program_invalid"
 msgstr "Your chosen favourite program is invalid."
 
-#: app.py:1326 app.py:1327
+#: app.py:1325 app.py:1326
 #, fuzzy
 msgid "public_profile_updated"
 msgstr "Public profile updated."
 
-#: app.py:1361 app.py:1385
+#: app.py:1360 app.py:1384
 #, fuzzy
 msgid "user_not_private"
 msgstr "This user doesn't exist or doesn't have a public profile"
 
-#: app.py:1394
+#: app.py:1393
 #, fuzzy
 msgid "invalid_teacher_invitation_code"
 msgstr ""
-"The teacher invitation code is invalid. To become a teacher, reach out to "
-"hedy@felienne.com."
+"The teacher invitation code is invalid. To become a teacher, reach out to"
+" hedy@felienne.com."
 
 #: utils.py:203
 #, fuzzy
@@ -223,25 +223,26 @@ msgstr "Something went wrong..."
 #, fuzzy
 msgid "Empty Program"
 msgstr ""
-"You created an empty program. Type Hedy code in the left field and try again"
+"You created an empty program. Type Hedy code in the left field and try "
+"again"
 
 #: coursedata/error-messages.txt:2
 msgid "Wrong Level"
 msgstr ""
-"Isso era código Hedy correcto, mas não no nível certo. Escreveste códio para "
-"o nível {working_level}, no nível {original_level}."
+"Isso era código Hedy correcto, mas não no nível certo. Escreveste códio "
+"para o nível {working_level}, no nível {original_level}."
 
 #: coursedata/error-messages.txt:3
 msgid "Incomplete"
 msgstr ""
-"Oops! Esqueceste-te de um pedaço de código! Na linha {line_number}, tens de "
-"introduzir texto a seguir de {incomplete_command}."
+"Oops! Esqueceste-te de um pedaço de código! Na linha {line_number}, tens "
+"de introduzir texto a seguir de {incomplete_command}."
 
 #: coursedata/error-messages.txt:4
 msgid "Invalid"
 msgstr ""
-"{invalid_command} não é um comando Hedy do nível {level}. Será que querias "
-"dizer {guessed_command}?"
+"{invalid_command} não é um comando Hedy do nível {level}. Será que "
+"querias dizer {guessed_command}?"
 
 #: coursedata/error-messages.txt:5
 msgid "Invalid Space"
@@ -253,24 +254,24 @@ msgstr ""
 #, fuzzy
 msgid "Has Blanks"
 msgstr ""
-"Your code is incomplete. It contains blanks that you have to replace with "
-"code."
+"Your code is incomplete. It contains blanks that you have to replace with"
+" code."
 
 #: coursedata/error-messages.txt:7
 #, fuzzy
 msgid "No Indentation"
 msgstr ""
 "You used too few spaces in line {line_number}. You used {leading_spaces} "
-"spaces, which is not enough. Start every new block with {indent_size} spaces "
-"more than the line before."
+"spaces, which is not enough. Start every new block with {indent_size} "
+"spaces more than the line before."
 
 #: coursedata/error-messages.txt:8
 #, fuzzy
 msgid "Unexpected Indentation"
 msgstr ""
-"You used too many spaces in line {line_number}. You used {leading_spaces} "
-"spaces, which is too much. Start every new block with {indent_size} spaces "
-"more than the line before."
+"You used too many spaces in line {line_number}. You used {leading_spaces}"
+" spaces, which is too much. Start every new block with {indent_size} "
+"spaces more than the line before."
 
 #: coursedata/error-messages.txt:9
 msgid "Parse"
@@ -289,8 +290,8 @@ msgstr ""
 #, fuzzy
 msgid "Unquoted Assignment"
 msgstr ""
-"From this level, you need to place texts to the right of the `is` between "
-"quotes. You forgot that for the text {text}."
+"From this level, you need to place texts to the right of the `is` between"
+" quotes. You forgot that for the text {text}."
 
 #: coursedata/error-messages.txt:12
 #, fuzzy
@@ -307,8 +308,8 @@ msgstr "Tentaste escrever {name}, mas não o instanciastes."
 #, fuzzy
 msgid "Cyclic Var Definition"
 msgstr ""
-"The name {variable} needs to be set before you can use it on the right-hand "
-"side of the is command"
+"The name {variable} needs to be set before you can use it on the right-"
+"hand side of the is command"
 
 #: coursedata/error-messages.txt:15
 #, fuzzy
@@ -321,46 +322,46 @@ msgstr ""
 #, fuzzy
 msgid "Too Big"
 msgstr ""
-"Wow! Your program has an impressive {lines_of_code} lines of code! But we "
-"can only process {max_lines} lines in this level. Make your program smaller "
-"and try again."
+"Wow! Your program has an impressive {lines_of_code} lines of code! But we"
+" can only process {max_lines} lines in this level. Make your program "
+"smaller and try again."
 
 #: coursedata/error-messages.txt:17
 #, fuzzy
 msgid "Invalid Argument Type"
 msgstr ""
-"You cannot use the command {command} with {invalid_argument} because it is "
-"{invalid_type}. Try changing {invalid_argument} to {allowed_types}."
+"You cannot use the command {command} with {invalid_argument} because it "
+"is {invalid_type}. Try changing {invalid_argument} to {allowed_types}."
 
 #: coursedata/error-messages.txt:18
 #, fuzzy
 msgid "Invalid Argument"
 msgstr ""
-"You cannot use the command {command} with {invalid_argument} . Try changing "
-"{invalid_argument} to {allowed_types}."
+"You cannot use the command {command} with {invalid_argument} . Try "
+"changing {invalid_argument} to {allowed_types}."
 
 #: coursedata/error-messages.txt:19
 #, fuzzy
 msgid "Invalid Type Combination"
 msgstr ""
-"You cannot use {invalid_argument} and {invalid_argument_2} in {operation} "
-"because one is {invalid_type} and the other is {invalid_type_2}. Try "
-"changing {invalid_argument} to {invalid_type_2} or {invalid_argument_2} to "
-"{invalid_type}."
+"You cannot use {invalid_argument} and {invalid_argument_2} in {operation}"
+" because one is {invalid_type} and the other is {invalid_type_2}. Try "
+"changing {invalid_argument} to {invalid_type_2} or {invalid_argument_2} "
+"to {invalid_type}."
 
 #: coursedata/error-messages.txt:20
 #, fuzzy
 msgid "Unsupported Float"
 msgstr ""
-"Non-integer numbers are not supported yet but they will be in a few levels. "
-"For now change {value} to an integer."
+"Non-integer numbers are not supported yet but they will be in a few "
+"levels. For now change {value} to an integer."
 
 #: coursedata/error-messages.txt:21
 #, fuzzy
 msgid "Locked Language Feature"
 msgstr ""
-"You are using {concept}! That is awesome, but {concept} is not unlocked yet! "
-"It will be unlocked in a later level."
+"You are using {concept}! That is awesome, but {concept} is not unlocked "
+"yet! It will be unlocked in a later level."
 
 #: coursedata/error-messages.txt:22
 #, fuzzy
@@ -371,15 +372,16 @@ msgstr "It looks like you forgot to use a command on line {line_number}."
 #, fuzzy
 msgid "ask_needs_var"
 msgstr ""
-"Starting in level 2, ask needs to be used with a variable. Example: name is "
-"ask What are you called?"
+"Starting in level 2, ask needs to be used with a variable. Example: name "
+"is ask What are you called?"
 
 #: coursedata/error-messages.txt:24
 #, fuzzy
 msgid "echo_out"
 msgstr ""
-"Starting in level 2 echo is no longer needed. You can repeat an answer with "
-"ask and print now. Example: name is ask What are you called? print hello name"
+"Starting in level 2 echo is no longer needed. You can repeat an answer "
+"with ask and print now. Example: name is ask What are you called? print "
+"hello name"
 
 #: coursedata/error-messages.txt:25
 msgid "space"
@@ -464,6 +466,11 @@ msgstr "a list"
 #, fuzzy
 msgid "input"
 msgstr "input from ask"
+
+#: templates/achievements.html:4
+#, fuzzy
+msgid "achievements_title"
+msgstr "achievements"
 
 #: templates/class-overview.html:16
 #, fuzzy
@@ -634,22 +641,21 @@ msgstr "Do you want to join this class?"
 #: templates/class-prejoin.html:17 website/teacher.py:183
 #, fuzzy
 msgid "join_prompt"
-msgstr ""
-"You need to have an account to join a class. Would you like to login now?"
+msgstr "You need to have an account to join a class. Would you like to login now?"
 
 #: templates/class-prejoin.html:17 templates/profile.html:14
 #, fuzzy
 msgid "join_class"
 msgstr "Join class"
 
-#: templates/class-stats.html:22 templates/customize-class.html:155
+#: templates/class-stats.html:22 templates/customize-class.html:150
 #, fuzzy
 msgid "back_to_class"
 msgstr "Go back to class"
 
 #: templates/code-page.html:25 templates/code-page.html:34
-#: templates/customize-class.html:28 templates/customize-class.html:64
-#: templates/customize-class.html:71 templates/customize-class.html:94
+#: templates/customize-class.html:23 templates/customize-class.html:59
+#: templates/customize-class.html:66 templates/customize-class.html:89
 #: templates/incl-adventure-tabs.html:5 templates/level-page.html:6
 #: templates/level-page.html:11 templates/quiz/startquiz.html:10
 #: templates/view-program-page.html:12 templates/view-program-page.html:28
@@ -665,21 +671,21 @@ msgstr "Create multiple accounts"
 #, fuzzy
 msgid "accounts_intro"
 msgstr ""
-"On this page you can create accounts for multiple students at the same time. "
-"It is also possible to directly add them to one of your classes. By pressing "
-"the green + on the bottom right of the page you can add extra rows. You can "
-"delete a row by pressing the corresponding red cross. Make sure no rows are "
-"empty when you press \"Create accounts\". Please keep in mind that every "
-"username and mail address needs to be unique and the password needs to be "
-"<b>at least</b> 6 characters."
+"On this page you can create accounts for multiple students at the same "
+"time. It is also possible to directly add them to one of your classes. By"
+" pressing the green + on the bottom right of the page you can add extra "
+"rows. You can delete a row by pressing the corresponding red cross. Make "
+"sure no rows are empty when you press \"Create accounts\". Please keep in"
+" mind that every username and mail address needs to be unique and the "
+"password needs to be <b>at least</b> 6 characters."
 
 #: templates/create-accounts.html:10
 #, fuzzy
 msgid "create_accounts_prompt"
 msgstr "Are you sure you want to create these accounts?"
 
-#: templates/create-accounts.html:17 templates/learn-more.html:10
-#: templates/profile.html:96 templates/recover.html:8 templates/signup.html:13
+#: templates/create-accounts.html:17 templates/profile.html:96
+#: templates/recover.html:8 templates/signup.html:13
 msgid "email"
 msgstr "Email"
 
@@ -735,10 +741,10 @@ msgstr "Nível"
 #, fuzzy
 msgid "adventure_exp_1"
 msgstr ""
-"Type your adventure of choice on the right-hand side. After creating your "
-"adventure you can include it in one of your classes under \"customizations"
-"\". If you want to include a command in your adventure please use code "
-"anchors like this:"
+"Type your adventure of choice on the right-hand side. After creating your"
+" adventure you can include it in one of your classes under "
+"\"customizations\". If you want to include a command in your adventure "
+"please use code anchors like this:"
 
 #: templates/customize-adventure.html:31
 #, fuzzy
@@ -752,11 +758,11 @@ msgstr ""
 msgid "adventure_exp_3"
 msgstr ""
 "You can use the \"preview\" button to view a styled version of your "
-"adventure. To view the adventure on a dedicated page, select \"view\" from "
-"the teachers page."
+"adventure. To view the adventure on a dedicated page, select \"view\" "
+"from the teachers page."
 
-#: templates/customize-adventure.html:43 templates/customize-class.html:28
-#: templates/customize-class.html:93 templates/explore.html:26
+#: templates/customize-adventure.html:43 templates/customize-class.html:23
+#: templates/customize-class.html:88 templates/explore.html:26
 #: templates/programs.html:18 templates/programs.html:48
 #: templates/view-adventure.html:6
 msgid "adventure"
@@ -786,7 +792,7 @@ msgstr "I agree that my adventure might be made publicly available on Hedy."
 msgid "preview"
 msgstr "Preview"
 
-#: templates/customize-adventure.html:51 templates/customize-class.html:150
+#: templates/customize-adventure.html:51 templates/customize-class.html:145
 #, fuzzy
 msgid "save"
 msgstr "Save"
@@ -796,128 +802,78 @@ msgstr "Save"
 msgid "delete_adventure_prompt"
 msgstr "Are you sure you want to remove this adventure?"
 
-#: templates/customize-class.html:7
-#, fuzzy
-msgid "customize_class_exp_1"
-msgstr "Customize class"
-
-#: templates/customize-class.html:10
-#, fuzzy
-msgid "customize_class_step_1"
-msgstr "Customize class"
-
-#: templates/customize-class.html:11
-#, fuzzy
-msgid "customize_class_step_2"
-msgstr "Customize class"
-
-#: templates/customize-class.html:12
-#, fuzzy
-msgid "customize_class_step_3"
-msgstr "Customize class"
-
-#: templates/customize-class.html:13
-#, fuzzy
-msgid "customize_class_step_4"
-msgstr "Customize class"
-
-#: templates/customize-class.html:14
-#, fuzzy
-msgid "customize_class_step_5"
-msgstr "Customize class"
-
-#: templates/customize-class.html:15
-#, fuzzy
-msgid "customize_class_step_6"
-msgstr "Customize class"
-
-#: templates/customize-class.html:16
-#, fuzzy
-msgid "customize_class_step_7"
-msgstr "Customize class"
-
-#: templates/customize-class.html:17
-#, fuzzy
-msgid "customize_class_step_8"
-msgstr "Customize class"
-
-#: templates/customize-class.html:20
-#, fuzzy
-msgid "customize_class_exp_2"
-msgstr "Customize class"
-
-#: templates/customize-class.html:23
+#: templates/customize-class.html:18
 #, fuzzy
 msgid "select_adventures"
 msgstr "Select adventures"
 
-#: templates/customize-class.html:59
+#: templates/customize-class.html:54
 #, fuzzy
 msgid "opening_dates"
 msgstr "Opening dates"
 
-#: templates/customize-class.html:65
+#: templates/customize-class.html:60
 #, fuzzy
 msgid "opening_date"
 msgstr "Opening date"
 
-#: templates/customize-class.html:77
+#: templates/customize-class.html:72
 #, fuzzy
 msgid "directly_available"
 msgstr "Directly open"
 
-#: templates/customize-class.html:88
+#: templates/customize-class.html:83
 #, fuzzy
 msgid "select_own_adventures"
 msgstr "Select own adventures"
 
-#: templates/customize-class.html:95 templates/customize-class.html:121
+#: templates/customize-class.html:90 templates/customize-class.html:116
 #: templates/profile.html:47 templates/profile.html:128
 #: templates/profile.html:137 templates/signup.html:26 templates/signup.html:45
 #: templates/signup.html:53
 msgid "select"
 msgstr "Selecciona"
 
-#: templates/customize-class.html:115
+#: templates/customize-class.html:110
 #, fuzzy
 msgid "other_settings"
 msgstr "Other settings"
 
-#: templates/customize-class.html:120
+#: templates/customize-class.html:115
 #, fuzzy
 msgid "option"
 msgstr "Option"
 
-#: templates/customize-class.html:126
+#: templates/customize-class.html:121
 #, fuzzy
 msgid "mandatory_mode"
 msgstr "Mandatory developer's mode"
 
-#: templates/customize-class.html:132
+#: templates/customize-class.html:127
 #, fuzzy
 msgid "hide_cheatsheet"
 msgstr "Hide cheatsheet"
 
-#: templates/customize-class.html:138
+#: templates/customize-class.html:133
 msgid "hide_keyword_switcher"
 msgstr ""
 
-#: templates/customize-class.html:149
+#: templates/customize-class.html:144
 #, fuzzy
 msgid "reset_adventure_prompt"
 msgstr "Are you sure you want to reset all selected adventures?"
 
-#: templates/customize-class.html:149
+#: templates/customize-class.html:144
 #, fuzzy
 msgid "reset_adventures"
 msgstr "Reset selected adventures"
 
-#: templates/customize-class.html:153
+#: templates/customize-class.html:148
 #, fuzzy
 msgid "remove_customizations_prompt"
 msgstr "Are you sure you want to remove this class their customizations?"
 
-#: templates/customize-class.html:154
+#: templates/customize-class.html:149
 #, fuzzy
 msgid "remove_customization"
 msgstr "Remove customization"
@@ -936,13 +892,13 @@ msgstr "Explore programs"
 #, fuzzy
 msgid "explore_explanation"
 msgstr ""
-"On this page you can look through programs created by other Hedy users. You "
-"can filter on both a Hedy level and adventure. Click on \"View program\" to "
-"open a program and run it. Programs with a red header contain a mistake. You "
-"can still open the program, but running it will result in an error. You can "
-"of course try to fix it! If the creator has a public profile you can click "
-"their username to visit their profile. There you will find all their shared "
-"programs and much more!"
+"On this page you can look through programs created by other Hedy users. "
+"You can filter on both a Hedy level and adventure. Click on \"View "
+"program\" to open a program and run it. Programs with a red header "
+"contain a mistake. You can still open the program, but running it will "
+"result in an error. You can of course try to fix it! If the creator has a"
+" public profile you can click their username to visit their profile. "
+"There you will find all their shared programs and much more!"
 
 #: templates/explore.html:35 templates/programs.html:27
 #, fuzzy
@@ -1009,8 +965,8 @@ msgstr "Create student accounts"
 #, fuzzy
 msgid "teacher_welcome"
 msgstr ""
-"Welcome to Hedy! Your are now the proud owner of a teachers account which "
-"allows you to create classes and invite students."
+"Welcome to Hedy! Your are now the proud owner of a teachers account which"
+" allows you to create classes and invite students."
 
 #: templates/incl-adventure-tabs.html:22
 #, fuzzy
@@ -1126,9 +1082,9 @@ msgstr "Welcome"
 msgid "intro_text_landing_page"
 msgstr ""
 "Welcome to the wonderful world of Hedy! Here you can learn to program in "
-"small steps, without unnecessary complicated stuff. We start easy at level "
-"1, and slowly build towards bigger and more complex programs! Choose one of "
-"the options below to get started"
+"small steps, without unnecessary complicated stuff. We start easy at "
+"level 1, and slowly build towards bigger and more complex programs! "
+"Choose one of the options below to get started"
 
 #: templates/landing-page.html:14 templates/landing-page.html:36
 #, fuzzy
@@ -1144,14 +1100,14 @@ msgstr "Start programming"
 #: templates/landing-page.html:21
 #, fuzzy
 msgid "create_class_text"
-msgstr ""
-"Group your students into classes and change the content for each class."
+msgstr "Group your students into classes and change the content for each class."
 
 #: templates/landing-page.html:28
 #, fuzzy
 msgid "read_docs_text"
 msgstr ""
-"Visit our teacher's manual for lesson plans and common mistakes by students."
+"Visit our teacher's manual for lesson plans and common mistakes by "
+"students."
 
 #: templates/landing-page.html:30
 #, fuzzy
@@ -1193,49 +1149,14 @@ msgstr "Copiar ligação de partilha"
 #, fuzzy
 msgid "set_preferred_lang"
 msgstr ""
-"Hedy now supports preferred user languages. You can set one for your profile "
-"in \"My profile\""
+"Hedy now supports preferred user languages. You can set one for your "
+"profile in \"My profile\""
 
 #: templates/layout.html:86 templates/quiz/endquiz.html:18
 #: templates/quiz/quiz.html:29
 #, fuzzy
 msgid "achievement_earned"
 msgstr "You've earned an achievement!"
-
-#: templates/learn-more.html:7
-#, fuzzy
-msgid "mailing_title"
-msgstr "Title"
-
-#: templates/learn-more.html:14
-#, fuzzy
-msgid "surname"
-msgstr "Utilizador"
-
-#: templates/learn-more.html:18
-#, fuzzy
-msgid "lastname"
-msgstr "Name"
-
-#: templates/learn-more.html:22 templates/profile.html:135
-#: templates/signup.html:52
-msgid "country"
-msgstr "País"
-
-#: templates/learn-more.html:31
-#, fuzzy
-msgid "subscribe"
-msgstr "Subscreve a nossa newsletter"
-
-#: templates/learn-more.html:32
-#, fuzzy
-msgid "required_field"
-msgstr "Fields marked with an * are required"
-
-#: templates/learn-more.html:35
-#, fuzzy
-msgid "previous_campaigns"
-msgstr "View previous campaigns"
 
 #: templates/level-page.html:8
 msgid "step_title"
@@ -1268,21 +1189,6 @@ msgstr "Criar conta"
 #: templates/login.html:33
 msgid "forgot_password"
 msgstr "Esqueceste-te da palavra-passe?"
-
-#: templates/main-page.html:9
-#, fuzzy
-msgid "main_title"
-msgstr "Title"
-
-#: templates/main-page.html:10
-#, fuzzy
-msgid "main_subtitle"
-msgstr "programs submitted"
-
-#: templates/main-page.html:13
-#, fuzzy
-msgid "try_it"
-msgstr "Experimenta"
 
 #: templates/profile.html:4
 #, fuzzy
@@ -1348,9 +1254,9 @@ msgstr "Favourite program"
 #, fuzzy
 msgid "public_profile_info"
 msgstr ""
-"By selecting this box I make my profile visible for everyone. Be careful not "
-"to share personal information like your name or home address, because "
-"everyone will be able to see it!"
+"By selecting this box I make my profile visible for everyone. Be careful "
+"not to share personal information like your name or home address, because"
+" everyone will be able to see it!"
 
 #: templates/profile.html:59
 #, fuzzy
@@ -1415,6 +1321,10 @@ msgstr "Masculino"
 #: templates/profile.html:131 templates/signup.html:48
 msgid "other"
 msgstr "Outro"
+
+#: templates/profile.html:135 templates/signup.html:52
+msgid "country"
+msgstr "País"
 
 #: templates/profile.html:141
 msgid "update_profile"
@@ -1614,8 +1524,8 @@ msgstr "Já tens uma conta?"
 #, fuzzy
 msgid "teacher_invitation_require_login"
 msgstr ""
-"To set up your profile as a teacher we will need you to log in. If you don't "
-"have an account, please create one."
+"To set up your profile as a teacher we will need you to log in. If you "
+"don't have an account, please create one."
 
 #: templates/view-program-page.html:13
 msgid "by"
@@ -1778,7 +1688,8 @@ msgstr "You have to agree with the privacy terms."
 #, fuzzy
 msgid "keyword_language_invalid"
 msgstr ""
-"Please select a valid keyword language (select English or your own language)."
+"Please select a valid keyword language (select English or your own "
+"language)."
 
 #: website/auth.py:371 website/auth.py:551
 msgid "year_invalid"
@@ -1843,7 +1754,8 @@ msgstr "Profile updated, page will be re-loaded."
 #: website/auth.py:670
 msgid "sent_password_recovery"
 msgstr ""
-"Receberás em breve um email com instruções de como recuperar a palavra-passe."
+"Receberás em breve um email com instruções de como recuperar a palavra-"
+"passe."
 
 #: website/auth.py:681 website/auth.py:691
 #, fuzzy
@@ -1852,8 +1764,7 @@ msgstr "Your token is invalid."
 
 #: website/auth.py:703
 msgid "password_resetted"
-msgstr ""
-"A tua palavra-passe foi reiniciada com sucesso. Por favor, inicia sessão."
+msgstr "A tua palavra-passe foi reiniciada com sucesso. Por favor, inicia sessão."
 
 #: website/auth.py:721
 #, fuzzy
@@ -1868,8 +1779,8 @@ msgstr "Program deleted successfully."
 #: website/programs.py:55
 msgid "save_prompt"
 msgstr ""
-"Precisas de ter uma conta para guardar o teu programa. Queres iniciar sessão "
-"agora?"
+"Precisas de ter uma conta para guardar o teu programa. Queres iniciar "
+"sessão agora?"
 
 #: website/programs.py:60
 #, fuzzy
@@ -2079,3 +1990,61 @@ msgstr "The adventure has been updated!"
 #, fuzzy
 msgid "adventure_empty"
 msgstr "You didn't enter an adventure name!"
+
+#~ msgid "customize_class_exp_1"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_1"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_2"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_3"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_4"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_5"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_6"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_7"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_8"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_exp_2"
+#~ msgstr "Customize class"
+
+#~ msgid "mailing_title"
+#~ msgstr "Title"
+
+#~ msgid "surname"
+#~ msgstr "Utilizador"
+
+#~ msgid "lastname"
+#~ msgstr "Name"
+
+#~ msgid "subscribe"
+#~ msgstr "Subscreve a nossa newsletter"
+
+#~ msgid "required_field"
+#~ msgstr "Fields marked with an * are required"
+
+#~ msgid "previous_campaigns"
+#~ msgstr "View previous campaigns"
+
+#~ msgid "main_title"
+#~ msgstr "Title"
+
+#~ msgid "main_subtitle"
+#~ msgstr "programs submitted"
+
+#~ msgid "try_it"
+#~ msgstr "Experimenta"
+

--- a/translations/sw/LC_MESSAGES/messages.po
+++ b/translations/sw/LC_MESSAGES/messages.po
@@ -1,18 +1,18 @@
+
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-03-29 10:01+0200\n"
+"POT-Creation-Date: 2022-03-30 08:43+0200\n"
 "PO-Revision-Date: 2022-03-30 09:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
-"Language-Team: Swahili <https://hosted.weblate.org/projects/hedy/web-texts/"
-"sw/>\n"
 "Language: sw\n"
+"Language-Team: Swahili <https://hosted.weblate.org/projects/hedy/web-"
+"texts/sw/>\n"
+"Plural-Forms: nplurals=2; plural=n != 1\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.12-dev\n"
 "Generated-By: Babel 2.9.1\n"
 
 #: app.py:571
@@ -20,27 +20,27 @@ msgstr ""
 msgid "program_contains_error"
 msgstr "This program contains an error, are you sure you want to share it?"
 
-#: app.py:723
+#: app.py:722
 #, fuzzy
 msgid "title_achievements"
 msgstr "Hedy - My achievements"
 
-#: app.py:740 app.py:1111 website/teacher.py:365 website/teacher.py:374
+#: app.py:739 app.py:1110 website/teacher.py:365 website/teacher.py:374
 #, fuzzy
 msgid "not_teacher"
 msgstr "Looks like you are not a teacher!"
 
-#: app.py:743
+#: app.py:742
 #, fuzzy
 msgid "not_enrolled"
 msgstr "Looks like you are not in this class!"
 
-#: app.py:775
+#: app.py:774
 #, fuzzy
 msgid "title_programs"
 msgstr "Hedy - My programs"
 
-#: app.py:785 app.py:795 app.py:799 app.py:813 app.py:1054 app.py:1357
+#: app.py:784 app.py:794 app.py:798 app.py:812 app.py:1053 app.py:1356
 #: website/admin.py:17 website/admin.py:25 website/admin.py:95
 #: website/admin.py:112 website/admin.py:130 website/auth.py:711
 #: website/auth.py:738 website/statistics.py:86
@@ -48,122 +48,122 @@ msgstr "Hedy - My programs"
 msgid "unauthorized"
 msgstr "You don't have access rights for this page"
 
-#: app.py:823
+#: app.py:822
 msgid "minutes"
 msgstr "dakika"
 
-#: app.py:826
+#: app.py:825
 msgid "hours"
 msgstr "Saa"
 
-#: app.py:829
+#: app.py:828
 msgid "days"
 msgstr "siku"
 
-#: app.py:832
+#: app.py:831
 #, fuzzy
 msgid "ago"
 msgstr "{time} ago"
 
-#: app.py:848 app.py:850 app.py:976
+#: app.py:847 app.py:849 app.py:975
 #, fuzzy
 msgid "no_such_level"
 msgstr "No such Hedy level!"
 
-#: app.py:858 app.py:865 app.py:931 app.py:937
+#: app.py:857 app.py:864 app.py:930 app.py:936
 #, fuzzy
 msgid "no_such_program"
 msgstr "No such Hedy program!"
 
-#: app.py:891
+#: app.py:890
 #, fuzzy
 msgid "level_not_translated"
 msgstr "This level is not translated in your language (yet)"
 
-#: app.py:893
+#: app.py:892
 #, fuzzy
 msgid "level_not_class"
 msgstr "You're in a class where this level has not been made available yet"
 
-#: app.py:986 website/teacher.py:432 website/teacher.py:448
+#: app.py:985 website/teacher.py:432 website/teacher.py:448
 #: website/teacher.py:477 website/teacher.py:503
 #, fuzzy
 msgid "no_such_adventure"
 msgstr "This adventure doesn't exist!"
 
-#: app.py:1005
+#: app.py:1004
 #, fuzzy
 msgid "page_not_found"
 msgstr "We could not find that page!"
 
-#: app.py:1025
+#: app.py:1024
 #, fuzzy
 msgid "title_signup"
 msgstr "Hedy - Create an account"
 
-#: app.py:1032
+#: app.py:1031
 #, fuzzy
 msgid "title_login"
 msgstr "Hedy - Login"
 
-#: app.py:1039
+#: app.py:1038
 #, fuzzy
 msgid "title_recover"
 msgstr "Hedy - Recover account"
 
-#: app.py:1055
+#: app.py:1054
 #, fuzzy
 msgid "title_reset"
 msgstr "Hedy - Reset password"
 
-#: app.py:1064
+#: app.py:1063
 #, fuzzy
 msgid "title_my-profile"
 msgstr "Hedy - My account"
 
-#: app.py:1078
+#: app.py:1077
 #, fuzzy
 msgid "title_learn-more"
 msgstr "Hedy - Learn more"
 
-#: app.py:1083
+#: app.py:1082
 #, fuzzy
 msgid "title_privacy"
 msgstr "Hedy - Privacy terms"
 
-#: app.py:1090
+#: app.py:1089
 #, fuzzy
 msgid "title_landing-page"
 msgstr "Welcome to Hedy!"
 
-#: app.py:1092
+#: app.py:1091
 #, fuzzy
 msgid "not_user"
 msgstr "Looks like you are not logged in!"
 
-#: app.py:1107
+#: app.py:1106
 #, fuzzy
 msgid "title_for-teacher"
 msgstr "Hedy - For teachers"
 
-#: app.py:1118
+#: app.py:1117
 #, fuzzy
 msgid "title_start"
 msgstr "Hedy - A gradual programming language"
 
-#: app.py:1171
+#: app.py:1170
 #, fuzzy
 msgid "title_explore"
 msgstr "Hedy - Explore"
 
-#: app.py:1190 app.py:1192
+#: app.py:1189 app.py:1191
 #, fuzzy
 msgid "translate_error"
 msgstr ""
-"Something went wrong while translating the code. Try running the code to see "
-"if it has an error. Code with errors can not be translated."
+"Something went wrong while translating the code. Try running the code to "
+"see if it has an error. Code with errors can not be translated."
 
-#: app.py:1301 website/auth.py:299 website/auth.py:347 website/auth.py:483
+#: app.py:1300 website/auth.py:299 website/auth.py:347 website/auth.py:483
 #: website/auth.py:509 website/auth.py:539 website/auth.py:645
 #: website/auth.py:677 website/auth.py:717 website/auth.py:744
 #: website/teacher.py:90 website/teacher.py:125 website/teacher.py:197
@@ -172,37 +172,37 @@ msgstr ""
 msgid "ajax_error"
 msgstr "Kulikuwa na hitilafu, tafadhali jaribu tena."
 
-#: app.py:1304
+#: app.py:1303
 #, fuzzy
 msgid "image_invalid"
 msgstr "Your chosen image is invalid."
 
-#: app.py:1306
+#: app.py:1305
 #, fuzzy
 msgid "personal_text_invalid"
 msgstr "Your personal text is invalid."
 
-#: app.py:1308 app.py:1314
+#: app.py:1307 app.py:1313
 #, fuzzy
 msgid "favourite_program_invalid"
 msgstr "Your chosen favourite program is invalid."
 
-#: app.py:1326 app.py:1327
+#: app.py:1325 app.py:1326
 #, fuzzy
 msgid "public_profile_updated"
 msgstr "Public profile updated."
 
-#: app.py:1361 app.py:1385
+#: app.py:1360 app.py:1384
 #, fuzzy
 msgid "user_not_private"
 msgstr "This user doesn't exist or doesn't have a public profile"
 
-#: app.py:1394
+#: app.py:1393
 #, fuzzy
 msgid "invalid_teacher_invitation_code"
 msgstr ""
-"The teacher invitation code is invalid. To become a teacher, reach out to "
-"hedy@felienne.com."
+"The teacher invitation code is invalid. To become a teacher, reach out to"
+" hedy@felienne.com."
 
 #: utils.py:203
 #, fuzzy
@@ -223,7 +223,8 @@ msgstr "Something went wrong..."
 #, fuzzy
 msgid "Empty Program"
 msgstr ""
-"You created an empty program. Type Hedy code in the left field and try again"
+"You created an empty program. Type Hedy code in the left field and try "
+"again"
 
 #: coursedata/error-messages.txt:2
 msgid "Wrong Level"
@@ -246,52 +247,53 @@ msgstr ""
 #: coursedata/error-messages.txt:5
 msgid "Invalid Space"
 msgstr ""
-"Oops! Ulianza mstari na nafasi(ujazo) katika mstari wa {line_number}. Nafasi "
-"huchanganya kompyuta, unaweza kuiondoa?"
+"Oops! Ulianza mstari na nafasi(ujazo) katika mstari wa {line_number}. "
+"Nafasi huchanganya kompyuta, unaweza kuiondoa?"
 
 #: coursedata/error-messages.txt:6
 #, fuzzy
 msgid "Has Blanks"
 msgstr ""
-"Your code is incomplete. It contains blanks that you have to replace with "
-"code."
+"Your code is incomplete. It contains blanks that you have to replace with"
+" code."
 
 #: coursedata/error-messages.txt:7
 #, fuzzy
 msgid "No Indentation"
 msgstr ""
 "You used too few spaces in line {line_number}. You used {leading_spaces} "
-"spaces, which is not enough. Start every new block with {indent_size} spaces "
-"more than the line before."
+"spaces, which is not enough. Start every new block with {indent_size} "
+"spaces more than the line before."
 
 #: coursedata/error-messages.txt:8
 #, fuzzy
 msgid "Unexpected Indentation"
 msgstr ""
-"You used too many spaces in line {line_number}. You used {leading_spaces} "
-"spaces, which is too much. Start every new block with {indent_size} spaces "
-"more than the line before."
+"You used too many spaces in line {line_number}. You used {leading_spaces}"
+" spaces, which is too much. Start every new block with {indent_size} "
+"spaces more than the line before."
 
 #: coursedata/error-messages.txt:9
 #, fuzzy
 msgid "Parse"
 msgstr ""
 "The code you entered is not valid Hedy code. There is a mistake on line "
-"{location[0]}, at position {location[1]}. You typed {character_found}, but "
-"that is not allowed."
+"{location[0]}, at position {location[1]}. You typed {character_found}, "
+"but that is not allowed."
 
 #: coursedata/error-messages.txt:10
 msgid "Unquoted Text"
 msgstr ""
-"Kuwa makini. Ikiwa unachapisha kitu maandishi yanapaswa kuanza na kumaliza "
-"na alama ya nukuu. Umesahau alamu ya nukuu(funga semi na fungua semi) mahali."
+"Kuwa makini. Ikiwa unachapisha kitu maandishi yanapaswa kuanza na "
+"kumaliza na alama ya nukuu. Umesahau alamu ya nukuu(funga semi na fungua "
+"semi) mahali."
 
 #: coursedata/error-messages.txt:11
 #, fuzzy
 msgid "Unquoted Assignment"
 msgstr ""
-"From this level, you need to place texts to the right of the `is` between "
-"quotes. You forgot that for the text {text}."
+"From this level, you need to place texts to the right of the `is` between"
+" quotes. You forgot that for the text {text}."
 
 #: coursedata/error-messages.txt:12
 #, fuzzy
@@ -308,8 +310,8 @@ msgstr "Umejaribu kuchapisha {name}, lakini hukuiimarisha."
 #, fuzzy
 msgid "Cyclic Var Definition"
 msgstr ""
-"The name {variable} needs to be set before you can use it on the right-hand "
-"side of the is command"
+"The name {variable} needs to be set before you can use it on the right-"
+"hand side of the is command"
 
 #: coursedata/error-messages.txt:15
 #, fuzzy
@@ -322,46 +324,46 @@ msgstr ""
 #, fuzzy
 msgid "Too Big"
 msgstr ""
-"Wow! Your program has an impressive {lines_of_code} lines of code! But we "
-"can only process {max_lines} lines in this level. Make your program smaller "
-"and try again."
+"Wow! Your program has an impressive {lines_of_code} lines of code! But we"
+" can only process {max_lines} lines in this level. Make your program "
+"smaller and try again."
 
 #: coursedata/error-messages.txt:17
 #, fuzzy
 msgid "Invalid Argument Type"
 msgstr ""
-"You cannot use the command {command} with {invalid_argument} because it is "
-"{invalid_type}. Try changing {invalid_argument} to {allowed_types}."
+"You cannot use the command {command} with {invalid_argument} because it "
+"is {invalid_type}. Try changing {invalid_argument} to {allowed_types}."
 
 #: coursedata/error-messages.txt:18
 #, fuzzy
 msgid "Invalid Argument"
 msgstr ""
-"You cannot use the command {command} with {invalid_argument} . Try changing "
-"{invalid_argument} to {allowed_types}."
+"You cannot use the command {command} with {invalid_argument} . Try "
+"changing {invalid_argument} to {allowed_types}."
 
 #: coursedata/error-messages.txt:19
 #, fuzzy
 msgid "Invalid Type Combination"
 msgstr ""
-"You cannot use {invalid_argument} and {invalid_argument_2} in {operation} "
-"because one is {invalid_type} and the other is {invalid_type_2}. Try "
-"changing {invalid_argument} to {invalid_type_2} or {invalid_argument_2} to "
-"{invalid_type}."
+"You cannot use {invalid_argument} and {invalid_argument_2} in {operation}"
+" because one is {invalid_type} and the other is {invalid_type_2}. Try "
+"changing {invalid_argument} to {invalid_type_2} or {invalid_argument_2} "
+"to {invalid_type}."
 
 #: coursedata/error-messages.txt:20
 #, fuzzy
 msgid "Unsupported Float"
 msgstr ""
-"Non-integer numbers are not supported yet but they will be in a few levels. "
-"For now change {value} to an integer."
+"Non-integer numbers are not supported yet but they will be in a few "
+"levels. For now change {value} to an integer."
 
 #: coursedata/error-messages.txt:21
 #, fuzzy
 msgid "Locked Language Feature"
 msgstr ""
-"You are using {concept}! That is awesome, but {concept} is not unlocked yet! "
-"It will be unlocked in a later level."
+"You are using {concept}! That is awesome, but {concept} is not unlocked "
+"yet! It will be unlocked in a later level."
 
 #: coursedata/error-messages.txt:22
 #, fuzzy
@@ -372,15 +374,16 @@ msgstr "It looks like you forgot to use a command on line {line_number}."
 #, fuzzy
 msgid "ask_needs_var"
 msgstr ""
-"Starting in level 2, ask needs to be used with a variable. Example: name is "
-"ask What are you called?"
+"Starting in level 2, ask needs to be used with a variable. Example: name "
+"is ask What are you called?"
 
 #: coursedata/error-messages.txt:24
 #, fuzzy
 msgid "echo_out"
 msgstr ""
-"Starting in level 2 echo is no longer needed. You can repeat an answer with "
-"ask and print now. Example: name is ask What are you called? print hello name"
+"Starting in level 2 echo is no longer needed. You can repeat an answer "
+"with ask and print now. Example: name is ask What are you called? print "
+"hello name"
 
 #: coursedata/error-messages.txt:25
 msgid "space"
@@ -465,6 +468,11 @@ msgstr "a list"
 #, fuzzy
 msgid "input"
 msgstr "input from ask"
+
+#: templates/achievements.html:4
+#, fuzzy
+msgid "achievements_title"
+msgstr "achievements"
 
 #: templates/class-overview.html:16
 #, fuzzy
@@ -635,22 +643,21 @@ msgstr "Do you want to join this class?"
 #: templates/class-prejoin.html:17 website/teacher.py:183
 #, fuzzy
 msgid "join_prompt"
-msgstr ""
-"You need to have an account to join a class. Would you like to login now?"
+msgstr "You need to have an account to join a class. Would you like to login now?"
 
 #: templates/class-prejoin.html:17 templates/profile.html:14
 #, fuzzy
 msgid "join_class"
 msgstr "Join class"
 
-#: templates/class-stats.html:22 templates/customize-class.html:155
+#: templates/class-stats.html:22 templates/customize-class.html:150
 #, fuzzy
 msgid "back_to_class"
 msgstr "Go back to class"
 
 #: templates/code-page.html:25 templates/code-page.html:34
-#: templates/customize-class.html:28 templates/customize-class.html:64
-#: templates/customize-class.html:71 templates/customize-class.html:94
+#: templates/customize-class.html:23 templates/customize-class.html:59
+#: templates/customize-class.html:66 templates/customize-class.html:89
 #: templates/incl-adventure-tabs.html:5 templates/level-page.html:6
 #: templates/level-page.html:11 templates/quiz/startquiz.html:10
 #: templates/view-program-page.html:12 templates/view-program-page.html:28
@@ -666,21 +673,21 @@ msgstr "Create multiple accounts"
 #, fuzzy
 msgid "accounts_intro"
 msgstr ""
-"On this page you can create accounts for multiple students at the same time. "
-"It is also possible to directly add them to one of your classes. By pressing "
-"the green + on the bottom right of the page you can add extra rows. You can "
-"delete a row by pressing the corresponding red cross. Make sure no rows are "
-"empty when you press \"Create accounts\". Please keep in mind that every "
-"username and mail address needs to be unique and the password needs to be "
-"<b>at least</b> 6 characters."
+"On this page you can create accounts for multiple students at the same "
+"time. It is also possible to directly add them to one of your classes. By"
+" pressing the green + on the bottom right of the page you can add extra "
+"rows. You can delete a row by pressing the corresponding red cross. Make "
+"sure no rows are empty when you press \"Create accounts\". Please keep in"
+" mind that every username and mail address needs to be unique and the "
+"password needs to be <b>at least</b> 6 characters."
 
 #: templates/create-accounts.html:10
 #, fuzzy
 msgid "create_accounts_prompt"
 msgstr "Are you sure you want to create these accounts?"
 
-#: templates/create-accounts.html:17 templates/learn-more.html:10
-#: templates/profile.html:96 templates/recover.html:8 templates/signup.html:13
+#: templates/create-accounts.html:17 templates/profile.html:96
+#: templates/recover.html:8 templates/signup.html:13
 msgid "email"
 msgstr "Barua pepe"
 
@@ -736,10 +743,10 @@ msgstr "Kiwango"
 #, fuzzy
 msgid "adventure_exp_1"
 msgstr ""
-"Type your adventure of choice on the right-hand side. After creating your "
-"adventure you can include it in one of your classes under \"customizations"
-"\". If you want to include a command in your adventure please use code "
-"anchors like this:"
+"Type your adventure of choice on the right-hand side. After creating your"
+" adventure you can include it in one of your classes under "
+"\"customizations\". If you want to include a command in your adventure "
+"please use code anchors like this:"
 
 #: templates/customize-adventure.html:31
 #, fuzzy
@@ -753,11 +760,11 @@ msgstr ""
 msgid "adventure_exp_3"
 msgstr ""
 "You can use the \"preview\" button to view a styled version of your "
-"adventure. To view the adventure on a dedicated page, select \"view\" from "
-"the teachers page."
+"adventure. To view the adventure on a dedicated page, select \"view\" "
+"from the teachers page."
 
-#: templates/customize-adventure.html:43 templates/customize-class.html:28
-#: templates/customize-class.html:93 templates/explore.html:26
+#: templates/customize-adventure.html:43 templates/customize-class.html:23
+#: templates/customize-class.html:88 templates/explore.html:26
 #: templates/programs.html:18 templates/programs.html:48
 #: templates/view-adventure.html:6
 #, fuzzy
@@ -788,7 +795,7 @@ msgstr "I agree that my adventure might be made publicly available on Hedy."
 msgid "preview"
 msgstr "Preview"
 
-#: templates/customize-adventure.html:51 templates/customize-class.html:150
+#: templates/customize-adventure.html:51 templates/customize-class.html:145
 #, fuzzy
 msgid "save"
 msgstr "Save"
@@ -798,128 +805,78 @@ msgstr "Save"
 msgid "delete_adventure_prompt"
 msgstr "Are you sure you want to remove this adventure?"
 
-#: templates/customize-class.html:7
-#, fuzzy
-msgid "customize_class_exp_1"
-msgstr "Customize class"
-
-#: templates/customize-class.html:10
-#, fuzzy
-msgid "customize_class_step_1"
-msgstr "Customize class"
-
-#: templates/customize-class.html:11
-#, fuzzy
-msgid "customize_class_step_2"
-msgstr "Customize class"
-
-#: templates/customize-class.html:12
-#, fuzzy
-msgid "customize_class_step_3"
-msgstr "Customize class"
-
-#: templates/customize-class.html:13
-#, fuzzy
-msgid "customize_class_step_4"
-msgstr "Customize class"
-
-#: templates/customize-class.html:14
-#, fuzzy
-msgid "customize_class_step_5"
-msgstr "Customize class"
-
-#: templates/customize-class.html:15
-#, fuzzy
-msgid "customize_class_step_6"
-msgstr "Customize class"
-
-#: templates/customize-class.html:16
-#, fuzzy
-msgid "customize_class_step_7"
-msgstr "Customize class"
-
-#: templates/customize-class.html:17
-#, fuzzy
-msgid "customize_class_step_8"
-msgstr "Customize class"
-
-#: templates/customize-class.html:20
-#, fuzzy
-msgid "customize_class_exp_2"
-msgstr "Customize class"
-
-#: templates/customize-class.html:23
+#: templates/customize-class.html:18
 #, fuzzy
 msgid "select_adventures"
 msgstr "Select adventures"
 
-#: templates/customize-class.html:59
+#: templates/customize-class.html:54
 #, fuzzy
 msgid "opening_dates"
 msgstr "Opening dates"
 
-#: templates/customize-class.html:65
+#: templates/customize-class.html:60
 #, fuzzy
 msgid "opening_date"
 msgstr "Opening date"
 
-#: templates/customize-class.html:77
+#: templates/customize-class.html:72
 #, fuzzy
 msgid "directly_available"
 msgstr "Directly open"
 
-#: templates/customize-class.html:88
+#: templates/customize-class.html:83
 #, fuzzy
 msgid "select_own_adventures"
 msgstr "Select own adventures"
 
-#: templates/customize-class.html:95 templates/customize-class.html:121
+#: templates/customize-class.html:90 templates/customize-class.html:116
 #: templates/profile.html:47 templates/profile.html:128
 #: templates/profile.html:137 templates/signup.html:26 templates/signup.html:45
 #: templates/signup.html:53
 msgid "select"
 msgstr "Chagua"
 
-#: templates/customize-class.html:115
+#: templates/customize-class.html:110
 #, fuzzy
 msgid "other_settings"
 msgstr "Other settings"
 
-#: templates/customize-class.html:120
+#: templates/customize-class.html:115
 #, fuzzy
 msgid "option"
 msgstr "Option"
 
-#: templates/customize-class.html:126
+#: templates/customize-class.html:121
 #, fuzzy
 msgid "mandatory_mode"
 msgstr "Mandatory developer's mode"
 
-#: templates/customize-class.html:132
+#: templates/customize-class.html:127
 #, fuzzy
 msgid "hide_cheatsheet"
 msgstr "Hide cheatsheet"
 
-#: templates/customize-class.html:138
+#: templates/customize-class.html:133
 msgid "hide_keyword_switcher"
 msgstr ""
 
-#: templates/customize-class.html:149
+#: templates/customize-class.html:144
 #, fuzzy
 msgid "reset_adventure_prompt"
 msgstr "Are you sure you want to reset all selected adventures?"
 
-#: templates/customize-class.html:149
+#: templates/customize-class.html:144
 #, fuzzy
 msgid "reset_adventures"
 msgstr "Reset selected adventures"
 
-#: templates/customize-class.html:153
+#: templates/customize-class.html:148
 #, fuzzy
 msgid "remove_customizations_prompt"
 msgstr "Are you sure you want to remove this class their customizations?"
 
-#: templates/customize-class.html:154
+#: templates/customize-class.html:149
 #, fuzzy
 msgid "remove_customization"
 msgstr "Remove customization"
@@ -938,13 +895,13 @@ msgstr "Explore programs"
 #, fuzzy
 msgid "explore_explanation"
 msgstr ""
-"On this page you can look through programs created by other Hedy users. You "
-"can filter on both a Hedy level and adventure. Click on \"View program\" to "
-"open a program and run it. Programs with a red header contain a mistake. You "
-"can still open the program, but running it will result in an error. You can "
-"of course try to fix it! If the creator has a public profile you can click "
-"their username to visit their profile. There you will find all their shared "
-"programs and much more!"
+"On this page you can look through programs created by other Hedy users. "
+"You can filter on both a Hedy level and adventure. Click on \"View "
+"program\" to open a program and run it. Programs with a red header "
+"contain a mistake. You can still open the program, but running it will "
+"result in an error. You can of course try to fix it! If the creator has a"
+" public profile you can click their username to visit their profile. "
+"There you will find all their shared programs and much more!"
 
 #: templates/explore.html:35 templates/programs.html:27
 #, fuzzy
@@ -1011,8 +968,8 @@ msgstr "Create student accounts"
 #, fuzzy
 msgid "teacher_welcome"
 msgstr ""
-"Welcome to Hedy! Your are now the proud owner of a teachers account which "
-"allows you to create classes and invite students."
+"Welcome to Hedy! Your are now the proud owner of a teachers account which"
+" allows you to create classes and invite students."
 
 #: templates/incl-adventure-tabs.html:22
 #, fuzzy
@@ -1125,9 +1082,9 @@ msgstr "Welcome"
 msgid "intro_text_landing_page"
 msgstr ""
 "Welcome to the wonderful world of Hedy! Here you can learn to program in "
-"small steps, without unnecessary complicated stuff. We start easy at level "
-"1, and slowly build towards bigger and more complex programs! Choose one of "
-"the options below to get started"
+"small steps, without unnecessary complicated stuff. We start easy at "
+"level 1, and slowly build towards bigger and more complex programs! "
+"Choose one of the options below to get started"
 
 #: templates/landing-page.html:14 templates/landing-page.html:36
 #, fuzzy
@@ -1143,14 +1100,14 @@ msgstr "Start programming"
 #: templates/landing-page.html:21
 #, fuzzy
 msgid "create_class_text"
-msgstr ""
-"Group your students into classes and change the content for each class."
+msgstr "Group your students into classes and change the content for each class."
 
 #: templates/landing-page.html:28
 #, fuzzy
 msgid "read_docs_text"
 msgstr ""
-"Visit our teacher's manual for lesson plans and common mistakes by students."
+"Visit our teacher's manual for lesson plans and common mistakes by "
+"students."
 
 #: templates/landing-page.html:30
 #, fuzzy
@@ -1197,49 +1154,14 @@ msgstr "Copy link to share"
 #, fuzzy
 msgid "set_preferred_lang"
 msgstr ""
-"Hedy now supports preferred user languages. You can set one for your profile "
-"in \"My profile\""
+"Hedy now supports preferred user languages. You can set one for your "
+"profile in \"My profile\""
 
 #: templates/layout.html:86 templates/quiz/endquiz.html:18
 #: templates/quiz/quiz.html:29
 #, fuzzy
 msgid "achievement_earned"
 msgstr "You've earned an achievement!"
-
-#: templates/learn-more.html:7
-#, fuzzy
-msgid "mailing_title"
-msgstr "Hedy"
-
-#: templates/learn-more.html:14
-#, fuzzy
-msgid "surname"
-msgstr "Jina la mtumiaji"
-
-#: templates/learn-more.html:18
-#, fuzzy
-msgid "lastname"
-msgstr "Name"
-
-#: templates/learn-more.html:22 templates/profile.html:135
-#: templates/signup.html:52
-msgid "country"
-msgstr "Nchi"
-
-#: templates/learn-more.html:31
-#, fuzzy
-msgid "subscribe"
-msgstr "Jisajili kwa jarida"
-
-#: templates/learn-more.html:32
-#, fuzzy
-msgid "required_field"
-msgstr "Fields marked with an * are required"
-
-#: templates/learn-more.html:35
-#, fuzzy
-msgid "previous_campaigns"
-msgstr "View previous campaigns"
 
 #: templates/level-page.html:8
 msgid "step_title"
@@ -1273,18 +1195,6 @@ msgstr "Fungua Akaunti"
 #: templates/login.html:33
 msgid "forgot_password"
 msgstr "Umesahau nenosiri yako?"
-
-#: templates/main-page.html:9
-msgid "main_title"
-msgstr "Hedy"
-
-#: templates/main-page.html:10
-msgid "main_subtitle"
-msgstr "A gradual programming language"
-
-#: templates/main-page.html:13
-msgid "try_it"
-msgstr "Jaribu"
 
 #: templates/profile.html:4
 #, fuzzy
@@ -1350,9 +1260,9 @@ msgstr "Favourite program"
 #, fuzzy
 msgid "public_profile_info"
 msgstr ""
-"By selecting this box I make my profile visible for everyone. Be careful not "
-"to share personal information like your name or home address, because "
-"everyone will be able to see it!"
+"By selecting this box I make my profile visible for everyone. Be careful "
+"not to share personal information like your name or home address, because"
+" everyone will be able to see it!"
 
 #: templates/profile.html:59
 #, fuzzy
@@ -1417,6 +1327,10 @@ msgstr "Mwanaume"
 #: templates/profile.html:131 templates/signup.html:48
 msgid "other"
 msgstr "Nyingine"
+
+#: templates/profile.html:135 templates/signup.html:52
+msgid "country"
+msgstr "Nchi"
 
 #: templates/profile.html:141
 msgid "update_profile"
@@ -1625,8 +1539,8 @@ msgstr "Tayari una akaunti?"
 #, fuzzy
 msgid "teacher_invitation_require_login"
 msgstr ""
-"To set up your profile as a teacher we will need you to log in. If you don't "
-"have an account, please create one."
+"To set up your profile as a teacher we will need you to log in. If you "
+"don't have an account, please create one."
 
 #: templates/view-program-page.html:13
 #, fuzzy
@@ -1789,7 +1703,8 @@ msgstr "You have to agree with the privacy terms."
 #, fuzzy
 msgid "keyword_language_invalid"
 msgstr ""
-"Please select a valid keyword language (select English or your own language)."
+"Please select a valid keyword language (select English or your own "
+"language)."
 
 #: website/auth.py:371 website/auth.py:551
 #, fuzzy
@@ -1877,8 +1792,7 @@ msgstr "Program deleted successfully."
 
 #: website/programs.py:55
 msgid "save_prompt"
-msgstr ""
-"Unahitaji kuwa na akaunti kuokoa programu yako. Je! Ungependa login sasa?"
+msgstr "Unahitaji kuwa na akaunti kuokoa programu yako. Je! Ungependa login sasa?"
 
 #: website/programs.py:60
 #, fuzzy
@@ -2090,3 +2004,61 @@ msgstr "The adventure has been updated!"
 #, fuzzy
 msgid "adventure_empty"
 msgstr "You didn't enter an adventure name!"
+
+#~ msgid "customize_class_exp_1"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_1"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_2"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_3"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_4"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_5"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_6"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_7"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_8"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_exp_2"
+#~ msgstr "Customize class"
+
+#~ msgid "mailing_title"
+#~ msgstr "Hedy"
+
+#~ msgid "surname"
+#~ msgstr "Jina la mtumiaji"
+
+#~ msgid "lastname"
+#~ msgstr "Name"
+
+#~ msgid "subscribe"
+#~ msgstr "Jisajili kwa jarida"
+
+#~ msgid "required_field"
+#~ msgstr "Fields marked with an * are required"
+
+#~ msgid "previous_campaigns"
+#~ msgstr "View previous campaigns"
+
+#~ msgid "main_title"
+#~ msgstr "Hedy"
+
+#~ msgid "main_subtitle"
+#~ msgstr "A gradual programming language"
+
+#~ msgid "try_it"
+#~ msgstr "Jaribu"
+

--- a/translations/tr/LC_MESSAGES/messages.po
+++ b/translations/tr/LC_MESSAGES/messages.po
@@ -1,18 +1,18 @@
+
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-03-29 10:01+0200\n"
+"POT-Creation-Date: 2022-03-30 08:43+0200\n"
 "PO-Revision-Date: 2022-03-30 09:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
-"Language-Team: Turkish <https://hosted.weblate.org/projects/hedy/web-texts/"
-"tr/>\n"
 "Language: tr\n"
+"Language-Team: Turkish <https://hosted.weblate.org/projects/hedy/web-"
+"texts/tr/>\n"
+"Plural-Forms: nplurals=1; plural=0\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: Weblate 4.12-dev\n"
 "Generated-By: Babel 2.9.1\n"
 
 #: app.py:571
@@ -20,27 +20,27 @@ msgstr ""
 msgid "program_contains_error"
 msgstr "This program contains an error, are you sure you want to share it?"
 
-#: app.py:723
+#: app.py:722
 #, fuzzy
 msgid "title_achievements"
 msgstr "Hedy - My achievements"
 
-#: app.py:740 app.py:1111 website/teacher.py:365 website/teacher.py:374
+#: app.py:739 app.py:1110 website/teacher.py:365 website/teacher.py:374
 #, fuzzy
 msgid "not_teacher"
 msgstr "Looks like you are not a teacher!"
 
-#: app.py:743
+#: app.py:742
 #, fuzzy
 msgid "not_enrolled"
 msgstr "Looks like you are not in this class!"
 
-#: app.py:775
+#: app.py:774
 #, fuzzy
 msgid "title_programs"
 msgstr "Hedy - My programs"
 
-#: app.py:785 app.py:795 app.py:799 app.py:813 app.py:1054 app.py:1357
+#: app.py:784 app.py:794 app.py:798 app.py:812 app.py:1053 app.py:1356
 #: website/admin.py:17 website/admin.py:25 website/admin.py:95
 #: website/admin.py:112 website/admin.py:130 website/auth.py:711
 #: website/auth.py:738 website/statistics.py:86
@@ -48,125 +48,125 @@ msgstr "Hedy - My programs"
 msgid "unauthorized"
 msgstr "You don't have access rights for this page"
 
-#: app.py:823
+#: app.py:822
 #, fuzzy
 msgid "minutes"
 msgstr "minutes"
 
-#: app.py:826
+#: app.py:825
 #, fuzzy
 msgid "hours"
 msgstr "hours"
 
-#: app.py:829
+#: app.py:828
 #, fuzzy
 msgid "days"
 msgstr "days"
 
-#: app.py:832
+#: app.py:831
 #, fuzzy
 msgid "ago"
 msgstr "{time} ago"
 
-#: app.py:848 app.py:850 app.py:976
+#: app.py:847 app.py:849 app.py:975
 #, fuzzy
 msgid "no_such_level"
 msgstr "No such Hedy level!"
 
-#: app.py:858 app.py:865 app.py:931 app.py:937
+#: app.py:857 app.py:864 app.py:930 app.py:936
 #, fuzzy
 msgid "no_such_program"
 msgstr "No such Hedy program!"
 
-#: app.py:891
+#: app.py:890
 #, fuzzy
 msgid "level_not_translated"
 msgstr "This level is not translated in your language (yet)"
 
-#: app.py:893
+#: app.py:892
 #, fuzzy
 msgid "level_not_class"
 msgstr "You're in a class where this level has not been made available yet"
 
-#: app.py:986 website/teacher.py:432 website/teacher.py:448
+#: app.py:985 website/teacher.py:432 website/teacher.py:448
 #: website/teacher.py:477 website/teacher.py:503
 #, fuzzy
 msgid "no_such_adventure"
 msgstr "This adventure doesn't exist!"
 
-#: app.py:1005
+#: app.py:1004
 #, fuzzy
 msgid "page_not_found"
 msgstr "We could not find that page!"
 
-#: app.py:1025
+#: app.py:1024
 #, fuzzy
 msgid "title_signup"
 msgstr "Hedy - Create an account"
 
-#: app.py:1032
+#: app.py:1031
 #, fuzzy
 msgid "title_login"
 msgstr "Hedy - Login"
 
-#: app.py:1039
+#: app.py:1038
 #, fuzzy
 msgid "title_recover"
 msgstr "Hedy - Recover account"
 
-#: app.py:1055
+#: app.py:1054
 #, fuzzy
 msgid "title_reset"
 msgstr "Hedy - Reset password"
 
-#: app.py:1064
+#: app.py:1063
 #, fuzzy
 msgid "title_my-profile"
 msgstr "Hedy - My account"
 
-#: app.py:1078
+#: app.py:1077
 #, fuzzy
 msgid "title_learn-more"
 msgstr "Hedy - Learn more"
 
-#: app.py:1083
+#: app.py:1082
 #, fuzzy
 msgid "title_privacy"
 msgstr "Hedy - Privacy terms"
 
-#: app.py:1090
+#: app.py:1089
 #, fuzzy
 msgid "title_landing-page"
 msgstr "Welcome to Hedy!"
 
-#: app.py:1092
+#: app.py:1091
 #, fuzzy
 msgid "not_user"
 msgstr "Looks like you are not logged in!"
 
-#: app.py:1107
+#: app.py:1106
 #, fuzzy
 msgid "title_for-teacher"
 msgstr "Hedy - For teachers"
 
-#: app.py:1118
+#: app.py:1117
 #, fuzzy
 msgid "title_start"
 msgstr "Hedy - A gradual programming language"
 
-#: app.py:1171
+#: app.py:1170
 #, fuzzy
 msgid "title_explore"
 msgstr "Hedy - Explore"
 
-#: app.py:1190 app.py:1192
+#: app.py:1189 app.py:1191
 #, fuzzy
 msgid "translate_error"
 msgstr ""
-"Something went wrong while translating the code. Try running the code to see "
-"if it has an error. Code with errors can not be translated."
+"Something went wrong while translating the code. Try running the code to "
+"see if it has an error. Code with errors can not be translated."
 
-#: app.py:1301 website/auth.py:299 website/auth.py:347 website/auth.py:483
+#: app.py:1300 website/auth.py:299 website/auth.py:347 website/auth.py:483
 #: website/auth.py:509 website/auth.py:539 website/auth.py:645
 #: website/auth.py:677 website/auth.py:717 website/auth.py:744
 #: website/teacher.py:90 website/teacher.py:125 website/teacher.py:197
@@ -176,37 +176,37 @@ msgstr ""
 msgid "ajax_error"
 msgstr "There was an error, please try again."
 
-#: app.py:1304
+#: app.py:1303
 #, fuzzy
 msgid "image_invalid"
 msgstr "Your chosen image is invalid."
 
-#: app.py:1306
+#: app.py:1305
 #, fuzzy
 msgid "personal_text_invalid"
 msgstr "Your personal text is invalid."
 
-#: app.py:1308 app.py:1314
+#: app.py:1307 app.py:1313
 #, fuzzy
 msgid "favourite_program_invalid"
 msgstr "Your chosen favourite program is invalid."
 
-#: app.py:1326 app.py:1327
+#: app.py:1325 app.py:1326
 #, fuzzy
 msgid "public_profile_updated"
 msgstr "Public profile updated."
 
-#: app.py:1361 app.py:1385
+#: app.py:1360 app.py:1384
 #, fuzzy
 msgid "user_not_private"
 msgstr "This user doesn't exist or doesn't have a public profile"
 
-#: app.py:1394
+#: app.py:1393
 #, fuzzy
 msgid "invalid_teacher_invitation_code"
 msgstr ""
-"The teacher invitation code is invalid. To become a teacher, reach out to "
-"hedy@felienne.com."
+"The teacher invitation code is invalid. To become a teacher, reach out to"
+" hedy@felienne.com."
 
 #: utils.py:203
 #, fuzzy
@@ -227,7 +227,8 @@ msgstr "Something went wrong..."
 #, fuzzy
 msgid "Empty Program"
 msgstr ""
-"You created an empty program. Type Hedy code in the left field and try again"
+"You created an empty program. Type Hedy code in the left field and try "
+"again"
 
 #: coursedata/error-messages.txt:2
 #, fuzzy
@@ -254,53 +255,53 @@ msgstr ""
 #, fuzzy
 msgid "Invalid Space"
 msgstr ""
-"Oops! You started a line with a space on line {line_number}. Spaces confuse "
-"computers, can you remove it?"
+"Oops! You started a line with a space on line {line_number}. Spaces "
+"confuse computers, can you remove it?"
 
 #: coursedata/error-messages.txt:6
 #, fuzzy
 msgid "Has Blanks"
 msgstr ""
-"Your code is incomplete. It contains blanks that you have to replace with "
-"code."
+"Your code is incomplete. It contains blanks that you have to replace with"
+" code."
 
 #: coursedata/error-messages.txt:7
 #, fuzzy
 msgid "No Indentation"
 msgstr ""
 "You used too few spaces in line {line_number}. You used {leading_spaces} "
-"spaces, which is not enough. Start every new block with {indent_size} spaces "
-"more than the line before."
+"spaces, which is not enough. Start every new block with {indent_size} "
+"spaces more than the line before."
 
 #: coursedata/error-messages.txt:8
 #, fuzzy
 msgid "Unexpected Indentation"
 msgstr ""
-"You used too many spaces in line {line_number}. You used {leading_spaces} "
-"spaces, which is too much. Start every new block with {indent_size} spaces "
-"more than the line before."
+"You used too many spaces in line {line_number}. You used {leading_spaces}"
+" spaces, which is too much. Start every new block with {indent_size} "
+"spaces more than the line before."
 
 #: coursedata/error-messages.txt:9
 #, fuzzy
 msgid "Parse"
 msgstr ""
 "The code you entered is not valid Hedy code. There is a mistake on line "
-"{location[0]}, at position {location[1]}. You typed {character_found}, but "
-"that is not allowed."
+"{location[0]}, at position {location[1]}. You typed {character_found}, "
+"but that is not allowed."
 
 #: coursedata/error-messages.txt:10
 #, fuzzy
 msgid "Unquoted Text"
 msgstr ""
-"Be careful. If you ask or print something the text should start and finish "
-"with a quotation mark. You forgot one somewhere."
+"Be careful. If you ask or print something the text should start and "
+"finish with a quotation mark. You forgot one somewhere."
 
 #: coursedata/error-messages.txt:11
 #, fuzzy
 msgid "Unquoted Assignment"
 msgstr ""
-"From this level, you need to place texts to the right of the `is` between "
-"quotes. You forgot that for the text {text}."
+"From this level, you need to place texts to the right of the `is` between"
+" quotes. You forgot that for the text {text}."
 
 #: coursedata/error-messages.txt:12
 #, fuzzy
@@ -314,15 +315,15 @@ msgstr ""
 msgid "Var Undefined"
 msgstr ""
 "You tried to use the variable {name}, but you did not set it. It is also "
-"possible that you were trying to use the word {name} but forgot quotation "
-"marks."
+"possible that you were trying to use the word {name} but forgot quotation"
+" marks."
 
 #: coursedata/error-messages.txt:14
 #, fuzzy
 msgid "Cyclic Var Definition"
 msgstr ""
-"The name {variable} needs to be set before you can use it on the right-hand "
-"side of the is command"
+"The name {variable} needs to be set before you can use it on the right-"
+"hand side of the is command"
 
 #: coursedata/error-messages.txt:15
 #, fuzzy
@@ -335,46 +336,46 @@ msgstr ""
 #, fuzzy
 msgid "Too Big"
 msgstr ""
-"Wow! Your program has an impressive {lines_of_code} lines of code! But we "
-"can only process {max_lines} lines in this level. Make your program smaller "
-"and try again."
+"Wow! Your program has an impressive {lines_of_code} lines of code! But we"
+" can only process {max_lines} lines in this level. Make your program "
+"smaller and try again."
 
 #: coursedata/error-messages.txt:17
 #, fuzzy
 msgid "Invalid Argument Type"
 msgstr ""
-"You cannot use the command {command} with {invalid_argument} because it is "
-"{invalid_type}. Try changing {invalid_argument} to {allowed_types}."
+"You cannot use the command {command} with {invalid_argument} because it "
+"is {invalid_type}. Try changing {invalid_argument} to {allowed_types}."
 
 #: coursedata/error-messages.txt:18
 #, fuzzy
 msgid "Invalid Argument"
 msgstr ""
-"You cannot use the command {command} with {invalid_argument} . Try changing "
-"{invalid_argument} to {allowed_types}."
+"You cannot use the command {command} with {invalid_argument} . Try "
+"changing {invalid_argument} to {allowed_types}."
 
 #: coursedata/error-messages.txt:19
 #, fuzzy
 msgid "Invalid Type Combination"
 msgstr ""
-"You cannot use {invalid_argument} and {invalid_argument_2} in {operation} "
-"because one is {invalid_type} and the other is {invalid_type_2}. Try "
-"changing {invalid_argument} to {invalid_type_2} or {invalid_argument_2} to "
-"{invalid_type}."
+"You cannot use {invalid_argument} and {invalid_argument_2} in {operation}"
+" because one is {invalid_type} and the other is {invalid_type_2}. Try "
+"changing {invalid_argument} to {invalid_type_2} or {invalid_argument_2} "
+"to {invalid_type}."
 
 #: coursedata/error-messages.txt:20
 #, fuzzy
 msgid "Unsupported Float"
 msgstr ""
-"Non-integer numbers are not supported yet but they will be in a few levels. "
-"For now change {value} to an integer."
+"Non-integer numbers are not supported yet but they will be in a few "
+"levels. For now change {value} to an integer."
 
 #: coursedata/error-messages.txt:21
 #, fuzzy
 msgid "Locked Language Feature"
 msgstr ""
-"You are using {concept}! That is awesome, but {concept} is not unlocked yet! "
-"It will be unlocked in a later level."
+"You are using {concept}! That is awesome, but {concept} is not unlocked "
+"yet! It will be unlocked in a later level."
 
 #: coursedata/error-messages.txt:22
 #, fuzzy
@@ -385,15 +386,16 @@ msgstr "It looks like you forgot to use a command on line {line_number}."
 #, fuzzy
 msgid "ask_needs_var"
 msgstr ""
-"Starting in level 2, ask needs to be used with a variable. Example: name is "
-"ask What are you called?"
+"Starting in level 2, ask needs to be used with a variable. Example: name "
+"is ask What are you called?"
 
 #: coursedata/error-messages.txt:24
 #, fuzzy
 msgid "echo_out"
 msgstr ""
-"Starting in level 2 echo is no longer needed. You can repeat an answer with "
-"ask and print now. Example: name is ask What are you called? print hello name"
+"Starting in level 2 echo is no longer needed. You can repeat an answer "
+"with ask and print now. Example: name is ask What are you called? print "
+"hello name"
 
 #: coursedata/error-messages.txt:25
 #, fuzzy
@@ -489,6 +491,11 @@ msgstr "a list"
 #, fuzzy
 msgid "input"
 msgstr "input from ask"
+
+#: templates/achievements.html:4
+#, fuzzy
+msgid "achievements_title"
+msgstr "achievements"
 
 #: templates/class-overview.html:16
 #, fuzzy
@@ -660,22 +667,21 @@ msgstr "Do you want to join this class?"
 #: templates/class-prejoin.html:17 website/teacher.py:183
 #, fuzzy
 msgid "join_prompt"
-msgstr ""
-"You need to have an account to join a class. Would you like to login now?"
+msgstr "You need to have an account to join a class. Would you like to login now?"
 
 #: templates/class-prejoin.html:17 templates/profile.html:14
 #, fuzzy
 msgid "join_class"
 msgstr "Join class"
 
-#: templates/class-stats.html:22 templates/customize-class.html:155
+#: templates/class-stats.html:22 templates/customize-class.html:150
 #, fuzzy
 msgid "back_to_class"
 msgstr "Go back to class"
 
 #: templates/code-page.html:25 templates/code-page.html:34
-#: templates/customize-class.html:28 templates/customize-class.html:64
-#: templates/customize-class.html:71 templates/customize-class.html:94
+#: templates/customize-class.html:23 templates/customize-class.html:59
+#: templates/customize-class.html:66 templates/customize-class.html:89
 #: templates/incl-adventure-tabs.html:5 templates/level-page.html:6
 #: templates/level-page.html:11 templates/quiz/startquiz.html:10
 #: templates/view-program-page.html:12 templates/view-program-page.html:28
@@ -692,21 +698,21 @@ msgstr "Create multiple accounts"
 #, fuzzy
 msgid "accounts_intro"
 msgstr ""
-"On this page you can create accounts for multiple students at the same time. "
-"It is also possible to directly add them to one of your classes. By pressing "
-"the green + on the bottom right of the page you can add extra rows. You can "
-"delete a row by pressing the corresponding red cross. Make sure no rows are "
-"empty when you press \"Create accounts\". Please keep in mind that every "
-"username and mail address needs to be unique and the password needs to be "
-"<b>at least</b> 6 characters."
+"On this page you can create accounts for multiple students at the same "
+"time. It is also possible to directly add them to one of your classes. By"
+" pressing the green + on the bottom right of the page you can add extra "
+"rows. You can delete a row by pressing the corresponding red cross. Make "
+"sure no rows are empty when you press \"Create accounts\". Please keep in"
+" mind that every username and mail address needs to be unique and the "
+"password needs to be <b>at least</b> 6 characters."
 
 #: templates/create-accounts.html:10
 #, fuzzy
 msgid "create_accounts_prompt"
 msgstr "Are you sure you want to create these accounts?"
 
-#: templates/create-accounts.html:17 templates/learn-more.html:10
-#: templates/profile.html:96 templates/recover.html:8 templates/signup.html:13
+#: templates/create-accounts.html:17 templates/profile.html:96
+#: templates/recover.html:8 templates/signup.html:13
 #, fuzzy
 msgid "email"
 msgstr "Email"
@@ -764,10 +770,10 @@ msgstr "Level"
 #, fuzzy
 msgid "adventure_exp_1"
 msgstr ""
-"Type your adventure of choice on the right-hand side. After creating your "
-"adventure you can include it in one of your classes under \"customizations"
-"\". If you want to include a command in your adventure please use code "
-"anchors like this:"
+"Type your adventure of choice on the right-hand side. After creating your"
+" adventure you can include it in one of your classes under "
+"\"customizations\". If you want to include a command in your adventure "
+"please use code anchors like this:"
 
 #: templates/customize-adventure.html:31
 #, fuzzy
@@ -781,11 +787,11 @@ msgstr ""
 msgid "adventure_exp_3"
 msgstr ""
 "You can use the \"preview\" button to view a styled version of your "
-"adventure. To view the adventure on a dedicated page, select \"view\" from "
-"the teachers page."
+"adventure. To view the adventure on a dedicated page, select \"view\" "
+"from the teachers page."
 
-#: templates/customize-adventure.html:43 templates/customize-class.html:28
-#: templates/customize-class.html:93 templates/explore.html:26
+#: templates/customize-adventure.html:43 templates/customize-class.html:23
+#: templates/customize-class.html:88 templates/explore.html:26
 #: templates/programs.html:18 templates/programs.html:48
 #: templates/view-adventure.html:6
 #, fuzzy
@@ -816,7 +822,7 @@ msgstr "I agree that my adventure might be made publicly available on Hedy."
 msgid "preview"
 msgstr "Preview"
 
-#: templates/customize-adventure.html:51 templates/customize-class.html:150
+#: templates/customize-adventure.html:51 templates/customize-class.html:145
 #, fuzzy
 msgid "save"
 msgstr "Save"
@@ -826,82 +832,32 @@ msgstr "Save"
 msgid "delete_adventure_prompt"
 msgstr "Are you sure you want to remove this adventure?"
 
-#: templates/customize-class.html:7
-#, fuzzy
-msgid "customize_class_exp_1"
-msgstr "Customize class"
-
-#: templates/customize-class.html:10
-#, fuzzy
-msgid "customize_class_step_1"
-msgstr "Customize class"
-
-#: templates/customize-class.html:11
-#, fuzzy
-msgid "customize_class_step_2"
-msgstr "Customize class"
-
-#: templates/customize-class.html:12
-#, fuzzy
-msgid "customize_class_step_3"
-msgstr "Customize class"
-
-#: templates/customize-class.html:13
-#, fuzzy
-msgid "customize_class_step_4"
-msgstr "Customize class"
-
-#: templates/customize-class.html:14
-#, fuzzy
-msgid "customize_class_step_5"
-msgstr "Customize class"
-
-#: templates/customize-class.html:15
-#, fuzzy
-msgid "customize_class_step_6"
-msgstr "Customize class"
-
-#: templates/customize-class.html:16
-#, fuzzy
-msgid "customize_class_step_7"
-msgstr "Customize class"
-
-#: templates/customize-class.html:17
-#, fuzzy
-msgid "customize_class_step_8"
-msgstr "Customize class"
-
-#: templates/customize-class.html:20
-#, fuzzy
-msgid "customize_class_exp_2"
-msgstr "Customize class"
-
-#: templates/customize-class.html:23
+#: templates/customize-class.html:18
 #, fuzzy
 msgid "select_adventures"
 msgstr "Select adventures"
 
-#: templates/customize-class.html:59
+#: templates/customize-class.html:54
 #, fuzzy
 msgid "opening_dates"
 msgstr "Opening dates"
 
-#: templates/customize-class.html:65
+#: templates/customize-class.html:60
 #, fuzzy
 msgid "opening_date"
 msgstr "Opening date"
 
-#: templates/customize-class.html:77
+#: templates/customize-class.html:72
 #, fuzzy
 msgid "directly_available"
 msgstr "Directly open"
 
-#: templates/customize-class.html:88
+#: templates/customize-class.html:83
 #, fuzzy
 msgid "select_own_adventures"
 msgstr "Select own adventures"
 
-#: templates/customize-class.html:95 templates/customize-class.html:121
+#: templates/customize-class.html:90 templates/customize-class.html:116
 #: templates/profile.html:47 templates/profile.html:128
 #: templates/profile.html:137 templates/signup.html:26 templates/signup.html:45
 #: templates/signup.html:53
@@ -909,46 +865,46 @@ msgstr "Select own adventures"
 msgid "select"
 msgstr "Select"
 
-#: templates/customize-class.html:115
+#: templates/customize-class.html:110
 #, fuzzy
 msgid "other_settings"
 msgstr "Other settings"
 
-#: templates/customize-class.html:120
+#: templates/customize-class.html:115
 #, fuzzy
 msgid "option"
 msgstr "Option"
 
-#: templates/customize-class.html:126
+#: templates/customize-class.html:121
 #, fuzzy
 msgid "mandatory_mode"
 msgstr "Mandatory developer's mode"
 
-#: templates/customize-class.html:132
+#: templates/customize-class.html:127
 #, fuzzy
 msgid "hide_cheatsheet"
 msgstr "Hide cheatsheet"
 
-#: templates/customize-class.html:138
+#: templates/customize-class.html:133
 msgid "hide_keyword_switcher"
 msgstr ""
 
-#: templates/customize-class.html:149
+#: templates/customize-class.html:144
 #, fuzzy
 msgid "reset_adventure_prompt"
 msgstr "Are you sure you want to reset all selected adventures?"
 
-#: templates/customize-class.html:149
+#: templates/customize-class.html:144
 #, fuzzy
 msgid "reset_adventures"
 msgstr "Reset selected adventures"
 
-#: templates/customize-class.html:153
+#: templates/customize-class.html:148
 #, fuzzy
 msgid "remove_customizations_prompt"
 msgstr "Are you sure you want to remove this class their customizations?"
 
-#: templates/customize-class.html:154
+#: templates/customize-class.html:149
 #, fuzzy
 msgid "remove_customization"
 msgstr "Remove customization"
@@ -967,13 +923,13 @@ msgstr "Explore programs"
 #, fuzzy
 msgid "explore_explanation"
 msgstr ""
-"On this page you can look through programs created by other Hedy users. You "
-"can filter on both a Hedy level and adventure. Click on \"View program\" to "
-"open a program and run it. Programs with a red header contain a mistake. You "
-"can still open the program, but running it will result in an error. You can "
-"of course try to fix it! If the creator has a public profile you can click "
-"their username to visit their profile. There you will find all their shared "
-"programs and much more!"
+"On this page you can look through programs created by other Hedy users. "
+"You can filter on both a Hedy level and adventure. Click on \"View "
+"program\" to open a program and run it. Programs with a red header "
+"contain a mistake. You can still open the program, but running it will "
+"result in an error. You can of course try to fix it! If the creator has a"
+" public profile you can click their username to visit their profile. "
+"There you will find all their shared programs and much more!"
 
 #: templates/explore.html:35 templates/programs.html:27
 #, fuzzy
@@ -1040,8 +996,8 @@ msgstr "Create student accounts"
 #, fuzzy
 msgid "teacher_welcome"
 msgstr ""
-"Welcome to Hedy! Your are now the proud owner of a teachers account which "
-"allows you to create classes and invite students."
+"Welcome to Hedy! Your are now the proud owner of a teachers account which"
+" allows you to create classes and invite students."
 
 #: templates/incl-adventure-tabs.html:22
 #, fuzzy
@@ -1166,9 +1122,9 @@ msgstr "Welcome"
 msgid "intro_text_landing_page"
 msgstr ""
 "Welcome to the wonderful world of Hedy! Here you can learn to program in "
-"small steps, without unnecessary complicated stuff. We start easy at level "
-"1, and slowly build towards bigger and more complex programs! Choose one of "
-"the options below to get started"
+"small steps, without unnecessary complicated stuff. We start easy at "
+"level 1, and slowly build towards bigger and more complex programs! "
+"Choose one of the options below to get started"
 
 #: templates/landing-page.html:14 templates/landing-page.html:36
 #, fuzzy
@@ -1184,14 +1140,14 @@ msgstr "Start programming"
 #: templates/landing-page.html:21
 #, fuzzy
 msgid "create_class_text"
-msgstr ""
-"Group your students into classes and change the content for each class."
+msgstr "Group your students into classes and change the content for each class."
 
 #: templates/landing-page.html:28
 #, fuzzy
 msgid "read_docs_text"
 msgstr ""
-"Visit our teacher's manual for lesson plans and common mistakes by students."
+"Visit our teacher's manual for lesson plans and common mistakes by "
+"students."
 
 #: templates/landing-page.html:30
 #, fuzzy
@@ -1238,50 +1194,14 @@ msgstr "Copy link to share"
 #, fuzzy
 msgid "set_preferred_lang"
 msgstr ""
-"Hedy now supports preferred user languages. You can set one for your profile "
-"in \"My profile\""
+"Hedy now supports preferred user languages. You can set one for your "
+"profile in \"My profile\""
 
 #: templates/layout.html:86 templates/quiz/endquiz.html:18
 #: templates/quiz/quiz.html:29
 #, fuzzy
 msgid "achievement_earned"
 msgstr "You've earned an achievement!"
-
-#: templates/learn-more.html:7
-#, fuzzy
-msgid "mailing_title"
-msgstr "Title"
-
-#: templates/learn-more.html:14
-#, fuzzy
-msgid "surname"
-msgstr "Kullanıcı adı"
-
-#: templates/learn-more.html:18
-#, fuzzy
-msgid "lastname"
-msgstr "Name"
-
-#: templates/learn-more.html:22 templates/profile.html:135
-#: templates/signup.html:52
-#, fuzzy
-msgid "country"
-msgstr "Country"
-
-#: templates/learn-more.html:31
-#, fuzzy
-msgid "subscribe"
-msgstr "Subscribe to the newsletter"
-
-#: templates/learn-more.html:32
-#, fuzzy
-msgid "required_field"
-msgstr "Fields marked with an * are required"
-
-#: templates/learn-more.html:35
-#, fuzzy
-msgid "previous_campaigns"
-msgstr "View previous campaigns"
 
 #: templates/level-page.html:8
 #, fuzzy
@@ -1318,21 +1238,6 @@ msgstr "Hesap oluştur"
 #: templates/login.html:33
 msgid "forgot_password"
 msgstr "Parolanızı mı unuttunuz?"
-
-#: templates/main-page.html:9
-#, fuzzy
-msgid "main_title"
-msgstr "Title"
-
-#: templates/main-page.html:10
-#, fuzzy
-msgid "main_subtitle"
-msgstr "programs submitted"
-
-#: templates/main-page.html:13
-#, fuzzy
-msgid "try_it"
-msgstr "Try"
 
 #: templates/profile.html:4
 #, fuzzy
@@ -1398,9 +1303,9 @@ msgstr "Favourite program"
 #, fuzzy
 msgid "public_profile_info"
 msgstr ""
-"By selecting this box I make my profile visible for everyone. Be careful not "
-"to share personal information like your name or home address, because "
-"everyone will be able to see it!"
+"By selecting this box I make my profile visible for everyone. Be careful "
+"not to share personal information like your name or home address, because"
+" everyone will be able to see it!"
 
 #: templates/profile.html:59
 #, fuzzy
@@ -1471,6 +1376,11 @@ msgstr "Male"
 #, fuzzy
 msgid "other"
 msgstr "Other"
+
+#: templates/profile.html:135 templates/signup.html:52
+#, fuzzy
+msgid "country"
+msgstr "Country"
 
 #: templates/profile.html:141
 #, fuzzy
@@ -1698,8 +1608,8 @@ msgstr "Already have an account?"
 #, fuzzy
 msgid "teacher_invitation_require_login"
 msgstr ""
-"To set up your profile as a teacher we will need you to log in. If you don't "
-"have an account, please create one."
+"To set up your profile as a teacher we will need you to log in. If you "
+"don't have an account, please create one."
 
 #: templates/view-program-page.html:13
 #, fuzzy
@@ -1869,7 +1779,8 @@ msgstr "You have to agree with the privacy terms."
 #, fuzzy
 msgid "keyword_language_invalid"
 msgstr ""
-"Please select a valid keyword language (select English or your own language)."
+"Please select a valid keyword language (select English or your own "
+"language)."
 
 #: website/auth.py:371 website/auth.py:551
 #, fuzzy
@@ -1953,8 +1864,8 @@ msgstr "Your token is invalid."
 #, fuzzy
 msgid "password_resetted"
 msgstr ""
-"Your password has been successfully reset. You are being redirected to the "
-"login page."
+"Your password has been successfully reset. You are being redirected to "
+"the login page."
 
 #: website/auth.py:721
 #, fuzzy
@@ -1970,8 +1881,8 @@ msgstr "Program deleted successfully."
 #, fuzzy
 msgid "save_prompt"
 msgstr ""
-"You need to have an account to save your program. Would you like to login "
-"now?"
+"You need to have an account to save your program. Would you like to login"
+" now?"
 
 #: website/programs.py:60
 #, fuzzy
@@ -2184,3 +2095,61 @@ msgstr "The adventure has been updated!"
 #, fuzzy
 msgid "adventure_empty"
 msgstr "You didn't enter an adventure name!"
+
+#~ msgid "customize_class_exp_1"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_1"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_2"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_3"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_4"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_5"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_6"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_7"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_8"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_exp_2"
+#~ msgstr "Customize class"
+
+#~ msgid "mailing_title"
+#~ msgstr "Title"
+
+#~ msgid "surname"
+#~ msgstr "Kullanıcı adı"
+
+#~ msgid "lastname"
+#~ msgstr "Name"
+
+#~ msgid "subscribe"
+#~ msgstr "Subscribe to the newsletter"
+
+#~ msgid "required_field"
+#~ msgstr "Fields marked with an * are required"
+
+#~ msgid "previous_campaigns"
+#~ msgstr "View previous campaigns"
+
+#~ msgid "main_title"
+#~ msgstr "Title"
+
+#~ msgid "main_subtitle"
+#~ msgstr "programs submitted"
+
+#~ msgid "try_it"
+#~ msgstr "Try"
+

--- a/translations/zh_Hans/LC_MESSAGES/messages.po
+++ b/translations/zh_Hans/LC_MESSAGES/messages.po
@@ -1,18 +1,18 @@
+
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-03-29 10:01+0200\n"
+"POT-Creation-Date: 2022-03-30 08:43+0200\n"
 "PO-Revision-Date: 2022-03-30 09:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
-"Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
-"hedy/web-texts/zh_Hans/>\n"
 "Language: zh_Hans\n"
+"Language-Team: Chinese (Simplified) "
+"<https://hosted.weblate.org/projects/hedy/web-texts/zh_Hans/>\n"
+"Plural-Forms: nplurals=1; plural=0\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: Weblate 4.12-dev\n"
 "Generated-By: Babel 2.9.1\n"
 
 #: app.py:571
@@ -20,27 +20,27 @@ msgstr ""
 msgid "program_contains_error"
 msgstr "This program contains an error, are you sure you want to share it?"
 
-#: app.py:723
+#: app.py:722
 #, fuzzy
 msgid "title_achievements"
 msgstr "Hedy - My achievements"
 
-#: app.py:740 app.py:1111 website/teacher.py:365 website/teacher.py:374
+#: app.py:739 app.py:1110 website/teacher.py:365 website/teacher.py:374
 #, fuzzy
 msgid "not_teacher"
 msgstr "Looks like you are not a teacher!"
 
-#: app.py:743
+#: app.py:742
 #, fuzzy
 msgid "not_enrolled"
 msgstr "Looks like you are not in this class!"
 
-#: app.py:775
+#: app.py:774
 #, fuzzy
 msgid "title_programs"
 msgstr "Hedy - My programs"
 
-#: app.py:785 app.py:795 app.py:799 app.py:813 app.py:1054 app.py:1357
+#: app.py:784 app.py:794 app.py:798 app.py:812 app.py:1053 app.py:1356
 #: website/admin.py:17 website/admin.py:25 website/admin.py:95
 #: website/admin.py:112 website/admin.py:130 website/auth.py:711
 #: website/auth.py:738 website/statistics.py:86
@@ -48,122 +48,122 @@ msgstr "Hedy - My programs"
 msgid "unauthorized"
 msgstr "You don't have access rights for this page"
 
-#: app.py:823
+#: app.py:822
 msgid "minutes"
 msgstr "分钟"
 
-#: app.py:826
+#: app.py:825
 msgid "hours"
 msgstr "小时"
 
-#: app.py:829
+#: app.py:828
 msgid "days"
 msgstr "天"
 
-#: app.py:832
+#: app.py:831
 #, fuzzy
 msgid "ago"
 msgstr "{time} ago"
 
-#: app.py:848 app.py:850 app.py:976
+#: app.py:847 app.py:849 app.py:975
 #, fuzzy
 msgid "no_such_level"
 msgstr "No such Hedy level!"
 
-#: app.py:858 app.py:865 app.py:931 app.py:937
+#: app.py:857 app.py:864 app.py:930 app.py:936
 #, fuzzy
 msgid "no_such_program"
 msgstr "No such Hedy program!"
 
-#: app.py:891
+#: app.py:890
 #, fuzzy
 msgid "level_not_translated"
 msgstr "This level is not translated in your language (yet)"
 
-#: app.py:893
+#: app.py:892
 #, fuzzy
 msgid "level_not_class"
 msgstr "You're in a class where this level has not been made available yet"
 
-#: app.py:986 website/teacher.py:432 website/teacher.py:448
+#: app.py:985 website/teacher.py:432 website/teacher.py:448
 #: website/teacher.py:477 website/teacher.py:503
 #, fuzzy
 msgid "no_such_adventure"
 msgstr "This adventure doesn't exist!"
 
-#: app.py:1005
+#: app.py:1004
 #, fuzzy
 msgid "page_not_found"
 msgstr "We could not find that page!"
 
-#: app.py:1025
+#: app.py:1024
 #, fuzzy
 msgid "title_signup"
 msgstr "Hedy - Create an account"
 
-#: app.py:1032
+#: app.py:1031
 #, fuzzy
 msgid "title_login"
 msgstr "Hedy - Login"
 
-#: app.py:1039
+#: app.py:1038
 #, fuzzy
 msgid "title_recover"
 msgstr "Hedy - Recover account"
 
-#: app.py:1055
+#: app.py:1054
 #, fuzzy
 msgid "title_reset"
 msgstr "Hedy - Reset password"
 
-#: app.py:1064
+#: app.py:1063
 #, fuzzy
 msgid "title_my-profile"
 msgstr "Hedy - My account"
 
-#: app.py:1078
+#: app.py:1077
 #, fuzzy
 msgid "title_learn-more"
 msgstr "Hedy - Learn more"
 
-#: app.py:1083
+#: app.py:1082
 #, fuzzy
 msgid "title_privacy"
 msgstr "Hedy - Privacy terms"
 
-#: app.py:1090
+#: app.py:1089
 #, fuzzy
 msgid "title_landing-page"
 msgstr "Welcome to Hedy!"
 
-#: app.py:1092
+#: app.py:1091
 #, fuzzy
 msgid "not_user"
 msgstr "Looks like you are not logged in!"
 
-#: app.py:1107
+#: app.py:1106
 #, fuzzy
 msgid "title_for-teacher"
 msgstr "Hedy - For teachers"
 
-#: app.py:1118
+#: app.py:1117
 #, fuzzy
 msgid "title_start"
 msgstr "Hedy - A gradual programming language"
 
-#: app.py:1171
+#: app.py:1170
 #, fuzzy
 msgid "title_explore"
 msgstr "Hedy - Explore"
 
-#: app.py:1190 app.py:1192
+#: app.py:1189 app.py:1191
 #, fuzzy
 msgid "translate_error"
 msgstr ""
-"Something went wrong while translating the code. Try running the code to see "
-"if it has an error. Code with errors can not be translated."
+"Something went wrong while translating the code. Try running the code to "
+"see if it has an error. Code with errors can not be translated."
 
-#: app.py:1301 website/auth.py:299 website/auth.py:347 website/auth.py:483
+#: app.py:1300 website/auth.py:299 website/auth.py:347 website/auth.py:483
 #: website/auth.py:509 website/auth.py:539 website/auth.py:645
 #: website/auth.py:677 website/auth.py:717 website/auth.py:744
 #: website/teacher.py:90 website/teacher.py:125 website/teacher.py:197
@@ -172,37 +172,37 @@ msgstr ""
 msgid "ajax_error"
 msgstr "出现错误，请再试一次."
 
-#: app.py:1304
+#: app.py:1303
 #, fuzzy
 msgid "image_invalid"
 msgstr "Your chosen image is invalid."
 
-#: app.py:1306
+#: app.py:1305
 #, fuzzy
 msgid "personal_text_invalid"
 msgstr "Your personal text is invalid."
 
-#: app.py:1308 app.py:1314
+#: app.py:1307 app.py:1313
 #, fuzzy
 msgid "favourite_program_invalid"
 msgstr "Your chosen favourite program is invalid."
 
-#: app.py:1326 app.py:1327
+#: app.py:1325 app.py:1326
 #, fuzzy
 msgid "public_profile_updated"
 msgstr "Public profile updated."
 
-#: app.py:1361 app.py:1385
+#: app.py:1360 app.py:1384
 #, fuzzy
 msgid "user_not_private"
 msgstr "This user doesn't exist or doesn't have a public profile"
 
-#: app.py:1394
+#: app.py:1393
 #, fuzzy
 msgid "invalid_teacher_invitation_code"
 msgstr ""
-"The teacher invitation code is invalid. To become a teacher, reach out to "
-"hedy@felienne.com."
+"The teacher invitation code is invalid. To become a teacher, reach out to"
+" hedy@felienne.com."
 
 #: utils.py:203
 #, fuzzy
@@ -223,54 +223,47 @@ msgstr "Something went wrong..."
 #, fuzzy
 msgid "Empty Program"
 msgstr ""
-"You created an empty program. Type Hedy code in the left field and try again"
+"You created an empty program. Type Hedy code in the left field and try "
+"again"
 
 #: coursedata/error-messages.txt:2
 msgid "Wrong Level"
-msgstr ""
-"这个 Hedy代码是正确的，但级别不对.你在第{original_level}级使用的是第"
-"{working_level}级的代码."
+msgstr "这个 Hedy代码是正确的，但级别不对.你在第{original_level}级使用的是第{working_level}级的代码."
 
 #: coursedata/error-messages.txt:3
 msgid "Incomplete"
-msgstr ""
-"糟糕! 你好像在第 {line_number}行忘写了一段代码!, 你需要在{incomplete_command}"
-"后面输入文字."
+msgstr "糟糕! 你好像在第 {line_number}行忘写了一段代码!, 你需要在{incomplete_command}后面输入文字."
 
 #: coursedata/error-messages.txt:4
 msgid "Invalid"
-msgstr ""
-"{invalid_command} 不是一个第{level}级的 Hedy命令. 你编写的是{guessed_command}"
-"吗?"
+msgstr "{invalid_command} 不是一个第{level}级的 Hedy命令. 你编写的是{guessed_command}吗?"
 
 #: coursedata/error-messages.txt:5
 msgid "Invalid Space"
-msgstr ""
-"糟糕!你在第{line_number}行句首空了一格. 这个空格让计算机产生了困惑，你能不能"
-"删除这个空格?"
+msgstr "糟糕!你在第{line_number}行句首空了一格. 这个空格让计算机产生了困惑，你能不能删除这个空格?"
 
 #: coursedata/error-messages.txt:6
 #, fuzzy
 msgid "Has Blanks"
 msgstr ""
-"Your code is incomplete. It contains blanks that you have to replace with "
-"code."
+"Your code is incomplete. It contains blanks that you have to replace with"
+" code."
 
 #: coursedata/error-messages.txt:7
 #, fuzzy
 msgid "No Indentation"
 msgstr ""
 "You used too few spaces in line {line_number}. You used {leading_spaces} "
-"spaces, which is not enough. Start every new block with {indent_size} spaces "
-"more than the line before."
+"spaces, which is not enough. Start every new block with {indent_size} "
+"spaces more than the line before."
 
 #: coursedata/error-messages.txt:8
 #, fuzzy
 msgid "Unexpected Indentation"
 msgstr ""
-"You used too many spaces in line {line_number}. You used {leading_spaces} "
-"spaces, which is too much. Start every new block with {indent_size} spaces "
-"more than the line before."
+"You used too many spaces in line {line_number}. You used {leading_spaces}"
+" spaces, which is too much. Start every new block with {indent_size} "
+"spaces more than the line before."
 
 #: coursedata/error-messages.txt:9
 msgid "Parse"
@@ -278,16 +271,14 @@ msgstr "您输入的代码是无效的Hedy代码.错误是: {parse_error}."
 
 #: coursedata/error-messages.txt:10
 msgid "Unquoted Text"
-msgstr ""
-"请注意. 如果你有内容需要打印，那么这部分内容前后两端都必须用引号标示清楚。现"
-"在有一个引号被你忘记输入啦."
+msgstr "请注意. 如果你有内容需要打印，那么这部分内容前后两端都必须用引号标示清楚。现在有一个引号被你忘记输入啦."
 
 #: coursedata/error-messages.txt:11
 #, fuzzy
 msgid "Unquoted Assignment"
 msgstr ""
-"From this level, you need to place texts to the right of the `is` between "
-"quotes. You forgot that for the text {text}."
+"From this level, you need to place texts to the right of the `is` between"
+" quotes. You forgot that for the text {text}."
 
 #: coursedata/error-messages.txt:12
 #, fuzzy
@@ -304,8 +295,8 @@ msgstr "您试图打印{name},但您没有实例化它."
 #, fuzzy
 msgid "Cyclic Var Definition"
 msgstr ""
-"The name {variable} needs to be set before you can use it on the right-hand "
-"side of the is command"
+"The name {variable} needs to be set before you can use it on the right-"
+"hand side of the is command"
 
 #: coursedata/error-messages.txt:15
 #, fuzzy
@@ -318,46 +309,46 @@ msgstr ""
 #, fuzzy
 msgid "Too Big"
 msgstr ""
-"Wow! Your program has an impressive {lines_of_code} lines of code! But we "
-"can only process {max_lines} lines in this level. Make your program smaller "
-"and try again."
+"Wow! Your program has an impressive {lines_of_code} lines of code! But we"
+" can only process {max_lines} lines in this level. Make your program "
+"smaller and try again."
 
 #: coursedata/error-messages.txt:17
 #, fuzzy
 msgid "Invalid Argument Type"
 msgstr ""
-"You cannot use the command {command} with {invalid_argument} because it is "
-"{invalid_type}. Try changing {invalid_argument} to {allowed_types}."
+"You cannot use the command {command} with {invalid_argument} because it "
+"is {invalid_type}. Try changing {invalid_argument} to {allowed_types}."
 
 #: coursedata/error-messages.txt:18
 #, fuzzy
 msgid "Invalid Argument"
 msgstr ""
-"You cannot use the command {command} with {invalid_argument} . Try changing "
-"{invalid_argument} to {allowed_types}."
+"You cannot use the command {command} with {invalid_argument} . Try "
+"changing {invalid_argument} to {allowed_types}."
 
 #: coursedata/error-messages.txt:19
 #, fuzzy
 msgid "Invalid Type Combination"
 msgstr ""
-"You cannot use {invalid_argument} and {invalid_argument_2} in {operation} "
-"because one is {invalid_type} and the other is {invalid_type_2}. Try "
-"changing {invalid_argument} to {invalid_type_2} or {invalid_argument_2} to "
-"{invalid_type}."
+"You cannot use {invalid_argument} and {invalid_argument_2} in {operation}"
+" because one is {invalid_type} and the other is {invalid_type_2}. Try "
+"changing {invalid_argument} to {invalid_type_2} or {invalid_argument_2} "
+"to {invalid_type}."
 
 #: coursedata/error-messages.txt:20
 #, fuzzy
 msgid "Unsupported Float"
 msgstr ""
-"Non-integer numbers are not supported yet but they will be in a few levels. "
-"For now change {value} to an integer."
+"Non-integer numbers are not supported yet but they will be in a few "
+"levels. For now change {value} to an integer."
 
 #: coursedata/error-messages.txt:21
 #, fuzzy
 msgid "Locked Language Feature"
 msgstr ""
-"You are using {concept}! That is awesome, but {concept} is not unlocked yet! "
-"It will be unlocked in a later level."
+"You are using {concept}! That is awesome, but {concept} is not unlocked "
+"yet! It will be unlocked in a later level."
 
 #: coursedata/error-messages.txt:22
 #, fuzzy
@@ -368,15 +359,16 @@ msgstr "It looks like you forgot to use a command on line {line_number}."
 #, fuzzy
 msgid "ask_needs_var"
 msgstr ""
-"Starting in level 2, ask needs to be used with a variable. Example: name is "
-"ask What are you called?"
+"Starting in level 2, ask needs to be used with a variable. Example: name "
+"is ask What are you called?"
 
 #: coursedata/error-messages.txt:24
 #, fuzzy
 msgid "echo_out"
 msgstr ""
-"Starting in level 2 echo is no longer needed. You can repeat an answer with "
-"ask and print now. Example: name is ask What are you called? print hello name"
+"Starting in level 2 echo is no longer needed. You can repeat an answer "
+"with ask and print now. Example: name is ask What are you called? print "
+"hello name"
 
 #: coursedata/error-messages.txt:25
 msgid "space"
@@ -461,6 +453,11 @@ msgstr "a list"
 #, fuzzy
 msgid "input"
 msgstr "input from ask"
+
+#: templates/achievements.html:4
+#, fuzzy
+msgid "achievements_title"
+msgstr "achievements"
 
 #: templates/class-overview.html:16
 #, fuzzy
@@ -631,22 +628,21 @@ msgstr "Do you want to join this class?"
 #: templates/class-prejoin.html:17 website/teacher.py:183
 #, fuzzy
 msgid "join_prompt"
-msgstr ""
-"You need to have an account to join a class. Would you like to login now?"
+msgstr "You need to have an account to join a class. Would you like to login now?"
 
 #: templates/class-prejoin.html:17 templates/profile.html:14
 #, fuzzy
 msgid "join_class"
 msgstr "Join class"
 
-#: templates/class-stats.html:22 templates/customize-class.html:155
+#: templates/class-stats.html:22 templates/customize-class.html:150
 #, fuzzy
 msgid "back_to_class"
 msgstr "Go back to class"
 
 #: templates/code-page.html:25 templates/code-page.html:34
-#: templates/customize-class.html:28 templates/customize-class.html:64
-#: templates/customize-class.html:71 templates/customize-class.html:94
+#: templates/customize-class.html:23 templates/customize-class.html:59
+#: templates/customize-class.html:66 templates/customize-class.html:89
 #: templates/incl-adventure-tabs.html:5 templates/level-page.html:6
 #: templates/level-page.html:11 templates/quiz/startquiz.html:10
 #: templates/view-program-page.html:12 templates/view-program-page.html:28
@@ -662,21 +658,21 @@ msgstr "Create multiple accounts"
 #, fuzzy
 msgid "accounts_intro"
 msgstr ""
-"On this page you can create accounts for multiple students at the same time. "
-"It is also possible to directly add them to one of your classes. By pressing "
-"the green + on the bottom right of the page you can add extra rows. You can "
-"delete a row by pressing the corresponding red cross. Make sure no rows are "
-"empty when you press \"Create accounts\". Please keep in mind that every "
-"username and mail address needs to be unique and the password needs to be "
-"<b>at least</b> 6 characters."
+"On this page you can create accounts for multiple students at the same "
+"time. It is also possible to directly add them to one of your classes. By"
+" pressing the green + on the bottom right of the page you can add extra "
+"rows. You can delete a row by pressing the corresponding red cross. Make "
+"sure no rows are empty when you press \"Create accounts\". Please keep in"
+" mind that every username and mail address needs to be unique and the "
+"password needs to be <b>at least</b> 6 characters."
 
 #: templates/create-accounts.html:10
 #, fuzzy
 msgid "create_accounts_prompt"
 msgstr "Are you sure you want to create these accounts?"
 
-#: templates/create-accounts.html:17 templates/learn-more.html:10
-#: templates/profile.html:96 templates/recover.html:8 templates/signup.html:13
+#: templates/create-accounts.html:17 templates/profile.html:96
+#: templates/recover.html:8 templates/signup.html:13
 msgid "email"
 msgstr "电子邮箱"
 
@@ -732,10 +728,10 @@ msgstr "级别"
 #, fuzzy
 msgid "adventure_exp_1"
 msgstr ""
-"Type your adventure of choice on the right-hand side. After creating your "
-"adventure you can include it in one of your classes under \"customizations"
-"\". If you want to include a command in your adventure please use code "
-"anchors like this:"
+"Type your adventure of choice on the right-hand side. After creating your"
+" adventure you can include it in one of your classes under "
+"\"customizations\". If you want to include a command in your adventure "
+"please use code anchors like this:"
 
 #: templates/customize-adventure.html:31
 #, fuzzy
@@ -749,11 +745,11 @@ msgstr ""
 msgid "adventure_exp_3"
 msgstr ""
 "You can use the \"preview\" button to view a styled version of your "
-"adventure. To view the adventure on a dedicated page, select \"view\" from "
-"the teachers page."
+"adventure. To view the adventure on a dedicated page, select \"view\" "
+"from the teachers page."
 
-#: templates/customize-adventure.html:43 templates/customize-class.html:28
-#: templates/customize-class.html:93 templates/explore.html:26
+#: templates/customize-adventure.html:43 templates/customize-class.html:23
+#: templates/customize-class.html:88 templates/explore.html:26
 #: templates/programs.html:18 templates/programs.html:48
 #: templates/view-adventure.html:6
 #, fuzzy
@@ -784,7 +780,7 @@ msgstr "I agree that my adventure might be made publicly available on Hedy."
 msgid "preview"
 msgstr "Preview"
 
-#: templates/customize-adventure.html:51 templates/customize-class.html:150
+#: templates/customize-adventure.html:51 templates/customize-class.html:145
 #, fuzzy
 msgid "save"
 msgstr "Save"
@@ -794,128 +790,78 @@ msgstr "Save"
 msgid "delete_adventure_prompt"
 msgstr "Are you sure you want to remove this adventure?"
 
-#: templates/customize-class.html:7
-#, fuzzy
-msgid "customize_class_exp_1"
-msgstr "Customize class"
-
-#: templates/customize-class.html:10
-#, fuzzy
-msgid "customize_class_step_1"
-msgstr "Customize class"
-
-#: templates/customize-class.html:11
-#, fuzzy
-msgid "customize_class_step_2"
-msgstr "Customize class"
-
-#: templates/customize-class.html:12
-#, fuzzy
-msgid "customize_class_step_3"
-msgstr "Customize class"
-
-#: templates/customize-class.html:13
-#, fuzzy
-msgid "customize_class_step_4"
-msgstr "Customize class"
-
-#: templates/customize-class.html:14
-#, fuzzy
-msgid "customize_class_step_5"
-msgstr "Customize class"
-
-#: templates/customize-class.html:15
-#, fuzzy
-msgid "customize_class_step_6"
-msgstr "Customize class"
-
-#: templates/customize-class.html:16
-#, fuzzy
-msgid "customize_class_step_7"
-msgstr "Customize class"
-
-#: templates/customize-class.html:17
-#, fuzzy
-msgid "customize_class_step_8"
-msgstr "Customize class"
-
-#: templates/customize-class.html:20
-#, fuzzy
-msgid "customize_class_exp_2"
-msgstr "Customize class"
-
-#: templates/customize-class.html:23
+#: templates/customize-class.html:18
 #, fuzzy
 msgid "select_adventures"
 msgstr "Select adventures"
 
-#: templates/customize-class.html:59
+#: templates/customize-class.html:54
 #, fuzzy
 msgid "opening_dates"
 msgstr "Opening dates"
 
-#: templates/customize-class.html:65
+#: templates/customize-class.html:60
 #, fuzzy
 msgid "opening_date"
 msgstr "Opening date"
 
-#: templates/customize-class.html:77
+#: templates/customize-class.html:72
 #, fuzzy
 msgid "directly_available"
 msgstr "Directly open"
 
-#: templates/customize-class.html:88
+#: templates/customize-class.html:83
 #, fuzzy
 msgid "select_own_adventures"
 msgstr "Select own adventures"
 
-#: templates/customize-class.html:95 templates/customize-class.html:121
+#: templates/customize-class.html:90 templates/customize-class.html:116
 #: templates/profile.html:47 templates/profile.html:128
 #: templates/profile.html:137 templates/signup.html:26 templates/signup.html:45
 #: templates/signup.html:53
 msgid "select"
 msgstr "选择"
 
-#: templates/customize-class.html:115
+#: templates/customize-class.html:110
 #, fuzzy
 msgid "other_settings"
 msgstr "Other settings"
 
-#: templates/customize-class.html:120
+#: templates/customize-class.html:115
 #, fuzzy
 msgid "option"
 msgstr "Option"
 
-#: templates/customize-class.html:126
+#: templates/customize-class.html:121
 #, fuzzy
 msgid "mandatory_mode"
 msgstr "Mandatory developer's mode"
 
-#: templates/customize-class.html:132
+#: templates/customize-class.html:127
 #, fuzzy
 msgid "hide_cheatsheet"
 msgstr "Hide cheatsheet"
 
-#: templates/customize-class.html:138
+#: templates/customize-class.html:133
 msgid "hide_keyword_switcher"
 msgstr ""
 
-#: templates/customize-class.html:149
+#: templates/customize-class.html:144
 #, fuzzy
 msgid "reset_adventure_prompt"
 msgstr "Are you sure you want to reset all selected adventures?"
 
-#: templates/customize-class.html:149
+#: templates/customize-class.html:144
 #, fuzzy
 msgid "reset_adventures"
 msgstr "Reset selected adventures"
 
-#: templates/customize-class.html:153
+#: templates/customize-class.html:148
 #, fuzzy
 msgid "remove_customizations_prompt"
 msgstr "Are you sure you want to remove this class their customizations?"
 
-#: templates/customize-class.html:154
+#: templates/customize-class.html:149
 #, fuzzy
 msgid "remove_customization"
 msgstr "Remove customization"
@@ -934,13 +880,13 @@ msgstr "Explore programs"
 #, fuzzy
 msgid "explore_explanation"
 msgstr ""
-"On this page you can look through programs created by other Hedy users. You "
-"can filter on both a Hedy level and adventure. Click on \"View program\" to "
-"open a program and run it. Programs with a red header contain a mistake. You "
-"can still open the program, but running it will result in an error. You can "
-"of course try to fix it! If the creator has a public profile you can click "
-"their username to visit their profile. There you will find all their shared "
-"programs and much more!"
+"On this page you can look through programs created by other Hedy users. "
+"You can filter on both a Hedy level and adventure. Click on \"View "
+"program\" to open a program and run it. Programs with a red header "
+"contain a mistake. You can still open the program, but running it will "
+"result in an error. You can of course try to fix it! If the creator has a"
+" public profile you can click their username to visit their profile. "
+"There you will find all their shared programs and much more!"
 
 #: templates/explore.html:35 templates/programs.html:27
 #, fuzzy
@@ -1007,8 +953,8 @@ msgstr "Create student accounts"
 #, fuzzy
 msgid "teacher_welcome"
 msgstr ""
-"Welcome to Hedy! Your are now the proud owner of a teachers account which "
-"allows you to create classes and invite students."
+"Welcome to Hedy! Your are now the proud owner of a teachers account which"
+" allows you to create classes and invite students."
 
 #: templates/incl-adventure-tabs.html:22
 #, fuzzy
@@ -1121,9 +1067,9 @@ msgstr "Welcome"
 msgid "intro_text_landing_page"
 msgstr ""
 "Welcome to the wonderful world of Hedy! Here you can learn to program in "
-"small steps, without unnecessary complicated stuff. We start easy at level "
-"1, and slowly build towards bigger and more complex programs! Choose one of "
-"the options below to get started"
+"small steps, without unnecessary complicated stuff. We start easy at "
+"level 1, and slowly build towards bigger and more complex programs! "
+"Choose one of the options below to get started"
 
 #: templates/landing-page.html:14 templates/landing-page.html:36
 #, fuzzy
@@ -1139,14 +1085,14 @@ msgstr "Start programming"
 #: templates/landing-page.html:21
 #, fuzzy
 msgid "create_class_text"
-msgstr ""
-"Group your students into classes and change the content for each class."
+msgstr "Group your students into classes and change the content for each class."
 
 #: templates/landing-page.html:28
 #, fuzzy
 msgid "read_docs_text"
 msgstr ""
-"Visit our teacher's manual for lesson plans and common mistakes by students."
+"Visit our teacher's manual for lesson plans and common mistakes by "
+"students."
 
 #: templates/landing-page.html:30
 #, fuzzy
@@ -1193,48 +1139,14 @@ msgstr "Copy link to share"
 #, fuzzy
 msgid "set_preferred_lang"
 msgstr ""
-"Hedy now supports preferred user languages. You can set one for your profile "
-"in \"My profile\""
+"Hedy now supports preferred user languages. You can set one for your "
+"profile in \"My profile\""
 
 #: templates/layout.html:86 templates/quiz/endquiz.html:18
 #: templates/quiz/quiz.html:29
 #, fuzzy
 msgid "achievement_earned"
 msgstr "You've earned an achievement!"
-
-#: templates/learn-more.html:7
-msgid "mailing_title"
-msgstr "订阅Hedy海迪通讯报"
-
-#: templates/learn-more.html:14
-#, fuzzy
-msgid "surname"
-msgstr "用户名"
-
-#: templates/learn-more.html:18
-#, fuzzy
-msgid "lastname"
-msgstr "Name"
-
-#: templates/learn-more.html:22 templates/profile.html:135
-#: templates/signup.html:52
-msgid "country"
-msgstr "国家"
-
-#: templates/learn-more.html:31
-#, fuzzy
-msgid "subscribe"
-msgstr "订阅新闻简报"
-
-#: templates/learn-more.html:32
-#, fuzzy
-msgid "required_field"
-msgstr "Fields marked with an * are required"
-
-#: templates/learn-more.html:35
-#, fuzzy
-msgid "previous_campaigns"
-msgstr "View previous campaigns"
 
 #: templates/level-page.html:8
 msgid "step_title"
@@ -1268,21 +1180,6 @@ msgstr "注册账号"
 #: templates/login.html:33
 msgid "forgot_password"
 msgstr "忘记你的密码?"
-
-#: templates/main-page.html:9
-#, fuzzy
-msgid "main_title"
-msgstr "Title"
-
-#: templates/main-page.html:10
-#, fuzzy
-msgid "main_subtitle"
-msgstr "programs submitted"
-
-#: templates/main-page.html:13
-#, fuzzy
-msgid "try_it"
-msgstr "试一试"
 
 #: templates/profile.html:4
 #, fuzzy
@@ -1348,9 +1245,9 @@ msgstr "Favourite program"
 #, fuzzy
 msgid "public_profile_info"
 msgstr ""
-"By selecting this box I make my profile visible for everyone. Be careful not "
-"to share personal information like your name or home address, because "
-"everyone will be able to see it!"
+"By selecting this box I make my profile visible for everyone. Be careful "
+"not to share personal information like your name or home address, because"
+" everyone will be able to see it!"
 
 #: templates/profile.html:59
 #, fuzzy
@@ -1415,6 +1312,10 @@ msgstr "男"
 #: templates/profile.html:131 templates/signup.html:48
 msgid "other"
 msgstr "其他"
+
+#: templates/profile.html:135 templates/signup.html:52
+msgid "country"
+msgstr "国家"
 
 #: templates/profile.html:141
 msgid "update_profile"
@@ -1623,8 +1524,8 @@ msgstr "已经有账号了？"
 #, fuzzy
 msgid "teacher_invitation_require_login"
 msgstr ""
-"To set up your profile as a teacher we will need you to log in. If you don't "
-"have an account, please create one."
+"To set up your profile as a teacher we will need you to log in. If you "
+"don't have an account, please create one."
 
 #: templates/view-program-page.html:13
 #, fuzzy
@@ -1787,7 +1688,8 @@ msgstr "You have to agree with the privacy terms."
 #, fuzzy
 msgid "keyword_language_invalid"
 msgstr ""
-"Please select a valid keyword language (select English or your own language)."
+"Please select a valid keyword language (select English or your own "
+"language)."
 
 #: website/auth.py:371 website/auth.py:551
 msgid "year_invalid"
@@ -2086,3 +1988,61 @@ msgstr "The adventure has been updated!"
 #, fuzzy
 msgid "adventure_empty"
 msgstr "You didn't enter an adventure name!"
+
+#~ msgid "customize_class_exp_1"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_1"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_2"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_3"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_4"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_5"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_6"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_7"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_step_8"
+#~ msgstr "Customize class"
+
+#~ msgid "customize_class_exp_2"
+#~ msgstr "Customize class"
+
+#~ msgid "mailing_title"
+#~ msgstr "订阅Hedy海迪通讯报"
+
+#~ msgid "surname"
+#~ msgstr "用户名"
+
+#~ msgid "lastname"
+#~ msgstr "Name"
+
+#~ msgid "subscribe"
+#~ msgstr "订阅新闻简报"
+
+#~ msgid "required_field"
+#~ msgstr "Fields marked with an * are required"
+
+#~ msgid "previous_campaigns"
+#~ msgstr "View previous campaigns"
+
+#~ msgid "main_title"
+#~ msgstr "Title"
+
+#~ msgid "main_subtitle"
+#~ msgstr "programs submitted"
+
+#~ msgid "try_it"
+#~ msgstr "试一试"
+


### PR DESCRIPTION
**Description**
In this PR we fix the forgotten nl achievements structure. We re-structured the achievements in #2358 but for some reason forgot the nl file. We also add the missing achievements header title and fix some issues with achievements pop-ups.

**Fixes**
This PR fixes #2386

**How to test**
Verify that the achievements page is now correctly shown in dutch.
