### PR TITLE
Fix issue #2447: Add a missing quotation mark in hedy level 4 NL

### DIFF
--- a/content/level-defaults/nl.yaml
+++ b/content/level-defaults/nl.yaml
@@ -102,7 +102,7 @@
         ## Voorbeeld Hedy code
         ```
         {print} 'Vanaf nu gebruiken we aanhalingstekens!'
-        antwoord {is} {ask} 'Wat gebruiken we vanaf nu?
+        antwoord {is} {ask} 'Wat gebruiken we vanaf nu?'
         {print} 'We gebruiken ' antwoord
         ```
 


### PR DESCRIPTION
The title describes the fix.

**Fixes**
This PR fixes #2447 