### PR TITLE
[IMPROVEMENT] Reduces db calls by simplifying user data retrieval

### DIFF
--- a/app.py
+++ b/app.py
@@ -960,11 +960,13 @@ def reset_page():
 @app.route('/my-profile', methods=['GET'])
 @requires_login
 def profile_page(user):
+
+    profile = DATABASE.user_by_username(user['username'])
     programs = DATABASE.public_programs_for_user(user['username'])
     public_profile_settings = DATABASE.get_public_profile_settings(current_user()['username'])
 
     return render_template('profile.html', page_title=gettext('title_my-profile'), programs=programs,
-                           public_settings=public_profile_settings, current_page='my-profile')
+                           user_data=profile, public_settings=public_profile_settings, current_page='my-profile')
 
 
 @app.route('/<page>')

--- a/app.py
+++ b/app.py
@@ -182,26 +182,6 @@ babel = Babel(app)
 def get_locale():
     return session.get("lang", request.accept_languages.best_match(ALL_LANGUAGES.keys(), 'en'))
 
-"""
-    Some important notes relates to Flask-Babel usage:
-    -   We can always get a translation using gettext('english string')
-        NOTE: We can shorten this notation by simply using _('english string')
-    -   We can insert some variable like this: gettext('some string %(value)s', value=42)
-    -   More interesting for us might be the 'lazy string' the can be defined outside requests, like this:
-    -       lazy_gettext('Account successfully saved')
-    -   This will be really useful when wanting to return translated error messages
-    
-    - We have to mark ALL translatable string (in english!) with gettext() -> then create a .pot file
-    - We create the file as follows: 
-        pybabel extract -F babel.cfg -o messages.pot .
-    - To add a translation (for dutch): 
-        pybabel init -i messages.pot -d translations -l nl
-    - To update your files (when adding new strings):
-        FIRST create new file:  pybabel extract -F babel.cfg -o messages.pot . 
-        THEN:                   pybabel update -i messages.pot -d translations
-    LASTLY compile the files:   pybabel compile -d translations
-"""
-
 
 cdn.Cdn(app, os.getenv('CDN_PREFIX'), os.getenv('HEROKU_SLUG_COMMIT', 'dev'))
 

--- a/app.py
+++ b/app.py
@@ -597,11 +597,13 @@ def achievements_page():
         url = request.url.replace('/my-achievements', '/login')
         return redirect(url, code=302)
 
+    user_achievements = DATABASE.achievements_by_username(user.get('username'))
     achievement_translations = hedyweb.PageTranslations('achievements').get_page_translations(g.lang)
     achievements = ACHIEVEMENTS_TRANSLATIONS.get_translations(g.lang)
 
-    return render_template('achievements.html', page_title=gettext('title_achievements'),
-                           achievements=achievements, template_achievements=achievement_translations, current_page='my-profile')
+    return render_template('achievements.html', page_title=gettext('title_achievements'), achievements=achievements,
+                            user_achievements=user_achievements, template_achievements=achievement_translations,
+                            current_page='my-profile')
 
 
 @app.route('/programs', methods=['GET'])

--- a/app.py
+++ b/app.py
@@ -307,34 +307,8 @@ if utils.is_heroku() and not os.getenv('HEROKU_RELEASE_CREATED_AT'):
 # A context processor injects variables in the context that are available to all templates.
 @app.context_processor
 def enrich_context_with_user_info():
-    session['set_keyword_lang'] = False
     user = current_user()
-    data = {'username': user.get('username', ''), 'is_teacher': is_teacher(user), 'is_admin': is_admin(user)}
-    if len(data['username']) > 0: #If so, there is a user -> Retrieve all relevant info
-        user_data = DATABASE.user_by_username(user.get('username'))
-        data['user_messages'] = 0
-        if user_data.get('language', '') in ALL_LANGUAGES.keys():
-            g.lang = session['lang'] = user_data['language']
-        if user_data.get('keyword_language', '') in ALL_LANGUAGES.keys():
-            g.keyword_lang = session['keyword_lang'] = user_data['keyword_language']
-            session['set_keyword_lang'] = True
-
-        data['user_data'] = user_data
-        if 'classes' in user_data:
-            data['user_classes'] = DATABASE.get_student_classes(user.get('username'))
-        user_achievements = DATABASE.achievements_by_username(user.get('username'))
-        if user_achievements:
-            data['user_achievements'] = user_achievements
-        user_invites = DATABASE.get_username_invite(user.get('username'))
-        if user_invites:
-            Class = DATABASE.get_class(user_invites['class_id'])
-            if Class:
-                invite_data = user_invites.copy()
-                invite_data['class_name'] = Class.get('name')
-                invite_data['teacher'] = Class.get('teacher')
-                invite_data['join_link'] = Class.get('link')
-                data['invite_data'] = invite_data
-                data['user_messages'] += 1
+    data = {'username': user.get('username', ''), 'is_teacher': is_teacher(user)}
     return data
 
 

--- a/app.py
+++ b/app.py
@@ -597,9 +597,10 @@ def achievements_page():
         url = request.url.replace('/my-achievements', '/login')
         return redirect(url, code=302)
 
-    user_achievements = DATABASE.achievements_by_username(user.get('username'))
+    user_achievements = DATABASE.achievements_by_username(user.get('username')) or []
     achievement_translations = hedyweb.PageTranslations('achievements').get_page_translations(g.lang)
     achievements = ACHIEVEMENTS_TRANSLATIONS.get_translations(g.lang)
+
 
     return render_template('achievements.html', page_title=gettext('title_achievements'), achievements=achievements,
                             user_achievements=user_achievements, template_achievements=achievement_translations,

--- a/app.py
+++ b/app.py
@@ -965,8 +965,23 @@ def profile_page(user):
     programs = DATABASE.public_programs_for_user(user['username'])
     public_profile_settings = DATABASE.get_public_profile_settings(current_user()['username'])
 
+    classes = []
+    if profile.get('classes'):
+        for class_id in profile.get('classes'):
+            classes.append(DATABASE.get_class(class_id))
+
+    invite = DATABASE.get_username_invite(user['username'])
+    if invite:
+        # If there is an invite: retrieve the class information
+        class_info = DATABASE.get_class(invite.get('class_id', None))
+        if class_info:
+            invite['teacher'] = class_info.get('teacher')
+            invite['class_name'] = class_info.get('name')
+            invite['join_link'] = class_info.get('link')
+
     return render_template('profile.html', page_title=gettext('title_my-profile'), programs=programs,
-                           user_data=profile, public_settings=public_profile_settings, current_page='my-profile')
+                           user_data=profile, invite_data=invite, public_settings=public_profile_settings,
+                           user_classes=classes, current_page='my-profile')
 
 
 @app.route('/<page>')

--- a/app.py
+++ b/app.py
@@ -1281,7 +1281,7 @@ def public_user_page(username):
     user_public_info = DATABASE.get_public_profile_settings(username)
     if user_public_info:
         user_programs = DATABASE.public_programs_for_user(username)
-        user_achievements = DATABASE.progress_by_username(username)
+        user_achievements = DATABASE.progress_by_username(username) or {}
 
         favourite_program = None
         if 'favourite_program' in user_public_info and user_public_info['favourite_program']:
@@ -1290,7 +1290,7 @@ def public_user_page(username):
             user_programs = user_programs[:5]
 
         last_achieved = None
-        if 'achieved' in user_achievements:
+        if user_achievements.get('achieved'):
             last_achieved = user_achievements['achieved'][-1]
 
         # Todo: TB -> In the near future: add achievement for user visiting their own profile

--- a/templates/incl-menubar.html
+++ b/templates/incl-menubar.html
@@ -20,7 +20,7 @@
               <li class="hover:bg-blue-600 text-white rounded-lg py-2 px-4 block"><span class="fas fa-trophy ltr:mr-4 rtl:ml-4"></span> {{_('my_achievements')}}</li>
           </a>
           <a class="no-underline" href="/my-profile">
-              <li class="hover:bg-blue-600 text-white rounded-lg py-2 px-4 block"><span class="fas fa-user-cog ltr:mr-4 rtl:ml-4"></span> {{_('my_account')}}{% if user_messages > 0 %} ({{ user_messages }}){% endif %}</li>
+              <li class="hover:bg-blue-600 text-white rounded-lg py-2 px-4 block"><span class="fas fa-user-cog ltr:mr-4 rtl:ml-4"></span> {{_('my_account')}}</li>
           </a>
           {% if is_teacher %}
               <a class="no-underline" href="/for-teachers">
@@ -35,7 +35,7 @@
     {% else %}
       <a class="menubar-btn hover:bg-blue-600 {% if current_page == 'login' %}border-white{% else %}border-transparent{% endif %}" href="/login">{{_('login')}}</a>
     {% endif %}
-    {% if not username or not 'language' in user_data %}
+    {% if not username %}
       <div class="dropdown inline-block relative {% if not username %}ltr:ml-auto rtl:mr-auto{% endif %} py-2 z-40">
           <button class="bg-blue-400 text-white font-semibold py-1 px-2 rounded inline-flex items-center">
             <span class="ltr:mr-1 rtl:ml-1">{{ current_language().sym }}</span>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -74,9 +74,6 @@
       {% filter indent(width=6) %}{% include "incl-menubar.html" %}{% endfilter %}
       {% endif %}
       {# Can't reindent this as it may contain preformatted code blocks whose indentation is important. #}
-      {% if username and not 'language' in user_data %}
-          <h3 class="text-black text-center bg-yellow-300 mt-1 mb-1 border-red-500 py-4">{{_('set_preferred_lang')}}</h3>
-      {% endif %}
       {% block body %}{% endblock %}
 
       <canvas id="confetti" style="width: 60vw;" class="hidden"></canvas>

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -2,7 +2,7 @@
 
 {% block main %}
    <h2 class="px-8 mb-4">{{_('account_overview')}}</h2>
-   {% if user_messages and user_messages > 0 %}
+   {% if invite_data %}
        <h1 class="bg-blue-200 px-8 py-2 mb-4 rounded-lg text-3xl cursor-pointer" onclick="$ ('#messages').toggle()">{{_('my_messages')}}</h1>
        <div id="messages" class="bg-white shadow-md rounded px-8 pt-6 pb-8 mx-auto mb-4 w-3/4 hidden">
          <h2 class="mb-4 pb-4 border-b-2 inline-block w-3/4">{{_('my_messages')}}</h2>
@@ -12,7 +12,7 @@
                  {{_('sent_by')}} <b>{{ invite_data['teacher'] }}</b>. {{_('prompt_join_class')}}
                  <div class="flex flex-row mt-4">
                         <button type="reset" class="green-btn" onclick="window.open('/hedy/l/{{ invite_data['join_link'] }}', '_self');">{{_('join_class')}}</button>
-                        <button type="submit" class="red-btn mx-4 px-4" onclick="hedyApp.remove_student_invite('{{invite_data['username']}}', '{{invite_data['class_id']}}', '{{_('delete_invite_prompt')}}')">{{_('delete_invite')}}</button>
+                        <button type="submit" class="red-btn mx-4 px-4" onclick="hedyApp.remove_student_invite('{{user_data['username']}}', '{{invite_data['class_id']}}', '{{_('delete_invite_prompt')}}')">{{_('delete_invite')}}</button>
                 </div>
              </div>
          {% endif %}

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -67,13 +67,6 @@
      </div>
      </form>
    </div>
-   <h1 class="bg-blue-200 px-8 py-2 mb-4 rounded-lg text-3xl cursor-pointer" onclick="$ ('#statistics').toggle()">{{_('statistics')}}</h1>
-   <div id="statistics" class="bg-white shadow-md rounded px-8 pt-6 pb-8 mx-auto mb-4 w-3/4 hidden">
-     <h2 class="mb-4 pb-4 border-b-2 inline-block w-3/4">{{_('statistics')}}</h2>
-     <ul>
-         <li>{{_('number_programs')}}: <b>{{ user_data['program_count']}}</b></li>
-     </ul>
-   </div>
    {% if user_classes %}
        <h1 class="bg-blue-200 px-8 py-2 mb-4 rounded-lg text-3xl cursor-pointer" onclick="$ ('#classes').toggle()">{{_('my_classes')}}</h1>
        <div id="classes" class="bg-white shadow-md rounded px-8 pt-6 pb-8 mx-auto mb-4 w-3/4 hidden">

--- a/translations/ar/LC_MESSAGES/messages.po
+++ b/translations/ar/LC_MESSAGES/messages.po
@@ -1,29 +1,29 @@
-#: app.py:497
+#: app.py:451
 #, fuzzy
 msgid "program_contains_error"
 msgstr "This program contains an error, are you sure you want to share it?"
 
-#: app.py:649
+#: app.py:604
 #, fuzzy
 msgid "title_achievements"
 msgstr "Hedy - My achievements"
 
-#: app.py:666 app.py:1057 website/teacher.py:363 website/teacher.py:372
+#: app.py:622 app.py:1030 website/teacher.py:363 website/teacher.py:372
 #, fuzzy
 msgid "not_teacher"
 msgstr "Looks like you are not a teacher!"
 
-#: app.py:669
+#: app.py:625
 #, fuzzy
 msgid "not_enrolled"
 msgstr "Looks like you are not in this class!"
 
-#: app.py:701
+#: app.py:657
 #, fuzzy
 msgid "title_programs"
 msgstr "Hedy - My programs"
 
-#: app.py:711 app.py:721 app.py:725 app.py:739 app.py:1000 app.py:1302
+#: app.py:667 app.py:677 app.py:681 app.py:695 app.py:956 app.py:1275
 #: website/admin.py:17 website/admin.py:25 website/admin.py:95
 #: website/admin.py:112 website/admin.py:130 website/auth.py:653
 #: website/auth.py:680 website/statistics.py:86
@@ -31,125 +31,125 @@ msgstr "Hedy - My programs"
 msgid "unauthorized"
 msgstr "You don't have access rights for this page"
 
-#: app.py:749
+#: app.py:705
 #, fuzzy
 msgid "minutes"
 msgstr "minutes"
 
-#: app.py:752
+#: app.py:708
 #, fuzzy
 msgid "hours"
 msgstr "hours"
 
-#: app.py:755
+#: app.py:711
 #, fuzzy
 msgid "days"
 msgstr "days"
 
-#: app.py:758
+#: app.py:714
 #, fuzzy
 msgid "ago"
 msgstr "{time} ago"
 
-#: app.py:774 app.py:776 app.py:915 app.py:939 app.py:941
+#: app.py:730 app.py:732 app.py:871 app.py:895 app.py:897
 #, fuzzy
 msgid "no_such_level"
 msgstr "No such Hedy level!"
 
-#: app.py:784 app.py:791 app.py:865 app.py:871
+#: app.py:740 app.py:747 app.py:821 app.py:827
 #, fuzzy
 msgid "no_such_program"
 msgstr "No such Hedy program!"
 
-#: app.py:820
+#: app.py:776
 #, fuzzy
 msgid "level_not_translated"
 msgstr "This level is not translated in your language (yet)"
 
-#: app.py:822
+#: app.py:778
 #, fuzzy
 msgid "level_not_class"
 msgstr "You're in a class where this level has not been made available yet"
 
-#: app.py:925 website/teacher.py:430 website/teacher.py:446
+#: app.py:881 website/teacher.py:430 website/teacher.py:446
 #: website/teacher.py:475 website/teacher.py:501
 #, fuzzy
 msgid "no_such_adventure"
 msgstr "This adventure doesn't exist!"
 
-#: app.py:951
+#: app.py:907
 #, fuzzy
 msgid "page_not_found"
 msgstr "We could not find that page!"
 
-#: app.py:971
+#: app.py:927
 #, fuzzy
 msgid "title_signup"
 msgstr "Hedy - Create an account"
 
-#: app.py:978
+#: app.py:934
 #, fuzzy
 msgid "title_login"
 msgstr "Hedy - Login"
 
-#: app.py:985
+#: app.py:941
 #, fuzzy
 msgid "title_recover"
 msgstr "Hedy - Recover account"
 
-#: app.py:1001
+#: app.py:957
 #, fuzzy
 msgid "title_reset"
 msgstr "Hedy - Reset password"
 
-#: app.py:1010
+#: app.py:982
 #, fuzzy
 msgid "title_my-profile"
 msgstr "Hedy - My account"
 
-#: app.py:1024
+#: app.py:997
 #, fuzzy
 msgid "title_learn-more"
 msgstr "Hedy - Learn more"
 
-#: app.py:1029
+#: app.py:1002
 #, fuzzy
 msgid "title_privacy"
 msgstr "Hedy - Privacy terms"
 
-#: app.py:1036
+#: app.py:1009
 #, fuzzy
 msgid "title_landing-page"
 msgstr "Welcome to Hedy!"
 
-#: app.py:1038
+#: app.py:1011
 #, fuzzy
 msgid "not_user"
 msgstr "Looks like you are not logged in!"
 
-#: app.py:1053
+#: app.py:1026
 #, fuzzy
 msgid "title_for-teacher"
 msgstr "Hedy - For teachers"
 
-#: app.py:1064
+#: app.py:1037
 #, fuzzy
 msgid "title_start"
 msgstr "Hedy - A gradual programming language"
 
-#: app.py:1117
+#: app.py:1090
 #, fuzzy
 msgid "title_explore"
 msgstr "Hedy - Explore"
 
-#: app.py:1135 app.py:1137
+#: app.py:1108 app.py:1110
 #, fuzzy
 msgid "translate_error"
 msgstr ""
 "Something went wrong while translating the code. Try running the code to "
 "see if it has an error. Code with errors can not be translated."
 
-#: app.py:1246 website/auth.py:241 website/auth.py:290 website/auth.py:426
+#: app.py:1219 website/auth.py:241 website/auth.py:290 website/auth.py:426
 #: website/auth.py:451 website/auth.py:481 website/auth.py:587
 #: website/auth.py:619 website/auth.py:659 website/auth.py:686
 #: website/teacher.py:90 website/teacher.py:125 website/teacher.py:197
@@ -159,32 +159,32 @@ msgstr ""
 msgid "ajax_error"
 msgstr "There was an error, please try again."
 
-#: app.py:1249
+#: app.py:1222
 #, fuzzy
 msgid "image_invalid"
 msgstr "Your chosen image is invalid."
 
-#: app.py:1251
+#: app.py:1224
 #, fuzzy
 msgid "personal_text_invalid"
 msgstr "Your personal text is invalid."
 
-#: app.py:1253 app.py:1259
+#: app.py:1226 app.py:1232
 #, fuzzy
 msgid "favourite_program_invalid"
 msgstr "Your chosen favourite program is invalid."
 
-#: app.py:1271 app.py:1272
+#: app.py:1244 app.py:1245
 #, fuzzy
 msgid "public_profile_updated"
 msgstr "Public profile updated."
 
-#: app.py:1306 app.py:1330
+#: app.py:1279 app.py:1303
 #, fuzzy
 msgid "user_not_private"
 msgstr "This user doesn't exist or doesn't have a public profile"
 
-#: app.py:1339
+#: app.py:1312
 #, fuzzy
 msgid "invalid_teacher_invitation_code"
 msgstr ""
@@ -491,7 +491,7 @@ msgstr "Visible columns"
 
 #: templates/class-overview.html:21 templates/class-overview.html:64
 #: templates/class-overview.html:108 templates/create-accounts.html:16
-#: templates/login.html:12 templates/profile.html:93 templates/recover.html:8
+#: templates/login.html:12 templates/profile.html:86 templates/recover.html:8
 #: templates/signup.html:10
 #, fuzzy
 msgid "username"
@@ -508,7 +508,6 @@ msgid "highest_level_reached"
 msgstr "Highest level reached"
 
 #: templates/class-overview.html:35 templates/class-overview.html:67
-#: templates/profile.html:74
 #, fuzzy
 msgid "number_programs"
 msgstr "Number of programs"
@@ -524,8 +523,8 @@ msgid "latest_shared_program"
 msgstr "Latest shared program"
 
 #: templates/class-overview.html:49 templates/class-overview.html:70
-#: templates/class-overview.html:83 templates/profile.html:151
-#: templates/profile.html:153 templates/profile.html:166
+#: templates/class-overview.html:83 templates/profile.html:144
+#: templates/profile.html:146 templates/profile.html:159
 #, fuzzy
 msgid "change_password"
 msgstr "Change password"
@@ -700,7 +699,7 @@ msgid "create_accounts_prompt"
 msgstr "Are you sure you want to create these accounts?"
 
 #: templates/create-accounts.html:17 templates/learn-more.html:10
-#: templates/profile.html:96 templates/recover.html:8 templates/signup.html:13
+#: templates/profile.html:89 templates/recover.html:8 templates/signup.html:13
 #, fuzzy
 msgid "email"
 msgstr "Email"
@@ -897,8 +896,8 @@ msgid "select_own_adventures"
 msgstr "Select own adventures"
 
 #: templates/customize-class.html:95 templates/customize-class.html:121
-#: templates/profile.html:47 templates/profile.html:128
-#: templates/profile.html:137 templates/signup.html:26 templates/signup.html:45
+#: templates/profile.html:47 templates/profile.html:121
+#: templates/profile.html:130 templates/signup.html:26 templates/signup.html:45
 #: templates/signup.html:53
 #, fuzzy
 msgid "select"
@@ -986,8 +985,8 @@ msgstr "Creator"
 msgid "view_program"
 msgstr "View program"
 
-#: templates/for-teachers.html:5 templates/profile.html:78
-#: templates/profile.html:80
+#: templates/for-teachers.html:5 templates/profile.html:71
+#: templates/profile.html:73
 #, fuzzy
 msgid "my_classes"
 msgstr "My classes"
@@ -1228,14 +1227,7 @@ msgstr "Cancel"
 msgid "copy_link_to_share"
 msgstr "Copy link to share"
 
-#: templates/layout.html:78
-#, fuzzy
-msgid "set_preferred_lang"
-msgstr ""
-"Hedy now supports preferred user languages. You can set one for your "
-"profile in \"My profile\""
-
-#: templates/layout.html:86 templates/quiz/endquiz.html:18
+#: templates/layout.html:83 templates/quiz/endquiz.html:18
 #: templates/quiz/quiz.html:29
 #, fuzzy
 msgid "achievement_earned"
@@ -1256,7 +1248,7 @@ msgstr "Username"
 msgid "lastname"
 msgstr "Name"
 
-#: templates/learn-more.html:22 templates/profile.html:135
+#: templates/learn-more.html:22 templates/profile.html:128
 #: templates/signup.html:52
 #, fuzzy
 msgid "country"
@@ -1405,7 +1397,7 @@ msgstr ""
 msgid "update_public"
 msgstr "Update public profile"
 
-#: templates/profile.html:61 templates/profile.html:148
+#: templates/profile.html:61 templates/profile.html:141
 #, fuzzy
 msgid "are_you_sure"
 msgstr "Are you sure? You cannot revert this action."
@@ -1415,82 +1407,77 @@ msgstr "Are you sure? You cannot revert this action."
 msgid "delete_public"
 msgstr "Delete public profile"
 
-#: templates/profile.html:70 templates/profile.html:72
-#, fuzzy
-msgid "statistics"
-msgstr "My statistics"
-
-#: templates/profile.html:83
+#: templates/profile.html:76
 #, fuzzy
 msgid "self_removal_prompt"
 msgstr "Are you sure you want to leave this class?"
 
-#: templates/profile.html:83
+#: templates/profile.html:76
 #, fuzzy
 msgid "leave_class"
 msgstr "Leave class"
 
-#: templates/profile.html:88 templates/profile.html:91
+#: templates/profile.html:81 templates/profile.html:84
 #, fuzzy
 msgid "settings"
 msgstr "My personal settings"
 
-#: templates/profile.html:99 templates/signup.html:41
+#: templates/profile.html:92 templates/signup.html:41
 #, fuzzy
 msgid "birth_year"
 msgstr "Birth year"
 
-#: templates/profile.html:102 templates/signup.html:25
+#: templates/profile.html:95 templates/signup.html:25
 #, fuzzy
 msgid "preferred_language"
 msgstr "Preferred language"
 
-#: templates/profile.html:112 templates/signup.html:34
+#: templates/profile.html:105 templates/signup.html:34
 #, fuzzy
 msgid "preferred_keyword_language"
 msgstr "Preferred keyword language"
 
-#: templates/profile.html:126 templates/signup.html:44
+#: templates/profile.html:119 templates/signup.html:44
 #, fuzzy
 msgid "gender"
 msgstr "Gender"
 
-#: templates/profile.html:129 templates/signup.html:46
+#: templates/profile.html:122 templates/signup.html:46
 #, fuzzy
 msgid "female"
 msgstr "Female"
 
-#: templates/profile.html:130 templates/signup.html:47
+#: templates/profile.html:123 templates/signup.html:47
 #, fuzzy
 msgid "male"
 msgstr "Male"
 
-#: templates/profile.html:131 templates/signup.html:48
+#: templates/profile.html:124 templates/signup.html:48
 #, fuzzy
 msgid "other"
 msgstr "Other"
 
-#: templates/profile.html:144
+#: templates/profile.html:137
 #, fuzzy
 msgid "update_profile"
 msgstr "Update profile"
 
-#: templates/profile.html:148
+#: templates/profile.html:141
 #, fuzzy
 msgid "destroy_profile"
 msgstr "Delete profile"
 
-#: templates/profile.html:155
+#: templates/profile.html:148
 #, fuzzy
 msgid "current_password"
 msgstr "Current password"
 
-#: templates/profile.html:159
+#: templates/profile.html:152
 #, fuzzy
 msgid "new_password"
 msgstr "New password"
 
-#: templates/profile.html:163
+#: templates/profile.html:156
 #, fuzzy
 msgid "repeat_new_password"
 msgstr "Repeat new password"
@@ -2186,4 +2173,13 @@ msgstr "The adventure has been updated!"
 #, fuzzy
 msgid "adventure_empty"
 msgstr "You didn't enter an adventure name!"
+
+#~ msgid "set_preferred_lang"
+#~ msgstr ""
+#~ "Hedy now supports preferred user "
+#~ "languages. You can set one for "
+#~ "your profile in \"My profile\""
+
+#~ msgid "statistics"
+#~ msgstr "My statistics"
 

--- a/translations/bg/LC_MESSAGES/messages.po
+++ b/translations/bg/LC_MESSAGES/messages.po
@@ -1,29 +1,29 @@
-#: app.py:497
+#: app.py:451
 #, fuzzy
 msgid "program_contains_error"
 msgstr "This program contains an error, are you sure you want to share it?"
 
-#: app.py:649
+#: app.py:604
 #, fuzzy
 msgid "title_achievements"
 msgstr "Hedy - My achievements"
 
-#: app.py:666 app.py:1057 website/teacher.py:363 website/teacher.py:372
+#: app.py:622 app.py:1030 website/teacher.py:363 website/teacher.py:372
 #, fuzzy
 msgid "not_teacher"
 msgstr "Looks like you are not a teacher!"
 
-#: app.py:669
+#: app.py:625
 #, fuzzy
 msgid "not_enrolled"
 msgstr "Looks like you are not in this class!"
 
-#: app.py:701
+#: app.py:657
 #, fuzzy
 msgid "title_programs"
 msgstr "Hedy - My programs"
 
-#: app.py:711 app.py:721 app.py:725 app.py:739 app.py:1000 app.py:1302
+#: app.py:667 app.py:677 app.py:681 app.py:695 app.py:956 app.py:1275
 #: website/admin.py:17 website/admin.py:25 website/admin.py:95
 #: website/admin.py:112 website/admin.py:130 website/auth.py:653
 #: website/auth.py:680 website/statistics.py:86
@@ -31,122 +31,122 @@ msgstr "Hedy - My programs"
 msgid "unauthorized"
 msgstr "You don't have access rights for this page"
 
-#: app.py:749
+#: app.py:705
 msgid "minutes"
 msgstr "минути"
 
-#: app.py:752
+#: app.py:708
 msgid "hours"
 msgstr "часа"
 
-#: app.py:755
+#: app.py:711
 msgid "days"
 msgstr "дни"
 
-#: app.py:758
+#: app.py:714
 #, fuzzy
 msgid "ago"
 msgstr "{time} ago"
 
-#: app.py:774 app.py:776 app.py:915 app.py:939 app.py:941
+#: app.py:730 app.py:732 app.py:871 app.py:895 app.py:897
 #, fuzzy
 msgid "no_such_level"
 msgstr "No such Hedy level!"
 
-#: app.py:784 app.py:791 app.py:865 app.py:871
+#: app.py:740 app.py:747 app.py:821 app.py:827
 #, fuzzy
 msgid "no_such_program"
 msgstr "No such Hedy program!"
 
-#: app.py:820
+#: app.py:776
 #, fuzzy
 msgid "level_not_translated"
 msgstr "This level is not translated in your language (yet)"
 
-#: app.py:822
+#: app.py:778
 #, fuzzy
 msgid "level_not_class"
 msgstr "You're in a class where this level has not been made available yet"
 
-#: app.py:925 website/teacher.py:430 website/teacher.py:446
+#: app.py:881 website/teacher.py:430 website/teacher.py:446
 #: website/teacher.py:475 website/teacher.py:501
 #, fuzzy
 msgid "no_such_adventure"
 msgstr "This adventure doesn't exist!"
 
-#: app.py:951
+#: app.py:907
 #, fuzzy
 msgid "page_not_found"
 msgstr "We could not find that page!"
 
-#: app.py:971
+#: app.py:927
 #, fuzzy
 msgid "title_signup"
 msgstr "Hedy - Create an account"
 
-#: app.py:978
+#: app.py:934
 #, fuzzy
 msgid "title_login"
 msgstr "Hedy - Login"
 
-#: app.py:985
+#: app.py:941
 #, fuzzy
 msgid "title_recover"
 msgstr "Hedy - Recover account"
 
-#: app.py:1001
+#: app.py:957
 #, fuzzy
 msgid "title_reset"
 msgstr "Hedy - Reset password"
 
-#: app.py:1010
+#: app.py:982
 #, fuzzy
 msgid "title_my-profile"
 msgstr "Hedy - My account"
 
-#: app.py:1024
+#: app.py:997
 #, fuzzy
 msgid "title_learn-more"
 msgstr "Hedy - Learn more"
 
-#: app.py:1029
+#: app.py:1002
 #, fuzzy
 msgid "title_privacy"
 msgstr "Hedy - Privacy terms"
 
-#: app.py:1036
+#: app.py:1009
 #, fuzzy
 msgid "title_landing-page"
 msgstr "Welcome to Hedy!"
 
-#: app.py:1038
+#: app.py:1011
 #, fuzzy
 msgid "not_user"
 msgstr "Looks like you are not logged in!"
 
-#: app.py:1053
+#: app.py:1026
 #, fuzzy
 msgid "title_for-teacher"
 msgstr "Hedy - For teachers"
 
-#: app.py:1064
+#: app.py:1037
 #, fuzzy
 msgid "title_start"
 msgstr "Hedy - A gradual programming language"
 
-#: app.py:1117
+#: app.py:1090
 #, fuzzy
 msgid "title_explore"
 msgstr "Hedy - Explore"
 
-#: app.py:1135 app.py:1137
+#: app.py:1108 app.py:1110
 #, fuzzy
 msgid "translate_error"
 msgstr ""
 "Something went wrong while translating the code. Try running the code to "
 "see if it has an error. Code with errors can not be translated."
 
-#: app.py:1246 website/auth.py:241 website/auth.py:290 website/auth.py:426
+#: app.py:1219 website/auth.py:241 website/auth.py:290 website/auth.py:426
 #: website/auth.py:451 website/auth.py:481 website/auth.py:587
 #: website/auth.py:619 website/auth.py:659 website/auth.py:686
 #: website/teacher.py:90 website/teacher.py:125 website/teacher.py:197
@@ -156,32 +156,32 @@ msgstr ""
 msgid "ajax_error"
 msgstr "There was an error, please try again."
 
-#: app.py:1249
+#: app.py:1222
 #, fuzzy
 msgid "image_invalid"
 msgstr "Your chosen image is invalid."
 
-#: app.py:1251
+#: app.py:1224
 #, fuzzy
 msgid "personal_text_invalid"
 msgstr "Your personal text is invalid."
 
-#: app.py:1253 app.py:1259
+#: app.py:1226 app.py:1232
 #, fuzzy
 msgid "favourite_program_invalid"
 msgstr "Your chosen favourite program is invalid."
 
-#: app.py:1271 app.py:1272
+#: app.py:1244 app.py:1245
 #, fuzzy
 msgid "public_profile_updated"
 msgstr "Public profile updated."
 
-#: app.py:1306 app.py:1330
+#: app.py:1279 app.py:1303
 #, fuzzy
 msgid "user_not_private"
 msgstr "This user doesn't exist or doesn't have a public profile"
 
-#: app.py:1339
+#: app.py:1312
 msgid "invalid_teacher_invitation_code"
 msgstr "Този код не е валиден."
 
@@ -460,7 +460,7 @@ msgstr "Visible columns"
 
 #: templates/class-overview.html:21 templates/class-overview.html:64
 #: templates/class-overview.html:108 templates/create-accounts.html:16
-#: templates/login.html:12 templates/profile.html:93 templates/recover.html:8
+#: templates/login.html:12 templates/profile.html:86 templates/recover.html:8
 #: templates/signup.html:10
 msgid "username"
 msgstr "Потребителско име"
@@ -476,7 +476,6 @@ msgid "highest_level_reached"
 msgstr "Highest level reached"
 
 #: templates/class-overview.html:35 templates/class-overview.html:67
-#: templates/profile.html:74
 #, fuzzy
 msgid "number_programs"
 msgstr "Number of programs"
@@ -492,8 +491,8 @@ msgid "latest_shared_program"
 msgstr "Latest shared program"
 
 #: templates/class-overview.html:49 templates/class-overview.html:70
-#: templates/class-overview.html:83 templates/profile.html:151
-#: templates/profile.html:153 templates/profile.html:166
+#: templates/class-overview.html:83 templates/profile.html:144
+#: templates/profile.html:146 templates/profile.html:159
 msgid "change_password"
 msgstr "Смяна на паролата"
 
@@ -666,7 +665,7 @@ msgid "create_accounts_prompt"
 msgstr "Are you sure you want to create these accounts?"
 
 #: templates/create-accounts.html:17 templates/learn-more.html:10
-#: templates/profile.html:96 templates/recover.html:8 templates/signup.html:13
+#: templates/profile.html:89 templates/recover.html:8 templates/signup.html:13
 msgid "email"
 msgstr "Имейл адрес"
 
@@ -859,8 +858,8 @@ msgid "select_own_adventures"
 msgstr "Select own adventures"
 
 #: templates/customize-class.html:95 templates/customize-class.html:121
-#: templates/profile.html:47 templates/profile.html:128
-#: templates/profile.html:137 templates/signup.html:26 templates/signup.html:45
+#: templates/profile.html:47 templates/profile.html:121
+#: templates/profile.html:130 templates/signup.html:26 templates/signup.html:45
 #: templates/signup.html:53
 msgid "select"
 msgstr "Избери"
@@ -947,8 +946,8 @@ msgstr "Creator"
 msgid "view_program"
 msgstr "View program"
 
-#: templates/for-teachers.html:5 templates/profile.html:78
-#: templates/profile.html:80
+#: templates/for-teachers.html:5 templates/profile.html:71
+#: templates/profile.html:73
 #, fuzzy
 msgid "my_classes"
 msgstr "My classes"
@@ -1179,14 +1178,7 @@ msgstr "Cancel"
 msgid "copy_link_to_share"
 msgstr "Copy link to share"
 
-#: templates/layout.html:78
-#, fuzzy
-msgid "set_preferred_lang"
-msgstr ""
-"Hedy now supports preferred user languages. You can set one for your "
-"profile in \"My profile\""
-
-#: templates/layout.html:86 templates/quiz/endquiz.html:18
+#: templates/layout.html:83 templates/quiz/endquiz.html:18
 #: templates/quiz/quiz.html:29
 #, fuzzy
 msgid "achievement_earned"
@@ -1207,7 +1199,7 @@ msgstr "Потребителско име"
 msgid "lastname"
 msgstr "Name"
 
-#: templates/learn-more.html:22 templates/profile.html:135
+#: templates/learn-more.html:22 templates/profile.html:128
 #: templates/signup.html:52
 msgid "country"
 msgstr "Държава"
@@ -1347,7 +1339,7 @@ msgstr ""
 msgid "update_public"
 msgstr "Update public profile"
 
-#: templates/profile.html:61 templates/profile.html:148
+#: templates/profile.html:61 templates/profile.html:141
 msgid "are_you_sure"
 msgstr "Внимание! Това действие е необратимо."
 
@@ -1356,73 +1348,68 @@ msgstr "Внимание! Това действие е необратимо."
 msgid "delete_public"
 msgstr "Delete public profile"
 
-#: templates/profile.html:70 templates/profile.html:72
-#, fuzzy
-msgid "statistics"
-msgstr "My statistics"
-
-#: templates/profile.html:83
+#: templates/profile.html:76
 #, fuzzy
 msgid "self_removal_prompt"
 msgstr "Are you sure you want to leave this class?"
 
-#: templates/profile.html:83
+#: templates/profile.html:76
 #, fuzzy
 msgid "leave_class"
 msgstr "Leave class"
 
-#: templates/profile.html:88 templates/profile.html:91
+#: templates/profile.html:81 templates/profile.html:84
 #, fuzzy
 msgid "settings"
 msgstr "My personal settings"
 
-#: templates/profile.html:99 templates/signup.html:41
+#: templates/profile.html:92 templates/signup.html:41
 msgid "birth_year"
 msgstr "Година на раждане"
 
-#: templates/profile.html:102 templates/signup.html:25
+#: templates/profile.html:95 templates/signup.html:25
 #, fuzzy
 msgid "preferred_language"
 msgstr "Preferred language"
 
-#: templates/profile.html:112 templates/signup.html:34
+#: templates/profile.html:105 templates/signup.html:34
 #, fuzzy
 msgid "preferred_keyword_language"
 msgstr "Preferred keyword language"
 
-#: templates/profile.html:126 templates/signup.html:44
+#: templates/profile.html:119 templates/signup.html:44
 msgid "gender"
 msgstr "Пол"
 
-#: templates/profile.html:129 templates/signup.html:46
+#: templates/profile.html:122 templates/signup.html:46
 msgid "female"
 msgstr "Женски"
 
-#: templates/profile.html:130 templates/signup.html:47
+#: templates/profile.html:123 templates/signup.html:47
 msgid "male"
 msgstr "Мъжки"
 
-#: templates/profile.html:131 templates/signup.html:48
+#: templates/profile.html:124 templates/signup.html:48
 msgid "other"
 msgstr "Друг"
 
-#: templates/profile.html:144
+#: templates/profile.html:137
 msgid "update_profile"
 msgstr "Обновяване на профила"
 
-#: templates/profile.html:148
+#: templates/profile.html:141
 msgid "destroy_profile"
 msgstr "Изтриване на акаунта"
 
-#: templates/profile.html:155
+#: templates/profile.html:148
 msgid "current_password"
 msgstr "Настояща парола"
 
-#: templates/profile.html:159
+#: templates/profile.html:152
 msgid "new_password"
 msgstr "Нова парола"
 
-#: templates/profile.html:163
+#: templates/profile.html:156
 msgid "repeat_new_password"
 msgstr "Повтаряне на паролата"
 
@@ -2098,4 +2085,13 @@ msgstr "The adventure has been updated!"
 #, fuzzy
 msgid "adventure_empty"
 msgstr "You didn't enter an adventure name!"
+
+#~ msgid "set_preferred_lang"
+#~ msgstr ""
+#~ "Hedy now supports preferred user "
+#~ "languages. You can set one for "
+#~ "your profile in \"My profile\""
+
+#~ msgid "statistics"
+#~ msgstr "My statistics"
 

--- a/translations/bn/LC_MESSAGES/messages.po
+++ b/translations/bn/LC_MESSAGES/messages.po
@@ -1,29 +1,29 @@
-#: app.py:497
+#: app.py:451
 #, fuzzy
 msgid "program_contains_error"
 msgstr "This program contains an error, are you sure you want to share it?"
 
-#: app.py:649
+#: app.py:604
 #, fuzzy
 msgid "title_achievements"
 msgstr "Hedy - My achievements"
 
-#: app.py:666 app.py:1057 website/teacher.py:363 website/teacher.py:372
+#: app.py:622 app.py:1030 website/teacher.py:363 website/teacher.py:372
 #, fuzzy
 msgid "not_teacher"
 msgstr "Looks like you are not a teacher!"
 
-#: app.py:669
+#: app.py:625
 #, fuzzy
 msgid "not_enrolled"
 msgstr "Looks like you are not in this class!"
 
-#: app.py:701
+#: app.py:657
 #, fuzzy
 msgid "title_programs"
 msgstr "Hedy - My programs"
 
-#: app.py:711 app.py:721 app.py:725 app.py:739 app.py:1000 app.py:1302
+#: app.py:667 app.py:677 app.py:681 app.py:695 app.py:956 app.py:1275
 #: website/admin.py:17 website/admin.py:25 website/admin.py:95
 #: website/admin.py:112 website/admin.py:130 website/auth.py:653
 #: website/auth.py:680 website/statistics.py:86
@@ -31,125 +31,125 @@ msgstr "Hedy - My programs"
 msgid "unauthorized"
 msgstr "You don't have access rights for this page"
 
-#: app.py:749
+#: app.py:705
 #, fuzzy
 msgid "minutes"
 msgstr "minutes"
 
-#: app.py:752
+#: app.py:708
 #, fuzzy
 msgid "hours"
 msgstr "hours"
 
-#: app.py:755
+#: app.py:711
 #, fuzzy
 msgid "days"
 msgstr "days"
 
-#: app.py:758
+#: app.py:714
 #, fuzzy
 msgid "ago"
 msgstr "{time} ago"
 
-#: app.py:774 app.py:776 app.py:915 app.py:939 app.py:941
+#: app.py:730 app.py:732 app.py:871 app.py:895 app.py:897
 #, fuzzy
 msgid "no_such_level"
 msgstr "No such Hedy level!"
 
-#: app.py:784 app.py:791 app.py:865 app.py:871
+#: app.py:740 app.py:747 app.py:821 app.py:827
 #, fuzzy
 msgid "no_such_program"
 msgstr "No such Hedy program!"
 
-#: app.py:820
+#: app.py:776
 #, fuzzy
 msgid "level_not_translated"
 msgstr "This level is not translated in your language (yet)"
 
-#: app.py:822
+#: app.py:778
 #, fuzzy
 msgid "level_not_class"
 msgstr "You're in a class where this level has not been made available yet"
 
-#: app.py:925 website/teacher.py:430 website/teacher.py:446
+#: app.py:881 website/teacher.py:430 website/teacher.py:446
 #: website/teacher.py:475 website/teacher.py:501
 #, fuzzy
 msgid "no_such_adventure"
 msgstr "This adventure doesn't exist!"
 
-#: app.py:951
+#: app.py:907
 #, fuzzy
 msgid "page_not_found"
 msgstr "We could not find that page!"
 
-#: app.py:971
+#: app.py:927
 #, fuzzy
 msgid "title_signup"
 msgstr "Hedy - Create an account"
 
-#: app.py:978
+#: app.py:934
 #, fuzzy
 msgid "title_login"
 msgstr "Hedy - Login"
 
-#: app.py:985
+#: app.py:941
 #, fuzzy
 msgid "title_recover"
 msgstr "Hedy - Recover account"
 
-#: app.py:1001
+#: app.py:957
 #, fuzzy
 msgid "title_reset"
 msgstr "Hedy - Reset password"
 
-#: app.py:1010
+#: app.py:982
 #, fuzzy
 msgid "title_my-profile"
 msgstr "Hedy - My account"
 
-#: app.py:1024
+#: app.py:997
 #, fuzzy
 msgid "title_learn-more"
 msgstr "Hedy - Learn more"
 
-#: app.py:1029
+#: app.py:1002
 #, fuzzy
 msgid "title_privacy"
 msgstr "Hedy - Privacy terms"
 
-#: app.py:1036
+#: app.py:1009
 #, fuzzy
 msgid "title_landing-page"
 msgstr "Welcome to Hedy!"
 
-#: app.py:1038
+#: app.py:1011
 #, fuzzy
 msgid "not_user"
 msgstr "Looks like you are not logged in!"
 
-#: app.py:1053
+#: app.py:1026
 #, fuzzy
 msgid "title_for-teacher"
 msgstr "Hedy - For teachers"
 
-#: app.py:1064
+#: app.py:1037
 #, fuzzy
 msgid "title_start"
 msgstr "Hedy - A gradual programming language"
 
-#: app.py:1117
+#: app.py:1090
 #, fuzzy
 msgid "title_explore"
 msgstr "Hedy - Explore"
 
-#: app.py:1135 app.py:1137
+#: app.py:1108 app.py:1110
 #, fuzzy
 msgid "translate_error"
 msgstr ""
 "Something went wrong while translating the code. Try running the code to "
 "see if it has an error. Code with errors can not be translated."
 
-#: app.py:1246 website/auth.py:241 website/auth.py:290 website/auth.py:426
+#: app.py:1219 website/auth.py:241 website/auth.py:290 website/auth.py:426
 #: website/auth.py:451 website/auth.py:481 website/auth.py:587
 #: website/auth.py:619 website/auth.py:659 website/auth.py:686
 #: website/teacher.py:90 website/teacher.py:125 website/teacher.py:197
@@ -159,32 +159,32 @@ msgstr ""
 msgid "ajax_error"
 msgstr "There was an error, please try again."
 
-#: app.py:1249
+#: app.py:1222
 #, fuzzy
 msgid "image_invalid"
 msgstr "Your chosen image is invalid."
 
-#: app.py:1251
+#: app.py:1224
 #, fuzzy
 msgid "personal_text_invalid"
 msgstr "Your personal text is invalid."
 
-#: app.py:1253 app.py:1259
+#: app.py:1226 app.py:1232
 #, fuzzy
 msgid "favourite_program_invalid"
 msgstr "Your chosen favourite program is invalid."
 
-#: app.py:1271 app.py:1272
+#: app.py:1244 app.py:1245
 #, fuzzy
 msgid "public_profile_updated"
 msgstr "Public profile updated."
 
-#: app.py:1306 app.py:1330
+#: app.py:1279 app.py:1303
 #, fuzzy
 msgid "user_not_private"
 msgstr "This user doesn't exist or doesn't have a public profile"
 
-#: app.py:1339
+#: app.py:1312
 #, fuzzy
 msgid "invalid_teacher_invitation_code"
 msgstr ""
@@ -491,7 +491,7 @@ msgstr "Visible columns"
 
 #: templates/class-overview.html:21 templates/class-overview.html:64
 #: templates/class-overview.html:108 templates/create-accounts.html:16
-#: templates/login.html:12 templates/profile.html:93 templates/recover.html:8
+#: templates/login.html:12 templates/profile.html:86 templates/recover.html:8
 #: templates/signup.html:10
 #, fuzzy
 msgid "username"
@@ -508,7 +508,6 @@ msgid "highest_level_reached"
 msgstr "Highest level reached"
 
 #: templates/class-overview.html:35 templates/class-overview.html:67
-#: templates/profile.html:74
 #, fuzzy
 msgid "number_programs"
 msgstr "Number of programs"
@@ -524,8 +523,8 @@ msgid "latest_shared_program"
 msgstr "Latest shared program"
 
 #: templates/class-overview.html:49 templates/class-overview.html:70
-#: templates/class-overview.html:83 templates/profile.html:151
-#: templates/profile.html:153 templates/profile.html:166
+#: templates/class-overview.html:83 templates/profile.html:144
+#: templates/profile.html:146 templates/profile.html:159
 #, fuzzy
 msgid "change_password"
 msgstr "Change password"
@@ -700,7 +699,7 @@ msgid "create_accounts_prompt"
 msgstr "Are you sure you want to create these accounts?"
 
 #: templates/create-accounts.html:17 templates/learn-more.html:10
-#: templates/profile.html:96 templates/recover.html:8 templates/signup.html:13
+#: templates/profile.html:89 templates/recover.html:8 templates/signup.html:13
 #, fuzzy
 msgid "email"
 msgstr "Email"
@@ -897,8 +896,8 @@ msgid "select_own_adventures"
 msgstr "Select own adventures"
 
 #: templates/customize-class.html:95 templates/customize-class.html:121
-#: templates/profile.html:47 templates/profile.html:128
-#: templates/profile.html:137 templates/signup.html:26 templates/signup.html:45
+#: templates/profile.html:47 templates/profile.html:121
+#: templates/profile.html:130 templates/signup.html:26 templates/signup.html:45
 #: templates/signup.html:53
 #, fuzzy
 msgid "select"
@@ -986,8 +985,8 @@ msgstr "Creator"
 msgid "view_program"
 msgstr "View program"
 
-#: templates/for-teachers.html:5 templates/profile.html:78
-#: templates/profile.html:80
+#: templates/for-teachers.html:5 templates/profile.html:71
+#: templates/profile.html:73
 #, fuzzy
 msgid "my_classes"
 msgstr "My classes"
@@ -1232,14 +1231,7 @@ msgstr "Cancel"
 msgid "copy_link_to_share"
 msgstr "Copy link to share"
 
-#: templates/layout.html:78
-#, fuzzy
-msgid "set_preferred_lang"
-msgstr ""
-"Hedy now supports preferred user languages. You can set one for your "
-"profile in \"My profile\""
-
-#: templates/layout.html:86 templates/quiz/endquiz.html:18
+#: templates/layout.html:83 templates/quiz/endquiz.html:18
 #: templates/quiz/quiz.html:29
 #, fuzzy
 msgid "achievement_earned"
@@ -1260,7 +1252,7 @@ msgstr "Username"
 msgid "lastname"
 msgstr "Name"
 
-#: templates/learn-more.html:22 templates/profile.html:135
+#: templates/learn-more.html:22 templates/profile.html:128
 #: templates/signup.html:52
 #, fuzzy
 msgid "country"
@@ -1409,7 +1401,7 @@ msgstr ""
 msgid "update_public"
 msgstr "Update public profile"
 
-#: templates/profile.html:61 templates/profile.html:148
+#: templates/profile.html:61 templates/profile.html:141
 #, fuzzy
 msgid "are_you_sure"
 msgstr "Are you sure? You cannot revert this action."
@@ -1419,82 +1411,77 @@ msgstr "Are you sure? You cannot revert this action."
 msgid "delete_public"
 msgstr "Delete public profile"
 
-#: templates/profile.html:70 templates/profile.html:72
-#, fuzzy
-msgid "statistics"
-msgstr "My statistics"
-
-#: templates/profile.html:83
+#: templates/profile.html:76
 #, fuzzy
 msgid "self_removal_prompt"
 msgstr "Are you sure you want to leave this class?"
 
-#: templates/profile.html:83
+#: templates/profile.html:76
 #, fuzzy
 msgid "leave_class"
 msgstr "Leave class"
 
-#: templates/profile.html:88 templates/profile.html:91
+#: templates/profile.html:81 templates/profile.html:84
 #, fuzzy
 msgid "settings"
 msgstr "My personal settings"
 
-#: templates/profile.html:99 templates/signup.html:41
+#: templates/profile.html:92 templates/signup.html:41
 #, fuzzy
 msgid "birth_year"
 msgstr "Birth year"
 
-#: templates/profile.html:102 templates/signup.html:25
+#: templates/profile.html:95 templates/signup.html:25
 #, fuzzy
 msgid "preferred_language"
 msgstr "Preferred language"
 
-#: templates/profile.html:112 templates/signup.html:34
+#: templates/profile.html:105 templates/signup.html:34
 #, fuzzy
 msgid "preferred_keyword_language"
 msgstr "Preferred keyword language"
 
-#: templates/profile.html:126 templates/signup.html:44
+#: templates/profile.html:119 templates/signup.html:44
 #, fuzzy
 msgid "gender"
 msgstr "Gender"
 
-#: templates/profile.html:129 templates/signup.html:46
+#: templates/profile.html:122 templates/signup.html:46
 #, fuzzy
 msgid "female"
 msgstr "Female"
 
-#: templates/profile.html:130 templates/signup.html:47
+#: templates/profile.html:123 templates/signup.html:47
 #, fuzzy
 msgid "male"
 msgstr "Male"
 
-#: templates/profile.html:131 templates/signup.html:48
+#: templates/profile.html:124 templates/signup.html:48
 #, fuzzy
 msgid "other"
 msgstr "Other"
 
-#: templates/profile.html:144
+#: templates/profile.html:137
 #, fuzzy
 msgid "update_profile"
 msgstr "Update profile"
 
-#: templates/profile.html:148
+#: templates/profile.html:141
 #, fuzzy
 msgid "destroy_profile"
 msgstr "Delete profile"
 
-#: templates/profile.html:155
+#: templates/profile.html:148
 #, fuzzy
 msgid "current_password"
 msgstr "Current password"
 
-#: templates/profile.html:159
+#: templates/profile.html:152
 #, fuzzy
 msgid "new_password"
 msgstr "New password"
 
-#: templates/profile.html:163
+#: templates/profile.html:156
 #, fuzzy
 msgid "repeat_new_password"
 msgstr "Repeat new password"
@@ -2190,4 +2177,13 @@ msgstr "The adventure has been updated!"
 #, fuzzy
 msgid "adventure_empty"
 msgstr "You didn't enter an adventure name!"
+
+#~ msgid "set_preferred_lang"
+#~ msgstr ""
+#~ "Hedy now supports preferred user "
+#~ "languages. You can set one for "
+#~ "your profile in \"My profile\""
+
+#~ msgid "statistics"
+#~ msgstr "My statistics"
 

--- a/translations/cs/LC_MESSAGES/messages.po
+++ b/translations/cs/LC_MESSAGES/messages.po
@@ -1,29 +1,29 @@
-#: app.py:497
+#: app.py:451
 #, fuzzy
 msgid "program_contains_error"
 msgstr "This program contains an error, are you sure you want to share it?"
 
-#: app.py:649
+#: app.py:604
 #, fuzzy
 msgid "title_achievements"
 msgstr "Hedy - My achievements"
 
-#: app.py:666 app.py:1057 website/teacher.py:363 website/teacher.py:372
+#: app.py:622 app.py:1030 website/teacher.py:363 website/teacher.py:372
 #, fuzzy
 msgid "not_teacher"
 msgstr "Looks like you are not a teacher!"
 
-#: app.py:669
+#: app.py:625
 #, fuzzy
 msgid "not_enrolled"
 msgstr "Looks like you are not in this class!"
 
-#: app.py:701
+#: app.py:657
 #, fuzzy
 msgid "title_programs"
 msgstr "Hedy - My programs"
 
-#: app.py:711 app.py:721 app.py:725 app.py:739 app.py:1000 app.py:1302
+#: app.py:667 app.py:677 app.py:681 app.py:695 app.py:956 app.py:1275
 #: website/admin.py:17 website/admin.py:25 website/admin.py:95
 #: website/admin.py:112 website/admin.py:130 website/auth.py:653
 #: website/auth.py:680 website/statistics.py:86
@@ -31,125 +31,125 @@ msgstr "Hedy - My programs"
 msgid "unauthorized"
 msgstr "You don't have access rights for this page"
 
-#: app.py:749
+#: app.py:705
 #, fuzzy
 msgid "minutes"
 msgstr "minutes"
 
-#: app.py:752
+#: app.py:708
 #, fuzzy
 msgid "hours"
 msgstr "hours"
 
-#: app.py:755
+#: app.py:711
 #, fuzzy
 msgid "days"
 msgstr "days"
 
-#: app.py:758
+#: app.py:714
 #, fuzzy
 msgid "ago"
 msgstr "{time} ago"
 
-#: app.py:774 app.py:776 app.py:915 app.py:939 app.py:941
+#: app.py:730 app.py:732 app.py:871 app.py:895 app.py:897
 #, fuzzy
 msgid "no_such_level"
 msgstr "No such Hedy level!"
 
-#: app.py:784 app.py:791 app.py:865 app.py:871
+#: app.py:740 app.py:747 app.py:821 app.py:827
 #, fuzzy
 msgid "no_such_program"
 msgstr "No such Hedy program!"
 
-#: app.py:820
+#: app.py:776
 #, fuzzy
 msgid "level_not_translated"
 msgstr "This level is not translated in your language (yet)"
 
-#: app.py:822
+#: app.py:778
 #, fuzzy
 msgid "level_not_class"
 msgstr "You're in a class where this level has not been made available yet"
 
-#: app.py:925 website/teacher.py:430 website/teacher.py:446
+#: app.py:881 website/teacher.py:430 website/teacher.py:446
 #: website/teacher.py:475 website/teacher.py:501
 #, fuzzy
 msgid "no_such_adventure"
 msgstr "This adventure doesn't exist!"
 
-#: app.py:951
+#: app.py:907
 #, fuzzy
 msgid "page_not_found"
 msgstr "We could not find that page!"
 
-#: app.py:971
+#: app.py:927
 #, fuzzy
 msgid "title_signup"
 msgstr "Hedy - Create an account"
 
-#: app.py:978
+#: app.py:934
 #, fuzzy
 msgid "title_login"
 msgstr "Hedy - Login"
 
-#: app.py:985
+#: app.py:941
 #, fuzzy
 msgid "title_recover"
 msgstr "Hedy - Recover account"
 
-#: app.py:1001
+#: app.py:957
 #, fuzzy
 msgid "title_reset"
 msgstr "Hedy - Reset password"
 
-#: app.py:1010
+#: app.py:982
 #, fuzzy
 msgid "title_my-profile"
 msgstr "Hedy - My account"
 
-#: app.py:1024
+#: app.py:997
 #, fuzzy
 msgid "title_learn-more"
 msgstr "Hedy - Learn more"
 
-#: app.py:1029
+#: app.py:1002
 #, fuzzy
 msgid "title_privacy"
 msgstr "Hedy - Privacy terms"
 
-#: app.py:1036
+#: app.py:1009
 #, fuzzy
 msgid "title_landing-page"
 msgstr "Welcome to Hedy!"
 
-#: app.py:1038
+#: app.py:1011
 #, fuzzy
 msgid "not_user"
 msgstr "Looks like you are not logged in!"
 
-#: app.py:1053
+#: app.py:1026
 #, fuzzy
 msgid "title_for-teacher"
 msgstr "Hedy - For teachers"
 
-#: app.py:1064
+#: app.py:1037
 #, fuzzy
 msgid "title_start"
 msgstr "Hedy - A gradual programming language"
 
-#: app.py:1117
+#: app.py:1090
 #, fuzzy
 msgid "title_explore"
 msgstr "Hedy - Explore"
 
-#: app.py:1135 app.py:1137
+#: app.py:1108 app.py:1110
 #, fuzzy
 msgid "translate_error"
 msgstr ""
 "Something went wrong while translating the code. Try running the code to "
 "see if it has an error. Code with errors can not be translated."
 
-#: app.py:1246 website/auth.py:241 website/auth.py:290 website/auth.py:426
+#: app.py:1219 website/auth.py:241 website/auth.py:290 website/auth.py:426
 #: website/auth.py:451 website/auth.py:481 website/auth.py:587
 #: website/auth.py:619 website/auth.py:659 website/auth.py:686
 #: website/teacher.py:90 website/teacher.py:125 website/teacher.py:197
@@ -158,32 +158,32 @@ msgstr ""
 msgid "ajax_error"
 msgstr "Nastala chyba, prosím zkus to znova."
 
-#: app.py:1249
+#: app.py:1222
 #, fuzzy
 msgid "image_invalid"
 msgstr "Your chosen image is invalid."
 
-#: app.py:1251
+#: app.py:1224
 #, fuzzy
 msgid "personal_text_invalid"
 msgstr "Your personal text is invalid."
 
-#: app.py:1253 app.py:1259
+#: app.py:1226 app.py:1232
 #, fuzzy
 msgid "favourite_program_invalid"
 msgstr "Your chosen favourite program is invalid."
 
-#: app.py:1271 app.py:1272
+#: app.py:1244 app.py:1245
 #, fuzzy
 msgid "public_profile_updated"
 msgstr "Public profile updated."
 
-#: app.py:1306 app.py:1330
+#: app.py:1279 app.py:1303
 #, fuzzy
 msgid "user_not_private"
 msgstr "This user doesn't exist or doesn't have a public profile"
 
-#: app.py:1339
+#: app.py:1312
 #, fuzzy
 msgid "invalid_teacher_invitation_code"
 msgstr ""
@@ -469,7 +469,7 @@ msgstr "Visible columns"
 
 #: templates/class-overview.html:21 templates/class-overview.html:64
 #: templates/class-overview.html:108 templates/create-accounts.html:16
-#: templates/login.html:12 templates/profile.html:93 templates/recover.html:8
+#: templates/login.html:12 templates/profile.html:86 templates/recover.html:8
 #: templates/signup.html:10
 msgid "username"
 msgstr "Uživatelské jméno"
@@ -485,7 +485,6 @@ msgid "highest_level_reached"
 msgstr "Highest level reached"
 
 #: templates/class-overview.html:35 templates/class-overview.html:67
-#: templates/profile.html:74
 #, fuzzy
 msgid "number_programs"
 msgstr "Number of programs"
@@ -501,8 +500,8 @@ msgid "latest_shared_program"
 msgstr "Latest shared program"
 
 #: templates/class-overview.html:49 templates/class-overview.html:70
-#: templates/class-overview.html:83 templates/profile.html:151
-#: templates/profile.html:153 templates/profile.html:166
+#: templates/class-overview.html:83 templates/profile.html:144
+#: templates/profile.html:146 templates/profile.html:159
 msgid "change_password"
 msgstr "Změnit heslo"
 
@@ -675,7 +674,7 @@ msgid "create_accounts_prompt"
 msgstr "Are you sure you want to create these accounts?"
 
 #: templates/create-accounts.html:17 templates/learn-more.html:10
-#: templates/profile.html:96 templates/recover.html:8 templates/signup.html:13
+#: templates/profile.html:89 templates/recover.html:8 templates/signup.html:13
 msgid "email"
 msgstr "Email"
 
@@ -869,8 +868,8 @@ msgid "select_own_adventures"
 msgstr "Select own adventures"
 
 #: templates/customize-class.html:95 templates/customize-class.html:121
-#: templates/profile.html:47 templates/profile.html:128
-#: templates/profile.html:137 templates/signup.html:26 templates/signup.html:45
+#: templates/profile.html:47 templates/profile.html:121
+#: templates/profile.html:130 templates/signup.html:26 templates/signup.html:45
 #: templates/signup.html:53
 msgid "select"
 msgstr "Vyber"
@@ -957,8 +956,8 @@ msgstr "Creator"
 msgid "view_program"
 msgstr "View program"
 
-#: templates/for-teachers.html:5 templates/profile.html:78
-#: templates/profile.html:80
+#: templates/for-teachers.html:5 templates/profile.html:71
+#: templates/profile.html:73
 #, fuzzy
 msgid "my_classes"
 msgstr "My classes"
@@ -1188,14 +1187,7 @@ msgstr "Cancel"
 msgid "copy_link_to_share"
 msgstr "Zkopírovat odkaz ke sdílení"
 
-#: templates/layout.html:78
-#, fuzzy
-msgid "set_preferred_lang"
-msgstr ""
-"Hedy now supports preferred user languages. You can set one for your "
-"profile in \"My profile\""
-
-#: templates/layout.html:86 templates/quiz/endquiz.html:18
+#: templates/layout.html:83 templates/quiz/endquiz.html:18
 #: templates/quiz/quiz.html:29
 #, fuzzy
 msgid "achievement_earned"
@@ -1213,7 +1205,7 @@ msgstr "Jméno"
 msgid "lastname"
 msgstr "Příjmení"
 
-#: templates/learn-more.html:22 templates/profile.html:135
+#: templates/learn-more.html:22 templates/profile.html:128
 #: templates/signup.html:52
 msgid "country"
 msgstr "Země"
@@ -1347,7 +1339,7 @@ msgstr ""
 msgid "update_public"
 msgstr "Update public profile"
 
-#: templates/profile.html:61 templates/profile.html:148
+#: templates/profile.html:61 templates/profile.html:141
 msgid "are_you_sure"
 msgstr "Opravdu to chceš udělat? Tato akce je nevratná."
 
@@ -1356,73 +1348,68 @@ msgstr "Opravdu to chceš udělat? Tato akce je nevratná."
 msgid "delete_public"
 msgstr "Delete public profile"
 
-#: templates/profile.html:70 templates/profile.html:72
-#, fuzzy
-msgid "statistics"
-msgstr "My statistics"
-
-#: templates/profile.html:83
+#: templates/profile.html:76
 #, fuzzy
 msgid "self_removal_prompt"
 msgstr "Are you sure you want to leave this class?"
 
-#: templates/profile.html:83
+#: templates/profile.html:76
 #, fuzzy
 msgid "leave_class"
 msgstr "Leave class"
 
-#: templates/profile.html:88 templates/profile.html:91
+#: templates/profile.html:81 templates/profile.html:84
 #, fuzzy
 msgid "settings"
 msgstr "My personal settings"
 
-#: templates/profile.html:99 templates/signup.html:41
+#: templates/profile.html:92 templates/signup.html:41
 msgid "birth_year"
 msgstr "Rok narození"
 
-#: templates/profile.html:102 templates/signup.html:25
+#: templates/profile.html:95 templates/signup.html:25
 #, fuzzy
 msgid "preferred_language"
 msgstr "Preferred language"
 
-#: templates/profile.html:112 templates/signup.html:34
+#: templates/profile.html:105 templates/signup.html:34
 #, fuzzy
 msgid "preferred_keyword_language"
 msgstr "Preferred keyword language"
 
-#: templates/profile.html:126 templates/signup.html:44
+#: templates/profile.html:119 templates/signup.html:44
 msgid "gender"
 msgstr "Pohlaví"
 
-#: templates/profile.html:129 templates/signup.html:46
+#: templates/profile.html:122 templates/signup.html:46
 msgid "female"
 msgstr "Žena"
 
-#: templates/profile.html:130 templates/signup.html:47
+#: templates/profile.html:123 templates/signup.html:47
 msgid "male"
 msgstr "Muž"
 
-#: templates/profile.html:131 templates/signup.html:48
+#: templates/profile.html:124 templates/signup.html:48
 msgid "other"
 msgstr "Jiné"
 
-#: templates/profile.html:144
+#: templates/profile.html:137
 msgid "update_profile"
 msgstr "Upravit profil"
 
-#: templates/profile.html:148
+#: templates/profile.html:141
 msgid "destroy_profile"
 msgstr "Trvale odstranit účet"
 
-#: templates/profile.html:155
+#: templates/profile.html:148
 msgid "current_password"
 msgstr "Současné heslo"
 
-#: templates/profile.html:159
+#: templates/profile.html:152
 msgid "new_password"
 msgstr "Nové heslo"
 
-#: templates/profile.html:163
+#: templates/profile.html:156
 msgid "repeat_new_password"
 msgstr "Zopakuj nové heslo"
 
@@ -2093,4 +2080,13 @@ msgstr "You didn't enter an adventure name!"
 
 #~ msgid "required"
 #~ msgstr ""
+
+#~ msgid "set_preferred_lang"
+#~ msgstr ""
+#~ "Hedy now supports preferred user "
+#~ "languages. You can set one for "
+#~ "your profile in \"My profile\""
+
+#~ msgid "statistics"
+#~ msgstr "My statistics"
 

--- a/translations/de/LC_MESSAGES/messages.po
+++ b/translations/de/LC_MESSAGES/messages.po
@@ -1,29 +1,29 @@
-#: app.py:497
+#: app.py:451
 #, fuzzy
 msgid "program_contains_error"
 msgstr "This program contains an error, are you sure you want to share it?"
 
-#: app.py:649
+#: app.py:604
 #, fuzzy
 msgid "title_achievements"
 msgstr "Hedy - My achievements"
 
-#: app.py:666 app.py:1057 website/teacher.py:363 website/teacher.py:372
+#: app.py:622 app.py:1030 website/teacher.py:363 website/teacher.py:372
 #, fuzzy
 msgid "not_teacher"
 msgstr "Looks like you are not a teacher!"
 
-#: app.py:669
+#: app.py:625
 #, fuzzy
 msgid "not_enrolled"
 msgstr "Looks like you are not in this class!"
 
-#: app.py:701
+#: app.py:657
 #, fuzzy
 msgid "title_programs"
 msgstr "Hedy - My programs"
 
-#: app.py:711 app.py:721 app.py:725 app.py:739 app.py:1000 app.py:1302
+#: app.py:667 app.py:677 app.py:681 app.py:695 app.py:956 app.py:1275
 #: website/admin.py:17 website/admin.py:25 website/admin.py:95
 #: website/admin.py:112 website/admin.py:130 website/auth.py:653
 #: website/auth.py:680 website/statistics.py:86
@@ -31,122 +31,122 @@ msgstr "Hedy - My programs"
 msgid "unauthorized"
 msgstr "You don't have access rights for this page"
 
-#: app.py:749
+#: app.py:705
 msgid "minutes"
 msgstr "Minuten"
 
-#: app.py:752
+#: app.py:708
 msgid "hours"
 msgstr "Stunden"
 
-#: app.py:755
+#: app.py:711
 msgid "days"
 msgstr "Tage"
 
-#: app.py:758
+#: app.py:714
 #, fuzzy
 msgid "ago"
 msgstr "{time} ago"
 
-#: app.py:774 app.py:776 app.py:915 app.py:939 app.py:941
+#: app.py:730 app.py:732 app.py:871 app.py:895 app.py:897
 #, fuzzy
 msgid "no_such_level"
 msgstr "No such Hedy level!"
 
-#: app.py:784 app.py:791 app.py:865 app.py:871
+#: app.py:740 app.py:747 app.py:821 app.py:827
 #, fuzzy
 msgid "no_such_program"
 msgstr "No such Hedy program!"
 
-#: app.py:820
+#: app.py:776
 #, fuzzy
 msgid "level_not_translated"
 msgstr "This level is not translated in your language (yet)"
 
-#: app.py:822
+#: app.py:778
 #, fuzzy
 msgid "level_not_class"
 msgstr "You're in a class where this level has not been made available yet"
 
-#: app.py:925 website/teacher.py:430 website/teacher.py:446
+#: app.py:881 website/teacher.py:430 website/teacher.py:446
 #: website/teacher.py:475 website/teacher.py:501
 #, fuzzy
 msgid "no_such_adventure"
 msgstr "This adventure doesn't exist!"
 
-#: app.py:951
+#: app.py:907
 #, fuzzy
 msgid "page_not_found"
 msgstr "We could not find that page!"
 
-#: app.py:971
+#: app.py:927
 #, fuzzy
 msgid "title_signup"
 msgstr "Hedy - Create an account"
 
-#: app.py:978
+#: app.py:934
 #, fuzzy
 msgid "title_login"
 msgstr "Hedy - Login"
 
-#: app.py:985
+#: app.py:941
 #, fuzzy
 msgid "title_recover"
 msgstr "Hedy - Recover account"
 
-#: app.py:1001
+#: app.py:957
 #, fuzzy
 msgid "title_reset"
 msgstr "Hedy - Reset password"
 
-#: app.py:1010
+#: app.py:982
 #, fuzzy
 msgid "title_my-profile"
 msgstr "Hedy - My account"
 
-#: app.py:1024
+#: app.py:997
 #, fuzzy
 msgid "title_learn-more"
 msgstr "Hedy - Learn more"
 
-#: app.py:1029
+#: app.py:1002
 #, fuzzy
 msgid "title_privacy"
 msgstr "Hedy - Privacy terms"
 
-#: app.py:1036
+#: app.py:1009
 #, fuzzy
 msgid "title_landing-page"
 msgstr "Welcome to Hedy!"
 
-#: app.py:1038
+#: app.py:1011
 #, fuzzy
 msgid "not_user"
 msgstr "Looks like you are not logged in!"
 
-#: app.py:1053
+#: app.py:1026
 #, fuzzy
 msgid "title_for-teacher"
 msgstr "Hedy - For teachers"
 
-#: app.py:1064
+#: app.py:1037
 #, fuzzy
 msgid "title_start"
 msgstr "Hedy - A gradual programming language"
 
-#: app.py:1117
+#: app.py:1090
 #, fuzzy
 msgid "title_explore"
 msgstr "Hedy - Explore"
 
-#: app.py:1135 app.py:1137
+#: app.py:1108 app.py:1110
 #, fuzzy
 msgid "translate_error"
 msgstr ""
 "Something went wrong while translating the code. Try running the code to "
 "see if it has an error. Code with errors can not be translated."
 
-#: app.py:1246 website/auth.py:241 website/auth.py:290 website/auth.py:426
+#: app.py:1219 website/auth.py:241 website/auth.py:290 website/auth.py:426
 #: website/auth.py:451 website/auth.py:481 website/auth.py:587
 #: website/auth.py:619 website/auth.py:659 website/auth.py:686
 #: website/teacher.py:90 website/teacher.py:125 website/teacher.py:197
@@ -155,32 +155,32 @@ msgstr ""
 msgid "ajax_error"
 msgstr "Ein Fehler ist aufgetreten. Bitte nochmal versuchen."
 
-#: app.py:1249
+#: app.py:1222
 #, fuzzy
 msgid "image_invalid"
 msgstr "Your chosen image is invalid."
 
-#: app.py:1251
+#: app.py:1224
 #, fuzzy
 msgid "personal_text_invalid"
 msgstr "Your personal text is invalid."
 
-#: app.py:1253 app.py:1259
+#: app.py:1226 app.py:1232
 #, fuzzy
 msgid "favourite_program_invalid"
 msgstr "Your chosen favourite program is invalid."
 
-#: app.py:1271 app.py:1272
+#: app.py:1244 app.py:1245
 #, fuzzy
 msgid "public_profile_updated"
 msgstr "Public profile updated."
 
-#: app.py:1306 app.py:1330
+#: app.py:1279 app.py:1303
 #, fuzzy
 msgid "user_not_private"
 msgstr "This user doesn't exist or doesn't have a public profile"
 
-#: app.py:1339
+#: app.py:1312
 #, fuzzy
 msgid "invalid_teacher_invitation_code"
 msgstr ""
@@ -319,8 +319,8 @@ msgstr ""
 msgid "Invalid Type Combination"
 msgstr ""
 "Du kannst die Argumente {invalid_argument} und {invalid_argument_2} nicht"
-" in {command} verwenden weil das eine ein {invalid_type} und das andere"
-" ein {invalid_type_2} ist. Ändere {invalid_argument} zu {invalid_type_2} "
+" in {command} verwenden weil das eine ein {invalid_type} und das andere "
+"ein {invalid_type_2} ist. Ändere {invalid_argument} zu {invalid_type_2} "
 "or {invalid_argument_2} zu {invalid_type} und versuche ob es "
 "funktioniert."
 
@@ -451,7 +451,7 @@ msgstr "Visible columns"
 
 #: templates/class-overview.html:21 templates/class-overview.html:64
 #: templates/class-overview.html:108 templates/create-accounts.html:16
-#: templates/login.html:12 templates/profile.html:93 templates/recover.html:8
+#: templates/login.html:12 templates/profile.html:86 templates/recover.html:8
 #: templates/signup.html:10
 msgid "username"
 msgstr "Benutzername"
@@ -465,7 +465,6 @@ msgid "highest_level_reached"
 msgstr "Höchstes erreichtes Level"
 
 #: templates/class-overview.html:35 templates/class-overview.html:67
-#: templates/profile.html:74
 msgid "number_programs"
 msgstr "Anzahl von Programmen"
 
@@ -478,8 +477,8 @@ msgid "latest_shared_program"
 msgstr "Zuletzt weitergegebenes Programm"
 
 #: templates/class-overview.html:49 templates/class-overview.html:70
-#: templates/class-overview.html:83 templates/profile.html:151
-#: templates/profile.html:153 templates/profile.html:166
+#: templates/class-overview.html:83 templates/profile.html:144
+#: templates/profile.html:146 templates/profile.html:159
 msgid "change_password"
 msgstr "Ändere Passwort"
 
@@ -636,7 +635,7 @@ msgid "create_accounts_prompt"
 msgstr "Are you sure you want to create these accounts?"
 
 #: templates/create-accounts.html:17 templates/learn-more.html:10
-#: templates/profile.html:96 templates/recover.html:8 templates/signup.html:13
+#: templates/profile.html:89 templates/recover.html:8 templates/signup.html:13
 msgid "email"
 msgstr "E-mail"
 
@@ -827,8 +826,8 @@ msgid "select_own_adventures"
 msgstr "Select own adventures"
 
 #: templates/customize-class.html:95 templates/customize-class.html:121
-#: templates/profile.html:47 templates/profile.html:128
-#: templates/profile.html:137 templates/signup.html:26 templates/signup.html:45
+#: templates/profile.html:47 templates/profile.html:121
+#: templates/profile.html:130 templates/signup.html:26 templates/signup.html:45
 #: templates/signup.html:53
 msgid "select"
 msgstr "Auswahl"
@@ -912,8 +911,8 @@ msgstr "Ersteller"
 msgid "view_program"
 msgstr "View program"
 
-#: templates/for-teachers.html:5 templates/profile.html:78
-#: templates/profile.html:80
+#: templates/for-teachers.html:5 templates/profile.html:71
+#: templates/profile.html:73
 msgid "my_classes"
 msgstr "Meine Klassen"
 
@@ -1124,14 +1123,7 @@ msgstr "Abbrechen"
 msgid "copy_link_to_share"
 msgstr "Kopiere Link zum Weitergeben"
 
-#: templates/layout.html:78
-msgid "set_preferred_lang"
-msgstr ""
-"Hedy unterstützt jetzt durch den Nutzer bevorzugte Sprache. Du kannst "
-"deine bevorzugte Sprache in deinem Profil einstellen unter \"Mein "
-"Profil\""
-
-#: templates/layout.html:86 templates/quiz/endquiz.html:18
+#: templates/layout.html:83 templates/quiz/endquiz.html:18
 #: templates/quiz/quiz.html:29
 msgid "achievement_earned"
 msgstr "Du hast eine Leistung erbracht!"
@@ -1148,7 +1140,7 @@ msgstr "Vorname"
 msgid "lastname"
 msgstr "Nachname"
 
-#: templates/learn-more.html:22 templates/profile.html:135
+#: templates/learn-more.html:22 templates/profile.html:128
 #: templates/signup.html:52
 msgid "country"
 msgstr "Land"
@@ -1284,7 +1276,7 @@ msgstr ""
 msgid "update_public"
 msgstr "Update public profile"
 
-#: templates/profile.html:61 templates/profile.html:148
+#: templates/profile.html:61 templates/profile.html:141
 msgid "are_you_sure"
 msgstr "Bist du sicher? Du kannst diese Aktion nicht rückgängig machen."
 
@@ -1293,69 +1285,65 @@ msgstr "Bist du sicher? Du kannst diese Aktion nicht rückgängig machen."
 msgid "delete_public"
 msgstr "Delete public profile"
 
-#: templates/profile.html:70 templates/profile.html:72
-msgid "statistics"
-msgstr "Meine Statistiken"
-
-#: templates/profile.html:83
+#: templates/profile.html:76
 msgid "self_removal_prompt"
 msgstr "Bist du dir sicher, dass du die Klasse verlassen möchtest?"
 
-#: templates/profile.html:83
+#: templates/profile.html:76
 msgid "leave_class"
 msgstr "Verlasse die Klasse"
 
-#: templates/profile.html:88 templates/profile.html:91
+#: templates/profile.html:81 templates/profile.html:84
 #, fuzzy
 msgid "settings"
 msgstr "My personal settings"
 
-#: templates/profile.html:99 templates/signup.html:41
+#: templates/profile.html:92 templates/signup.html:41
 msgid "birth_year"
 msgstr "Geburtjahr"
 
-#: templates/profile.html:102 templates/signup.html:25
+#: templates/profile.html:95 templates/signup.html:25
 msgid "preferred_language"
 msgstr "Bevorzugte Sprache"
 
-#: templates/profile.html:112 templates/signup.html:34
+#: templates/profile.html:105 templates/signup.html:34
 #, fuzzy
 msgid "preferred_keyword_language"
 msgstr "Preferred keyword language"
 
-#: templates/profile.html:126 templates/signup.html:44
+#: templates/profile.html:119 templates/signup.html:44
 msgid "gender"
 msgstr "Geschlecht"
 
-#: templates/profile.html:129 templates/signup.html:46
+#: templates/profile.html:122 templates/signup.html:46
 msgid "female"
 msgstr "weiblich"
 
-#: templates/profile.html:130 templates/signup.html:47
+#: templates/profile.html:123 templates/signup.html:47
 msgid "male"
 msgstr "männlich"
 
-#: templates/profile.html:131 templates/signup.html:48
+#: templates/profile.html:124 templates/signup.html:48
 msgid "other"
 msgstr "divers"
 
-#: templates/profile.html:144
+#: templates/profile.html:137
 msgid "update_profile"
 msgstr "Aktualisiere dein Profil"
 
-#: templates/profile.html:148
+#: templates/profile.html:141
 msgid "destroy_profile"
 msgstr "Konto endgültig löschen"
 
-#: templates/profile.html:155
+#: templates/profile.html:148
 msgid "current_password"
 msgstr "Aktuelles Passwort"
 
-#: templates/profile.html:159
+#: templates/profile.html:152
 msgid "new_password"
 msgstr "Neues Passwort"
 
-#: templates/profile.html:163
+#: templates/profile.html:156
 msgid "repeat_new_password"
 msgstr "Wiederhole neues Passwort"
 
@@ -2000,4 +1988,14 @@ msgstr "You didn't enter an adventure name!"
 
 #~ msgid "required"
 #~ msgstr ""
+
+#~ msgid "set_preferred_lang"
+#~ msgstr ""
+#~ "Hedy unterstützt jetzt durch den Nutzer"
+#~ " bevorzugte Sprache. Du kannst deine "
+#~ "bevorzugte Sprache in deinem Profil "
+#~ "einstellen unter \"Mein Profil\""
+
+#~ msgid "statistics"
+#~ msgstr "Meine Statistiken"
 

--- a/translations/el/LC_MESSAGES/messages.po
+++ b/translations/el/LC_MESSAGES/messages.po
@@ -1,27 +1,27 @@
-#: app.py:497
+#: app.py:451
 #, fuzzy
 msgid "program_contains_error"
 msgstr "This program contains an error, are you sure you want to share it?"
 
-#: app.py:649
+#: app.py:604
 #, fuzzy
 msgid "title_achievements"
 msgstr "Hedy - My achievements"
 
-#: app.py:666 app.py:1057 website/teacher.py:363 website/teacher.py:372
+#: app.py:622 app.py:1030 website/teacher.py:363 website/teacher.py:372
 msgid "not_teacher"
 msgstr "Φαίνεται πως δεν είσαι καθηγητής!"
 
-#: app.py:669
+#: app.py:625
 msgid "not_enrolled"
 msgstr "Φαίνεται πως δεν είστε σ' αυτήν την τάξη!"
 
-#: app.py:701
+#: app.py:657
 #, fuzzy
 msgid "title_programs"
 msgstr "Hedy - My programs"
 
-#: app.py:711 app.py:721 app.py:725 app.py:739 app.py:1000 app.py:1302
+#: app.py:667 app.py:677 app.py:681 app.py:695 app.py:956 app.py:1275
 #: website/admin.py:17 website/admin.py:25 website/admin.py:95
 #: website/admin.py:112 website/admin.py:130 website/auth.py:653
 #: website/auth.py:680 website/statistics.py:86
@@ -29,115 +29,115 @@ msgstr "Hedy - My programs"
 msgid "unauthorized"
 msgstr "You don't have access rights for this page"
 
-#: app.py:749
+#: app.py:705
 msgid "minutes"
 msgstr "λεπτά"
 
-#: app.py:752
+#: app.py:708
 msgid "hours"
 msgstr "ώρες"
 
-#: app.py:755
+#: app.py:711
 msgid "days"
 msgstr "ημέρες"
 
-#: app.py:758
+#: app.py:714
 #, fuzzy
 msgid "ago"
 msgstr "{time} ago"
 
-#: app.py:774 app.py:776 app.py:915 app.py:939 app.py:941
+#: app.py:730 app.py:732 app.py:871 app.py:895 app.py:897
 msgid "no_such_level"
 msgstr "Δεν υπάρχει τέτοιο επίπεδο Hedy!"
 
-#: app.py:784 app.py:791 app.py:865 app.py:871
+#: app.py:740 app.py:747 app.py:821 app.py:827
 msgid "no_such_program"
 msgstr "Δεν υπάρχει τέτοιο πρόγραμμα Hedy!"
 
-#: app.py:820
+#: app.py:776
 msgid "level_not_translated"
 msgstr "Αυτό το επίπεδο δεν είναι μεταφρασμένο στη γλώσσα σου (ακόμα)"
 
-#: app.py:822
+#: app.py:778
 msgid "level_not_class"
 msgstr "Είσαι σε μια τάξη στην οποία δεν είναι ακόμα διαθέσιμο αυτό το επίπεδο"
 
-#: app.py:925 website/teacher.py:430 website/teacher.py:446
+#: app.py:881 website/teacher.py:430 website/teacher.py:446
 #: website/teacher.py:475 website/teacher.py:501
 msgid "no_such_adventure"
 msgstr "Αυτή η περιπέτεια δεν υπάρχει!"
 
-#: app.py:951
+#: app.py:907
 msgid "page_not_found"
 msgstr "Δεν μπορούμε να βρούμε αυτήν τη σελίδα!"
 
-#: app.py:971
+#: app.py:927
 #, fuzzy
 msgid "title_signup"
 msgstr "Hedy - Create an account"
 
-#: app.py:978
+#: app.py:934
 #, fuzzy
 msgid "title_login"
 msgstr "Hedy - Login"
 
-#: app.py:985
+#: app.py:941
 #, fuzzy
 msgid "title_recover"
 msgstr "Hedy - Recover account"
 
-#: app.py:1001
+#: app.py:957
 #, fuzzy
 msgid "title_reset"
 msgstr "Hedy - Reset password"
 
-#: app.py:1010
+#: app.py:982
 #, fuzzy
 msgid "title_my-profile"
 msgstr "Hedy - My account"
 
-#: app.py:1024
+#: app.py:997
 #, fuzzy
 msgid "title_learn-more"
 msgstr "Hedy - Learn more"
 
-#: app.py:1029
+#: app.py:1002
 #, fuzzy
 msgid "title_privacy"
 msgstr "Hedy - Privacy terms"
 
-#: app.py:1036
+#: app.py:1009
 #, fuzzy
 msgid "title_landing-page"
 msgstr "Welcome to Hedy!"
 
-#: app.py:1038
+#: app.py:1011
 msgid "not_user"
 msgstr "Φαίνεται ότι δεν είστε συνδεδεμένοι!"
 
-#: app.py:1053
+#: app.py:1026
 #, fuzzy
 msgid "title_for-teacher"
 msgstr "Hedy - For teachers"
 
-#: app.py:1064
+#: app.py:1037
 #, fuzzy
 msgid "title_start"
 msgstr "Hedy - A gradual programming language"
 
-#: app.py:1117
+#: app.py:1090
 #, fuzzy
 msgid "title_explore"
 msgstr "Hedy - Explore"
 
-#: app.py:1135 app.py:1137
+#: app.py:1108 app.py:1110
 msgid "translate_error"
 msgstr ""
 "Κάτι πήγε στραβά κατά τη μετάφραση του κώδικα. Δοκίμασε να εκτελέσεις τον"
 " κώδικα για να δεις αν έχει κάποιο σφάλμα. Ο κώδικας με σφάλματα δεν "
 "μπορεί να μεταφραστεί."
 
-#: app.py:1246 website/auth.py:241 website/auth.py:290 website/auth.py:426
+#: app.py:1219 website/auth.py:241 website/auth.py:290 website/auth.py:426
 #: website/auth.py:451 website/auth.py:481 website/auth.py:587
 #: website/auth.py:619 website/auth.py:659 website/auth.py:686
 #: website/teacher.py:90 website/teacher.py:125 website/teacher.py:197
@@ -146,27 +146,27 @@ msgstr ""
 msgid "ajax_error"
 msgstr "Παρουσιάστηκε κάποιο σφάλμα, παρακαλώ ξαναπροσπάθησε."
 
-#: app.py:1249
+#: app.py:1222
 msgid "image_invalid"
 msgstr "Η εικόνα σου δεν είναι έγκυρη"
 
-#: app.py:1251
+#: app.py:1224
 msgid "personal_text_invalid"
 msgstr "Το προσωπικό σου κείμενο δεν είναι έγκυρο"
 
-#: app.py:1253 app.py:1259
+#: app.py:1226 app.py:1232
 msgid "favourite_program_invalid"
 msgstr "Το αγαπημένο σου πρόγραμμα δεν είναι έγκυρο"
 
-#: app.py:1271 app.py:1272
+#: app.py:1244 app.py:1245
 msgid "public_profile_updated"
 msgstr "Το δημόσιο προφίλ έχει ενημερωθεί."
 
-#: app.py:1306 app.py:1330
+#: app.py:1279 app.py:1303
 msgid "user_not_private"
 msgstr "Αυτός ο χρήστης δεν υπάρχει ή δεν έχει δημόσιο προφίλ"
 
-#: app.py:1339
+#: app.py:1312
 msgid "invalid_teacher_invitation_code"
 msgstr ""
 "Ο κωδικός πρόσκλησης καθηγητή δεν είναι έγκυρος. Για να γίνετε καθηγητής,"
@@ -303,8 +303,8 @@ msgstr ""
 msgid "Invalid Type Combination"
 msgstr ""
 "Δεν μπορείς να χρησιμοποιήσεις τα {invalid_argument} και "
-"{invalid_argument_2} στο {command} επειδή το ένα είναι {invalid_type} "
-"και το άλλο είναι {invalid_type_2}. Δοκίμασε να αλλάξεις το "
+"{invalid_argument_2} στο {command} επειδή το ένα είναι {invalid_type} και"
+" το άλλο είναι {invalid_type_2}. Δοκίμασε να αλλάξεις το "
 "{invalid_argument} σε {invalid_type_2} ή το {invalid_argument_2} σε "
 "{invalid_type}."
 
@@ -430,7 +430,7 @@ msgstr "Ορατές στήλες"
 
 #: templates/class-overview.html:21 templates/class-overview.html:64
 #: templates/class-overview.html:108 templates/create-accounts.html:16
-#: templates/login.html:12 templates/profile.html:93 templates/recover.html:8
+#: templates/login.html:12 templates/profile.html:86 templates/recover.html:8
 #: templates/signup.html:10
 msgid "username"
 msgstr "Όνομα Χρήστη"
@@ -444,7 +444,6 @@ msgid "highest_level_reached"
 msgstr "Το υψηλότερο επίπεδο που έφτασες"
 
 #: templates/class-overview.html:35 templates/class-overview.html:67
-#: templates/profile.html:74
 msgid "number_programs"
 msgstr "Πλήθος προγραμμάτων"
 
@@ -457,8 +456,8 @@ msgid "latest_shared_program"
 msgstr "Τελευταίο πρόγραμμα που μοιράστηκε"
 
 #: templates/class-overview.html:49 templates/class-overview.html:70
-#: templates/class-overview.html:83 templates/profile.html:151
-#: templates/profile.html:153 templates/profile.html:166
+#: templates/class-overview.html:83 templates/profile.html:144
+#: templates/profile.html:146 templates/profile.html:159
 msgid "change_password"
 msgstr "Άλλαξε συνθηματικό"
 
@@ -609,7 +608,7 @@ msgid "create_accounts_prompt"
 msgstr "Είσαι σίγουρος ότι θέλεις να δημιουργήσεις αυτούς τους λογαριασμούς;"
 
 #: templates/create-accounts.html:17 templates/learn-more.html:10
-#: templates/profile.html:96 templates/recover.html:8 templates/signup.html:13
+#: templates/profile.html:89 templates/recover.html:8 templates/signup.html:13
 msgid "email"
 msgstr "Email"
 
@@ -796,8 +795,8 @@ msgid "select_own_adventures"
 msgstr "Επίλεξε τις δικές σου περιπέτειες"
 
 #: templates/customize-class.html:95 templates/customize-class.html:121
-#: templates/profile.html:47 templates/profile.html:128
-#: templates/profile.html:137 templates/signup.html:26 templates/signup.html:45
+#: templates/profile.html:47 templates/profile.html:121
+#: templates/profile.html:130 templates/signup.html:26 templates/signup.html:45
 #: templates/signup.html:53
 msgid "select"
 msgstr "Επίλεξε"
@@ -874,8 +873,8 @@ msgstr "Δημιουργός"
 msgid "view_program"
 msgstr "Προβολή προγράμματος"
 
-#: templates/for-teachers.html:5 templates/profile.html:78
-#: templates/profile.html:80
+#: templates/for-teachers.html:5 templates/profile.html:71
+#: templates/profile.html:73
 msgid "my_classes"
 msgstr "Οι τάξεις μου"
 
@@ -1081,13 +1080,7 @@ msgstr "Ακύρωση"
 msgid "copy_link_to_share"
 msgstr "Αντίγραψε τον σύνδεσμο για κοινή χρήση"
 
-#: templates/layout.html:78
-msgid "set_preferred_lang"
-msgstr ""
-"Το Hedy υποστηρίζει πλέον προτιμώμενες γλώσσες χρήστη. Μπορείς να ορίσεις"
-" μια για το προφίλ σου στο \"Το προφίλ μου\""
-
-#: templates/layout.html:86 templates/quiz/endquiz.html:18
+#: templates/layout.html:83 templates/quiz/endquiz.html:18
 #: templates/quiz/quiz.html:29
 msgid "achievement_earned"
 msgstr "Κέρδισες ένα επίτευγμα!"
@@ -1104,7 +1097,7 @@ msgstr "Μικρό Όνομα"
 msgid "lastname"
 msgstr "Επίθετο"
 
-#: templates/learn-more.html:22 templates/profile.html:135
+#: templates/learn-more.html:22 templates/profile.html:128
 #: templates/signup.html:52
 msgid "country"
 msgstr "Χώρα"
@@ -1225,7 +1218,7 @@ msgstr ""
 msgid "update_public"
 msgstr "Ενημέρωση δημόσιου προφίλ"
 
-#: templates/profile.html:61 templates/profile.html:148
+#: templates/profile.html:61 templates/profile.html:141
 msgid "are_you_sure"
 msgstr "Είσαι σίγουρος/η; Δεν μπορείς να αναιρέσεις αυτήν την ενέργεια."
 
@@ -1233,67 +1226,63 @@ msgstr "Είσαι σίγουρος/η; Δεν μπορείς να αναιρέ�
 msgid "delete_public"
 msgstr "Διαγραφή δημόσιου προφίλ"
 
-#: templates/profile.html:70 templates/profile.html:72
-msgid "statistics"
-msgstr "Τα στατιστικά μου"
-
-#: templates/profile.html:83
+#: templates/profile.html:76
 msgid "self_removal_prompt"
 msgstr "Είστε βέβαιος/α ότι θέλεις να αποχωρήσεις από αυτήν την τάξη;"
 
-#: templates/profile.html:83
+#: templates/profile.html:76
 msgid "leave_class"
 msgstr "Έξοδος από την τάξη"
 
-#: templates/profile.html:88 templates/profile.html:91
+#: templates/profile.html:81 templates/profile.html:84
 msgid "settings"
 msgstr "Οι προσωπικές μου ρυθμίσεις"
 
-#: templates/profile.html:99 templates/signup.html:41
+#: templates/profile.html:92 templates/signup.html:41
 msgid "birth_year"
 msgstr "Έτος γέννησης"
 
-#: templates/profile.html:102 templates/signup.html:25
+#: templates/profile.html:95 templates/signup.html:25
 msgid "preferred_language"
 msgstr "Προτιμώμενη γλώσσα"
 
-#: templates/profile.html:112 templates/signup.html:34
+#: templates/profile.html:105 templates/signup.html:34
 msgid "preferred_keyword_language"
 msgstr "Προτιμώμενη γλώσσα για τα keywords"
 
-#: templates/profile.html:126 templates/signup.html:44
+#: templates/profile.html:119 templates/signup.html:44
 msgid "gender"
 msgstr "Φύλο"
 
-#: templates/profile.html:129 templates/signup.html:46
+#: templates/profile.html:122 templates/signup.html:46
 msgid "female"
 msgstr "Γυναίκα"
 
-#: templates/profile.html:130 templates/signup.html:47
+#: templates/profile.html:123 templates/signup.html:47
 msgid "male"
 msgstr "Άνδρας"
 
-#: templates/profile.html:131 templates/signup.html:48
+#: templates/profile.html:124 templates/signup.html:48
 msgid "other"
 msgstr "Άλλο"
 
-#: templates/profile.html:144
+#: templates/profile.html:137
 msgid "update_profile"
 msgstr "Ενημέρωση προφίλ"
 
-#: templates/profile.html:148
+#: templates/profile.html:141
 msgid "destroy_profile"
 msgstr "Μόνιμη διαγραφή λογαριασμού"
 
-#: templates/profile.html:155
+#: templates/profile.html:148
 msgid "current_password"
 msgstr "Τρέχον συνθηματικό"
 
-#: templates/profile.html:159
+#: templates/profile.html:152
 msgid "new_password"
 msgstr "Νέο συνθηματικό"
 
-#: templates/profile.html:163
+#: templates/profile.html:156
 msgid "repeat_new_password"
 msgstr "Επανάλαβε το νέο συνθηματικό"
 
@@ -1885,4 +1874,14 @@ msgstr "Δεν έδωσες όνομα περιπέτειας!"
 
 #~ msgid "ago-2"
 #~ msgstr "πριν"
+
+#~ msgid "set_preferred_lang"
+#~ msgstr ""
+#~ "Το Hedy υποστηρίζει πλέον προτιμώμενες "
+#~ "γλώσσες χρήστη. Μπορείς να ορίσεις μια"
+#~ " για το προφίλ σου στο \"Το "
+#~ "προφίλ μου\""
+
+#~ msgid "statistics"
+#~ msgstr "Τα στατιστικά μου"
 

--- a/translations/en/LC_MESSAGES/messages.po
+++ b/translations/en/LC_MESSAGES/messages.po
@@ -1,126 +1,126 @@
-#: app.py:497
+#: app.py:451
 msgid "program_contains_error"
 msgstr "This program contains an error, are you sure you want to share it?"
 
-#: app.py:649
+#: app.py:604
 msgid "title_achievements"
 msgstr "Hedy - My achievements"
 
-#: app.py:666 app.py:1057 website/teacher.py:363 website/teacher.py:372
+#: app.py:622 app.py:1030 website/teacher.py:363 website/teacher.py:372
 msgid "not_teacher"
 msgstr "Looks like you are not a teacher!"
 
-#: app.py:669
+#: app.py:625
 msgid "not_enrolled"
 msgstr "Looks like you are not in this class!"
 
-#: app.py:701
+#: app.py:657
 msgid "title_programs"
 msgstr "Hedy - My programs"
 
-#: app.py:711 app.py:721 app.py:725 app.py:739 app.py:1000 app.py:1302
+#: app.py:667 app.py:677 app.py:681 app.py:695 app.py:956 app.py:1275
 #: website/admin.py:17 website/admin.py:25 website/admin.py:95
 #: website/admin.py:112 website/admin.py:130 website/auth.py:653
 #: website/auth.py:680 website/statistics.py:86
 msgid "unauthorized"
 msgstr "You don't have access rights for this page"
 
-#: app.py:749
+#: app.py:705
 msgid "minutes"
 msgstr "minutes"
 
-#: app.py:752
+#: app.py:708
 msgid "hours"
 msgstr "hours"
 
-#: app.py:755
+#: app.py:711
 msgid "days"
 msgstr "days"
 
-#: app.py:758
+#: app.py:714
 msgid "ago"
 msgstr "{time} ago"
 
-#: app.py:774 app.py:776 app.py:915 app.py:939 app.py:941
+#: app.py:730 app.py:732 app.py:871 app.py:895 app.py:897
 msgid "no_such_level"
 msgstr "No such Hedy level!"
 
-#: app.py:784 app.py:791 app.py:865 app.py:871
+#: app.py:740 app.py:747 app.py:821 app.py:827
 msgid "no_such_program"
 msgstr "No such Hedy program!"
 
-#: app.py:820
+#: app.py:776
 msgid "level_not_translated"
 msgstr "This level is not translated in your language (yet)"
 
-#: app.py:822
+#: app.py:778
 msgid "level_not_class"
 msgstr "You're in a class where this level has not been made available yet"
 
-#: app.py:925 website/teacher.py:430 website/teacher.py:446
+#: app.py:881 website/teacher.py:430 website/teacher.py:446
 #: website/teacher.py:475 website/teacher.py:501
 msgid "no_such_adventure"
 msgstr "This adventure doesn't exist!"
 
-#: app.py:951
+#: app.py:907
 msgid "page_not_found"
 msgstr "We could not find that page!"
 
-#: app.py:971
+#: app.py:927
 msgid "title_signup"
 msgstr "Hedy - Create an account"
 
-#: app.py:978
+#: app.py:934
 msgid "title_login"
 msgstr "Hedy - Login"
 
-#: app.py:985
+#: app.py:941
 msgid "title_recover"
 msgstr "Hedy - Recover account"
 
-#: app.py:1001
+#: app.py:957
 msgid "title_reset"
 msgstr "Hedy - Reset password"
 
-#: app.py:1010
+#: app.py:982
 msgid "title_my-profile"
 msgstr "Hedy - My account"
 
-#: app.py:1024
+#: app.py:997
 msgid "title_learn-more"
 msgstr "Hedy - Learn more"
 
-#: app.py:1029
+#: app.py:1002
 msgid "title_privacy"
 msgstr "Hedy - Privacy terms"
 
-#: app.py:1036
+#: app.py:1009
 msgid "title_landing-page"
 msgstr "Welcome to Hedy!"
 
-#: app.py:1038
+#: app.py:1011
 msgid "not_user"
 msgstr "Looks like you are not logged in!"
 
-#: app.py:1053
+#: app.py:1026
 msgid "title_for-teacher"
 msgstr "Hedy - For teachers"
 
-#: app.py:1064
+#: app.py:1037
 msgid "title_start"
 msgstr "Hedy - A gradual programming language"
 
-#: app.py:1117
+#: app.py:1090
 msgid "title_explore"
 msgstr "Hedy - Explore"
 
-#: app.py:1135 app.py:1137
+#: app.py:1108 app.py:1110
 msgid "translate_error"
 msgstr ""
 "Something went wrong while translating the code. Try running the code to "
 "see if it has an error. Code with errors can not be translated."
 
-#: app.py:1246 website/auth.py:241 website/auth.py:290 website/auth.py:426
+#: app.py:1219 website/auth.py:241 website/auth.py:290 website/auth.py:426
 #: website/auth.py:451 website/auth.py:481 website/auth.py:587
 #: website/auth.py:619 website/auth.py:659 website/auth.py:686
 #: website/teacher.py:90 website/teacher.py:125 website/teacher.py:197
@@ -129,27 +129,27 @@ msgstr ""
 msgid "ajax_error"
 msgstr "There was an error, please try again."
 
-#: app.py:1249
+#: app.py:1222
 msgid "image_invalid"
 msgstr "Your chosen image is invalid."
 
-#: app.py:1251
+#: app.py:1224
 msgid "personal_text_invalid"
 msgstr "Your personal text is invalid."
 
-#: app.py:1253 app.py:1259
+#: app.py:1226 app.py:1232
 msgid "favourite_program_invalid"
 msgstr "Your chosen favourite program is invalid."
 
-#: app.py:1271 app.py:1272
+#: app.py:1244 app.py:1245
 msgid "public_profile_updated"
 msgstr "Public profile updated."
 
-#: app.py:1306 app.py:1330
+#: app.py:1279 app.py:1303
 msgid "user_not_private"
 msgstr "This user doesn't exist or doesn't have a public profile"
 
-#: app.py:1339
+#: app.py:1312
 msgid "invalid_teacher_invitation_code"
 msgstr ""
 "The teacher invitation code is invalid. To become a teacher, reach out to"
@@ -407,7 +407,7 @@ msgstr "Visible columns"
 
 #: templates/class-overview.html:21 templates/class-overview.html:64
 #: templates/class-overview.html:108 templates/create-accounts.html:16
-#: templates/login.html:12 templates/profile.html:93 templates/recover.html:8
+#: templates/login.html:12 templates/profile.html:86 templates/recover.html:8
 #: templates/signup.html:10
 msgid "username"
 msgstr "Username"
@@ -421,7 +421,6 @@ msgid "highest_level_reached"
 msgstr "Highest level reached"
 
 #: templates/class-overview.html:35 templates/class-overview.html:67
-#: templates/profile.html:74
 msgid "number_programs"
 msgstr "Number of programs"
 
@@ -434,8 +433,8 @@ msgid "latest_shared_program"
 msgstr "Latest shared program"
 
 #: templates/class-overview.html:49 templates/class-overview.html:70
-#: templates/class-overview.html:83 templates/profile.html:151
-#: templates/profile.html:153 templates/profile.html:166
+#: templates/class-overview.html:83 templates/profile.html:144
+#: templates/profile.html:146 templates/profile.html:159
 msgid "change_password"
 msgstr "Change password"
 
@@ -578,7 +577,7 @@ msgid "create_accounts_prompt"
 msgstr "Are you sure you want to create these accounts?"
 
 #: templates/create-accounts.html:17 templates/learn-more.html:10
-#: templates/profile.html:96 templates/recover.html:8 templates/signup.html:13
+#: templates/profile.html:89 templates/recover.html:8 templates/signup.html:13
 msgid "email"
 msgstr "Email"
 
@@ -753,8 +752,8 @@ msgid "select_own_adventures"
 msgstr "Select own adventures"
 
 #: templates/customize-class.html:95 templates/customize-class.html:121
-#: templates/profile.html:47 templates/profile.html:128
-#: templates/profile.html:137 templates/signup.html:26 templates/signup.html:45
+#: templates/profile.html:47 templates/profile.html:121
+#: templates/profile.html:130 templates/signup.html:26 templates/signup.html:45
 #: templates/signup.html:53
 msgid "select"
 msgstr "Select"
@@ -826,8 +825,8 @@ msgstr "Creator"
 msgid "view_program"
 msgstr "View program"
 
-#: templates/for-teachers.html:5 templates/profile.html:78
-#: templates/profile.html:80
+#: templates/for-teachers.html:5 templates/profile.html:71
+#: templates/profile.html:73
 msgid "my_classes"
 msgstr "My classes"
 
@@ -1026,13 +1025,7 @@ msgstr "Cancel"
 msgid "copy_link_to_share"
 msgstr "Copy link to share"
 
-#: templates/layout.html:78
-msgid "set_preferred_lang"
-msgstr ""
-"Hedy now supports preferred user languages. You can set one for your "
-"profile in \"My profile\""
-
-#: templates/layout.html:86 templates/quiz/endquiz.html:18
+#: templates/layout.html:83 templates/quiz/endquiz.html:18
 #: templates/quiz/quiz.html:29
 msgid "achievement_earned"
 msgstr "You've earned an achievement!"
@@ -1049,7 +1042,7 @@ msgstr "First Name"
 msgid "lastname"
 msgstr "Last Name"
 
-#: templates/learn-more.html:22 templates/profile.html:135
+#: templates/learn-more.html:22 templates/profile.html:128
 #: templates/signup.html:52
 msgid "country"
 msgstr "Country"
@@ -1169,7 +1162,7 @@ msgstr ""
 msgid "update_public"
 msgstr "Update public profile"
 
-#: templates/profile.html:61 templates/profile.html:148
+#: templates/profile.html:61 templates/profile.html:141
 msgid "are_you_sure"
 msgstr "Are you sure? You cannot revert this action."
 
@@ -1177,67 +1170,63 @@ msgstr "Are you sure? You cannot revert this action."
 msgid "delete_public"
 msgstr "Delete public profile"
 
-#: templates/profile.html:70 templates/profile.html:72
-msgid "statistics"
-msgstr "My statistics"
-
-#: templates/profile.html:83
+#: templates/profile.html:76
 msgid "self_removal_prompt"
 msgstr "Are you sure you want to leave this class?"
 
-#: templates/profile.html:83
+#: templates/profile.html:76
 msgid "leave_class"
 msgstr "Leave class"
 
-#: templates/profile.html:88 templates/profile.html:91
+#: templates/profile.html:81 templates/profile.html:84
 msgid "settings"
 msgstr "My personal settings"
 
-#: templates/profile.html:99 templates/signup.html:41
+#: templates/profile.html:92 templates/signup.html:41
 msgid "birth_year"
 msgstr "Birth year"
 
-#: templates/profile.html:102 templates/signup.html:25
+#: templates/profile.html:95 templates/signup.html:25
 msgid "preferred_language"
 msgstr "Preferred language"
 
-#: templates/profile.html:112 templates/signup.html:34
+#: templates/profile.html:105 templates/signup.html:34
 msgid "preferred_keyword_language"
 msgstr "Preferred keyword language"
 
-#: templates/profile.html:126 templates/signup.html:44
+#: templates/profile.html:119 templates/signup.html:44
 msgid "gender"
 msgstr "Gender"
 
-#: templates/profile.html:129 templates/signup.html:46
+#: templates/profile.html:122 templates/signup.html:46
 msgid "female"
 msgstr "Female"
 
-#: templates/profile.html:130 templates/signup.html:47
+#: templates/profile.html:123 templates/signup.html:47
 msgid "male"
 msgstr "Male"
 
-#: templates/profile.html:131 templates/signup.html:48
+#: templates/profile.html:124 templates/signup.html:48
 msgid "other"
 msgstr "Other"
 
-#: templates/profile.html:144
+#: templates/profile.html:137
 msgid "update_profile"
 msgstr "Update profile"
 
-#: templates/profile.html:148
+#: templates/profile.html:141
 msgid "destroy_profile"
 msgstr "Delete profile"
 
-#: templates/profile.html:155
+#: templates/profile.html:148
 msgid "current_password"
 msgstr "Current password"
 
-#: templates/profile.html:159
+#: templates/profile.html:152
 msgid "new_password"
 msgstr "New password"
 
-#: templates/profile.html:163
+#: templates/profile.html:156
 msgid "repeat_new_password"
 msgstr "Repeat new password"
 
@@ -1803,4 +1792,13 @@ msgstr "You didn't enter an adventure name!"
 
 #~ msgid "required"
 #~ msgstr ""
+
+#~ msgid "set_preferred_lang"
+#~ msgstr ""
+#~ "Hedy now supports preferred user "
+#~ "languages. You can set one for "
+#~ "your profile in \"My profile\""
+
+#~ msgid "statistics"
+#~ msgstr "My statistics"
 

--- a/translations/es/LC_MESSAGES/messages.po
+++ b/translations/es/LC_MESSAGES/messages.po
@@ -1,27 +1,27 @@
-#: app.py:497
+#: app.py:451
 #, fuzzy
 msgid "program_contains_error"
 msgstr "This program contains an error, are you sure you want to share it?"
 
-#: app.py:649
+#: app.py:604
 #, fuzzy
 msgid "title_achievements"
 msgstr "Hedy - My achievements"
 
-#: app.py:666 app.py:1057 website/teacher.py:363 website/teacher.py:372
+#: app.py:622 app.py:1030 website/teacher.py:363 website/teacher.py:372
 msgid "not_teacher"
 msgstr "Parece que no eres un instructor."
 
-#: app.py:669
+#: app.py:625
 msgid "not_enrolled"
 msgstr "No se encontró tu registro para esta clase"
 
-#: app.py:701
+#: app.py:657
 #, fuzzy
 msgid "title_programs"
 msgstr "Hedy - My programs"
 
-#: app.py:711 app.py:721 app.py:725 app.py:739 app.py:1000 app.py:1302
+#: app.py:667 app.py:677 app.py:681 app.py:695 app.py:956 app.py:1275
 #: website/admin.py:17 website/admin.py:25 website/admin.py:95
 #: website/admin.py:112 website/admin.py:130 website/auth.py:653
 #: website/auth.py:680 website/statistics.py:86
@@ -29,118 +29,118 @@ msgstr "Hedy - My programs"
 msgid "unauthorized"
 msgstr "You don't have access rights for this page"
 
-#: app.py:749
+#: app.py:705
 msgid "minutes"
 msgstr "minutos"
 
-#: app.py:752
+#: app.py:708
 msgid "hours"
 msgstr "horas"
 
-#: app.py:755
+#: app.py:711
 msgid "days"
 msgstr "días"
 
-#: app.py:758
+#: app.py:714
 #, fuzzy
 msgid "ago"
 msgstr "{time} ago"
 
-#: app.py:774 app.py:776 app.py:915 app.py:939 app.py:941
+#: app.py:730 app.py:732 app.py:871 app.py:895 app.py:897
 msgid "no_such_level"
 msgstr "No se encontró ese nivel de Hedy"
 
-#: app.py:784 app.py:791 app.py:865 app.py:871
+#: app.py:740 app.py:747 app.py:821 app.py:827
 msgid "no_such_program"
 msgstr "No se encontró el programa de Hedy"
 
-#: app.py:820
+#: app.py:776
 #, fuzzy
 msgid "level_not_translated"
 msgstr "This level is not translated in your language (yet)"
 
-#: app.py:822
+#: app.py:778
 #, fuzzy
 msgid "level_not_class"
 msgstr "You're in a class where this level has not been made available yet"
 
-#: app.py:925 website/teacher.py:430 website/teacher.py:446
+#: app.py:881 website/teacher.py:430 website/teacher.py:446
 #: website/teacher.py:475 website/teacher.py:501
 #, fuzzy
 msgid "no_such_adventure"
 msgstr "This adventure doesn't exist!"
 
-#: app.py:951
+#: app.py:907
 msgid "page_not_found"
 msgstr "¡No pudimos encontrar esta página!"
 
-#: app.py:971
+#: app.py:927
 #, fuzzy
 msgid "title_signup"
 msgstr "Hedy - Create an account"
 
-#: app.py:978
+#: app.py:934
 #, fuzzy
 msgid "title_login"
 msgstr "Hedy - Login"
 
-#: app.py:985
+#: app.py:941
 #, fuzzy
 msgid "title_recover"
 msgstr "Hedy - Recover account"
 
-#: app.py:1001
+#: app.py:957
 #, fuzzy
 msgid "title_reset"
 msgstr "Hedy - Reset password"
 
-#: app.py:1010
+#: app.py:982
 #, fuzzy
 msgid "title_my-profile"
 msgstr "Hedy - My account"
 
-#: app.py:1024
+#: app.py:997
 #, fuzzy
 msgid "title_learn-more"
 msgstr "Hedy - Learn more"
 
-#: app.py:1029
+#: app.py:1002
 #, fuzzy
 msgid "title_privacy"
 msgstr "Hedy - Privacy terms"
 
-#: app.py:1036
+#: app.py:1009
 #, fuzzy
 msgid "title_landing-page"
 msgstr "Welcome to Hedy!"
 
-#: app.py:1038
+#: app.py:1011
 msgid "not_user"
 msgstr "Parece que hay que registrarse o ingresar a tu cuenta"
 
-#: app.py:1053
+#: app.py:1026
 #, fuzzy
 msgid "title_for-teacher"
 msgstr "Hedy - For teachers"
 
-#: app.py:1064
+#: app.py:1037
 #, fuzzy
 msgid "title_start"
 msgstr "Hedy - A gradual programming language"
 
-#: app.py:1117
+#: app.py:1090
 #, fuzzy
 msgid "title_explore"
 msgstr "Hedy - Explore"
 
-#: app.py:1135 app.py:1137
+#: app.py:1108 app.py:1110
 #, fuzzy
 msgid "translate_error"
 msgstr ""
 "Something went wrong while translating the code. Try running the code to "
 "see if it has an error. Code with errors can not be translated."
 
-#: app.py:1246 website/auth.py:241 website/auth.py:290 website/auth.py:426
+#: app.py:1219 website/auth.py:241 website/auth.py:290 website/auth.py:426
 #: website/auth.py:451 website/auth.py:481 website/auth.py:587
 #: website/auth.py:619 website/auth.py:659 website/auth.py:686
 #: website/teacher.py:90 website/teacher.py:125 website/teacher.py:197
@@ -149,32 +149,32 @@ msgstr ""
 msgid "ajax_error"
 msgstr "Hubo un error, por favor intenta nuevamente."
 
-#: app.py:1249
+#: app.py:1222
 #, fuzzy
 msgid "image_invalid"
 msgstr "Your chosen image is invalid."
 
-#: app.py:1251
+#: app.py:1224
 #, fuzzy
 msgid "personal_text_invalid"
 msgstr "Your personal text is invalid."
 
-#: app.py:1253 app.py:1259
+#: app.py:1226 app.py:1232
 #, fuzzy
 msgid "favourite_program_invalid"
 msgstr "Your chosen favourite program is invalid."
 
-#: app.py:1271 app.py:1272
+#: app.py:1244 app.py:1245
 #, fuzzy
 msgid "public_profile_updated"
 msgstr "Public profile updated."
 
-#: app.py:1306 app.py:1330
+#: app.py:1279 app.py:1303
 #, fuzzy
 msgid "user_not_private"
 msgstr "This user doesn't exist or doesn't have a public profile"
 
-#: app.py:1339
+#: app.py:1312
 msgid "invalid_teacher_invitation_code"
 msgstr ""
 "El código de instructor es inválido. Para ser instructor, por favor mande"
@@ -457,7 +457,7 @@ msgstr "Visible columns"
 
 #: templates/class-overview.html:21 templates/class-overview.html:64
 #: templates/class-overview.html:108 templates/create-accounts.html:16
-#: templates/login.html:12 templates/profile.html:93 templates/recover.html:8
+#: templates/login.html:12 templates/profile.html:86 templates/recover.html:8
 #: templates/signup.html:10
 msgid "username"
 msgstr "Usuario"
@@ -471,7 +471,6 @@ msgid "highest_level_reached"
 msgstr "Nivel más alto alcanzado"
 
 #: templates/class-overview.html:35 templates/class-overview.html:67
-#: templates/profile.html:74
 msgid "number_programs"
 msgstr "Número de programas"
 
@@ -485,8 +484,8 @@ msgid "latest_shared_program"
 msgstr "Último programa compartido"
 
 #: templates/class-overview.html:49 templates/class-overview.html:70
-#: templates/class-overview.html:83 templates/profile.html:151
-#: templates/profile.html:153 templates/profile.html:166
+#: templates/class-overview.html:83 templates/profile.html:144
+#: templates/profile.html:146 templates/profile.html:159
 msgid "change_password"
 msgstr "Cambiar contraseña"
 
@@ -652,7 +651,7 @@ msgid "create_accounts_prompt"
 msgstr "Are you sure you want to create these accounts?"
 
 #: templates/create-accounts.html:17 templates/learn-more.html:10
-#: templates/profile.html:96 templates/recover.html:8 templates/signup.html:13
+#: templates/profile.html:89 templates/recover.html:8 templates/signup.html:13
 msgid "email"
 msgstr "Correo electrónico"
 
@@ -844,8 +843,8 @@ msgid "select_own_adventures"
 msgstr "Select own adventures"
 
 #: templates/customize-class.html:95 templates/customize-class.html:121
-#: templates/profile.html:47 templates/profile.html:128
-#: templates/profile.html:137 templates/signup.html:26 templates/signup.html:45
+#: templates/profile.html:47 templates/profile.html:121
+#: templates/profile.html:130 templates/signup.html:26 templates/signup.html:45
 #: templates/signup.html:53
 msgid "select"
 msgstr "Seleccionar"
@@ -931,8 +930,8 @@ msgstr "Creator"
 msgid "view_program"
 msgstr "View program"
 
-#: templates/for-teachers.html:5 templates/profile.html:78
-#: templates/profile.html:80
+#: templates/for-teachers.html:5 templates/profile.html:71
+#: templates/profile.html:73
 msgid "my_classes"
 msgstr "Mis clases"
 
@@ -1152,14 +1151,7 @@ msgstr "Cancelar"
 msgid "copy_link_to_share"
 msgstr "Copiar vínculo para compartir"
 
-#: templates/layout.html:78
-#, fuzzy
-msgid "set_preferred_lang"
-msgstr ""
-"Hedy now supports preferred user languages. You can set one for your "
-"profile in \"My profile\""
-
-#: templates/layout.html:86 templates/quiz/endquiz.html:18
+#: templates/layout.html:83 templates/quiz/endquiz.html:18
 #: templates/quiz/quiz.html:29
 #, fuzzy
 msgid "achievement_earned"
@@ -1180,7 +1172,7 @@ msgstr "Usuario"
 msgid "lastname"
 msgstr "Nombre"
 
-#: templates/learn-more.html:22 templates/profile.html:135
+#: templates/learn-more.html:22 templates/profile.html:128
 #: templates/signup.html:52
 msgid "country"
 msgstr "País"
@@ -1316,7 +1308,7 @@ msgstr ""
 msgid "update_public"
 msgstr "Update public profile"
 
-#: templates/profile.html:61 templates/profile.html:148
+#: templates/profile.html:61 templates/profile.html:141
 msgid "are_you_sure"
 msgstr "¿Estás segura/o? No puedes revertir esta acción."
 
@@ -1325,73 +1317,68 @@ msgstr "¿Estás segura/o? No puedes revertir esta acción."
 msgid "delete_public"
 msgstr "Delete public profile"
 
-#: templates/profile.html:70 templates/profile.html:72
-#, fuzzy
-msgid "statistics"
-msgstr "My statistics"
-
-#: templates/profile.html:83
+#: templates/profile.html:76
 #, fuzzy
 msgid "self_removal_prompt"
 msgstr "Are you sure you want to leave this class?"
 
-#: templates/profile.html:83
+#: templates/profile.html:76
 #, fuzzy
 msgid "leave_class"
 msgstr "Leave class"
 
-#: templates/profile.html:88 templates/profile.html:91
+#: templates/profile.html:81 templates/profile.html:84
 #, fuzzy
 msgid "settings"
 msgstr "My personal settings"
 
-#: templates/profile.html:99 templates/signup.html:41
+#: templates/profile.html:92 templates/signup.html:41
 msgid "birth_year"
 msgstr "Año de nacimiento"
 
-#: templates/profile.html:102 templates/signup.html:25
+#: templates/profile.html:95 templates/signup.html:25
 #, fuzzy
 msgid "preferred_language"
 msgstr "Preferred language"
 
-#: templates/profile.html:112 templates/signup.html:34
+#: templates/profile.html:105 templates/signup.html:34
 #, fuzzy
 msgid "preferred_keyword_language"
 msgstr "Preferred keyword language"
 
-#: templates/profile.html:126 templates/signup.html:44
+#: templates/profile.html:119 templates/signup.html:44
 msgid "gender"
 msgstr "Género"
 
-#: templates/profile.html:129 templates/signup.html:46
+#: templates/profile.html:122 templates/signup.html:46
 msgid "female"
 msgstr "Femenino"
 
-#: templates/profile.html:130 templates/signup.html:47
+#: templates/profile.html:123 templates/signup.html:47
 msgid "male"
 msgstr "Masculino"
 
-#: templates/profile.html:131 templates/signup.html:48
+#: templates/profile.html:124 templates/signup.html:48
 msgid "other"
 msgstr "Otro"
 
-#: templates/profile.html:144
+#: templates/profile.html:137
 msgid "update_profile"
 msgstr "Actualizar perfil"
 
-#: templates/profile.html:148
+#: templates/profile.html:141
 msgid "destroy_profile"
 msgstr "Borrar mi cuenta permanentemente"
 
-#: templates/profile.html:155
+#: templates/profile.html:148
 msgid "current_password"
 msgstr "Contraseña actual"
 
-#: templates/profile.html:159
+#: templates/profile.html:152
 msgid "new_password"
 msgstr "Nueva contraseña"
 
-#: templates/profile.html:163
+#: templates/profile.html:156
 msgid "repeat_new_password"
 msgstr "Repetir nueva contraseña"
 
@@ -2026,4 +2013,13 @@ msgstr "The adventure has been updated!"
 #, fuzzy
 msgid "adventure_empty"
 msgstr "You didn't enter an adventure name!"
+
+#~ msgid "set_preferred_lang"
+#~ msgstr ""
+#~ "Hedy now supports preferred user "
+#~ "languages. You can set one for "
+#~ "your profile in \"My profile\""
+
+#~ msgid "statistics"
+#~ msgstr "My statistics"
 

--- a/translations/fa/LC_MESSAGES/messages.po
+++ b/translations/fa/LC_MESSAGES/messages.po
@@ -1,29 +1,29 @@
-#: app.py:497
+#: app.py:451
 #, fuzzy
 msgid "program_contains_error"
 msgstr "This program contains an error, are you sure you want to share it?"
 
-#: app.py:649
+#: app.py:604
 #, fuzzy
 msgid "title_achievements"
 msgstr "Hedy - My achievements"
 
-#: app.py:666 app.py:1057 website/teacher.py:363 website/teacher.py:372
+#: app.py:622 app.py:1030 website/teacher.py:363 website/teacher.py:372
 #, fuzzy
 msgid "not_teacher"
 msgstr "Looks like you are not a teacher!"
 
-#: app.py:669
+#: app.py:625
 #, fuzzy
 msgid "not_enrolled"
 msgstr "Looks like you are not in this class!"
 
-#: app.py:701
+#: app.py:657
 #, fuzzy
 msgid "title_programs"
 msgstr "Hedy - My programs"
 
-#: app.py:711 app.py:721 app.py:725 app.py:739 app.py:1000 app.py:1302
+#: app.py:667 app.py:677 app.py:681 app.py:695 app.py:956 app.py:1275
 #: website/admin.py:17 website/admin.py:25 website/admin.py:95
 #: website/admin.py:112 website/admin.py:130 website/auth.py:653
 #: website/auth.py:680 website/statistics.py:86
@@ -31,125 +31,125 @@ msgstr "Hedy - My programs"
 msgid "unauthorized"
 msgstr "You don't have access rights for this page"
 
-#: app.py:749
+#: app.py:705
 #, fuzzy
 msgid "minutes"
 msgstr "minutes"
 
-#: app.py:752
+#: app.py:708
 #, fuzzy
 msgid "hours"
 msgstr "hours"
 
-#: app.py:755
+#: app.py:711
 #, fuzzy
 msgid "days"
 msgstr "days"
 
-#: app.py:758
+#: app.py:714
 #, fuzzy
 msgid "ago"
 msgstr "{time} ago"
 
-#: app.py:774 app.py:776 app.py:915 app.py:939 app.py:941
+#: app.py:730 app.py:732 app.py:871 app.py:895 app.py:897
 #, fuzzy
 msgid "no_such_level"
 msgstr "No such Hedy level!"
 
-#: app.py:784 app.py:791 app.py:865 app.py:871
+#: app.py:740 app.py:747 app.py:821 app.py:827
 #, fuzzy
 msgid "no_such_program"
 msgstr "No such Hedy program!"
 
-#: app.py:820
+#: app.py:776
 #, fuzzy
 msgid "level_not_translated"
 msgstr "This level is not translated in your language (yet)"
 
-#: app.py:822
+#: app.py:778
 #, fuzzy
 msgid "level_not_class"
 msgstr "You're in a class where this level has not been made available yet"
 
-#: app.py:925 website/teacher.py:430 website/teacher.py:446
+#: app.py:881 website/teacher.py:430 website/teacher.py:446
 #: website/teacher.py:475 website/teacher.py:501
 #, fuzzy
 msgid "no_such_adventure"
 msgstr "This adventure doesn't exist!"
 
-#: app.py:951
+#: app.py:907
 #, fuzzy
 msgid "page_not_found"
 msgstr "We could not find that page!"
 
-#: app.py:971
+#: app.py:927
 #, fuzzy
 msgid "title_signup"
 msgstr "Hedy - Create an account"
 
-#: app.py:978
+#: app.py:934
 #, fuzzy
 msgid "title_login"
 msgstr "Hedy - Login"
 
-#: app.py:985
+#: app.py:941
 #, fuzzy
 msgid "title_recover"
 msgstr "Hedy - Recover account"
 
-#: app.py:1001
+#: app.py:957
 #, fuzzy
 msgid "title_reset"
 msgstr "Hedy - Reset password"
 
-#: app.py:1010
+#: app.py:982
 #, fuzzy
 msgid "title_my-profile"
 msgstr "Hedy - My account"
 
-#: app.py:1024
+#: app.py:997
 #, fuzzy
 msgid "title_learn-more"
 msgstr "Hedy - Learn more"
 
-#: app.py:1029
+#: app.py:1002
 #, fuzzy
 msgid "title_privacy"
 msgstr "Hedy - Privacy terms"
 
-#: app.py:1036
+#: app.py:1009
 #, fuzzy
 msgid "title_landing-page"
 msgstr "Welcome to Hedy!"
 
-#: app.py:1038
+#: app.py:1011
 #, fuzzy
 msgid "not_user"
 msgstr "Looks like you are not logged in!"
 
-#: app.py:1053
+#: app.py:1026
 #, fuzzy
 msgid "title_for-teacher"
 msgstr "Hedy - For teachers"
 
-#: app.py:1064
+#: app.py:1037
 #, fuzzy
 msgid "title_start"
 msgstr "Hedy - A gradual programming language"
 
-#: app.py:1117
+#: app.py:1090
 #, fuzzy
 msgid "title_explore"
 msgstr "Hedy - Explore"
 
-#: app.py:1135 app.py:1137
+#: app.py:1108 app.py:1110
 #, fuzzy
 msgid "translate_error"
 msgstr ""
 "Something went wrong while translating the code. Try running the code to "
 "see if it has an error. Code with errors can not be translated."
 
-#: app.py:1246 website/auth.py:241 website/auth.py:290 website/auth.py:426
+#: app.py:1219 website/auth.py:241 website/auth.py:290 website/auth.py:426
 #: website/auth.py:451 website/auth.py:481 website/auth.py:587
 #: website/auth.py:619 website/auth.py:659 website/auth.py:686
 #: website/teacher.py:90 website/teacher.py:125 website/teacher.py:197
@@ -159,32 +159,32 @@ msgstr ""
 msgid "ajax_error"
 msgstr "There was an error, please try again."
 
-#: app.py:1249
+#: app.py:1222
 #, fuzzy
 msgid "image_invalid"
 msgstr "Your chosen image is invalid."
 
-#: app.py:1251
+#: app.py:1224
 #, fuzzy
 msgid "personal_text_invalid"
 msgstr "Your personal text is invalid."
 
-#: app.py:1253 app.py:1259
+#: app.py:1226 app.py:1232
 #, fuzzy
 msgid "favourite_program_invalid"
 msgstr "Your chosen favourite program is invalid."
 
-#: app.py:1271 app.py:1272
+#: app.py:1244 app.py:1245
 #, fuzzy
 msgid "public_profile_updated"
 msgstr "Public profile updated."
 
-#: app.py:1306 app.py:1330
+#: app.py:1279 app.py:1303
 #, fuzzy
 msgid "user_not_private"
 msgstr "This user doesn't exist or doesn't have a public profile"
 
-#: app.py:1339
+#: app.py:1312
 #, fuzzy
 msgid "invalid_teacher_invitation_code"
 msgstr ""
@@ -491,7 +491,7 @@ msgstr "Visible columns"
 
 #: templates/class-overview.html:21 templates/class-overview.html:64
 #: templates/class-overview.html:108 templates/create-accounts.html:16
-#: templates/login.html:12 templates/profile.html:93 templates/recover.html:8
+#: templates/login.html:12 templates/profile.html:86 templates/recover.html:8
 #: templates/signup.html:10
 #, fuzzy
 msgid "username"
@@ -508,7 +508,6 @@ msgid "highest_level_reached"
 msgstr "Highest level reached"
 
 #: templates/class-overview.html:35 templates/class-overview.html:67
-#: templates/profile.html:74
 #, fuzzy
 msgid "number_programs"
 msgstr "Number of programs"
@@ -524,8 +523,8 @@ msgid "latest_shared_program"
 msgstr "Latest shared program"
 
 #: templates/class-overview.html:49 templates/class-overview.html:70
-#: templates/class-overview.html:83 templates/profile.html:151
-#: templates/profile.html:153 templates/profile.html:166
+#: templates/class-overview.html:83 templates/profile.html:144
+#: templates/profile.html:146 templates/profile.html:159
 #, fuzzy
 msgid "change_password"
 msgstr "Change password"
@@ -700,7 +699,7 @@ msgid "create_accounts_prompt"
 msgstr "Are you sure you want to create these accounts?"
 
 #: templates/create-accounts.html:17 templates/learn-more.html:10
-#: templates/profile.html:96 templates/recover.html:8 templates/signup.html:13
+#: templates/profile.html:89 templates/recover.html:8 templates/signup.html:13
 #, fuzzy
 msgid "email"
 msgstr "Email"
@@ -909,8 +908,8 @@ msgid "select_own_adventures"
 msgstr "Select own adventures"
 
 #: templates/customize-class.html:95 templates/customize-class.html:121
-#: templates/profile.html:47 templates/profile.html:128
-#: templates/profile.html:137 templates/signup.html:26 templates/signup.html:45
+#: templates/profile.html:47 templates/profile.html:121
+#: templates/profile.html:130 templates/signup.html:26 templates/signup.html:45
 #: templates/signup.html:53
 #, fuzzy
 msgid "select"
@@ -998,8 +997,8 @@ msgstr "Creator"
 msgid "view_program"
 msgstr "View program"
 
-#: templates/for-teachers.html:5 templates/profile.html:78
-#: templates/profile.html:80
+#: templates/for-teachers.html:5 templates/profile.html:71
+#: templates/profile.html:73
 #, fuzzy
 msgid "my_classes"
 msgstr "My classes"
@@ -1244,14 +1243,7 @@ msgstr "Cancel"
 msgid "copy_link_to_share"
 msgstr "Copy link to share"
 
-#: templates/layout.html:78
-#, fuzzy
-msgid "set_preferred_lang"
-msgstr ""
-"Hedy now supports preferred user languages. You can set one for your "
-"profile in \"My profile\""
-
-#: templates/layout.html:86 templates/quiz/endquiz.html:18
+#: templates/layout.html:83 templates/quiz/endquiz.html:18
 #: templates/quiz/quiz.html:29
 #, fuzzy
 msgid "achievement_earned"
@@ -1272,7 +1264,7 @@ msgstr "First Name"
 msgid "lastname"
 msgstr "Last Name"
 
-#: templates/learn-more.html:22 templates/profile.html:135
+#: templates/learn-more.html:22 templates/profile.html:128
 #: templates/signup.html:52
 #, fuzzy
 msgid "country"
@@ -1421,7 +1413,7 @@ msgstr ""
 msgid "update_public"
 msgstr "Update public profile"
 
-#: templates/profile.html:61 templates/profile.html:148
+#: templates/profile.html:61 templates/profile.html:141
 #, fuzzy
 msgid "are_you_sure"
 msgstr "Are you sure? You cannot revert this action."
@@ -1431,82 +1423,77 @@ msgstr "Are you sure? You cannot revert this action."
 msgid "delete_public"
 msgstr "Delete public profile"
 
-#: templates/profile.html:70 templates/profile.html:72
-#, fuzzy
-msgid "statistics"
-msgstr "My statistics"
-
-#: templates/profile.html:83
+#: templates/profile.html:76
 #, fuzzy
 msgid "self_removal_prompt"
 msgstr "Are you sure you want to leave this class?"
 
-#: templates/profile.html:83
+#: templates/profile.html:76
 #, fuzzy
 msgid "leave_class"
 msgstr "Leave class"
 
-#: templates/profile.html:88 templates/profile.html:91
+#: templates/profile.html:81 templates/profile.html:84
 #, fuzzy
 msgid "settings"
 msgstr "My personal settings"
 
-#: templates/profile.html:99 templates/signup.html:41
+#: templates/profile.html:92 templates/signup.html:41
 #, fuzzy
 msgid "birth_year"
 msgstr "Birth year"
 
-#: templates/profile.html:102 templates/signup.html:25
+#: templates/profile.html:95 templates/signup.html:25
 #, fuzzy
 msgid "preferred_language"
 msgstr "Preferred language"
 
-#: templates/profile.html:112 templates/signup.html:34
+#: templates/profile.html:105 templates/signup.html:34
 #, fuzzy
 msgid "preferred_keyword_language"
 msgstr "Preferred keyword language"
 
-#: templates/profile.html:126 templates/signup.html:44
+#: templates/profile.html:119 templates/signup.html:44
 #, fuzzy
 msgid "gender"
 msgstr "Gender"
 
-#: templates/profile.html:129 templates/signup.html:46
+#: templates/profile.html:122 templates/signup.html:46
 #, fuzzy
 msgid "female"
 msgstr "Female"
 
-#: templates/profile.html:130 templates/signup.html:47
+#: templates/profile.html:123 templates/signup.html:47
 #, fuzzy
 msgid "male"
 msgstr "Male"
 
-#: templates/profile.html:131 templates/signup.html:48
+#: templates/profile.html:124 templates/signup.html:48
 #, fuzzy
 msgid "other"
 msgstr "Other"
 
-#: templates/profile.html:144
+#: templates/profile.html:137
 #, fuzzy
 msgid "update_profile"
 msgstr "Update profile"
 
-#: templates/profile.html:148
+#: templates/profile.html:141
 #, fuzzy
 msgid "destroy_profile"
 msgstr "Delete profile"
 
-#: templates/profile.html:155
+#: templates/profile.html:148
 #, fuzzy
 msgid "current_password"
 msgstr "Current password"
 
-#: templates/profile.html:159
+#: templates/profile.html:152
 #, fuzzy
 msgid "new_password"
 msgstr "New password"
 
-#: templates/profile.html:163
+#: templates/profile.html:156
 #, fuzzy
 msgid "repeat_new_password"
 msgstr "Repeat new password"
@@ -2202,4 +2189,13 @@ msgstr "The adventure has been updated!"
 #, fuzzy
 msgid "adventure_empty"
 msgstr "You didn't enter an adventure name!"
+
+#~ msgid "set_preferred_lang"
+#~ msgstr ""
+#~ "Hedy now supports preferred user "
+#~ "languages. You can set one for "
+#~ "your profile in \"My profile\""
+
+#~ msgid "statistics"
+#~ msgstr "My statistics"
 

--- a/translations/fr/LC_MESSAGES/messages.po
+++ b/translations/fr/LC_MESSAGES/messages.po
@@ -1,29 +1,29 @@
-#: app.py:497
+#: app.py:451
 #, fuzzy
 msgid "program_contains_error"
 msgstr "This program contains an error, are you sure you want to share it?"
 
-#: app.py:649
+#: app.py:604
 #, fuzzy
 msgid "title_achievements"
 msgstr "Hedy - My achievements"
 
-#: app.py:666 app.py:1057 website/teacher.py:363 website/teacher.py:372
+#: app.py:622 app.py:1030 website/teacher.py:363 website/teacher.py:372
 #, fuzzy
 msgid "not_teacher"
 msgstr "Looks like you are not a teacher!"
 
-#: app.py:669
+#: app.py:625
 #, fuzzy
 msgid "not_enrolled"
 msgstr "Looks like you are not in this class!"
 
-#: app.py:701
+#: app.py:657
 #, fuzzy
 msgid "title_programs"
 msgstr "Hedy - My programs"
 
-#: app.py:711 app.py:721 app.py:725 app.py:739 app.py:1000 app.py:1302
+#: app.py:667 app.py:677 app.py:681 app.py:695 app.py:956 app.py:1275
 #: website/admin.py:17 website/admin.py:25 website/admin.py:95
 #: website/admin.py:112 website/admin.py:130 website/auth.py:653
 #: website/auth.py:680 website/statistics.py:86
@@ -31,122 +31,122 @@ msgstr "Hedy - My programs"
 msgid "unauthorized"
 msgstr "You don't have access rights for this page"
 
-#: app.py:749
+#: app.py:705
 msgid "minutes"
 msgstr "minutes"
 
-#: app.py:752
+#: app.py:708
 msgid "hours"
 msgstr "heures"
 
-#: app.py:755
+#: app.py:711
 msgid "days"
 msgstr "jours"
 
-#: app.py:758
+#: app.py:714
 #, fuzzy
 msgid "ago"
 msgstr "{time} ago"
 
-#: app.py:774 app.py:776 app.py:915 app.py:939 app.py:941
+#: app.py:730 app.py:732 app.py:871 app.py:895 app.py:897
 #, fuzzy
 msgid "no_such_level"
 msgstr "No such Hedy level!"
 
-#: app.py:784 app.py:791 app.py:865 app.py:871
+#: app.py:740 app.py:747 app.py:821 app.py:827
 #, fuzzy
 msgid "no_such_program"
 msgstr "No such Hedy program!"
 
-#: app.py:820
+#: app.py:776
 #, fuzzy
 msgid "level_not_translated"
 msgstr "This level is not translated in your language (yet)"
 
-#: app.py:822
+#: app.py:778
 #, fuzzy
 msgid "level_not_class"
 msgstr "You're in a class where this level has not been made available yet"
 
-#: app.py:925 website/teacher.py:430 website/teacher.py:446
+#: app.py:881 website/teacher.py:430 website/teacher.py:446
 #: website/teacher.py:475 website/teacher.py:501
 #, fuzzy
 msgid "no_such_adventure"
 msgstr "This adventure doesn't exist!"
 
-#: app.py:951
+#: app.py:907
 #, fuzzy
 msgid "page_not_found"
 msgstr "We could not find that page!"
 
-#: app.py:971
+#: app.py:927
 #, fuzzy
 msgid "title_signup"
 msgstr "Hedy - Create an account"
 
-#: app.py:978
+#: app.py:934
 #, fuzzy
 msgid "title_login"
 msgstr "Hedy - Login"
 
-#: app.py:985
+#: app.py:941
 #, fuzzy
 msgid "title_recover"
 msgstr "Hedy - Recover account"
 
-#: app.py:1001
+#: app.py:957
 #, fuzzy
 msgid "title_reset"
 msgstr "Hedy - Reset password"
 
-#: app.py:1010
+#: app.py:982
 #, fuzzy
 msgid "title_my-profile"
 msgstr "Hedy - My account"
 
-#: app.py:1024
+#: app.py:997
 #, fuzzy
 msgid "title_learn-more"
 msgstr "Hedy - Learn more"
 
-#: app.py:1029
+#: app.py:1002
 #, fuzzy
 msgid "title_privacy"
 msgstr "Hedy - Privacy terms"
 
-#: app.py:1036
+#: app.py:1009
 #, fuzzy
 msgid "title_landing-page"
 msgstr "Welcome to Hedy!"
 
-#: app.py:1038
+#: app.py:1011
 #, fuzzy
 msgid "not_user"
 msgstr "Looks like you are not logged in!"
 
-#: app.py:1053
+#: app.py:1026
 #, fuzzy
 msgid "title_for-teacher"
 msgstr "Hedy - For teachers"
 
-#: app.py:1064
+#: app.py:1037
 #, fuzzy
 msgid "title_start"
 msgstr "Hedy - A gradual programming language"
 
-#: app.py:1117
+#: app.py:1090
 #, fuzzy
 msgid "title_explore"
 msgstr "Hedy - Explore"
 
-#: app.py:1135 app.py:1137
+#: app.py:1108 app.py:1110
 #, fuzzy
 msgid "translate_error"
 msgstr ""
 "Something went wrong while translating the code. Try running the code to "
 "see if it has an error. Code with errors can not be translated."
 
-#: app.py:1246 website/auth.py:241 website/auth.py:290 website/auth.py:426
+#: app.py:1219 website/auth.py:241 website/auth.py:290 website/auth.py:426
 #: website/auth.py:451 website/auth.py:481 website/auth.py:587
 #: website/auth.py:619 website/auth.py:659 website/auth.py:686
 #: website/teacher.py:90 website/teacher.py:125 website/teacher.py:197
@@ -155,32 +155,32 @@ msgstr ""
 msgid "ajax_error"
 msgstr "Une erreur est survenue, merci de réessayer."
 
-#: app.py:1249
+#: app.py:1222
 #, fuzzy
 msgid "image_invalid"
 msgstr "Your chosen image is invalid."
 
-#: app.py:1251
+#: app.py:1224
 #, fuzzy
 msgid "personal_text_invalid"
 msgstr "Your personal text is invalid."
 
-#: app.py:1253 app.py:1259
+#: app.py:1226 app.py:1232
 #, fuzzy
 msgid "favourite_program_invalid"
 msgstr "Your chosen favourite program is invalid."
 
-#: app.py:1271 app.py:1272
+#: app.py:1244 app.py:1245
 #, fuzzy
 msgid "public_profile_updated"
 msgstr "Public profile updated."
 
-#: app.py:1306 app.py:1330
+#: app.py:1279 app.py:1303
 #, fuzzy
 msgid "user_not_private"
 msgstr "This user doesn't exist or doesn't have a public profile"
 
-#: app.py:1339
+#: app.py:1312
 #, fuzzy
 msgid "invalid_teacher_invitation_code"
 msgstr ""
@@ -466,7 +466,7 @@ msgstr "Visible columns"
 
 #: templates/class-overview.html:21 templates/class-overview.html:64
 #: templates/class-overview.html:108 templates/create-accounts.html:16
-#: templates/login.html:12 templates/profile.html:93 templates/recover.html:8
+#: templates/login.html:12 templates/profile.html:86 templates/recover.html:8
 #: templates/signup.html:10
 msgid "username"
 msgstr "Identifiant"
@@ -480,7 +480,6 @@ msgid "highest_level_reached"
 msgstr "Niveau le plus élevé atteint"
 
 #: templates/class-overview.html:35 templates/class-overview.html:67
-#: templates/profile.html:74
 msgid "number_programs"
 msgstr "Nombre de programmes"
 
@@ -494,8 +493,8 @@ msgid "latest_shared_program"
 msgstr "Dernier programme partagé"
 
 #: templates/class-overview.html:49 templates/class-overview.html:70
-#: templates/class-overview.html:83 templates/profile.html:151
-#: templates/profile.html:153 templates/profile.html:166
+#: templates/class-overview.html:83 templates/profile.html:144
+#: templates/profile.html:146 templates/profile.html:159
 msgid "change_password"
 msgstr "Modifier le mot de passe"
 
@@ -658,7 +657,7 @@ msgid "create_accounts_prompt"
 msgstr "Are you sure you want to create these accounts?"
 
 #: templates/create-accounts.html:17 templates/learn-more.html:10
-#: templates/profile.html:96 templates/recover.html:8 templates/signup.html:13
+#: templates/profile.html:89 templates/recover.html:8 templates/signup.html:13
 msgid "email"
 msgstr "Adresse email"
 
@@ -861,8 +860,8 @@ msgid "select_own_adventures"
 msgstr "Select own adventures"
 
 #: templates/customize-class.html:95 templates/customize-class.html:121
-#: templates/profile.html:47 templates/profile.html:128
-#: templates/profile.html:137 templates/signup.html:26 templates/signup.html:45
+#: templates/profile.html:47 templates/profile.html:121
+#: templates/profile.html:130 templates/signup.html:26 templates/signup.html:45
 #: templates/signup.html:53
 msgid "select"
 msgstr "Sélectionner"
@@ -949,8 +948,8 @@ msgstr "Creator"
 msgid "view_program"
 msgstr "View program"
 
-#: templates/for-teachers.html:5 templates/profile.html:78
-#: templates/profile.html:80
+#: templates/for-teachers.html:5 templates/profile.html:71
+#: templates/profile.html:73
 msgid "my_classes"
 msgstr "Mes classes"
 
@@ -1171,14 +1170,7 @@ msgstr "Cancel"
 msgid "copy_link_to_share"
 msgstr "Copier le lien pour le partager"
 
-#: templates/layout.html:78
-#, fuzzy
-msgid "set_preferred_lang"
-msgstr ""
-"Hedy now supports preferred user languages. You can set one for your "
-"profile in \"My profile\""
-
-#: templates/layout.html:86 templates/quiz/endquiz.html:18
+#: templates/layout.html:83 templates/quiz/endquiz.html:18
 #: templates/quiz/quiz.html:29
 #, fuzzy
 msgid "achievement_earned"
@@ -1196,7 +1188,7 @@ msgstr "Prénom"
 msgid "lastname"
 msgstr "Nom"
 
-#: templates/learn-more.html:22 templates/profile.html:135
+#: templates/learn-more.html:22 templates/profile.html:128
 #: templates/signup.html:52
 msgid "country"
 msgstr "Pays"
@@ -1330,7 +1322,7 @@ msgstr ""
 msgid "update_public"
 msgstr "Update public profile"
 
-#: templates/profile.html:61 templates/profile.html:148
+#: templates/profile.html:61 templates/profile.html:141
 msgid "are_you_sure"
 msgstr "Es-tu sûr(e) ? Tu ne pourras pas revenir en arrière."
 
@@ -1339,73 +1331,68 @@ msgstr "Es-tu sûr(e) ? Tu ne pourras pas revenir en arrière."
 msgid "delete_public"
 msgstr "Delete public profile"
 
-#: templates/profile.html:70 templates/profile.html:72
-#, fuzzy
-msgid "statistics"
-msgstr "My statistics"
-
-#: templates/profile.html:83
+#: templates/profile.html:76
 #, fuzzy
 msgid "self_removal_prompt"
 msgstr "Are you sure you want to leave this class?"
 
-#: templates/profile.html:83
+#: templates/profile.html:76
 #, fuzzy
 msgid "leave_class"
 msgstr "Leave class"
 
-#: templates/profile.html:88 templates/profile.html:91
+#: templates/profile.html:81 templates/profile.html:84
 #, fuzzy
 msgid "settings"
 msgstr "My personal settings"
 
-#: templates/profile.html:99 templates/signup.html:41
+#: templates/profile.html:92 templates/signup.html:41
 msgid "birth_year"
 msgstr "Année de naissance"
 
-#: templates/profile.html:102 templates/signup.html:25
+#: templates/profile.html:95 templates/signup.html:25
 #, fuzzy
 msgid "preferred_language"
 msgstr "Preferred language"
 
-#: templates/profile.html:112 templates/signup.html:34
+#: templates/profile.html:105 templates/signup.html:34
 #, fuzzy
 msgid "preferred_keyword_language"
 msgstr "Preferred keyword language"
 
-#: templates/profile.html:126 templates/signup.html:44
+#: templates/profile.html:119 templates/signup.html:44
 msgid "gender"
 msgstr "Sexe"
 
-#: templates/profile.html:129 templates/signup.html:46
+#: templates/profile.html:122 templates/signup.html:46
 msgid "female"
 msgstr "Femme"
 
-#: templates/profile.html:130 templates/signup.html:47
+#: templates/profile.html:123 templates/signup.html:47
 msgid "male"
 msgstr "Homme"
 
-#: templates/profile.html:131 templates/signup.html:48
+#: templates/profile.html:124 templates/signup.html:48
 msgid "other"
 msgstr "Autre"
 
-#: templates/profile.html:144
+#: templates/profile.html:137
 msgid "update_profile"
 msgstr "Mettre à jour le profil"
 
-#: templates/profile.html:148
+#: templates/profile.html:141
 msgid "destroy_profile"
 msgstr "Supprimer définitivement mon compte"
 
-#: templates/profile.html:155
+#: templates/profile.html:148
 msgid "current_password"
 msgstr "Mot de passe actuel"
 
-#: templates/profile.html:159
+#: templates/profile.html:152
 msgid "new_password"
 msgstr "Nouveau mot de passe"
 
-#: templates/profile.html:163
+#: templates/profile.html:156
 msgid "repeat_new_password"
 msgstr "Confirmation du nouveau mot de passe"
 
@@ -2053,4 +2040,13 @@ msgstr "You didn't enter an adventure name!"
 
 #~ msgid "required"
 #~ msgstr ""
+
+#~ msgid "set_preferred_lang"
+#~ msgstr ""
+#~ "Hedy now supports preferred user "
+#~ "languages. You can set one for "
+#~ "your profile in \"My profile\""
+
+#~ msgid "statistics"
+#~ msgstr "My statistics"
 

--- a/translations/fy/LC_MESSAGES/messages.po
+++ b/translations/fy/LC_MESSAGES/messages.po
@@ -1,29 +1,29 @@
-#: app.py:497
+#: app.py:451
 #, fuzzy
 msgid "program_contains_error"
 msgstr "This program contains an error, are you sure you want to share it?"
 
-#: app.py:649
+#: app.py:604
 #, fuzzy
 msgid "title_achievements"
 msgstr "Hedy - My achievements"
 
-#: app.py:666 app.py:1057 website/teacher.py:363 website/teacher.py:372
+#: app.py:622 app.py:1030 website/teacher.py:363 website/teacher.py:372
 #, fuzzy
 msgid "not_teacher"
 msgstr "Looks like you are not a teacher!"
 
-#: app.py:669
+#: app.py:625
 #, fuzzy
 msgid "not_enrolled"
 msgstr "Looks like you are not in this class!"
 
-#: app.py:701
+#: app.py:657
 #, fuzzy
 msgid "title_programs"
 msgstr "Hedy - My programs"
 
-#: app.py:711 app.py:721 app.py:725 app.py:739 app.py:1000 app.py:1302
+#: app.py:667 app.py:677 app.py:681 app.py:695 app.py:956 app.py:1275
 #: website/admin.py:17 website/admin.py:25 website/admin.py:95
 #: website/admin.py:112 website/admin.py:130 website/auth.py:653
 #: website/auth.py:680 website/statistics.py:86
@@ -31,122 +31,122 @@ msgstr "Hedy - My programs"
 msgid "unauthorized"
 msgstr "You don't have access rights for this page"
 
-#: app.py:749
+#: app.py:705
 msgid "minutes"
 msgstr "minuten"
 
-#: app.py:752
+#: app.py:708
 msgid "hours"
 msgstr "oeren"
 
-#: app.py:755
+#: app.py:711
 msgid "days"
 msgstr "dagen"
 
-#: app.py:758
+#: app.py:714
 #, fuzzy
 msgid "ago"
 msgstr "{time} ago"
 
-#: app.py:774 app.py:776 app.py:915 app.py:939 app.py:941
+#: app.py:730 app.py:732 app.py:871 app.py:895 app.py:897
 #, fuzzy
 msgid "no_such_level"
 msgstr "No such Hedy level!"
 
-#: app.py:784 app.py:791 app.py:865 app.py:871
+#: app.py:740 app.py:747 app.py:821 app.py:827
 #, fuzzy
 msgid "no_such_program"
 msgstr "No such Hedy program!"
 
-#: app.py:820
+#: app.py:776
 #, fuzzy
 msgid "level_not_translated"
 msgstr "This level is not translated in your language (yet)"
 
-#: app.py:822
+#: app.py:778
 #, fuzzy
 msgid "level_not_class"
 msgstr "You're in a class where this level has not been made available yet"
 
-#: app.py:925 website/teacher.py:430 website/teacher.py:446
+#: app.py:881 website/teacher.py:430 website/teacher.py:446
 #: website/teacher.py:475 website/teacher.py:501
 #, fuzzy
 msgid "no_such_adventure"
 msgstr "This adventure doesn't exist!"
 
-#: app.py:951
+#: app.py:907
 #, fuzzy
 msgid "page_not_found"
 msgstr "We could not find that page!"
 
-#: app.py:971
+#: app.py:927
 #, fuzzy
 msgid "title_signup"
 msgstr "Hedy - Create an account"
 
-#: app.py:978
+#: app.py:934
 #, fuzzy
 msgid "title_login"
 msgstr "Hedy - Login"
 
-#: app.py:985
+#: app.py:941
 #, fuzzy
 msgid "title_recover"
 msgstr "Hedy - Recover account"
 
-#: app.py:1001
+#: app.py:957
 #, fuzzy
 msgid "title_reset"
 msgstr "Hedy - Reset password"
 
-#: app.py:1010
+#: app.py:982
 #, fuzzy
 msgid "title_my-profile"
 msgstr "Hedy - My account"
 
-#: app.py:1024
+#: app.py:997
 #, fuzzy
 msgid "title_learn-more"
 msgstr "Hedy - Learn more"
 
-#: app.py:1029
+#: app.py:1002
 #, fuzzy
 msgid "title_privacy"
 msgstr "Hedy - Privacy terms"
 
-#: app.py:1036
+#: app.py:1009
 #, fuzzy
 msgid "title_landing-page"
 msgstr "Welcome to Hedy!"
 
-#: app.py:1038
+#: app.py:1011
 #, fuzzy
 msgid "not_user"
 msgstr "Looks like you are not logged in!"
 
-#: app.py:1053
+#: app.py:1026
 #, fuzzy
 msgid "title_for-teacher"
 msgstr "Hedy - For teachers"
 
-#: app.py:1064
+#: app.py:1037
 #, fuzzy
 msgid "title_start"
 msgstr "Hedy - A gradual programming language"
 
-#: app.py:1117
+#: app.py:1090
 #, fuzzy
 msgid "title_explore"
 msgstr "Hedy - Explore"
 
-#: app.py:1135 app.py:1137
+#: app.py:1108 app.py:1110
 #, fuzzy
 msgid "translate_error"
 msgstr ""
 "Something went wrong while translating the code. Try running the code to "
 "see if it has an error. Code with errors can not be translated."
 
-#: app.py:1246 website/auth.py:241 website/auth.py:290 website/auth.py:426
+#: app.py:1219 website/auth.py:241 website/auth.py:290 website/auth.py:426
 #: website/auth.py:451 website/auth.py:481 website/auth.py:587
 #: website/auth.py:619 website/auth.py:659 website/auth.py:686
 #: website/teacher.py:90 website/teacher.py:125 website/teacher.py:197
@@ -155,32 +155,32 @@ msgstr ""
 msgid "ajax_error"
 msgstr "Der gong wat mis, besykje it nochris."
 
-#: app.py:1249
+#: app.py:1222
 #, fuzzy
 msgid "image_invalid"
 msgstr "Your chosen image is invalid."
 
-#: app.py:1251
+#: app.py:1224
 #, fuzzy
 msgid "personal_text_invalid"
 msgstr "Your personal text is invalid."
 
-#: app.py:1253 app.py:1259
+#: app.py:1226 app.py:1232
 #, fuzzy
 msgid "favourite_program_invalid"
 msgstr "Your chosen favourite program is invalid."
 
-#: app.py:1271 app.py:1272
+#: app.py:1244 app.py:1245
 #, fuzzy
 msgid "public_profile_updated"
 msgstr "Public profile updated."
 
-#: app.py:1306 app.py:1330
+#: app.py:1279 app.py:1303
 #, fuzzy
 msgid "user_not_private"
 msgstr "This user doesn't exist or doesn't have a public profile"
 
-#: app.py:1339
+#: app.py:1312
 #, fuzzy
 msgid "invalid_teacher_invitation_code"
 msgstr ""
@@ -464,7 +464,7 @@ msgstr "Visible columns"
 
 #: templates/class-overview.html:21 templates/class-overview.html:64
 #: templates/class-overview.html:108 templates/create-accounts.html:16
-#: templates/login.html:12 templates/profile.html:93 templates/recover.html:8
+#: templates/login.html:12 templates/profile.html:86 templates/recover.html:8
 #: templates/signup.html:10
 msgid "username"
 msgstr "Brûkersnamme"
@@ -478,7 +478,6 @@ msgid "highest_level_reached"
 msgstr "Heechste level berikke"
 
 #: templates/class-overview.html:35 templates/class-overview.html:67
-#: templates/profile.html:74
 msgid "number_programs"
 msgstr "Tal programma's"
 
@@ -492,8 +491,8 @@ msgid "latest_shared_program"
 msgstr "Lêste dielde programma"
 
 #: templates/class-overview.html:49 templates/class-overview.html:70
-#: templates/class-overview.html:83 templates/profile.html:151
-#: templates/profile.html:153 templates/profile.html:166
+#: templates/class-overview.html:83 templates/profile.html:144
+#: templates/profile.html:146 templates/profile.html:159
 msgid "change_password"
 msgstr "Feroarje wachtwurd"
 
@@ -658,7 +657,7 @@ msgid "create_accounts_prompt"
 msgstr "Are you sure you want to create these accounts?"
 
 #: templates/create-accounts.html:17 templates/learn-more.html:10
-#: templates/profile.html:96 templates/recover.html:8 templates/signup.html:13
+#: templates/profile.html:89 templates/recover.html:8 templates/signup.html:13
 msgid "email"
 msgstr "Email"
 
@@ -850,8 +849,8 @@ msgid "select_own_adventures"
 msgstr "Select own adventures"
 
 #: templates/customize-class.html:95 templates/customize-class.html:121
-#: templates/profile.html:47 templates/profile.html:128
-#: templates/profile.html:137 templates/signup.html:26 templates/signup.html:45
+#: templates/profile.html:47 templates/profile.html:121
+#: templates/profile.html:130 templates/signup.html:26 templates/signup.html:45
 #: templates/signup.html:53
 msgid "select"
 msgstr "Kies"
@@ -938,8 +937,8 @@ msgstr "Creator"
 msgid "view_program"
 msgstr "View program"
 
-#: templates/for-teachers.html:5 templates/profile.html:78
-#: templates/profile.html:80
+#: templates/for-teachers.html:5 templates/profile.html:71
+#: templates/profile.html:73
 msgid "my_classes"
 msgstr "Myn lessen"
 
@@ -1161,14 +1160,7 @@ msgstr "Ofbrekke"
 msgid "copy_link_to_share"
 msgstr "Diellink kopiëare"
 
-#: templates/layout.html:78
-#, fuzzy
-msgid "set_preferred_lang"
-msgstr ""
-"Hedy now supports preferred user languages. You can set one for your "
-"profile in \"My profile\""
-
-#: templates/layout.html:86 templates/quiz/endquiz.html:18
+#: templates/layout.html:83 templates/quiz/endquiz.html:18
 #: templates/quiz/quiz.html:29
 #, fuzzy
 msgid "achievement_earned"
@@ -1189,7 +1181,7 @@ msgstr "Brûkersnamme"
 msgid "lastname"
 msgstr "Namme"
 
-#: templates/learn-more.html:22 templates/profile.html:135
+#: templates/learn-more.html:22 templates/profile.html:128
 #: templates/signup.html:52
 msgid "country"
 msgstr "Lân wêrst wennest"
@@ -1329,7 +1321,7 @@ msgstr ""
 msgid "update_public"
 msgstr "Update public profile"
 
-#: templates/profile.html:61 templates/profile.html:148
+#: templates/profile.html:61 templates/profile.html:141
 msgid "are_you_sure"
 msgstr "Bisto wis? Kinst dit net mear weromdraaie."
 
@@ -1338,73 +1330,68 @@ msgstr "Bisto wis? Kinst dit net mear weromdraaie."
 msgid "delete_public"
 msgstr "Delete public profile"
 
-#: templates/profile.html:70 templates/profile.html:72
-#, fuzzy
-msgid "statistics"
-msgstr "My statistics"
-
-#: templates/profile.html:83
+#: templates/profile.html:76
 #, fuzzy
 msgid "self_removal_prompt"
 msgstr "Are you sure you want to leave this class?"
 
-#: templates/profile.html:83
+#: templates/profile.html:76
 #, fuzzy
 msgid "leave_class"
 msgstr "Leave class"
 
-#: templates/profile.html:88 templates/profile.html:91
+#: templates/profile.html:81 templates/profile.html:84
 #, fuzzy
 msgid "settings"
 msgstr "My personal settings"
 
-#: templates/profile.html:99 templates/signup.html:41
+#: templates/profile.html:92 templates/signup.html:41
 msgid "birth_year"
 msgstr "Bertejier"
 
-#: templates/profile.html:102 templates/signup.html:25
+#: templates/profile.html:95 templates/signup.html:25
 #, fuzzy
 msgid "preferred_language"
 msgstr "Preferred language"
 
-#: templates/profile.html:112 templates/signup.html:34
+#: templates/profile.html:105 templates/signup.html:34
 #, fuzzy
 msgid "preferred_keyword_language"
 msgstr "Preferred keyword language"
 
-#: templates/profile.html:126 templates/signup.html:44
+#: templates/profile.html:119 templates/signup.html:44
 msgid "gender"
 msgstr "Geslacht"
 
-#: templates/profile.html:129 templates/signup.html:46
+#: templates/profile.html:122 templates/signup.html:46
 msgid "female"
 msgstr "Famke"
 
-#: templates/profile.html:130 templates/signup.html:47
+#: templates/profile.html:123 templates/signup.html:47
 msgid "male"
 msgstr "Jonge"
 
-#: templates/profile.html:131 templates/signup.html:48
+#: templates/profile.html:124 templates/signup.html:48
 msgid "other"
 msgstr "Oars"
 
-#: templates/profile.html:144
+#: templates/profile.html:137
 msgid "update_profile"
 msgstr "Dyn profyl bywurkje"
 
-#: templates/profile.html:148
+#: templates/profile.html:141
 msgid "destroy_profile"
 msgstr "Dyn akkount fuortsmite"
 
-#: templates/profile.html:155
+#: templates/profile.html:148
 msgid "current_password"
 msgstr "wachtwurd"
 
-#: templates/profile.html:159
+#: templates/profile.html:152
 msgid "new_password"
 msgstr "Nij wachtwurd"
 
-#: templates/profile.html:163
+#: templates/profile.html:156
 msgid "repeat_new_password"
 msgstr "Werhelje nije wachtwurd"
 
@@ -2052,4 +2039,13 @@ msgstr "The adventure has been updated!"
 #, fuzzy
 msgid "adventure_empty"
 msgstr "You didn't enter an adventure name!"
+
+#~ msgid "set_preferred_lang"
+#~ msgstr ""
+#~ "Hedy now supports preferred user "
+#~ "languages. You can set one for "
+#~ "your profile in \"My profile\""
+
+#~ msgid "statistics"
+#~ msgstr "My statistics"
 

--- a/translations/hi/LC_MESSAGES/messages.po
+++ b/translations/hi/LC_MESSAGES/messages.po
@@ -1,27 +1,27 @@
-#: app.py:497
+#: app.py:451
 #, fuzzy
 msgid "program_contains_error"
 msgstr "This program contains an error, are you sure you want to share it?"
 
-#: app.py:649
+#: app.py:604
 #, fuzzy
 msgid "title_achievements"
 msgstr "Hedy - My achievements"
 
-#: app.py:666 app.py:1057 website/teacher.py:363 website/teacher.py:372
+#: app.py:622 app.py:1030 website/teacher.py:363 website/teacher.py:372
 msgid "not_teacher"
 msgstr "लगता है आप शिक्षक नहीं हैं!"
 
-#: app.py:669
+#: app.py:625
 msgid "not_enrolled"
 msgstr "ऐसा लगता है कि आप इस कक्षा में नहीं हैं!"
 
-#: app.py:701
+#: app.py:657
 #, fuzzy
 msgid "title_programs"
 msgstr "Hedy - My programs"
 
-#: app.py:711 app.py:721 app.py:725 app.py:739 app.py:1000 app.py:1302
+#: app.py:667 app.py:677 app.py:681 app.py:695 app.py:956 app.py:1275
 #: website/admin.py:17 website/admin.py:25 website/admin.py:95
 #: website/admin.py:112 website/admin.py:130 website/auth.py:653
 #: website/auth.py:680 website/statistics.py:86
@@ -29,118 +29,118 @@ msgstr "Hedy - My programs"
 msgid "unauthorized"
 msgstr "You don't have access rights for this page"
 
-#: app.py:749
+#: app.py:705
 msgid "minutes"
 msgstr "मिनट "
 
-#: app.py:752
+#: app.py:708
 msgid "hours"
 msgstr "घंटे"
 
-#: app.py:755
+#: app.py:711
 msgid "days"
 msgstr "दिन"
 
-#: app.py:758
+#: app.py:714
 #, fuzzy
 msgid "ago"
 msgstr "{time} ago"
 
-#: app.py:774 app.py:776 app.py:915 app.py:939 app.py:941
+#: app.py:730 app.py:732 app.py:871 app.py:895 app.py:897
 msgid "no_such_level"
 msgstr "ऐसा कोई हेडी स्तर नहीं!"
 
-#: app.py:784 app.py:791 app.py:865 app.py:871
+#: app.py:740 app.py:747 app.py:821 app.py:827
 msgid "no_such_program"
 msgstr "ऐसा कोई हेडी प्रोग्राम नहीं!"
 
-#: app.py:820
+#: app.py:776
 #, fuzzy
 msgid "level_not_translated"
 msgstr "This level is not translated in your language (yet)"
 
-#: app.py:822
+#: app.py:778
 #, fuzzy
 msgid "level_not_class"
 msgstr "You're in a class where this level has not been made available yet"
 
-#: app.py:925 website/teacher.py:430 website/teacher.py:446
+#: app.py:881 website/teacher.py:430 website/teacher.py:446
 #: website/teacher.py:475 website/teacher.py:501
 #, fuzzy
 msgid "no_such_adventure"
 msgstr "This adventure doesn't exist!"
 
-#: app.py:951
+#: app.py:907
 msgid "page_not_found"
 msgstr "हमें वह पृष्ठ नहीं मिला!"
 
-#: app.py:971
+#: app.py:927
 #, fuzzy
 msgid "title_signup"
 msgstr "Hedy - Create an account"
 
-#: app.py:978
+#: app.py:934
 #, fuzzy
 msgid "title_login"
 msgstr "Hedy - Login"
 
-#: app.py:985
+#: app.py:941
 #, fuzzy
 msgid "title_recover"
 msgstr "Hedy - Recover account"
 
-#: app.py:1001
+#: app.py:957
 #, fuzzy
 msgid "title_reset"
 msgstr "Hedy - Reset password"
 
-#: app.py:1010
+#: app.py:982
 #, fuzzy
 msgid "title_my-profile"
 msgstr "Hedy - My account"
 
-#: app.py:1024
+#: app.py:997
 #, fuzzy
 msgid "title_learn-more"
 msgstr "Hedy - Learn more"
 
-#: app.py:1029
+#: app.py:1002
 #, fuzzy
 msgid "title_privacy"
 msgstr "Hedy - Privacy terms"
 
-#: app.py:1036
+#: app.py:1009
 #, fuzzy
 msgid "title_landing-page"
 msgstr "Welcome to Hedy!"
 
-#: app.py:1038
+#: app.py:1011
 msgid "not_user"
 msgstr "ऐसा लगता है कि आप लॉग इन नहीं हैं!"
 
-#: app.py:1053
+#: app.py:1026
 #, fuzzy
 msgid "title_for-teacher"
 msgstr "Hedy - For teachers"
 
-#: app.py:1064
+#: app.py:1037
 #, fuzzy
 msgid "title_start"
 msgstr "Hedy - A gradual programming language"
 
-#: app.py:1117
+#: app.py:1090
 #, fuzzy
 msgid "title_explore"
 msgstr "Hedy - Explore"
 
-#: app.py:1135 app.py:1137
+#: app.py:1108 app.py:1110
 #, fuzzy
 msgid "translate_error"
 msgstr ""
 "Something went wrong while translating the code. Try running the code to "
 "see if it has an error. Code with errors can not be translated."
 
-#: app.py:1246 website/auth.py:241 website/auth.py:290 website/auth.py:426
+#: app.py:1219 website/auth.py:241 website/auth.py:290 website/auth.py:426
 #: website/auth.py:451 website/auth.py:481 website/auth.py:587
 #: website/auth.py:619 website/auth.py:659 website/auth.py:686
 #: website/teacher.py:90 website/teacher.py:125 website/teacher.py:197
@@ -149,27 +149,27 @@ msgstr ""
 msgid "ajax_error"
 msgstr "एक त्रुटि थी, कृपया पुनः प्रयास करें।"
 
-#: app.py:1249
+#: app.py:1222
 msgid "image_invalid"
 msgstr "आपकी फोटो अमान्य है"
 
-#: app.py:1251
+#: app.py:1224
 msgid "personal_text_invalid"
 msgstr "आपका व्यक्तिगत पाठ अमान्य है"
 
-#: app.py:1253 app.py:1259
+#: app.py:1226 app.py:1232
 msgid "favourite_program_invalid"
 msgstr "आपका पसंदीदा प्रोग्राम अमान्य है"
 
-#: app.py:1271 app.py:1272
+#: app.py:1244 app.py:1245
 msgid "public_profile_updated"
 msgstr "सार्वजनिक प्रोफ़ाइल अद्यतन की गई।"
 
-#: app.py:1306 app.py:1330
+#: app.py:1279 app.py:1303
 msgid "user_not_private"
 msgstr "यह उपयोगकर्ता मौजूद नहीं है या उसकी कोई सार्वजनिक प्रोफ़ाइल नहीं है"
 
-#: app.py:1339
+#: app.py:1312
 msgid "invalid_teacher_invitation_code"
 msgstr ""
 "िक्षक आमंत्रण कोड अमान्य है| शिक्षक बनने के लिए, hedy@felienne.com पर "
@@ -430,7 +430,7 @@ msgstr "दृश्यमान स्तंभ"
 
 #: templates/class-overview.html:21 templates/class-overview.html:64
 #: templates/class-overview.html:108 templates/create-accounts.html:16
-#: templates/login.html:12 templates/profile.html:93 templates/recover.html:8
+#: templates/login.html:12 templates/profile.html:86 templates/recover.html:8
 #: templates/signup.html:10
 msgid "username"
 msgstr "उपयोगकर्ता नाम"
@@ -444,7 +444,6 @@ msgid "highest_level_reached"
 msgstr "पहुंचा गया उच्चतम स्तर"
 
 #: templates/class-overview.html:35 templates/class-overview.html:67
-#: templates/profile.html:74
 msgid "number_programs"
 msgstr "प्रोग्राम्स की संख्या"
 
@@ -457,8 +456,8 @@ msgid "latest_shared_program"
 msgstr "नवीनतम साझा प्रोग्राम"
 
 #: templates/class-overview.html:49 templates/class-overview.html:70
-#: templates/class-overview.html:83 templates/profile.html:151
-#: templates/profile.html:153 templates/profile.html:166
+#: templates/class-overview.html:83 templates/profile.html:144
+#: templates/profile.html:146 templates/profile.html:159
 msgid "change_password"
 msgstr "सांकेतिक शब्द बदलें"
 
@@ -607,7 +606,7 @@ msgid "create_accounts_prompt"
 msgstr "Are you sure you want to create these accounts?"
 
 #: templates/create-accounts.html:17 templates/learn-more.html:10
-#: templates/profile.html:96 templates/recover.html:8 templates/signup.html:13
+#: templates/profile.html:89 templates/recover.html:8 templates/signup.html:13
 msgid "email"
 msgstr "ईमेल"
 
@@ -789,8 +788,8 @@ msgid "select_own_adventures"
 msgstr "खुद के adventures चुनें"
 
 #: templates/customize-class.html:95 templates/customize-class.html:121
-#: templates/profile.html:47 templates/profile.html:128
-#: templates/profile.html:137 templates/signup.html:26 templates/signup.html:45
+#: templates/profile.html:47 templates/profile.html:121
+#: templates/profile.html:130 templates/signup.html:26 templates/signup.html:45
 #: templates/signup.html:53
 msgid "select"
 msgstr "चुनें"
@@ -869,8 +868,8 @@ msgstr "बनाने वाला"
 msgid "view_program"
 msgstr "प्रोग्राम देखें"
 
-#: templates/for-teachers.html:5 templates/profile.html:78
-#: templates/profile.html:80
+#: templates/for-teachers.html:5 templates/profile.html:71
+#: templates/profile.html:73
 msgid "my_classes"
 msgstr "मेरी कक्षाएँ"
 
@@ -1079,13 +1078,7 @@ msgstr "रद्द करें"
 msgid "copy_link_to_share"
 msgstr "शेयर करने के लिए लिंक कॉपी करें"
 
-#: templates/layout.html:78
-msgid "set_preferred_lang"
-msgstr ""
-"हेडी अब पसंदीदा उपयोगकर्ता भाषाओं का समर्थन करता है। आप \"मेरी "
-"प्रोफ़ाइल\" में अपनी प्रोफ़ाइल के लिए एक सेट कर सकते हैं"
-
-#: templates/layout.html:86 templates/quiz/endquiz.html:18
+#: templates/layout.html:83 templates/quiz/endquiz.html:18
 #: templates/quiz/quiz.html:29
 msgid "achievement_earned"
 msgstr "आपने एक उपलब्धि अर्जित की है!"
@@ -1105,7 +1098,7 @@ msgstr "उपयोगकर्ता नाम"
 msgid "lastname"
 msgstr "नाम"
 
-#: templates/learn-more.html:22 templates/profile.html:135
+#: templates/learn-more.html:22 templates/profile.html:128
 #: templates/signup.html:52
 msgid "country"
 msgstr "देश"
@@ -1231,7 +1224,7 @@ msgstr ""
 msgid "update_public"
 msgstr "सार्वजनिक प्रोफ़ाइल अद्यतन करें"
 
-#: templates/profile.html:61 templates/profile.html:148
+#: templates/profile.html:61 templates/profile.html:141
 msgid "are_you_sure"
 msgstr "क्या आपको यकीन है? आप इस क्रिया को लौटा नहीं सकते| "
 
@@ -1239,68 +1232,64 @@ msgstr "क्या आपको यकीन है? आप इस क्र�
 msgid "delete_public"
 msgstr "सार्वजनिक प्रोफ़ाइल हटाएं"
 
-#: templates/profile.html:70 templates/profile.html:72
-msgid "statistics"
-msgstr "मेरे आंकड़े"
-
-#: templates/profile.html:83
+#: templates/profile.html:76
 msgid "self_removal_prompt"
 msgstr "क्या आप वाकई इस कक्षा को छोड़ना चाहते हैं?"
 
-#: templates/profile.html:83
+#: templates/profile.html:76
 msgid "leave_class"
 msgstr "कक्षा छोड़ें"
 
-#: templates/profile.html:88 templates/profile.html:91
+#: templates/profile.html:81 templates/profile.html:84
 msgid "settings"
 msgstr "ेरी व्यक्तिगत सेटिंग"
 
-#: templates/profile.html:99 templates/signup.html:41
+#: templates/profile.html:92 templates/signup.html:41
 msgid "birth_year"
 msgstr "जन्म वर्ष"
 
-#: templates/profile.html:102 templates/signup.html:25
+#: templates/profile.html:95 templates/signup.html:25
 msgid "preferred_language"
 msgstr "पसंदीदा भाषा"
 
-#: templates/profile.html:112 templates/signup.html:34
+#: templates/profile.html:105 templates/signup.html:34
 #, fuzzy
 msgid "preferred_keyword_language"
 msgstr "Preferred keyword language"
 
-#: templates/profile.html:126 templates/signup.html:44
+#: templates/profile.html:119 templates/signup.html:44
 msgid "gender"
 msgstr "लिंग"
 
-#: templates/profile.html:129 templates/signup.html:46
+#: templates/profile.html:122 templates/signup.html:46
 msgid "female"
 msgstr "महिला"
 
-#: templates/profile.html:130 templates/signup.html:47
+#: templates/profile.html:123 templates/signup.html:47
 msgid "male"
 msgstr "पुरुष"
 
-#: templates/profile.html:131 templates/signup.html:48
+#: templates/profile.html:124 templates/signup.html:48
 msgid "other"
 msgstr "अन्य"
 
-#: templates/profile.html:144
+#: templates/profile.html:137
 msgid "update_profile"
 msgstr "्रोफ़ाइल अपडेट करें"
 
-#: templates/profile.html:148
+#: templates/profile.html:141
 msgid "destroy_profile"
 msgstr "खाता स्थायी रूप से हटाएं"
 
-#: templates/profile.html:155
+#: templates/profile.html:148
 msgid "current_password"
 msgstr "वर्तमान सांकेतिक शब्द"
 
-#: templates/profile.html:159
+#: templates/profile.html:152
 msgid "new_password"
 msgstr "नया सांकेतिक शब्द"
 
-#: templates/profile.html:163
+#: templates/profile.html:156
 msgid "repeat_new_password"
 msgstr "नया सांकेतिक शब्द दोहराएं"
 
@@ -1899,4 +1888,14 @@ msgstr "आपने एक adventure नाम दर्ज नहीं कि
 
 #~ msgid "ago-2"
 #~ msgstr "पहले"
+
+#~ msgid "set_preferred_lang"
+#~ msgstr ""
+#~ "हेडी अब पसंदीदा उपयोगकर्ता भाषाओं का "
+#~ "समर्थन करता है। आप \"मेरी प्रोफ़ाइल\""
+#~ " में अपनी प्रोफ़ाइल के लिए एक "
+#~ "सेट कर सकते हैं"
+
+#~ msgid "statistics"
+#~ msgstr "मेरे आंकड़े"
 

--- a/translations/hu/LC_MESSAGES/messages.po
+++ b/translations/hu/LC_MESSAGES/messages.po
@@ -1,29 +1,29 @@
-#: app.py:497
+#: app.py:451
 #, fuzzy
 msgid "program_contains_error"
 msgstr "This program contains an error, are you sure you want to share it?"
 
-#: app.py:649
+#: app.py:604
 #, fuzzy
 msgid "title_achievements"
 msgstr "Hedy - My achievements"
 
-#: app.py:666 app.py:1057 website/teacher.py:363 website/teacher.py:372
+#: app.py:622 app.py:1030 website/teacher.py:363 website/teacher.py:372
 #, fuzzy
 msgid "not_teacher"
 msgstr "Looks like you are not a teacher!"
 
-#: app.py:669
+#: app.py:625
 #, fuzzy
 msgid "not_enrolled"
 msgstr "Looks like you are not in this class!"
 
-#: app.py:701
+#: app.py:657
 #, fuzzy
 msgid "title_programs"
 msgstr "Hedy - My programs"
 
-#: app.py:711 app.py:721 app.py:725 app.py:739 app.py:1000 app.py:1302
+#: app.py:667 app.py:677 app.py:681 app.py:695 app.py:956 app.py:1275
 #: website/admin.py:17 website/admin.py:25 website/admin.py:95
 #: website/admin.py:112 website/admin.py:130 website/auth.py:653
 #: website/auth.py:680 website/statistics.py:86
@@ -31,122 +31,122 @@ msgstr "Hedy - My programs"
 msgid "unauthorized"
 msgstr "You don't have access rights for this page"
 
-#: app.py:749
+#: app.py:705
 msgid "minutes"
 msgstr "percek"
 
-#: app.py:752
+#: app.py:708
 msgid "hours"
 msgstr "órák"
 
-#: app.py:755
+#: app.py:711
 msgid "days"
 msgstr "napok"
 
-#: app.py:758
+#: app.py:714
 #, fuzzy
 msgid "ago"
 msgstr "{time} ago"
 
-#: app.py:774 app.py:776 app.py:915 app.py:939 app.py:941
+#: app.py:730 app.py:732 app.py:871 app.py:895 app.py:897
 #, fuzzy
 msgid "no_such_level"
 msgstr "No such Hedy level!"
 
-#: app.py:784 app.py:791 app.py:865 app.py:871
+#: app.py:740 app.py:747 app.py:821 app.py:827
 #, fuzzy
 msgid "no_such_program"
 msgstr "No such Hedy program!"
 
-#: app.py:820
+#: app.py:776
 #, fuzzy
 msgid "level_not_translated"
 msgstr "This level is not translated in your language (yet)"
 
-#: app.py:822
+#: app.py:778
 #, fuzzy
 msgid "level_not_class"
 msgstr "You're in a class where this level has not been made available yet"
 
-#: app.py:925 website/teacher.py:430 website/teacher.py:446
+#: app.py:881 website/teacher.py:430 website/teacher.py:446
 #: website/teacher.py:475 website/teacher.py:501
 #, fuzzy
 msgid "no_such_adventure"
 msgstr "This adventure doesn't exist!"
 
-#: app.py:951
+#: app.py:907
 #, fuzzy
 msgid "page_not_found"
 msgstr "We could not find that page!"
 
-#: app.py:971
+#: app.py:927
 #, fuzzy
 msgid "title_signup"
 msgstr "Hedy - Create an account"
 
-#: app.py:978
+#: app.py:934
 #, fuzzy
 msgid "title_login"
 msgstr "Hedy - Login"
 
-#: app.py:985
+#: app.py:941
 #, fuzzy
 msgid "title_recover"
 msgstr "Hedy - Recover account"
 
-#: app.py:1001
+#: app.py:957
 #, fuzzy
 msgid "title_reset"
 msgstr "Hedy - Reset password"
 
-#: app.py:1010
+#: app.py:982
 #, fuzzy
 msgid "title_my-profile"
 msgstr "Hedy - My account"
 
-#: app.py:1024
+#: app.py:997
 #, fuzzy
 msgid "title_learn-more"
 msgstr "Hedy - Learn more"
 
-#: app.py:1029
+#: app.py:1002
 #, fuzzy
 msgid "title_privacy"
 msgstr "Hedy - Privacy terms"
 
-#: app.py:1036
+#: app.py:1009
 #, fuzzy
 msgid "title_landing-page"
 msgstr "Welcome to Hedy!"
 
-#: app.py:1038
+#: app.py:1011
 #, fuzzy
 msgid "not_user"
 msgstr "Looks like you are not logged in!"
 
-#: app.py:1053
+#: app.py:1026
 #, fuzzy
 msgid "title_for-teacher"
 msgstr "Hedy - For teachers"
 
-#: app.py:1064
+#: app.py:1037
 #, fuzzy
 msgid "title_start"
 msgstr "Hedy - A gradual programming language"
 
-#: app.py:1117
+#: app.py:1090
 #, fuzzy
 msgid "title_explore"
 msgstr "Hedy - Explore"
 
-#: app.py:1135 app.py:1137
+#: app.py:1108 app.py:1110
 #, fuzzy
 msgid "translate_error"
 msgstr ""
 "Something went wrong while translating the code. Try running the code to "
 "see if it has an error. Code with errors can not be translated."
 
-#: app.py:1246 website/auth.py:241 website/auth.py:290 website/auth.py:426
+#: app.py:1219 website/auth.py:241 website/auth.py:290 website/auth.py:426
 #: website/auth.py:451 website/auth.py:481 website/auth.py:587
 #: website/auth.py:619 website/auth.py:659 website/auth.py:686
 #: website/teacher.py:90 website/teacher.py:125 website/teacher.py:197
@@ -155,32 +155,32 @@ msgstr ""
 msgid "ajax_error"
 msgstr "Hiba történt, próbálkozz újra."
 
-#: app.py:1249
+#: app.py:1222
 #, fuzzy
 msgid "image_invalid"
 msgstr "Your chosen image is invalid."
 
-#: app.py:1251
+#: app.py:1224
 #, fuzzy
 msgid "personal_text_invalid"
 msgstr "Your personal text is invalid."
 
-#: app.py:1253 app.py:1259
+#: app.py:1226 app.py:1232
 #, fuzzy
 msgid "favourite_program_invalid"
 msgstr "Your chosen favourite program is invalid."
 
-#: app.py:1271 app.py:1272
+#: app.py:1244 app.py:1245
 #, fuzzy
 msgid "public_profile_updated"
 msgstr "Public profile updated."
 
-#: app.py:1306 app.py:1330
+#: app.py:1279 app.py:1303
 #, fuzzy
 msgid "user_not_private"
 msgstr "This user doesn't exist or doesn't have a public profile"
 
-#: app.py:1339
+#: app.py:1312
 #, fuzzy
 msgid "invalid_teacher_invitation_code"
 msgstr ""
@@ -463,7 +463,7 @@ msgstr "Visible columns"
 
 #: templates/class-overview.html:21 templates/class-overview.html:64
 #: templates/class-overview.html:108 templates/create-accounts.html:16
-#: templates/login.html:12 templates/profile.html:93 templates/recover.html:8
+#: templates/login.html:12 templates/profile.html:86 templates/recover.html:8
 #: templates/signup.html:10
 msgid "username"
 msgstr "Felhasználónév"
@@ -477,7 +477,6 @@ msgid "highest_level_reached"
 msgstr "A legnagyobb elért szint"
 
 #: templates/class-overview.html:35 templates/class-overview.html:67
-#: templates/profile.html:74
 msgid "number_programs"
 msgstr "A programok száma"
 
@@ -490,8 +489,8 @@ msgid "latest_shared_program"
 msgstr "Utolsó megosztott program"
 
 #: templates/class-overview.html:49 templates/class-overview.html:70
-#: templates/class-overview.html:83 templates/profile.html:151
-#: templates/profile.html:153 templates/profile.html:166
+#: templates/class-overview.html:83 templates/profile.html:144
+#: templates/profile.html:146 templates/profile.html:159
 msgid "change_password"
 msgstr "Jelszó megváltoztatása"
 
@@ -654,7 +653,7 @@ msgid "create_accounts_prompt"
 msgstr "Are you sure you want to create these accounts?"
 
 #: templates/create-accounts.html:17 templates/learn-more.html:10
-#: templates/profile.html:96 templates/recover.html:8 templates/signup.html:13
+#: templates/profile.html:89 templates/recover.html:8 templates/signup.html:13
 msgid "email"
 msgstr "Email"
 
@@ -846,8 +845,8 @@ msgid "select_own_adventures"
 msgstr "Select own adventures"
 
 #: templates/customize-class.html:95 templates/customize-class.html:121
-#: templates/profile.html:47 templates/profile.html:128
-#: templates/profile.html:137 templates/signup.html:26 templates/signup.html:45
+#: templates/profile.html:47 templates/profile.html:121
+#: templates/profile.html:130 templates/signup.html:26 templates/signup.html:45
 #: templates/signup.html:53
 msgid "select"
 msgstr "Választ"
@@ -934,8 +933,8 @@ msgstr "Creator"
 msgid "view_program"
 msgstr "View program"
 
-#: templates/for-teachers.html:5 templates/profile.html:78
-#: templates/profile.html:80
+#: templates/for-teachers.html:5 templates/profile.html:71
+#: templates/profile.html:73
 msgid "my_classes"
 msgstr "Osztályaim"
 
@@ -1159,14 +1158,7 @@ msgstr "Mégsem"
 msgid "copy_link_to_share"
 msgstr "Link másolása a megosztáshoz"
 
-#: templates/layout.html:78
-#, fuzzy
-msgid "set_preferred_lang"
-msgstr ""
-"Hedy now supports preferred user languages. You can set one for your "
-"profile in \"My profile\""
-
-#: templates/layout.html:86 templates/quiz/endquiz.html:18
+#: templates/layout.html:83 templates/quiz/endquiz.html:18
 #: templates/quiz/quiz.html:29
 #, fuzzy
 msgid "achievement_earned"
@@ -1187,7 +1179,7 @@ msgstr "Felhasználónév"
 msgid "lastname"
 msgstr "Név"
 
-#: templates/learn-more.html:22 templates/profile.html:135
+#: templates/learn-more.html:22 templates/profile.html:128
 #: templates/signup.html:52
 msgid "country"
 msgstr "Ország"
@@ -1324,7 +1316,7 @@ msgstr ""
 msgid "update_public"
 msgstr "Update public profile"
 
-#: templates/profile.html:61 templates/profile.html:148
+#: templates/profile.html:61 templates/profile.html:141
 msgid "are_you_sure"
 msgstr "Biztos vagy ebben? Ezt a műveletet nem lehet visszavonni."
 
@@ -1333,73 +1325,68 @@ msgstr "Biztos vagy ebben? Ezt a műveletet nem lehet visszavonni."
 msgid "delete_public"
 msgstr "Delete public profile"
 
-#: templates/profile.html:70 templates/profile.html:72
-#, fuzzy
-msgid "statistics"
-msgstr "My statistics"
-
-#: templates/profile.html:83
+#: templates/profile.html:76
 #, fuzzy
 msgid "self_removal_prompt"
 msgstr "Are you sure you want to leave this class?"
 
-#: templates/profile.html:83
+#: templates/profile.html:76
 #, fuzzy
 msgid "leave_class"
 msgstr "Leave class"
 
-#: templates/profile.html:88 templates/profile.html:91
+#: templates/profile.html:81 templates/profile.html:84
 #, fuzzy
 msgid "settings"
 msgstr "My personal settings"
 
-#: templates/profile.html:99 templates/signup.html:41
+#: templates/profile.html:92 templates/signup.html:41
 msgid "birth_year"
 msgstr "Születési év"
 
-#: templates/profile.html:102 templates/signup.html:25
+#: templates/profile.html:95 templates/signup.html:25
 #, fuzzy
 msgid "preferred_language"
 msgstr "Preferred language"
 
-#: templates/profile.html:112 templates/signup.html:34
+#: templates/profile.html:105 templates/signup.html:34
 #, fuzzy
 msgid "preferred_keyword_language"
 msgstr "Preferred keyword language"
 
-#: templates/profile.html:126 templates/signup.html:44
+#: templates/profile.html:119 templates/signup.html:44
 msgid "gender"
 msgstr "Neme"
 
-#: templates/profile.html:129 templates/signup.html:46
+#: templates/profile.html:122 templates/signup.html:46
 msgid "female"
 msgstr "Nő"
 
-#: templates/profile.html:130 templates/signup.html:47
+#: templates/profile.html:123 templates/signup.html:47
 msgid "male"
 msgstr "Férfi"
 
-#: templates/profile.html:131 templates/signup.html:48
+#: templates/profile.html:124 templates/signup.html:48
 msgid "other"
 msgstr "Más"
 
-#: templates/profile.html:144
+#: templates/profile.html:137
 msgid "update_profile"
 msgstr "Profil frissítése"
 
-#: templates/profile.html:148
+#: templates/profile.html:141
 msgid "destroy_profile"
 msgstr "Véglegesen törli a fiókot "
 
-#: templates/profile.html:155
+#: templates/profile.html:148
 msgid "current_password"
 msgstr "Jelenlegi jelszó"
 
-#: templates/profile.html:159
+#: templates/profile.html:152
 msgid "new_password"
 msgstr "Új jelszó"
 
-#: templates/profile.html:163
+#: templates/profile.html:156
 msgid "repeat_new_password"
 msgstr "Új jelszó mégegyszer"
 
@@ -2051,4 +2038,13 @@ msgstr "The adventure has been updated!"
 #, fuzzy
 msgid "adventure_empty"
 msgstr "You didn't enter an adventure name!"
+
+#~ msgid "set_preferred_lang"
+#~ msgstr ""
+#~ "Hedy now supports preferred user "
+#~ "languages. You can set one for "
+#~ "your profile in \"My profile\""
+
+#~ msgid "statistics"
+#~ msgstr "My statistics"
 

--- a/translations/id/LC_MESSAGES/messages.po
+++ b/translations/id/LC_MESSAGES/messages.po
@@ -1,29 +1,29 @@
-#: app.py:497
+#: app.py:451
 #, fuzzy
 msgid "program_contains_error"
 msgstr "This program contains an error, are you sure you want to share it?"
 
-#: app.py:649
+#: app.py:604
 #, fuzzy
 msgid "title_achievements"
 msgstr "Hedy - My achievements"
 
-#: app.py:666 app.py:1057 website/teacher.py:363 website/teacher.py:372
+#: app.py:622 app.py:1030 website/teacher.py:363 website/teacher.py:372
 #, fuzzy
 msgid "not_teacher"
 msgstr "Looks like you are not a teacher!"
 
-#: app.py:669
+#: app.py:625
 #, fuzzy
 msgid "not_enrolled"
 msgstr "Looks like you are not in this class!"
 
-#: app.py:701
+#: app.py:657
 #, fuzzy
 msgid "title_programs"
 msgstr "Hedy - My programs"
 
-#: app.py:711 app.py:721 app.py:725 app.py:739 app.py:1000 app.py:1302
+#: app.py:667 app.py:677 app.py:681 app.py:695 app.py:956 app.py:1275
 #: website/admin.py:17 website/admin.py:25 website/admin.py:95
 #: website/admin.py:112 website/admin.py:130 website/auth.py:653
 #: website/auth.py:680 website/statistics.py:86
@@ -31,122 +31,122 @@ msgstr "Hedy - My programs"
 msgid "unauthorized"
 msgstr "You don't have access rights for this page"
 
-#: app.py:749
+#: app.py:705
 msgid "minutes"
 msgstr "menit"
 
-#: app.py:752
+#: app.py:708
 msgid "hours"
 msgstr "jam"
 
-#: app.py:755
+#: app.py:711
 msgid "days"
 msgstr "hari"
 
-#: app.py:758
+#: app.py:714
 #, fuzzy
 msgid "ago"
 msgstr "{time} ago"
 
-#: app.py:774 app.py:776 app.py:915 app.py:939 app.py:941
+#: app.py:730 app.py:732 app.py:871 app.py:895 app.py:897
 #, fuzzy
 msgid "no_such_level"
 msgstr "No such Hedy level!"
 
-#: app.py:784 app.py:791 app.py:865 app.py:871
+#: app.py:740 app.py:747 app.py:821 app.py:827
 #, fuzzy
 msgid "no_such_program"
 msgstr "No such Hedy program!"
 
-#: app.py:820
+#: app.py:776
 #, fuzzy
 msgid "level_not_translated"
 msgstr "This level is not translated in your language (yet)"
 
-#: app.py:822
+#: app.py:778
 #, fuzzy
 msgid "level_not_class"
 msgstr "You're in a class where this level has not been made available yet"
 
-#: app.py:925 website/teacher.py:430 website/teacher.py:446
+#: app.py:881 website/teacher.py:430 website/teacher.py:446
 #: website/teacher.py:475 website/teacher.py:501
 #, fuzzy
 msgid "no_such_adventure"
 msgstr "This adventure doesn't exist!"
 
-#: app.py:951
+#: app.py:907
 #, fuzzy
 msgid "page_not_found"
 msgstr "We could not find that page!"
 
-#: app.py:971
+#: app.py:927
 #, fuzzy
 msgid "title_signup"
 msgstr "Hedy - Create an account"
 
-#: app.py:978
+#: app.py:934
 #, fuzzy
 msgid "title_login"
 msgstr "Hedy - Login"
 
-#: app.py:985
+#: app.py:941
 #, fuzzy
 msgid "title_recover"
 msgstr "Hedy - Recover account"
 
-#: app.py:1001
+#: app.py:957
 #, fuzzy
 msgid "title_reset"
 msgstr "Hedy - Reset password"
 
-#: app.py:1010
+#: app.py:982
 #, fuzzy
 msgid "title_my-profile"
 msgstr "Hedy - My account"
 
-#: app.py:1024
+#: app.py:997
 #, fuzzy
 msgid "title_learn-more"
 msgstr "Hedy - Learn more"
 
-#: app.py:1029
+#: app.py:1002
 #, fuzzy
 msgid "title_privacy"
 msgstr "Hedy - Privacy terms"
 
-#: app.py:1036
+#: app.py:1009
 #, fuzzy
 msgid "title_landing-page"
 msgstr "Welcome to Hedy!"
 
-#: app.py:1038
+#: app.py:1011
 #, fuzzy
 msgid "not_user"
 msgstr "Looks like you are not logged in!"
 
-#: app.py:1053
+#: app.py:1026
 #, fuzzy
 msgid "title_for-teacher"
 msgstr "Hedy - For teachers"
 
-#: app.py:1064
+#: app.py:1037
 #, fuzzy
 msgid "title_start"
 msgstr "Hedy - A gradual programming language"
 
-#: app.py:1117
+#: app.py:1090
 #, fuzzy
 msgid "title_explore"
 msgstr "Hedy - Explore"
 
-#: app.py:1135 app.py:1137
+#: app.py:1108 app.py:1110
 #, fuzzy
 msgid "translate_error"
 msgstr ""
 "Something went wrong while translating the code. Try running the code to "
 "see if it has an error. Code with errors can not be translated."
 
-#: app.py:1246 website/auth.py:241 website/auth.py:290 website/auth.py:426
+#: app.py:1219 website/auth.py:241 website/auth.py:290 website/auth.py:426
 #: website/auth.py:451 website/auth.py:481 website/auth.py:587
 #: website/auth.py:619 website/auth.py:659 website/auth.py:686
 #: website/teacher.py:90 website/teacher.py:125 website/teacher.py:197
@@ -155,32 +155,32 @@ msgstr ""
 msgid "ajax_error"
 msgstr "Ditemukan sebuah error. Silakan coba lagi."
 
-#: app.py:1249
+#: app.py:1222
 #, fuzzy
 msgid "image_invalid"
 msgstr "Your chosen image is invalid."
 
-#: app.py:1251
+#: app.py:1224
 #, fuzzy
 msgid "personal_text_invalid"
 msgstr "Your personal text is invalid."
 
-#: app.py:1253 app.py:1259
+#: app.py:1226 app.py:1232
 #, fuzzy
 msgid "favourite_program_invalid"
 msgstr "Your chosen favourite program is invalid."
 
-#: app.py:1271 app.py:1272
+#: app.py:1244 app.py:1245
 #, fuzzy
 msgid "public_profile_updated"
 msgstr "Public profile updated."
 
-#: app.py:1306 app.py:1330
+#: app.py:1279 app.py:1303
 #, fuzzy
 msgid "user_not_private"
 msgstr "This user doesn't exist or doesn't have a public profile"
 
-#: app.py:1339
+#: app.py:1312
 #, fuzzy
 msgid "invalid_teacher_invitation_code"
 msgstr ""
@@ -468,7 +468,7 @@ msgstr "Visible columns"
 
 #: templates/class-overview.html:21 templates/class-overview.html:64
 #: templates/class-overview.html:108 templates/create-accounts.html:16
-#: templates/login.html:12 templates/profile.html:93 templates/recover.html:8
+#: templates/login.html:12 templates/profile.html:86 templates/recover.html:8
 #: templates/signup.html:10
 #, fuzzy
 msgid "username"
@@ -483,7 +483,6 @@ msgid "highest_level_reached"
 msgstr "Level tertinggi yang berhasil dicapai"
 
 #: templates/class-overview.html:35 templates/class-overview.html:67
-#: templates/profile.html:74
 msgid "number_programs"
 msgstr "Jumlah program"
 
@@ -497,8 +496,8 @@ msgid "latest_shared_program"
 msgstr "Latest shared program"
 
 #: templates/class-overview.html:49 templates/class-overview.html:70
-#: templates/class-overview.html:83 templates/profile.html:151
-#: templates/profile.html:153 templates/profile.html:166
+#: templates/class-overview.html:83 templates/profile.html:144
+#: templates/profile.html:146 templates/profile.html:159
 msgid "change_password"
 msgstr "Ubah password"
 
@@ -661,7 +660,7 @@ msgid "create_accounts_prompt"
 msgstr "Are you sure you want to create these accounts?"
 
 #: templates/create-accounts.html:17 templates/learn-more.html:10
-#: templates/profile.html:96 templates/recover.html:8 templates/signup.html:13
+#: templates/profile.html:89 templates/recover.html:8 templates/signup.html:13
 msgid "email"
 msgstr "Email"
 
@@ -853,8 +852,8 @@ msgid "select_own_adventures"
 msgstr "Select own adventures"
 
 #: templates/customize-class.html:95 templates/customize-class.html:121
-#: templates/profile.html:47 templates/profile.html:128
-#: templates/profile.html:137 templates/signup.html:26 templates/signup.html:45
+#: templates/profile.html:47 templates/profile.html:121
+#: templates/profile.html:130 templates/signup.html:26 templates/signup.html:45
 #: templates/signup.html:53
 msgid "select"
 msgstr "Pilih"
@@ -941,8 +940,8 @@ msgstr "Creator"
 msgid "view_program"
 msgstr "View program"
 
-#: templates/for-teachers.html:5 templates/profile.html:78
-#: templates/profile.html:80
+#: templates/for-teachers.html:5 templates/profile.html:71
+#: templates/profile.html:73
 msgid "my_classes"
 msgstr "Kelas-kelas saya"
 
@@ -1167,14 +1166,7 @@ msgstr "Batal"
 msgid "copy_link_to_share"
 msgstr "Salin tautan untuk berbagi"
 
-#: templates/layout.html:78
-#, fuzzy
-msgid "set_preferred_lang"
-msgstr ""
-"Hedy now supports preferred user languages. You can set one for your "
-"profile in \"My profile\""
-
-#: templates/layout.html:86 templates/quiz/endquiz.html:18
+#: templates/layout.html:83 templates/quiz/endquiz.html:18
 #: templates/quiz/quiz.html:29
 #, fuzzy
 msgid "achievement_earned"
@@ -1192,7 +1184,7 @@ msgstr "Nama Depan"
 msgid "lastname"
 msgstr "Nama Belakang"
 
-#: templates/learn-more.html:22 templates/profile.html:135
+#: templates/learn-more.html:22 templates/profile.html:128
 #: templates/signup.html:52
 msgid "country"
 msgstr "Negara"
@@ -1328,7 +1320,7 @@ msgstr ""
 msgid "update_public"
 msgstr "Update public profile"
 
-#: templates/profile.html:61 templates/profile.html:148
+#: templates/profile.html:61 templates/profile.html:141
 msgid "are_you_sure"
 msgstr "Apakah kamu yakin? Kamu tidak dapat membatalkan aksi ini."
 
@@ -1337,73 +1329,68 @@ msgstr "Apakah kamu yakin? Kamu tidak dapat membatalkan aksi ini."
 msgid "delete_public"
 msgstr "Delete public profile"
 
-#: templates/profile.html:70 templates/profile.html:72
-#, fuzzy
-msgid "statistics"
-msgstr "My statistics"
-
-#: templates/profile.html:83
+#: templates/profile.html:76
 #, fuzzy
 msgid "self_removal_prompt"
 msgstr "Are you sure you want to leave this class?"
 
-#: templates/profile.html:83
+#: templates/profile.html:76
 #, fuzzy
 msgid "leave_class"
 msgstr "Leave class"
 
-#: templates/profile.html:88 templates/profile.html:91
+#: templates/profile.html:81 templates/profile.html:84
 #, fuzzy
 msgid "settings"
 msgstr "My personal settings"
 
-#: templates/profile.html:99 templates/signup.html:41
+#: templates/profile.html:92 templates/signup.html:41
 msgid "birth_year"
 msgstr "Tahun lahir"
 
-#: templates/profile.html:102 templates/signup.html:25
+#: templates/profile.html:95 templates/signup.html:25
 #, fuzzy
 msgid "preferred_language"
 msgstr "Preferred language"
 
-#: templates/profile.html:112 templates/signup.html:34
+#: templates/profile.html:105 templates/signup.html:34
 #, fuzzy
 msgid "preferred_keyword_language"
 msgstr "Preferred keyword language"
 
-#: templates/profile.html:126 templates/signup.html:44
+#: templates/profile.html:119 templates/signup.html:44
 msgid "gender"
 msgstr "Jenis kelamin"
 
-#: templates/profile.html:129 templates/signup.html:46
+#: templates/profile.html:122 templates/signup.html:46
 msgid "female"
 msgstr "Perempuan"
 
-#: templates/profile.html:130 templates/signup.html:47
+#: templates/profile.html:123 templates/signup.html:47
 msgid "male"
 msgstr "Laki-laki"
 
-#: templates/profile.html:131 templates/signup.html:48
+#: templates/profile.html:124 templates/signup.html:48
 msgid "other"
 msgstr "Lainnya"
 
-#: templates/profile.html:144
+#: templates/profile.html:137
 msgid "update_profile"
 msgstr "Ubah profil"
 
-#: templates/profile.html:148
+#: templates/profile.html:141
 msgid "destroy_profile"
 msgstr "Hapus akun secara permanen"
 
-#: templates/profile.html:155
+#: templates/profile.html:148
 msgid "current_password"
 msgstr "Password sekarang"
 
-#: templates/profile.html:159
+#: templates/profile.html:152
 msgid "new_password"
 msgstr "Password baru"
 
-#: templates/profile.html:163
+#: templates/profile.html:156
 msgid "repeat_new_password"
 msgstr "Ulangi password baru"
 
@@ -2061,4 +2048,13 @@ msgstr "You didn't enter an adventure name!"
 
 #~ msgid "ago-2"
 #~ msgstr "lalu"
+
+#~ msgid "set_preferred_lang"
+#~ msgstr ""
+#~ "Hedy now supports preferred user "
+#~ "languages. You can set one for "
+#~ "your profile in \"My profile\""
+
+#~ msgid "statistics"
+#~ msgstr "My statistics"
 

--- a/translations/it/LC_MESSAGES/messages.po
+++ b/translations/it/LC_MESSAGES/messages.po
@@ -1,29 +1,29 @@
-#: app.py:497
+#: app.py:451
 #, fuzzy
 msgid "program_contains_error"
 msgstr "This program contains an error, are you sure you want to share it?"
 
-#: app.py:649
+#: app.py:604
 #, fuzzy
 msgid "title_achievements"
 msgstr "Hedy - My achievements"
 
-#: app.py:666 app.py:1057 website/teacher.py:363 website/teacher.py:372
+#: app.py:622 app.py:1030 website/teacher.py:363 website/teacher.py:372
 #, fuzzy
 msgid "not_teacher"
 msgstr "Looks like you are not a teacher!"
 
-#: app.py:669
+#: app.py:625
 #, fuzzy
 msgid "not_enrolled"
 msgstr "Looks like you are not in this class!"
 
-#: app.py:701
+#: app.py:657
 #, fuzzy
 msgid "title_programs"
 msgstr "Hedy - My programs"
 
-#: app.py:711 app.py:721 app.py:725 app.py:739 app.py:1000 app.py:1302
+#: app.py:667 app.py:677 app.py:681 app.py:695 app.py:956 app.py:1275
 #: website/admin.py:17 website/admin.py:25 website/admin.py:95
 #: website/admin.py:112 website/admin.py:130 website/auth.py:653
 #: website/auth.py:680 website/statistics.py:86
@@ -31,122 +31,122 @@ msgstr "Hedy - My programs"
 msgid "unauthorized"
 msgstr "You don't have access rights for this page"
 
-#: app.py:749
+#: app.py:705
 msgid "minutes"
 msgstr "minuti"
 
-#: app.py:752
+#: app.py:708
 msgid "hours"
 msgstr "ore"
 
-#: app.py:755
+#: app.py:711
 msgid "days"
 msgstr "giorni"
 
-#: app.py:758
+#: app.py:714
 #, fuzzy
 msgid "ago"
 msgstr "{time} ago"
 
-#: app.py:774 app.py:776 app.py:915 app.py:939 app.py:941
+#: app.py:730 app.py:732 app.py:871 app.py:895 app.py:897
 #, fuzzy
 msgid "no_such_level"
 msgstr "No such Hedy level!"
 
-#: app.py:784 app.py:791 app.py:865 app.py:871
+#: app.py:740 app.py:747 app.py:821 app.py:827
 #, fuzzy
 msgid "no_such_program"
 msgstr "No such Hedy program!"
 
-#: app.py:820
+#: app.py:776
 #, fuzzy
 msgid "level_not_translated"
 msgstr "This level is not translated in your language (yet)"
 
-#: app.py:822
+#: app.py:778
 #, fuzzy
 msgid "level_not_class"
 msgstr "You're in a class where this level has not been made available yet"
 
-#: app.py:925 website/teacher.py:430 website/teacher.py:446
+#: app.py:881 website/teacher.py:430 website/teacher.py:446
 #: website/teacher.py:475 website/teacher.py:501
 #, fuzzy
 msgid "no_such_adventure"
 msgstr "This adventure doesn't exist!"
 
-#: app.py:951
+#: app.py:907
 #, fuzzy
 msgid "page_not_found"
 msgstr "We could not find that page!"
 
-#: app.py:971
+#: app.py:927
 #, fuzzy
 msgid "title_signup"
 msgstr "Hedy - Create an account"
 
-#: app.py:978
+#: app.py:934
 #, fuzzy
 msgid "title_login"
 msgstr "Hedy - Login"
 
-#: app.py:985
+#: app.py:941
 #, fuzzy
 msgid "title_recover"
 msgstr "Hedy - Recover account"
 
-#: app.py:1001
+#: app.py:957
 #, fuzzy
 msgid "title_reset"
 msgstr "Hedy - Reset password"
 
-#: app.py:1010
+#: app.py:982
 #, fuzzy
 msgid "title_my-profile"
 msgstr "Hedy - My account"
 
-#: app.py:1024
+#: app.py:997
 #, fuzzy
 msgid "title_learn-more"
 msgstr "Hedy - Learn more"
 
-#: app.py:1029
+#: app.py:1002
 #, fuzzy
 msgid "title_privacy"
 msgstr "Hedy - Privacy terms"
 
-#: app.py:1036
+#: app.py:1009
 #, fuzzy
 msgid "title_landing-page"
 msgstr "Welcome to Hedy!"
 
-#: app.py:1038
+#: app.py:1011
 #, fuzzy
 msgid "not_user"
 msgstr "Looks like you are not logged in!"
 
-#: app.py:1053
+#: app.py:1026
 #, fuzzy
 msgid "title_for-teacher"
 msgstr "Hedy - For teachers"
 
-#: app.py:1064
+#: app.py:1037
 #, fuzzy
 msgid "title_start"
 msgstr "Hedy - A gradual programming language"
 
-#: app.py:1117
+#: app.py:1090
 #, fuzzy
 msgid "title_explore"
 msgstr "Hedy - Explore"
 
-#: app.py:1135 app.py:1137
+#: app.py:1108 app.py:1110
 #, fuzzy
 msgid "translate_error"
 msgstr ""
 "Something went wrong while translating the code. Try running the code to "
 "see if it has an error. Code with errors can not be translated."
 
-#: app.py:1246 website/auth.py:241 website/auth.py:290 website/auth.py:426
+#: app.py:1219 website/auth.py:241 website/auth.py:290 website/auth.py:426
 #: website/auth.py:451 website/auth.py:481 website/auth.py:587
 #: website/auth.py:619 website/auth.py:659 website/auth.py:686
 #: website/teacher.py:90 website/teacher.py:125 website/teacher.py:197
@@ -155,32 +155,32 @@ msgstr ""
 msgid "ajax_error"
 msgstr "C'è stato un problema, per favore riprova."
 
-#: app.py:1249
+#: app.py:1222
 #, fuzzy
 msgid "image_invalid"
 msgstr "Your chosen image is invalid."
 
-#: app.py:1251
+#: app.py:1224
 #, fuzzy
 msgid "personal_text_invalid"
 msgstr "Your personal text is invalid."
 
-#: app.py:1253 app.py:1259
+#: app.py:1226 app.py:1232
 #, fuzzy
 msgid "favourite_program_invalid"
 msgstr "Your chosen favourite program is invalid."
 
-#: app.py:1271 app.py:1272
+#: app.py:1244 app.py:1245
 #, fuzzy
 msgid "public_profile_updated"
 msgstr "Public profile updated."
 
-#: app.py:1306 app.py:1330
+#: app.py:1279 app.py:1303
 #, fuzzy
 msgid "user_not_private"
 msgstr "This user doesn't exist or doesn't have a public profile"
 
-#: app.py:1339
+#: app.py:1312
 #, fuzzy
 msgid "invalid_teacher_invitation_code"
 msgstr ""
@@ -466,7 +466,7 @@ msgstr "Visible columns"
 
 #: templates/class-overview.html:21 templates/class-overview.html:64
 #: templates/class-overview.html:108 templates/create-accounts.html:16
-#: templates/login.html:12 templates/profile.html:93 templates/recover.html:8
+#: templates/login.html:12 templates/profile.html:86 templates/recover.html:8
 #: templates/signup.html:10
 msgid "username"
 msgstr "Nome utente"
@@ -482,7 +482,6 @@ msgid "highest_level_reached"
 msgstr "Highest level reached"
 
 #: templates/class-overview.html:35 templates/class-overview.html:67
-#: templates/profile.html:74
 #, fuzzy
 msgid "number_programs"
 msgstr "Number of programs"
@@ -498,8 +497,8 @@ msgid "latest_shared_program"
 msgstr "Latest shared program"
 
 #: templates/class-overview.html:49 templates/class-overview.html:70
-#: templates/class-overview.html:83 templates/profile.html:151
-#: templates/profile.html:153 templates/profile.html:166
+#: templates/class-overview.html:83 templates/profile.html:144
+#: templates/profile.html:146 templates/profile.html:159
 msgid "change_password"
 msgstr "Cambia password"
 
@@ -672,7 +671,7 @@ msgid "create_accounts_prompt"
 msgstr "Are you sure you want to create these accounts?"
 
 #: templates/create-accounts.html:17 templates/learn-more.html:10
-#: templates/profile.html:96 templates/recover.html:8 templates/signup.html:13
+#: templates/profile.html:89 templates/recover.html:8 templates/signup.html:13
 msgid "email"
 msgstr "Email"
 
@@ -866,8 +865,8 @@ msgid "select_own_adventures"
 msgstr "Select own adventures"
 
 #: templates/customize-class.html:95 templates/customize-class.html:121
-#: templates/profile.html:47 templates/profile.html:128
-#: templates/profile.html:137 templates/signup.html:26 templates/signup.html:45
+#: templates/profile.html:47 templates/profile.html:121
+#: templates/profile.html:130 templates/signup.html:26 templates/signup.html:45
 #: templates/signup.html:53
 msgid "select"
 msgstr "Seleziona"
@@ -954,8 +953,8 @@ msgstr "Creator"
 msgid "view_program"
 msgstr "View program"
 
-#: templates/for-teachers.html:5 templates/profile.html:78
-#: templates/profile.html:80
+#: templates/for-teachers.html:5 templates/profile.html:71
+#: templates/profile.html:73
 #, fuzzy
 msgid "my_classes"
 msgstr "My classes"
@@ -1190,14 +1189,7 @@ msgstr "Cancel"
 msgid "copy_link_to_share"
 msgstr "Copy link to share"
 
-#: templates/layout.html:78
-#, fuzzy
-msgid "set_preferred_lang"
-msgstr ""
-"Hedy now supports preferred user languages. You can set one for your "
-"profile in \"My profile\""
-
-#: templates/layout.html:86 templates/quiz/endquiz.html:18
+#: templates/layout.html:83 templates/quiz/endquiz.html:18
 #: templates/quiz/quiz.html:29
 #, fuzzy
 msgid "achievement_earned"
@@ -1218,7 +1210,7 @@ msgstr "Nome utente"
 msgid "lastname"
 msgstr "Name"
 
-#: templates/learn-more.html:22 templates/profile.html:135
+#: templates/learn-more.html:22 templates/profile.html:128
 #: templates/signup.html:52
 msgid "country"
 msgstr "Paese"
@@ -1359,7 +1351,7 @@ msgstr ""
 msgid "update_public"
 msgstr "Update public profile"
 
-#: templates/profile.html:61 templates/profile.html:148
+#: templates/profile.html:61 templates/profile.html:141
 msgid "are_you_sure"
 msgstr "Sei sicuro? Questa azione è permanente."
 
@@ -1368,73 +1360,68 @@ msgstr "Sei sicuro? Questa azione è permanente."
 msgid "delete_public"
 msgstr "Delete public profile"
 
-#: templates/profile.html:70 templates/profile.html:72
-#, fuzzy
-msgid "statistics"
-msgstr "My statistics"
-
-#: templates/profile.html:83
+#: templates/profile.html:76
 #, fuzzy
 msgid "self_removal_prompt"
 msgstr "Are you sure you want to leave this class?"
 
-#: templates/profile.html:83
+#: templates/profile.html:76
 #, fuzzy
 msgid "leave_class"
 msgstr "Leave class"
 
-#: templates/profile.html:88 templates/profile.html:91
+#: templates/profile.html:81 templates/profile.html:84
 #, fuzzy
 msgid "settings"
 msgstr "My personal settings"
 
-#: templates/profile.html:99 templates/signup.html:41
+#: templates/profile.html:92 templates/signup.html:41
 msgid "birth_year"
 msgstr "Anno di nascita"
 
-#: templates/profile.html:102 templates/signup.html:25
+#: templates/profile.html:95 templates/signup.html:25
 #, fuzzy
 msgid "preferred_language"
 msgstr "Preferred language"
 
-#: templates/profile.html:112 templates/signup.html:34
+#: templates/profile.html:105 templates/signup.html:34
 #, fuzzy
 msgid "preferred_keyword_language"
 msgstr "Preferred keyword language"
 
-#: templates/profile.html:126 templates/signup.html:44
+#: templates/profile.html:119 templates/signup.html:44
 msgid "gender"
 msgstr "Genere"
 
-#: templates/profile.html:129 templates/signup.html:46
+#: templates/profile.html:122 templates/signup.html:46
 msgid "female"
 msgstr "Femmina"
 
-#: templates/profile.html:130 templates/signup.html:47
+#: templates/profile.html:123 templates/signup.html:47
 msgid "male"
 msgstr "Maschio"
 
-#: templates/profile.html:131 templates/signup.html:48
+#: templates/profile.html:124 templates/signup.html:48
 msgid "other"
 msgstr "Altro"
 
-#: templates/profile.html:144
+#: templates/profile.html:137
 msgid "update_profile"
 msgstr "Aggiorna profilo"
 
-#: templates/profile.html:148
+#: templates/profile.html:141
 msgid "destroy_profile"
 msgstr "Cancella account permanentemente"
 
-#: templates/profile.html:155
+#: templates/profile.html:148
 msgid "current_password"
 msgstr "Password attuale"
 
-#: templates/profile.html:159
+#: templates/profile.html:152
 msgid "new_password"
 msgstr "Nuova password"
 
-#: templates/profile.html:163
+#: templates/profile.html:156
 msgid "repeat_new_password"
 msgstr "Ripeti nuova password"
 
@@ -2099,4 +2086,13 @@ msgstr "The adventure has been updated!"
 #, fuzzy
 msgid "adventure_empty"
 msgstr "You didn't enter an adventure name!"
+
+#~ msgid "set_preferred_lang"
+#~ msgstr ""
+#~ "Hedy now supports preferred user "
+#~ "languages. You can set one for "
+#~ "your profile in \"My profile\""
+
+#~ msgid "statistics"
+#~ msgstr "My statistics"
 

--- a/translations/nb_NO/LC_MESSAGES/messages.po
+++ b/translations/nb_NO/LC_MESSAGES/messages.po
@@ -1,126 +1,126 @@
-#: app.py:497
+#: app.py:451
 msgid "program_contains_error"
 msgstr "Dette programmet inneholder en feil, er du sikker på at du vil dele det?"
 
-#: app.py:649
+#: app.py:604
 msgid "title_achievements"
 msgstr "Hedy - Mine prestasjoner"
 
-#: app.py:666 app.py:1057 website/teacher.py:363 website/teacher.py:372
+#: app.py:622 app.py:1030 website/teacher.py:363 website/teacher.py:372
 msgid "not_teacher"
 msgstr "Ser ut til at du ikke er en lærer!"
 
-#: app.py:669
+#: app.py:625
 msgid "not_enrolled"
 msgstr "Det ser ut som at du ikke er medlem i denne klassen!"
 
-#: app.py:701
+#: app.py:657
 msgid "title_programs"
 msgstr "Hedy - Mine programmer"
 
-#: app.py:711 app.py:721 app.py:725 app.py:739 app.py:1000 app.py:1302
+#: app.py:667 app.py:677 app.py:681 app.py:695 app.py:956 app.py:1275
 #: website/admin.py:17 website/admin.py:25 website/admin.py:95
 #: website/admin.py:112 website/admin.py:130 website/auth.py:653
 #: website/auth.py:680 website/statistics.py:86
 msgid "unauthorized"
 msgstr "Du har ikke rettigheter til å se denne siden"
 
-#: app.py:749
+#: app.py:705
 msgid "minutes"
 msgstr "minutter"
 
-#: app.py:752
+#: app.py:708
 msgid "hours"
 msgstr "timer"
 
-#: app.py:755
+#: app.py:711
 msgid "days"
 msgstr "dager"
 
-#: app.py:758
+#: app.py:714
 msgid "ago"
 msgstr "{time} siden"
 
-#: app.py:774 app.py:776 app.py:915 app.py:939 app.py:941
+#: app.py:730 app.py:732 app.py:871 app.py:895 app.py:897
 msgid "no_such_level"
 msgstr "Dette Hedy nivået fins ikke!"
 
-#: app.py:784 app.py:791 app.py:865 app.py:871
+#: app.py:740 app.py:747 app.py:821 app.py:827
 msgid "no_such_program"
 msgstr "Dette Hedy programmet fins ikke!"
 
-#: app.py:820
+#: app.py:776
 msgid "level_not_translated"
 msgstr "Dette nivået er ikke oversatt til ditt språk (foreløpig!)"
 
-#: app.py:822
+#: app.py:778
 msgid "level_not_class"
 msgstr "Klassen din har ikke tilgang til dette nivået enda"
 
-#: app.py:925 website/teacher.py:430 website/teacher.py:446
+#: app.py:881 website/teacher.py:430 website/teacher.py:446
 #: website/teacher.py:475 website/teacher.py:501
 msgid "no_such_adventure"
 msgstr "Dette eventyret eksisterer ikke!"
 
-#: app.py:951
+#: app.py:907
 msgid "page_not_found"
 msgstr "Vi klarte ikke å finne den siden!"
 
-#: app.py:971
+#: app.py:927
 msgid "title_signup"
 msgstr "Hedy - Opprett konto"
 
-#: app.py:978
+#: app.py:934
 msgid "title_login"
 msgstr "Hedy - Logg inn"
 
-#: app.py:985
+#: app.py:941
 msgid "title_recover"
 msgstr "Hedy - Gjennopprett konto"
 
-#: app.py:1001
+#: app.py:957
 msgid "title_reset"
 msgstr "Hedy - Tilbakestill passord"
 
-#: app.py:1010
+#: app.py:982
 msgid "title_my-profile"
 msgstr "Hedy - Min konto"
 
-#: app.py:1024
+#: app.py:997
 msgid "title_learn-more"
 msgstr "Hedy - Lær mer"
 
-#: app.py:1029
+#: app.py:1002
 msgid "title_privacy"
 msgstr "Hedy - Personvernsvilkår"
 
-#: app.py:1036
+#: app.py:1009
 msgid "title_landing-page"
 msgstr "Velkommen til Hedy!"
 
-#: app.py:1038
+#: app.py:1011
 msgid "not_user"
 msgstr "Ser ut til at du ikke er logget inn!"
 
-#: app.py:1053
+#: app.py:1026
 msgid "title_for-teacher"
 msgstr "Hedy - For lærere"
 
-#: app.py:1064
+#: app.py:1037
 msgid "title_start"
 msgstr "Hedy - Et gradvis programmeringsspråk"
 
-#: app.py:1117
+#: app.py:1090
 msgid "title_explore"
 msgstr "Hedy - Utforsk"
 
-#: app.py:1135 app.py:1137
+#: app.py:1108 app.py:1110
 msgid "translate_error"
 msgstr ""
 "Noe gikk galt når vi prøvde å oversette koden. Prøv å kjøre koden for å "
 "se om den inneholder en feil. Kode med feil i kan ikke oversettes."
 
-#: app.py:1246 website/auth.py:241 website/auth.py:290 website/auth.py:426
+#: app.py:1219 website/auth.py:241 website/auth.py:290 website/auth.py:426
 #: website/auth.py:451 website/auth.py:481 website/auth.py:587
 #: website/auth.py:619 website/auth.py:659 website/auth.py:686
 #: website/teacher.py:90 website/teacher.py:125 website/teacher.py:197
@@ -129,29 +129,29 @@ msgstr ""
 msgid "ajax_error"
 msgstr "Det skjedde noe feil, vennligst prøv igjen."
 
-#: app.py:1249
+#: app.py:1222
 msgid "image_invalid"
 msgstr "Bildet du valgte er ugyldig."
 
-#: app.py:1251
+#: app.py:1224
 msgid "personal_text_invalid"
 msgstr "Din personlige tekst er ugyldig."
 
-#: app.py:1253 app.py:1259
+#: app.py:1226 app.py:1232
 msgid "favourite_program_invalid"
 msgstr "Ditt valgte favorittprogram er ugyldig."
 
-#: app.py:1271 app.py:1272
+#: app.py:1244 app.py:1245
 msgid "public_profile_updated"
 msgstr "Din offentlige profil ble oppdatert."
 
-#: app.py:1306 app.py:1330
+#: app.py:1279 app.py:1303
 msgid "user_not_private"
 msgstr ""
 "Denne brukeren eksisterer ikke, eller så har de ikke opprettet en "
 "offentlig profil"
 
-#: app.py:1339
+#: app.py:1312
 msgid "invalid_teacher_invitation_code"
 msgstr ""
 "Invitasjonskoden til å bli lærer er ugyldig. For å bli en Hedy-lærer, ta "
@@ -283,10 +283,10 @@ msgstr ""
 #: content/error-messages.txt:19
 msgid "Invalid Type Combination"
 msgstr ""
-"Du kan ikke bruke {invalid_argument} og {invalid_argument_2} i "
-"{command} fordi en er {invalid_type} og den andre er {invalid_type_2}. "
-"Prøv å endre {invalid_argument} til {invalid_type_2} eller "
-"{invalid_argument_2} til {invalid_type}."
+"Du kan ikke bruke {invalid_argument} og {invalid_argument_2} i {command} "
+"fordi en er {invalid_type} og den andre er {invalid_type_2}. Prøv å endre"
+" {invalid_argument} til {invalid_type_2} eller {invalid_argument_2} til "
+"{invalid_type}."
 
 #: content/error-messages.txt:20
 msgid "Unsupported Float"
@@ -408,7 +408,7 @@ msgstr "Synlige kolonner"
 
 #: templates/class-overview.html:21 templates/class-overview.html:64
 #: templates/class-overview.html:108 templates/create-accounts.html:16
-#: templates/login.html:12 templates/profile.html:93 templates/recover.html:8
+#: templates/login.html:12 templates/profile.html:86 templates/recover.html:8
 #: templates/signup.html:10
 msgid "username"
 msgstr "Brukernavn"
@@ -422,7 +422,6 @@ msgid "highest_level_reached"
 msgstr "Høyeste nivå nådd"
 
 #: templates/class-overview.html:35 templates/class-overview.html:67
-#: templates/profile.html:74
 msgid "number_programs"
 msgstr "Antall programmer"
 
@@ -435,8 +434,8 @@ msgid "latest_shared_program"
 msgstr "Forrige delte program"
 
 #: templates/class-overview.html:49 templates/class-overview.html:70
-#: templates/class-overview.html:83 templates/profile.html:151
-#: templates/profile.html:153 templates/profile.html:166
+#: templates/class-overview.html:83 templates/profile.html:144
+#: templates/profile.html:146 templates/profile.html:159
 msgid "change_password"
 msgstr "Endre passord"
 
@@ -579,7 +578,7 @@ msgid "create_accounts_prompt"
 msgstr "Er du sikker på at du vil opprette disse kontoene?"
 
 #: templates/create-accounts.html:17 templates/learn-more.html:10
-#: templates/profile.html:96 templates/recover.html:8 templates/signup.html:13
+#: templates/profile.html:89 templates/recover.html:8 templates/signup.html:13
 msgid "email"
 msgstr "E-post"
 
@@ -761,8 +760,8 @@ msgid "select_own_adventures"
 msgstr "Velg egne eventyr"
 
 #: templates/customize-class.html:95 templates/customize-class.html:121
-#: templates/profile.html:47 templates/profile.html:128
-#: templates/profile.html:137 templates/signup.html:26 templates/signup.html:45
+#: templates/profile.html:47 templates/profile.html:121
+#: templates/profile.html:130 templates/signup.html:26 templates/signup.html:45
 #: templates/signup.html:53
 msgid "select"
 msgstr "Velg"
@@ -835,8 +834,8 @@ msgstr "Skaper"
 msgid "view_program"
 msgstr "Se program"
 
-#: templates/for-teachers.html:5 templates/profile.html:78
-#: templates/profile.html:80
+#: templates/for-teachers.html:5 templates/profile.html:71
+#: templates/profile.html:73
 msgid "my_classes"
 msgstr "Mine klasser"
 
@@ -1035,13 +1034,7 @@ msgstr "Avbryt"
 msgid "copy_link_to_share"
 msgstr "Kopier lenken for å dele"
 
-#: templates/layout.html:78
-msgid "set_preferred_lang"
-msgstr ""
-"Hedy støtter nå foretrukket brukerspråk. Du kan velge et språk for din "
-"profil i \"Min profil\""
-
-#: templates/layout.html:86 templates/quiz/endquiz.html:18
+#: templates/layout.html:83 templates/quiz/endquiz.html:18
 #: templates/quiz/quiz.html:29
 msgid "achievement_earned"
 msgstr "Du oppnådde en prestasjon!"
@@ -1058,7 +1051,7 @@ msgstr "Fornavn"
 msgid "lastname"
 msgstr "Etternavn"
 
-#: templates/learn-more.html:22 templates/profile.html:135
+#: templates/learn-more.html:22 templates/profile.html:128
 #: templates/signup.html:52
 msgid "country"
 msgstr "Land"
@@ -1178,7 +1171,7 @@ msgstr ""
 msgid "update_public"
 msgstr "Oppdater offentlig profil"
 
-#: templates/profile.html:61 templates/profile.html:148
+#: templates/profile.html:61 templates/profile.html:141
 msgid "are_you_sure"
 msgstr "Er du sikker? Du kan ikke angre på denne handlingen."
 
@@ -1186,67 +1179,63 @@ msgstr "Er du sikker? Du kan ikke angre på denne handlingen."
 msgid "delete_public"
 msgstr "Slett offentlig profil"
 
-#: templates/profile.html:70 templates/profile.html:72
-msgid "statistics"
-msgstr "Min statistikk"
-
-#: templates/profile.html:83
+#: templates/profile.html:76
 msgid "self_removal_prompt"
 msgstr "Er du sikker på at du vil forlate denne klassen?"
 
-#: templates/profile.html:83
+#: templates/profile.html:76
 msgid "leave_class"
 msgstr "Forlat klassen"
 
-#: templates/profile.html:88 templates/profile.html:91
+#: templates/profile.html:81 templates/profile.html:84
 msgid "settings"
 msgstr "Mine personlige innstillinger"
 
-#: templates/profile.html:99 templates/signup.html:41
+#: templates/profile.html:92 templates/signup.html:41
 msgid "birth_year"
 msgstr "Fødselsår"
 
-#: templates/profile.html:102 templates/signup.html:25
+#: templates/profile.html:95 templates/signup.html:25
 msgid "preferred_language"
 msgstr "Foretrukket språk"
 
-#: templates/profile.html:112 templates/signup.html:34
+#: templates/profile.html:105 templates/signup.html:34
 msgid "preferred_keyword_language"
 msgstr "Fortrukket språk for nøkkelord"
 
-#: templates/profile.html:126 templates/signup.html:44
+#: templates/profile.html:119 templates/signup.html:44
 msgid "gender"
 msgstr "Kjønn"
 
-#: templates/profile.html:129 templates/signup.html:46
+#: templates/profile.html:122 templates/signup.html:46
 msgid "female"
 msgstr "Jente"
 
-#: templates/profile.html:130 templates/signup.html:47
+#: templates/profile.html:123 templates/signup.html:47
 msgid "male"
 msgstr "Gutt"
 
-#: templates/profile.html:131 templates/signup.html:48
+#: templates/profile.html:124 templates/signup.html:48
 msgid "other"
 msgstr "Annet"
 
-#: templates/profile.html:144
+#: templates/profile.html:137
 msgid "update_profile"
 msgstr "Oppdater profil"
 
-#: templates/profile.html:148
+#: templates/profile.html:141
 msgid "destroy_profile"
 msgstr "Slett profil"
 
-#: templates/profile.html:155
+#: templates/profile.html:148
 msgid "current_password"
 msgstr "Nåværende passord"
 
-#: templates/profile.html:159
+#: templates/profile.html:152
 msgid "new_password"
 msgstr "Nytt passord"
 
-#: templates/profile.html:163
+#: templates/profile.html:156
 msgid "repeat_new_password"
 msgstr "Gjenta nytt passord"
 
@@ -1805,4 +1794,13 @@ msgstr "Eventyret har blitt oppdatert!"
 #: website/teacher.py:519
 msgid "adventure_empty"
 msgstr "Du skrev ikke noe navn på eventyret!"
+
+#~ msgid "set_preferred_lang"
+#~ msgstr ""
+#~ "Hedy støtter nå foretrukket brukerspråk. "
+#~ "Du kan velge et språk for din "
+#~ "profil i \"Min profil\""
+
+#~ msgid "statistics"
+#~ msgstr "Min statistikk"
 

--- a/translations/nl/LC_MESSAGES/messages.po
+++ b/translations/nl/LC_MESSAGES/messages.po
@@ -1,127 +1,127 @@
-#: app.py:497
+#: app.py:451
 msgid "program_contains_error"
 msgstr "Dit programma bevat een foutje, weet je zeker dat je hem wilt delen?"
 
-#: app.py:649
+#: app.py:604
 msgid "title_achievements"
 msgstr "Hedy - Mijn badges"
 
-#: app.py:666 app.py:1057 website/teacher.py:363 website/teacher.py:372
+#: app.py:622 app.py:1030 website/teacher.py:363 website/teacher.py:372
 msgid "not_teacher"
 msgstr "Jij bent geen leraar!"
 
-#: app.py:669
+#: app.py:625
 msgid "not_enrolled"
 msgstr "Jij zit niet in deze klas!"
 
-#: app.py:701
+#: app.py:657
 msgid "title_programs"
 msgstr "Hedy - Mijn programma's"
 
-#: app.py:711 app.py:721 app.py:725 app.py:739 app.py:1000 app.py:1302
+#: app.py:667 app.py:677 app.py:681 app.py:695 app.py:956 app.py:1275
 #: website/admin.py:17 website/admin.py:25 website/admin.py:95
 #: website/admin.py:112 website/admin.py:130 website/auth.py:653
 #: website/auth.py:680 website/statistics.py:86
 msgid "unauthorized"
 msgstr "Jij hebt geen rechten voor deze pagina"
 
-#: app.py:749
+#: app.py:705
 msgid "minutes"
 msgstr "minuten"
 
-#: app.py:752
+#: app.py:708
 msgid "hours"
 msgstr "uur"
 
-#: app.py:755
+#: app.py:711
 msgid "days"
 msgstr "dagen"
 
-#: app.py:758
+#: app.py:714
 msgid "ago"
 msgstr "{time} geleden"
 
-#: app.py:774 app.py:776 app.py:915 app.py:939 app.py:941
+#: app.py:730 app.py:732 app.py:871 app.py:895 app.py:897
 msgid "no_such_level"
 msgstr "Dit level bestaat niet!"
 
-#: app.py:784 app.py:791 app.py:865 app.py:871
+#: app.py:740 app.py:747 app.py:821 app.py:827
 msgid "no_such_program"
 msgstr "Dit programma bestaat niet!"
 
-#: app.py:820
+#: app.py:776
 msgid "level_not_translated"
 msgstr "Dit level is (nog) niet vertaald in jouw taal"
 
-#: app.py:822
+#: app.py:778
 msgid "level_not_class"
 msgstr "Je zit in een klas waar dit level nog niet beschikbaar is gemaakt"
 
-#: app.py:925 website/teacher.py:430 website/teacher.py:446
+#: app.py:881 website/teacher.py:430 website/teacher.py:446
 #: website/teacher.py:475 website/teacher.py:501
 msgid "no_such_adventure"
 msgstr "Dit avontuur bestaat niet!"
 
-#: app.py:951
+#: app.py:907
 msgid "page_not_found"
 msgstr "We konden deze pagina niet vinden!"
 
-#: app.py:971
+#: app.py:927
 msgid "title_signup"
 msgstr "Hedy - Account aanmaken"
 
-#: app.py:978
+#: app.py:934
 msgid "title_login"
 msgstr "Hedy - Inloggen"
 
-#: app.py:985
+#: app.py:941
 msgid "title_recover"
 msgstr "Hedy - Account herstellen"
 
-#: app.py:1001
+#: app.py:957
 msgid "title_reset"
 msgstr "Hedy - Wachtwoord resetten"
 
-#: app.py:1010
+#: app.py:982
 msgid "title_my-profile"
 msgstr "Hedy - Mijn account"
 
-#: app.py:1024
+#: app.py:997
 msgid "title_learn-more"
 msgstr "Hedy - Meer info"
 
-#: app.py:1029
+#: app.py:1002
 msgid "title_privacy"
 msgstr "Hedy - Privacyverklaring"
 
-#: app.py:1036
+#: app.py:1009
 msgid "title_landing-page"
 msgstr "Welkom bij Hedy!"
 
-#: app.py:1038
+#: app.py:1011
 msgid "not_user"
 msgstr "Jij bent niet ingelogd!"
 
-#: app.py:1053
+#: app.py:1026
 msgid "title_for-teacher"
 msgstr "Hedy - Voor leerkrachten"
 
-#: app.py:1064
+#: app.py:1037
 msgid "title_start"
 msgstr "Hedy - Een graduele programmeertaal"
 
-#: app.py:1117
+#: app.py:1090
 msgid "title_explore"
 msgstr "Hedy - Ontdekken"
 
-#: app.py:1135 app.py:1137
+#: app.py:1108 app.py:1110
 msgid "translate_error"
 msgstr ""
 "Er is iets misgegaan met het vertalen van de code. Probeer je code te "
 "runnen om te kijken of er misschien een foutje in zit. Code met foutjes "
 "kan niet vertaald worden."
 
-#: app.py:1246 website/auth.py:241 website/auth.py:290 website/auth.py:426
+#: app.py:1219 website/auth.py:241 website/auth.py:290 website/auth.py:426
 #: website/auth.py:451 website/auth.py:481 website/auth.py:587
 #: website/auth.py:619 website/auth.py:659 website/auth.py:686
 #: website/teacher.py:90 website/teacher.py:125 website/teacher.py:197
@@ -130,27 +130,27 @@ msgstr ""
 msgid "ajax_error"
 msgstr "Er is een fout opgetreden, probeer het nog eens."
 
-#: app.py:1249
+#: app.py:1222
 msgid "image_invalid"
 msgstr "Jouw gekozen profielfoto is ongeldig."
 
-#: app.py:1251
+#: app.py:1224
 msgid "personal_text_invalid"
 msgstr "Jouw persoonlijke tekst is ongeldig."
 
-#: app.py:1253 app.py:1259
+#: app.py:1226 app.py:1232
 msgid "favourite_program_invalid"
 msgstr "Jouw gekozen favoriete programma is ongeldig."
 
-#: app.py:1271 app.py:1272
+#: app.py:1244 app.py:1245
 msgid "public_profile_updated"
 msgstr "Je openbare profiel is aangepast."
 
-#: app.py:1306 app.py:1330
+#: app.py:1279 app.py:1303
 msgid "user_not_private"
 msgstr "Deze gebruiker bestaat niet of heeft geen openbaar profiel"
 
-#: app.py:1339
+#: app.py:1312
 msgid "invalid_teacher_invitation_code"
 msgstr ""
 "Deze leerkrachtenuitnodigingscode is niet geldig. Als je een nieuwe "
@@ -285,9 +285,9 @@ msgstr ""
 msgid "Invalid Type Combination"
 msgstr ""
 "Je kan {invalid_argument} en {invalid_argument_2} niet gebruiken met "
-"{command} omdat de ene {invalid_type} is, en de andere "
-"{invalid_type_2}. Verander {invalid_argument} in {invalid_type_2} of "
-"{invalid_argument_2} in {invalid_type}."
+"{command} omdat de ene {invalid_type} is, en de andere {invalid_type_2}. "
+"Verander {invalid_argument} in {invalid_type_2} of {invalid_argument_2} "
+"in {invalid_type}."
 
 #: content/error-messages.txt:20
 msgid "Unsupported Float"
@@ -410,7 +410,7 @@ msgstr "Zichtbare kolommen"
 
 #: templates/class-overview.html:21 templates/class-overview.html:64
 #: templates/class-overview.html:108 templates/create-accounts.html:16
-#: templates/login.html:12 templates/profile.html:93 templates/recover.html:8
+#: templates/login.html:12 templates/profile.html:86 templates/recover.html:8
 #: templates/signup.html:10
 msgid "username"
 msgstr "Gebruikersnaam"
@@ -424,7 +424,6 @@ msgid "highest_level_reached"
 msgstr "Hoogste level"
 
 #: templates/class-overview.html:35 templates/class-overview.html:67
-#: templates/profile.html:74
 msgid "number_programs"
 msgstr "Aantal programma's"
 
@@ -437,8 +436,8 @@ msgid "latest_shared_program"
 msgstr "Laatst gedeelde programma"
 
 #: templates/class-overview.html:49 templates/class-overview.html:70
-#: templates/class-overview.html:83 templates/profile.html:151
-#: templates/profile.html:153 templates/profile.html:166
+#: templates/class-overview.html:83 templates/profile.html:144
+#: templates/profile.html:146 templates/profile.html:159
 msgid "change_password"
 msgstr "Verander wachtwoord"
 
@@ -583,7 +582,7 @@ msgid "create_accounts_prompt"
 msgstr "Weet je zeker dat je deze accounts wilt aanmaken?"
 
 #: templates/create-accounts.html:17 templates/learn-more.html:10
-#: templates/profile.html:96 templates/recover.html:8 templates/signup.html:13
+#: templates/profile.html:89 templates/recover.html:8 templates/signup.html:13
 msgid "email"
 msgstr "Email"
 
@@ -762,8 +761,8 @@ msgid "select_own_adventures"
 msgstr "Eigen avonturen selecteren"
 
 #: templates/customize-class.html:95 templates/customize-class.html:121
-#: templates/profile.html:47 templates/profile.html:128
-#: templates/profile.html:137 templates/signup.html:26 templates/signup.html:45
+#: templates/profile.html:47 templates/profile.html:121
+#: templates/profile.html:130 templates/signup.html:26 templates/signup.html:45
 #: templates/signup.html:53
 msgid "select"
 msgstr "Kies"
@@ -836,8 +835,8 @@ msgstr "Maker"
 msgid "view_program"
 msgstr "Bekijk programma"
 
-#: templates/for-teachers.html:5 templates/profile.html:78
-#: templates/profile.html:80
+#: templates/for-teachers.html:5 templates/profile.html:71
+#: templates/profile.html:73
 msgid "my_classes"
 msgstr "Mijn klassen"
 
@@ -1035,13 +1034,7 @@ msgstr "Afbreken"
 msgid "copy_link_to_share"
 msgstr "Kopieer link voor delen"
 
-#: templates/layout.html:78
-msgid "set_preferred_lang"
-msgstr ""
-"Hedy accounts kunnen vanaf nu een voorkeurstaal kiezen. Je kunt er voor "
-"jouw account een instellen via \"Mijn profiel\""
-
-#: templates/layout.html:86 templates/quiz/endquiz.html:18
+#: templates/layout.html:83 templates/quiz/endquiz.html:18
 #: templates/quiz/quiz.html:29
 msgid "achievement_earned"
 msgstr "Je hebt een badge verdiend!"
@@ -1058,7 +1051,7 @@ msgstr "Voornaam"
 msgid "lastname"
 msgstr "Achternaam"
 
-#: templates/learn-more.html:22 templates/profile.html:135
+#: templates/learn-more.html:22 templates/profile.html:128
 #: templates/signup.html:52
 msgid "country"
 msgstr "Land waarin je woont"
@@ -1178,7 +1171,7 @@ msgstr ""
 msgid "update_public"
 msgstr "Openbaar profiel opslaan"
 
-#: templates/profile.html:61 templates/profile.html:148
+#: templates/profile.html:61 templates/profile.html:141
 msgid "are_you_sure"
 msgstr "Weet je het zeker? Je kunt dit niet meer ongedaan maken."
 
@@ -1186,67 +1179,63 @@ msgstr "Weet je het zeker? Je kunt dit niet meer ongedaan maken."
 msgid "delete_public"
 msgstr "Openbaar profiel verwijderen"
 
-#: templates/profile.html:70 templates/profile.html:72
-msgid "statistics"
-msgstr "Mijn statistieken"
-
-#: templates/profile.html:83
+#: templates/profile.html:76
 msgid "self_removal_prompt"
 msgstr "Weet je zeker dat je deze klas wilt verlaten?"
 
-#: templates/profile.html:83
+#: templates/profile.html:76
 msgid "leave_class"
 msgstr "Klas verlaten"
 
-#: templates/profile.html:88 templates/profile.html:91
+#: templates/profile.html:81 templates/profile.html:84
 msgid "settings"
 msgstr "Mijn gegevens"
 
-#: templates/profile.html:99 templates/signup.html:41
+#: templates/profile.html:92 templates/signup.html:41
 msgid "birth_year"
 msgstr "Geboortejaar"
 
-#: templates/profile.html:102 templates/signup.html:25
+#: templates/profile.html:95 templates/signup.html:25
 msgid "preferred_language"
 msgstr "Voorkeurstaal"
 
-#: templates/profile.html:112 templates/signup.html:34
+#: templates/profile.html:105 templates/signup.html:34
 msgid "preferred_keyword_language"
 msgstr "Commando voorkeurstaal"
 
-#: templates/profile.html:126 templates/signup.html:44
+#: templates/profile.html:119 templates/signup.html:44
 msgid "gender"
 msgstr "Geslacht"
 
-#: templates/profile.html:129 templates/signup.html:46
+#: templates/profile.html:122 templates/signup.html:46
 msgid "female"
 msgstr "Meisje"
 
-#: templates/profile.html:130 templates/signup.html:47
+#: templates/profile.html:123 templates/signup.html:47
 msgid "male"
 msgstr "Jongen"
 
-#: templates/profile.html:131 templates/signup.html:48
+#: templates/profile.html:124 templates/signup.html:48
 msgid "other"
 msgstr "Anders"
 
-#: templates/profile.html:144
+#: templates/profile.html:137
 msgid "update_profile"
 msgstr "Update je profiel"
 
-#: templates/profile.html:148
+#: templates/profile.html:141
 msgid "destroy_profile"
 msgstr "Profiel verwijderen"
 
-#: templates/profile.html:155
+#: templates/profile.html:148
 msgid "current_password"
 msgstr "Huidige wachtwoord"
 
-#: templates/profile.html:159
+#: templates/profile.html:152
 msgid "new_password"
 msgstr "Nieuw wachtwoord"
 
-#: templates/profile.html:163
+#: templates/profile.html:156
 msgid "repeat_new_password"
 msgstr "Herhaal nieuw wachtwoord"
 
@@ -1808,4 +1797,14 @@ msgstr "Je hebt geen avonturen naam ingevuld!"
 
 #~ msgid "required"
 #~ msgstr ""
+
+#~ msgid "set_preferred_lang"
+#~ msgstr ""
+#~ "Hedy accounts kunnen vanaf nu een "
+#~ "voorkeurstaal kiezen. Je kunt er voor"
+#~ " jouw account een instellen via "
+#~ "\"Mijn profiel\""
+
+#~ msgid "statistics"
+#~ msgstr "Mijn statistieken"
 

--- a/translations/pl/LC_MESSAGES/messages.po
+++ b/translations/pl/LC_MESSAGES/messages.po
@@ -1,27 +1,27 @@
-#: app.py:497
+#: app.py:451
 #, fuzzy
 msgid "program_contains_error"
 msgstr "This program contains an error, are you sure you want to share it?"
 
-#: app.py:649
+#: app.py:604
 msgid "title_achievements"
 msgstr "Hedy - Moje osiągnięcia"
 
-#: app.py:666 app.py:1057 website/teacher.py:363 website/teacher.py:372
+#: app.py:622 app.py:1030 website/teacher.py:363 website/teacher.py:372
 #, fuzzy
 msgid "not_teacher"
 msgstr "Looks like you are not a teacher!"
 
-#: app.py:669
+#: app.py:625
 #, fuzzy
 msgid "not_enrolled"
 msgstr "Looks like you are not in this class!"
 
-#: app.py:701
+#: app.py:657
 msgid "title_programs"
 msgstr "Hedy - Moje programy"
 
-#: app.py:711 app.py:721 app.py:725 app.py:739 app.py:1000 app.py:1302
+#: app.py:667 app.py:677 app.py:681 app.py:695 app.py:956 app.py:1275
 #: website/admin.py:17 website/admin.py:25 website/admin.py:95
 #: website/admin.py:112 website/admin.py:130 website/auth.py:653
 #: website/auth.py:680 website/statistics.py:86
@@ -29,108 +29,108 @@ msgstr "Hedy - Moje programy"
 msgid "unauthorized"
 msgstr "You don't have access rights for this page"
 
-#: app.py:749
+#: app.py:705
 msgid "minutes"
 msgstr "minut"
 
-#: app.py:752
+#: app.py:708
 msgid "hours"
 msgstr "godzin"
 
-#: app.py:755
+#: app.py:711
 msgid "days"
 msgstr "dni"
 
-#: app.py:758
+#: app.py:714
 msgid "ago"
 msgstr "{time} temu"
 
-#: app.py:774 app.py:776 app.py:915 app.py:939 app.py:941
+#: app.py:730 app.py:732 app.py:871 app.py:895 app.py:897
 msgid "no_such_level"
 msgstr "Nie ma takiego poziomu Hedy!"
 
-#: app.py:784 app.py:791 app.py:865 app.py:871
+#: app.py:740 app.py:747 app.py:821 app.py:827
 msgid "no_such_program"
 msgstr "Nie ma takiego programu Hedy!"
 
-#: app.py:820
+#: app.py:776
 msgid "level_not_translated"
 msgstr "Ten poziom nie jest (jeszcze) przetłumaczony na twój język"
 
-#: app.py:822
+#: app.py:778
 #, fuzzy
 msgid "level_not_class"
 msgstr "You're in a class where this level has not been made available yet"
 
-#: app.py:925 website/teacher.py:430 website/teacher.py:446
+#: app.py:881 website/teacher.py:430 website/teacher.py:446
 #: website/teacher.py:475 website/teacher.py:501
 msgid "no_such_adventure"
 msgstr "Ta przygoda nie istnieje!"
 
-#: app.py:951
+#: app.py:907
 msgid "page_not_found"
 msgstr "Nie możemy odnaleźć tej strony!"
 
-#: app.py:971
+#: app.py:927
 msgid "title_signup"
 msgstr "Hedy - Utwórz konto"
 
-#: app.py:978
+#: app.py:934
 msgid "title_login"
 msgstr "Hedy - Logowanie"
 
-#: app.py:985
+#: app.py:941
 msgid "title_recover"
 msgstr "Hedy - Odzyskaj konto"
 
-#: app.py:1001
+#: app.py:957
 msgid "title_reset"
 msgstr "Hedy - Zresetuj hasło"
 
-#: app.py:1010
+#: app.py:982
 msgid "title_my-profile"
 msgstr "Hedy - Moje konto"
 
-#: app.py:1024
+#: app.py:997
 msgid "title_learn-more"
 msgstr "Hedy - Dowiedz się więcej"
 
-#: app.py:1029
+#: app.py:1002
 #, fuzzy
 msgid "title_privacy"
 msgstr "Hedy - Privacy terms"
 
-#: app.py:1036
+#: app.py:1009
 #, fuzzy
 msgid "title_landing-page"
 msgstr "Welcome to Hedy!"
 
-#: app.py:1038
+#: app.py:1011
 #, fuzzy
 msgid "not_user"
 msgstr "Looks like you are not logged in!"
 
-#: app.py:1053
+#: app.py:1026
 msgid "title_for-teacher"
 msgstr "Hedy - Dla nauczycieli"
 
-#: app.py:1064
+#: app.py:1037
 msgid "title_start"
 msgstr "Hedy - Stopniowany język programowania"
 
-#: app.py:1117
+#: app.py:1090
 #, fuzzy
 msgid "title_explore"
 msgstr "Hedy - Explore"
 
-#: app.py:1135 app.py:1137
+#: app.py:1108 app.py:1110
 #, fuzzy
 msgid "translate_error"
 msgstr ""
 "Something went wrong while translating the code. Try running the code to "
 "see if it has an error. Code with errors can not be translated."
 
-#: app.py:1246 website/auth.py:241 website/auth.py:290 website/auth.py:426
+#: app.py:1219 website/auth.py:241 website/auth.py:290 website/auth.py:426
 #: website/auth.py:451 website/auth.py:481 website/auth.py:587
 #: website/auth.py:619 website/auth.py:659 website/auth.py:686
 #: website/teacher.py:90 website/teacher.py:125 website/teacher.py:197
@@ -139,32 +139,32 @@ msgstr ""
 msgid "ajax_error"
 msgstr "Wystąpił błąd, proszę spróbować ponownie."
 
-#: app.py:1249
+#: app.py:1222
 #, fuzzy
 msgid "image_invalid"
 msgstr "Your chosen image is invalid."
 
-#: app.py:1251
+#: app.py:1224
 #, fuzzy
 msgid "personal_text_invalid"
 msgstr "Your personal text is invalid."
 
-#: app.py:1253 app.py:1259
+#: app.py:1226 app.py:1232
 #, fuzzy
 msgid "favourite_program_invalid"
 msgstr "Your chosen favourite program is invalid."
 
-#: app.py:1271 app.py:1272
+#: app.py:1244 app.py:1245
 #, fuzzy
 msgid "public_profile_updated"
 msgstr "Public profile updated."
 
-#: app.py:1306 app.py:1330
+#: app.py:1279 app.py:1303
 #, fuzzy
 msgid "user_not_private"
 msgstr "This user doesn't exist or doesn't have a public profile"
 
-#: app.py:1339
+#: app.py:1312
 #, fuzzy
 msgid "invalid_teacher_invitation_code"
 msgstr ""
@@ -453,7 +453,7 @@ msgstr "Widoczne kolumny"
 
 #: templates/class-overview.html:21 templates/class-overview.html:64
 #: templates/class-overview.html:108 templates/create-accounts.html:16
-#: templates/login.html:12 templates/profile.html:93 templates/recover.html:8
+#: templates/login.html:12 templates/profile.html:86 templates/recover.html:8
 #: templates/signup.html:10
 msgid "username"
 msgstr "Nazwa użytkownika"
@@ -468,7 +468,6 @@ msgid "highest_level_reached"
 msgstr "Najwyższy osiągnięty poziom"
 
 #: templates/class-overview.html:35 templates/class-overview.html:67
-#: templates/profile.html:74
 msgid "number_programs"
 msgstr "Liczba programów"
 
@@ -482,8 +481,8 @@ msgid "latest_shared_program"
 msgstr "Latest shared program"
 
 #: templates/class-overview.html:49 templates/class-overview.html:70
-#: templates/class-overview.html:83 templates/profile.html:151
-#: templates/profile.html:153 templates/profile.html:166
+#: templates/class-overview.html:83 templates/profile.html:144
+#: templates/profile.html:146 templates/profile.html:159
 msgid "change_password"
 msgstr "Zmień hasło"
 
@@ -642,7 +641,7 @@ msgid "create_accounts_prompt"
 msgstr "Are you sure you want to create these accounts?"
 
 #: templates/create-accounts.html:17 templates/learn-more.html:10
-#: templates/profile.html:96 templates/recover.html:8 templates/signup.html:13
+#: templates/profile.html:89 templates/recover.html:8 templates/signup.html:13
 msgid "email"
 msgstr "Email"
 
@@ -828,8 +827,8 @@ msgid "select_own_adventures"
 msgstr "Wybierz własne przygody"
 
 #: templates/customize-class.html:95 templates/customize-class.html:121
-#: templates/profile.html:47 templates/profile.html:128
-#: templates/profile.html:137 templates/signup.html:26 templates/signup.html:45
+#: templates/profile.html:47 templates/profile.html:121
+#: templates/profile.html:130 templates/signup.html:26 templates/signup.html:45
 #: templates/signup.html:53
 msgid "select"
 msgstr "Wybierz"
@@ -911,8 +910,8 @@ msgstr "Creator"
 msgid "view_program"
 msgstr "Wyświetl program"
 
-#: templates/for-teachers.html:5 templates/profile.html:78
-#: templates/profile.html:80
+#: templates/for-teachers.html:5 templates/profile.html:71
+#: templates/profile.html:73
 msgid "my_classes"
 msgstr "Moje klasy"
 
@@ -1128,13 +1127,7 @@ msgstr "Cancel"
 msgid "copy_link_to_share"
 msgstr "Copy link to share"
 
-#: templates/layout.html:78
-msgid "set_preferred_lang"
-msgstr ""
-"Hedy wspiera teraz preferowany język użytkownika. Możesz ustawić go dla "
-"swojego profilu w \"Mój profil\""
-
-#: templates/layout.html:86 templates/quiz/endquiz.html:18
+#: templates/layout.html:83 templates/quiz/endquiz.html:18
 #: templates/quiz/quiz.html:29
 #, fuzzy
 msgid "achievement_earned"
@@ -1154,7 +1147,7 @@ msgstr "Imię"
 msgid "lastname"
 msgstr "Nazwisko"
 
-#: templates/learn-more.html:22 templates/profile.html:135
+#: templates/learn-more.html:22 templates/profile.html:128
 #: templates/signup.html:52
 msgid "country"
 msgstr "Kraj"
@@ -1284,7 +1277,7 @@ msgstr ""
 msgid "update_public"
 msgstr "Zaktualizuj profil publiczny"
 
-#: templates/profile.html:61 templates/profile.html:148
+#: templates/profile.html:61 templates/profile.html:141
 #, fuzzy
 msgid "are_you_sure"
 msgstr "Are you sure? You cannot revert this action."
@@ -1293,68 +1286,64 @@ msgstr "Are you sure? You cannot revert this action."
 msgid "delete_public"
 msgstr "Usuń profil publiczny"
 
-#: templates/profile.html:70 templates/profile.html:72
-msgid "statistics"
-msgstr "Moje statystyki"
-
-#: templates/profile.html:83
+#: templates/profile.html:76
 #, fuzzy
 msgid "self_removal_prompt"
 msgstr "Are you sure you want to leave this class?"
 
-#: templates/profile.html:83
+#: templates/profile.html:76
 msgid "leave_class"
 msgstr "Opuść klasę"
 
-#: templates/profile.html:88 templates/profile.html:91
+#: templates/profile.html:81 templates/profile.html:84
 msgid "settings"
 msgstr "Moje ustawienia osobiste"
 
-#: templates/profile.html:99 templates/signup.html:41
+#: templates/profile.html:92 templates/signup.html:41
 msgid "birth_year"
 msgstr "Rok urodzenia"
 
-#: templates/profile.html:102 templates/signup.html:25
+#: templates/profile.html:95 templates/signup.html:25
 msgid "preferred_language"
 msgstr "Preferowany język"
 
-#: templates/profile.html:112 templates/signup.html:34
+#: templates/profile.html:105 templates/signup.html:34
 msgid "preferred_keyword_language"
 msgstr "Preferowany język słów kluczowych"
 
-#: templates/profile.html:126 templates/signup.html:44
+#: templates/profile.html:119 templates/signup.html:44
 msgid "gender"
 msgstr "Płeć"
 
-#: templates/profile.html:129 templates/signup.html:46
+#: templates/profile.html:122 templates/signup.html:46
 msgid "female"
 msgstr "Żeńska"
 
-#: templates/profile.html:130 templates/signup.html:47
+#: templates/profile.html:123 templates/signup.html:47
 msgid "male"
 msgstr "Męska"
 
-#: templates/profile.html:131 templates/signup.html:48
+#: templates/profile.html:124 templates/signup.html:48
 msgid "other"
 msgstr "Inna"
 
-#: templates/profile.html:144
+#: templates/profile.html:137
 msgid "update_profile"
 msgstr "Zaktualizuj profil"
 
-#: templates/profile.html:148
+#: templates/profile.html:141
 msgid "destroy_profile"
 msgstr "Usuń profil"
 
-#: templates/profile.html:155
+#: templates/profile.html:148
 msgid "current_password"
 msgstr "Obecne hasło"
 
-#: templates/profile.html:159
+#: templates/profile.html:152
 msgid "new_password"
 msgstr "Nowe hasło"
 
-#: templates/profile.html:163
+#: templates/profile.html:156
 msgid "repeat_new_password"
 msgstr "Powtórz nowe hasło"
 
@@ -1998,4 +1987,13 @@ msgstr "You didn't enter an adventure name!"
 
 #~ msgid "required"
 #~ msgstr ""
+
+#~ msgid "set_preferred_lang"
+#~ msgstr ""
+#~ "Hedy wspiera teraz preferowany język "
+#~ "użytkownika. Możesz ustawić go dla "
+#~ "swojego profilu w \"Mój profil\""
+
+#~ msgid "statistics"
+#~ msgstr "Moje statystyki"
 

--- a/translations/pt_BR/LC_MESSAGES/messages.po
+++ b/translations/pt_BR/LC_MESSAGES/messages.po
@@ -1,29 +1,29 @@
-#: app.py:497
+#: app.py:451
 #, fuzzy
 msgid "program_contains_error"
 msgstr "This program contains an error, are you sure you want to share it?"
 
-#: app.py:649
+#: app.py:604
 #, fuzzy
 msgid "title_achievements"
 msgstr "Hedy - My achievements"
 
-#: app.py:666 app.py:1057 website/teacher.py:363 website/teacher.py:372
+#: app.py:622 app.py:1030 website/teacher.py:363 website/teacher.py:372
 #, fuzzy
 msgid "not_teacher"
 msgstr "Looks like you are not a teacher!"
 
-#: app.py:669
+#: app.py:625
 #, fuzzy
 msgid "not_enrolled"
 msgstr "Looks like you are not in this class!"
 
-#: app.py:701
+#: app.py:657
 #, fuzzy
 msgid "title_programs"
 msgstr "Hedy - My programs"
 
-#: app.py:711 app.py:721 app.py:725 app.py:739 app.py:1000 app.py:1302
+#: app.py:667 app.py:677 app.py:681 app.py:695 app.py:956 app.py:1275
 #: website/admin.py:17 website/admin.py:25 website/admin.py:95
 #: website/admin.py:112 website/admin.py:130 website/auth.py:653
 #: website/auth.py:680 website/statistics.py:86
@@ -31,122 +31,122 @@ msgstr "Hedy - My programs"
 msgid "unauthorized"
 msgstr "You don't have access rights for this page"
 
-#: app.py:749
+#: app.py:705
 msgid "minutes"
 msgstr "minutos"
 
-#: app.py:752
+#: app.py:708
 msgid "hours"
 msgstr "horas"
 
-#: app.py:755
+#: app.py:711
 msgid "days"
 msgstr "dias"
 
-#: app.py:758
+#: app.py:714
 #, fuzzy
 msgid "ago"
 msgstr "{time} ago"
 
-#: app.py:774 app.py:776 app.py:915 app.py:939 app.py:941
+#: app.py:730 app.py:732 app.py:871 app.py:895 app.py:897
 #, fuzzy
 msgid "no_such_level"
 msgstr "No such Hedy level!"
 
-#: app.py:784 app.py:791 app.py:865 app.py:871
+#: app.py:740 app.py:747 app.py:821 app.py:827
 #, fuzzy
 msgid "no_such_program"
 msgstr "No such Hedy program!"
 
-#: app.py:820
+#: app.py:776
 #, fuzzy
 msgid "level_not_translated"
 msgstr "This level is not translated in your language (yet)"
 
-#: app.py:822
+#: app.py:778
 #, fuzzy
 msgid "level_not_class"
 msgstr "You're in a class where this level has not been made available yet"
 
-#: app.py:925 website/teacher.py:430 website/teacher.py:446
+#: app.py:881 website/teacher.py:430 website/teacher.py:446
 #: website/teacher.py:475 website/teacher.py:501
 #, fuzzy
 msgid "no_such_adventure"
 msgstr "This adventure doesn't exist!"
 
-#: app.py:951
+#: app.py:907
 #, fuzzy
 msgid "page_not_found"
 msgstr "We could not find that page!"
 
-#: app.py:971
+#: app.py:927
 #, fuzzy
 msgid "title_signup"
 msgstr "Hedy - Create an account"
 
-#: app.py:978
+#: app.py:934
 #, fuzzy
 msgid "title_login"
 msgstr "Hedy - Login"
 
-#: app.py:985
+#: app.py:941
 #, fuzzy
 msgid "title_recover"
 msgstr "Hedy - Recover account"
 
-#: app.py:1001
+#: app.py:957
 #, fuzzy
 msgid "title_reset"
 msgstr "Hedy - Reset password"
 
-#: app.py:1010
+#: app.py:982
 #, fuzzy
 msgid "title_my-profile"
 msgstr "Hedy - My account"
 
-#: app.py:1024
+#: app.py:997
 #, fuzzy
 msgid "title_learn-more"
 msgstr "Hedy - Learn more"
 
-#: app.py:1029
+#: app.py:1002
 #, fuzzy
 msgid "title_privacy"
 msgstr "Hedy - Privacy terms"
 
-#: app.py:1036
+#: app.py:1009
 #, fuzzy
 msgid "title_landing-page"
 msgstr "Welcome to Hedy!"
 
-#: app.py:1038
+#: app.py:1011
 #, fuzzy
 msgid "not_user"
 msgstr "Looks like you are not logged in!"
 
-#: app.py:1053
+#: app.py:1026
 #, fuzzy
 msgid "title_for-teacher"
 msgstr "Hedy - For teachers"
 
-#: app.py:1064
+#: app.py:1037
 #, fuzzy
 msgid "title_start"
 msgstr "Hedy - A gradual programming language"
 
-#: app.py:1117
+#: app.py:1090
 #, fuzzy
 msgid "title_explore"
 msgstr "Hedy - Explore"
 
-#: app.py:1135 app.py:1137
+#: app.py:1108 app.py:1110
 #, fuzzy
 msgid "translate_error"
 msgstr ""
 "Something went wrong while translating the code. Try running the code to "
 "see if it has an error. Code with errors can not be translated."
 
-#: app.py:1246 website/auth.py:241 website/auth.py:290 website/auth.py:426
+#: app.py:1219 website/auth.py:241 website/auth.py:290 website/auth.py:426
 #: website/auth.py:451 website/auth.py:481 website/auth.py:587
 #: website/auth.py:619 website/auth.py:659 website/auth.py:686
 #: website/teacher.py:90 website/teacher.py:125 website/teacher.py:197
@@ -155,32 +155,32 @@ msgstr ""
 msgid "ajax_error"
 msgstr "Ocorreu um erro, por favor, tente novamente."
 
-#: app.py:1249
+#: app.py:1222
 #, fuzzy
 msgid "image_invalid"
 msgstr "Your chosen image is invalid."
 
-#: app.py:1251
+#: app.py:1224
 #, fuzzy
 msgid "personal_text_invalid"
 msgstr "Your personal text is invalid."
 
-#: app.py:1253 app.py:1259
+#: app.py:1226 app.py:1232
 #, fuzzy
 msgid "favourite_program_invalid"
 msgstr "Your chosen favourite program is invalid."
 
-#: app.py:1271 app.py:1272
+#: app.py:1244 app.py:1245
 #, fuzzy
 msgid "public_profile_updated"
 msgstr "Public profile updated."
 
-#: app.py:1306 app.py:1330
+#: app.py:1279 app.py:1303
 #, fuzzy
 msgid "user_not_private"
 msgstr "This user doesn't exist or doesn't have a public profile"
 
-#: app.py:1339
+#: app.py:1312
 #, fuzzy
 msgid "invalid_teacher_invitation_code"
 msgstr ""
@@ -466,7 +466,7 @@ msgstr "Visible columns"
 
 #: templates/class-overview.html:21 templates/class-overview.html:64
 #: templates/class-overview.html:108 templates/create-accounts.html:16
-#: templates/login.html:12 templates/profile.html:93 templates/recover.html:8
+#: templates/login.html:12 templates/profile.html:86 templates/recover.html:8
 #: templates/signup.html:10
 msgid "username"
 msgstr "Usuário"
@@ -480,7 +480,6 @@ msgid "highest_level_reached"
 msgstr "Nível mais alto alcançado"
 
 #: templates/class-overview.html:35 templates/class-overview.html:67
-#: templates/profile.html:74
 msgid "number_programs"
 msgstr "Número de programas"
 
@@ -494,8 +493,8 @@ msgid "latest_shared_program"
 msgstr "Último programa compartilhado"
 
 #: templates/class-overview.html:49 templates/class-overview.html:70
-#: templates/class-overview.html:83 templates/profile.html:151
-#: templates/profile.html:153 templates/profile.html:166
+#: templates/class-overview.html:83 templates/profile.html:144
+#: templates/profile.html:146 templates/profile.html:159
 msgid "change_password"
 msgstr "Mudar senha"
 
@@ -658,7 +657,7 @@ msgid "create_accounts_prompt"
 msgstr "Are you sure you want to create these accounts?"
 
 #: templates/create-accounts.html:17 templates/learn-more.html:10
-#: templates/profile.html:96 templates/recover.html:8 templates/signup.html:13
+#: templates/profile.html:89 templates/recover.html:8 templates/signup.html:13
 msgid "email"
 msgstr "Email"
 
@@ -851,8 +850,8 @@ msgid "select_own_adventures"
 msgstr "Select own adventures"
 
 #: templates/customize-class.html:95 templates/customize-class.html:121
-#: templates/profile.html:47 templates/profile.html:128
-#: templates/profile.html:137 templates/signup.html:26 templates/signup.html:45
+#: templates/profile.html:47 templates/profile.html:121
+#: templates/profile.html:130 templates/signup.html:26 templates/signup.html:45
 #: templates/signup.html:53
 msgid "select"
 msgstr "Selecione"
@@ -939,8 +938,8 @@ msgstr "Creator"
 msgid "view_program"
 msgstr "View program"
 
-#: templates/for-teachers.html:5 templates/profile.html:78
-#: templates/profile.html:80
+#: templates/for-teachers.html:5 templates/profile.html:71
+#: templates/profile.html:73
 msgid "my_classes"
 msgstr "Minhas Turmas"
 
@@ -1161,14 +1160,7 @@ msgstr "Cancelar"
 msgid "copy_link_to_share"
 msgstr "Copiar link para compartilhar"
 
-#: templates/layout.html:78
-#, fuzzy
-msgid "set_preferred_lang"
-msgstr ""
-"Hedy now supports preferred user languages. You can set one for your "
-"profile in \"My profile\""
-
-#: templates/layout.html:86 templates/quiz/endquiz.html:18
+#: templates/layout.html:83 templates/quiz/endquiz.html:18
 #: templates/quiz/quiz.html:29
 #, fuzzy
 msgid "achievement_earned"
@@ -1189,7 +1181,7 @@ msgstr "Usuário"
 msgid "lastname"
 msgstr "Name"
 
-#: templates/learn-more.html:22 templates/profile.html:135
+#: templates/learn-more.html:22 templates/profile.html:128
 #: templates/signup.html:52
 msgid "country"
 msgstr "País"
@@ -1326,7 +1318,7 @@ msgstr ""
 msgid "update_public"
 msgstr "Update public profile"
 
-#: templates/profile.html:61 templates/profile.html:148
+#: templates/profile.html:61 templates/profile.html:141
 msgid "are_you_sure"
 msgstr "Você tem certeza? Você não poderá reverter esta ação."
 
@@ -1335,73 +1327,68 @@ msgstr "Você tem certeza? Você não poderá reverter esta ação."
 msgid "delete_public"
 msgstr "Delete public profile"
 
-#: templates/profile.html:70 templates/profile.html:72
-#, fuzzy
-msgid "statistics"
-msgstr "My statistics"
-
-#: templates/profile.html:83
+#: templates/profile.html:76
 #, fuzzy
 msgid "self_removal_prompt"
 msgstr "Are you sure you want to leave this class?"
 
-#: templates/profile.html:83
+#: templates/profile.html:76
 #, fuzzy
 msgid "leave_class"
 msgstr "Leave class"
 
-#: templates/profile.html:88 templates/profile.html:91
+#: templates/profile.html:81 templates/profile.html:84
 #, fuzzy
 msgid "settings"
 msgstr "My personal settings"
 
-#: templates/profile.html:99 templates/signup.html:41
+#: templates/profile.html:92 templates/signup.html:41
 msgid "birth_year"
 msgstr "Ano de nascimento"
 
-#: templates/profile.html:102 templates/signup.html:25
+#: templates/profile.html:95 templates/signup.html:25
 #, fuzzy
 msgid "preferred_language"
 msgstr "Preferred language"
 
-#: templates/profile.html:112 templates/signup.html:34
+#: templates/profile.html:105 templates/signup.html:34
 #, fuzzy
 msgid "preferred_keyword_language"
 msgstr "Preferred keyword language"
 
-#: templates/profile.html:126 templates/signup.html:44
+#: templates/profile.html:119 templates/signup.html:44
 msgid "gender"
 msgstr "Gênero"
 
-#: templates/profile.html:129 templates/signup.html:46
+#: templates/profile.html:122 templates/signup.html:46
 msgid "female"
 msgstr "Feminino"
 
-#: templates/profile.html:130 templates/signup.html:47
+#: templates/profile.html:123 templates/signup.html:47
 msgid "male"
 msgstr "Masculino"
 
-#: templates/profile.html:131 templates/signup.html:48
+#: templates/profile.html:124 templates/signup.html:48
 msgid "other"
 msgstr "Outro"
 
-#: templates/profile.html:144
+#: templates/profile.html:137
 msgid "update_profile"
 msgstr "Atualizar perfil"
 
-#: templates/profile.html:148
+#: templates/profile.html:141
 msgid "destroy_profile"
 msgstr "Deletar sua contar permanentemente"
 
-#: templates/profile.html:155
+#: templates/profile.html:148
 msgid "current_password"
 msgstr "Senha atual"
 
-#: templates/profile.html:159
+#: templates/profile.html:152
 msgid "new_password"
 msgstr "Nova senha"
 
-#: templates/profile.html:163
+#: templates/profile.html:156
 msgid "repeat_new_password"
 msgstr "Repita sua senha"
 
@@ -2052,4 +2039,13 @@ msgstr "The adventure has been updated!"
 #, fuzzy
 msgid "adventure_empty"
 msgstr "You didn't enter an adventure name!"
+
+#~ msgid "set_preferred_lang"
+#~ msgstr ""
+#~ "Hedy now supports preferred user "
+#~ "languages. You can set one for "
+#~ "your profile in \"My profile\""
+
+#~ msgid "statistics"
+#~ msgstr "My statistics"
 

--- a/translations/pt_PT/LC_MESSAGES/messages.po
+++ b/translations/pt_PT/LC_MESSAGES/messages.po
@@ -1,29 +1,29 @@
-#: app.py:497
+#: app.py:451
 #, fuzzy
 msgid "program_contains_error"
 msgstr "This program contains an error, are you sure you want to share it?"
 
-#: app.py:649
+#: app.py:604
 #, fuzzy
 msgid "title_achievements"
 msgstr "Hedy - My achievements"
 
-#: app.py:666 app.py:1057 website/teacher.py:363 website/teacher.py:372
+#: app.py:622 app.py:1030 website/teacher.py:363 website/teacher.py:372
 #, fuzzy
 msgid "not_teacher"
 msgstr "Looks like you are not a teacher!"
 
-#: app.py:669
+#: app.py:625
 #, fuzzy
 msgid "not_enrolled"
 msgstr "Looks like you are not in this class!"
 
-#: app.py:701
+#: app.py:657
 #, fuzzy
 msgid "title_programs"
 msgstr "Hedy - My programs"
 
-#: app.py:711 app.py:721 app.py:725 app.py:739 app.py:1000 app.py:1302
+#: app.py:667 app.py:677 app.py:681 app.py:695 app.py:956 app.py:1275
 #: website/admin.py:17 website/admin.py:25 website/admin.py:95
 #: website/admin.py:112 website/admin.py:130 website/auth.py:653
 #: website/auth.py:680 website/statistics.py:86
@@ -31,122 +31,122 @@ msgstr "Hedy - My programs"
 msgid "unauthorized"
 msgstr "You don't have access rights for this page"
 
-#: app.py:749
+#: app.py:705
 msgid "minutes"
 msgstr "minutos"
 
-#: app.py:752
+#: app.py:708
 msgid "hours"
 msgstr "horas"
 
-#: app.py:755
+#: app.py:711
 msgid "days"
 msgstr "dias"
 
-#: app.py:758
+#: app.py:714
 #, fuzzy
 msgid "ago"
 msgstr "{time} ago"
 
-#: app.py:774 app.py:776 app.py:915 app.py:939 app.py:941
+#: app.py:730 app.py:732 app.py:871 app.py:895 app.py:897
 #, fuzzy
 msgid "no_such_level"
 msgstr "No such Hedy level!"
 
-#: app.py:784 app.py:791 app.py:865 app.py:871
+#: app.py:740 app.py:747 app.py:821 app.py:827
 #, fuzzy
 msgid "no_such_program"
 msgstr "No such Hedy program!"
 
-#: app.py:820
+#: app.py:776
 #, fuzzy
 msgid "level_not_translated"
 msgstr "This level is not translated in your language (yet)"
 
-#: app.py:822
+#: app.py:778
 #, fuzzy
 msgid "level_not_class"
 msgstr "You're in a class where this level has not been made available yet"
 
-#: app.py:925 website/teacher.py:430 website/teacher.py:446
+#: app.py:881 website/teacher.py:430 website/teacher.py:446
 #: website/teacher.py:475 website/teacher.py:501
 #, fuzzy
 msgid "no_such_adventure"
 msgstr "This adventure doesn't exist!"
 
-#: app.py:951
+#: app.py:907
 #, fuzzy
 msgid "page_not_found"
 msgstr "We could not find that page!"
 
-#: app.py:971
+#: app.py:927
 #, fuzzy
 msgid "title_signup"
 msgstr "Hedy - Create an account"
 
-#: app.py:978
+#: app.py:934
 #, fuzzy
 msgid "title_login"
 msgstr "Hedy - Login"
 
-#: app.py:985
+#: app.py:941
 #, fuzzy
 msgid "title_recover"
 msgstr "Hedy - Recover account"
 
-#: app.py:1001
+#: app.py:957
 #, fuzzy
 msgid "title_reset"
 msgstr "Hedy - Reset password"
 
-#: app.py:1010
+#: app.py:982
 #, fuzzy
 msgid "title_my-profile"
 msgstr "Hedy - My account"
 
-#: app.py:1024
+#: app.py:997
 #, fuzzy
 msgid "title_learn-more"
 msgstr "Hedy - Learn more"
 
-#: app.py:1029
+#: app.py:1002
 #, fuzzy
 msgid "title_privacy"
 msgstr "Hedy - Privacy terms"
 
-#: app.py:1036
+#: app.py:1009
 #, fuzzy
 msgid "title_landing-page"
 msgstr "Welcome to Hedy!"
 
-#: app.py:1038
+#: app.py:1011
 #, fuzzy
 msgid "not_user"
 msgstr "Looks like you are not logged in!"
 
-#: app.py:1053
+#: app.py:1026
 #, fuzzy
 msgid "title_for-teacher"
 msgstr "Hedy - For teachers"
 
-#: app.py:1064
+#: app.py:1037
 #, fuzzy
 msgid "title_start"
 msgstr "Hedy - A gradual programming language"
 
-#: app.py:1117
+#: app.py:1090
 #, fuzzy
 msgid "title_explore"
 msgstr "Hedy - Explore"
 
-#: app.py:1135 app.py:1137
+#: app.py:1108 app.py:1110
 #, fuzzy
 msgid "translate_error"
 msgstr ""
 "Something went wrong while translating the code. Try running the code to "
 "see if it has an error. Code with errors can not be translated."
 
-#: app.py:1246 website/auth.py:241 website/auth.py:290 website/auth.py:426
+#: app.py:1219 website/auth.py:241 website/auth.py:290 website/auth.py:426
 #: website/auth.py:451 website/auth.py:481 website/auth.py:587
 #: website/auth.py:619 website/auth.py:659 website/auth.py:686
 #: website/teacher.py:90 website/teacher.py:125 website/teacher.py:197
@@ -155,32 +155,32 @@ msgstr ""
 msgid "ajax_error"
 msgstr "Ocorreu um erro, por favor tenta novamente."
 
-#: app.py:1249
+#: app.py:1222
 #, fuzzy
 msgid "image_invalid"
 msgstr "Your chosen image is invalid."
 
-#: app.py:1251
+#: app.py:1224
 #, fuzzy
 msgid "personal_text_invalid"
 msgstr "Your personal text is invalid."
 
-#: app.py:1253 app.py:1259
+#: app.py:1226 app.py:1232
 #, fuzzy
 msgid "favourite_program_invalid"
 msgstr "Your chosen favourite program is invalid."
 
-#: app.py:1271 app.py:1272
+#: app.py:1244 app.py:1245
 #, fuzzy
 msgid "public_profile_updated"
 msgstr "Public profile updated."
 
-#: app.py:1306 app.py:1330
+#: app.py:1279 app.py:1303
 #, fuzzy
 msgid "user_not_private"
 msgstr "This user doesn't exist or doesn't have a public profile"
 
-#: app.py:1339
+#: app.py:1312
 #, fuzzy
 msgid "invalid_teacher_invitation_code"
 msgstr ""
@@ -466,7 +466,7 @@ msgstr "Visible columns"
 
 #: templates/class-overview.html:21 templates/class-overview.html:64
 #: templates/class-overview.html:108 templates/create-accounts.html:16
-#: templates/login.html:12 templates/profile.html:93 templates/recover.html:8
+#: templates/login.html:12 templates/profile.html:86 templates/recover.html:8
 #: templates/signup.html:10
 msgid "username"
 msgstr "Utilizador"
@@ -482,7 +482,6 @@ msgid "highest_level_reached"
 msgstr "Highest level reached"
 
 #: templates/class-overview.html:35 templates/class-overview.html:67
-#: templates/profile.html:74
 #, fuzzy
 msgid "number_programs"
 msgstr "Number of programs"
@@ -498,8 +497,8 @@ msgid "latest_shared_program"
 msgstr "Latest shared program"
 
 #: templates/class-overview.html:49 templates/class-overview.html:70
-#: templates/class-overview.html:83 templates/profile.html:151
-#: templates/profile.html:153 templates/profile.html:166
+#: templates/class-overview.html:83 templates/profile.html:144
+#: templates/profile.html:146 templates/profile.html:159
 msgid "change_password"
 msgstr "Muda palavra-passe"
 
@@ -672,7 +671,7 @@ msgid "create_accounts_prompt"
 msgstr "Are you sure you want to create these accounts?"
 
 #: templates/create-accounts.html:17 templates/learn-more.html:10
-#: templates/profile.html:96 templates/recover.html:8 templates/signup.html:13
+#: templates/profile.html:89 templates/recover.html:8 templates/signup.html:13
 msgid "email"
 msgstr "Email"
 
@@ -865,8 +864,8 @@ msgid "select_own_adventures"
 msgstr "Select own adventures"
 
 #: templates/customize-class.html:95 templates/customize-class.html:121
-#: templates/profile.html:47 templates/profile.html:128
-#: templates/profile.html:137 templates/signup.html:26 templates/signup.html:45
+#: templates/profile.html:47 templates/profile.html:121
+#: templates/profile.html:130 templates/signup.html:26 templates/signup.html:45
 #: templates/signup.html:53
 msgid "select"
 msgstr "Selecciona"
@@ -953,8 +952,8 @@ msgstr "Creator"
 msgid "view_program"
 msgstr "View program"
 
-#: templates/for-teachers.html:5 templates/profile.html:78
-#: templates/profile.html:80
+#: templates/for-teachers.html:5 templates/profile.html:71
+#: templates/profile.html:73
 #, fuzzy
 msgid "my_classes"
 msgstr "My classes"
@@ -1185,14 +1184,7 @@ msgstr "Cancel"
 msgid "copy_link_to_share"
 msgstr "Copiar ligação de partilha"
 
-#: templates/layout.html:78
-#, fuzzy
-msgid "set_preferred_lang"
-msgstr ""
-"Hedy now supports preferred user languages. You can set one for your "
-"profile in \"My profile\""
-
-#: templates/layout.html:86 templates/quiz/endquiz.html:18
+#: templates/layout.html:83 templates/quiz/endquiz.html:18
 #: templates/quiz/quiz.html:29
 #, fuzzy
 msgid "achievement_earned"
@@ -1213,7 +1205,7 @@ msgstr "Utilizador"
 msgid "lastname"
 msgstr "Name"
 
-#: templates/learn-more.html:22 templates/profile.html:135
+#: templates/learn-more.html:22 templates/profile.html:128
 #: templates/signup.html:52
 msgid "country"
 msgstr "País"
@@ -1353,7 +1345,7 @@ msgstr ""
 msgid "update_public"
 msgstr "Update public profile"
 
-#: templates/profile.html:61 templates/profile.html:148
+#: templates/profile.html:61 templates/profile.html:141
 msgid "are_you_sure"
 msgstr "Tens a certeza? Não podes reverter esta acção."
 
@@ -1362,73 +1354,68 @@ msgstr "Tens a certeza? Não podes reverter esta acção."
 msgid "delete_public"
 msgstr "Delete public profile"
 
-#: templates/profile.html:70 templates/profile.html:72
-#, fuzzy
-msgid "statistics"
-msgstr "My statistics"
-
-#: templates/profile.html:83
+#: templates/profile.html:76
 #, fuzzy
 msgid "self_removal_prompt"
 msgstr "Are you sure you want to leave this class?"
 
-#: templates/profile.html:83
+#: templates/profile.html:76
 #, fuzzy
 msgid "leave_class"
 msgstr "Leave class"
 
-#: templates/profile.html:88 templates/profile.html:91
+#: templates/profile.html:81 templates/profile.html:84
 #, fuzzy
 msgid "settings"
 msgstr "My personal settings"
 
-#: templates/profile.html:99 templates/signup.html:41
+#: templates/profile.html:92 templates/signup.html:41
 msgid "birth_year"
 msgstr "Ano de nascimento"
 
-#: templates/profile.html:102 templates/signup.html:25
+#: templates/profile.html:95 templates/signup.html:25
 #, fuzzy
 msgid "preferred_language"
 msgstr "Preferred language"
 
-#: templates/profile.html:112 templates/signup.html:34
+#: templates/profile.html:105 templates/signup.html:34
 #, fuzzy
 msgid "preferred_keyword_language"
 msgstr "Preferred keyword language"
 
-#: templates/profile.html:126 templates/signup.html:44
+#: templates/profile.html:119 templates/signup.html:44
 msgid "gender"
 msgstr "Género"
 
-#: templates/profile.html:129 templates/signup.html:46
+#: templates/profile.html:122 templates/signup.html:46
 msgid "female"
 msgstr "Feminino"
 
-#: templates/profile.html:130 templates/signup.html:47
+#: templates/profile.html:123 templates/signup.html:47
 msgid "male"
 msgstr "Masculino"
 
-#: templates/profile.html:131 templates/signup.html:48
+#: templates/profile.html:124 templates/signup.html:48
 msgid "other"
 msgstr "Outro"
 
-#: templates/profile.html:144
+#: templates/profile.html:137
 msgid "update_profile"
 msgstr "Atualiza o perfil"
 
-#: templates/profile.html:148
+#: templates/profile.html:141
 msgid "destroy_profile"
 msgstr "Elimina conta permanentemente"
 
-#: templates/profile.html:155
+#: templates/profile.html:148
 msgid "current_password"
 msgstr "Palavra-passe atual"
 
-#: templates/profile.html:159
+#: templates/profile.html:152
 msgid "new_password"
 msgstr "Palavra-passe atual"
 
-#: templates/profile.html:163
+#: templates/profile.html:156
 msgid "repeat_new_password"
 msgstr "Repete nova palavra-passe"
 
@@ -2079,4 +2066,13 @@ msgstr "The adventure has been updated!"
 #, fuzzy
 msgid "adventure_empty"
 msgstr "You didn't enter an adventure name!"
+
+#~ msgid "set_preferred_lang"
+#~ msgstr ""
+#~ "Hedy now supports preferred user "
+#~ "languages. You can set one for "
+#~ "your profile in \"My profile\""
+
+#~ msgid "statistics"
+#~ msgstr "My statistics"
 

--- a/translations/ru/LC_MESSAGES/messages.po
+++ b/translations/ru/LC_MESSAGES/messages.po
@@ -1,29 +1,29 @@
-#: app.py:497
+#: app.py:451
 #, fuzzy
 msgid "program_contains_error"
 msgstr "This program contains an error, are you sure you want to share it?"
 
-#: app.py:649
+#: app.py:604
 #, fuzzy
 msgid "title_achievements"
 msgstr "Hedy - My achievements"
 
-#: app.py:666 app.py:1057 website/teacher.py:363 website/teacher.py:372
+#: app.py:622 app.py:1030 website/teacher.py:363 website/teacher.py:372
 #, fuzzy
 msgid "not_teacher"
 msgstr "Looks like you are not a teacher!"
 
-#: app.py:669
+#: app.py:625
 #, fuzzy
 msgid "not_enrolled"
 msgstr "Looks like you are not in this class!"
 
-#: app.py:701
+#: app.py:657
 #, fuzzy
 msgid "title_programs"
 msgstr "Hedy - My programs"
 
-#: app.py:711 app.py:721 app.py:725 app.py:739 app.py:1000 app.py:1302
+#: app.py:667 app.py:677 app.py:681 app.py:695 app.py:956 app.py:1275
 #: website/admin.py:17 website/admin.py:25 website/admin.py:95
 #: website/admin.py:112 website/admin.py:130 website/auth.py:653
 #: website/auth.py:680 website/statistics.py:86
@@ -31,125 +31,125 @@ msgstr "Hedy - My programs"
 msgid "unauthorized"
 msgstr "You don't have access rights for this page"
 
-#: app.py:749
+#: app.py:705
 #, fuzzy
 msgid "minutes"
 msgstr "minutes"
 
-#: app.py:752
+#: app.py:708
 #, fuzzy
 msgid "hours"
 msgstr "hours"
 
-#: app.py:755
+#: app.py:711
 #, fuzzy
 msgid "days"
 msgstr "days"
 
-#: app.py:758
+#: app.py:714
 #, fuzzy
 msgid "ago"
 msgstr "{time} ago"
 
-#: app.py:774 app.py:776 app.py:915 app.py:939 app.py:941
+#: app.py:730 app.py:732 app.py:871 app.py:895 app.py:897
 #, fuzzy
 msgid "no_such_level"
 msgstr "No such Hedy level!"
 
-#: app.py:784 app.py:791 app.py:865 app.py:871
+#: app.py:740 app.py:747 app.py:821 app.py:827
 #, fuzzy
 msgid "no_such_program"
 msgstr "No such Hedy program!"
 
-#: app.py:820
+#: app.py:776
 #, fuzzy
 msgid "level_not_translated"
 msgstr "This level is not translated in your language (yet)"
 
-#: app.py:822
+#: app.py:778
 #, fuzzy
 msgid "level_not_class"
 msgstr "You're in a class where this level has not been made available yet"
 
-#: app.py:925 website/teacher.py:430 website/teacher.py:446
+#: app.py:881 website/teacher.py:430 website/teacher.py:446
 #: website/teacher.py:475 website/teacher.py:501
 #, fuzzy
 msgid "no_such_adventure"
 msgstr "This adventure doesn't exist!"
 
-#: app.py:951
+#: app.py:907
 #, fuzzy
 msgid "page_not_found"
 msgstr "We could not find that page!"
 
-#: app.py:971
+#: app.py:927
 #, fuzzy
 msgid "title_signup"
 msgstr "Hedy - Create an account"
 
-#: app.py:978
+#: app.py:934
 #, fuzzy
 msgid "title_login"
 msgstr "Hedy - Login"
 
-#: app.py:985
+#: app.py:941
 #, fuzzy
 msgid "title_recover"
 msgstr "Hedy - Recover account"
 
-#: app.py:1001
+#: app.py:957
 #, fuzzy
 msgid "title_reset"
 msgstr "Hedy - Reset password"
 
-#: app.py:1010
+#: app.py:982
 #, fuzzy
 msgid "title_my-profile"
 msgstr "Hedy - My account"
 
-#: app.py:1024
+#: app.py:997
 #, fuzzy
 msgid "title_learn-more"
 msgstr "Hedy - Learn more"
 
-#: app.py:1029
+#: app.py:1002
 #, fuzzy
 msgid "title_privacy"
 msgstr "Hedy - Privacy terms"
 
-#: app.py:1036
+#: app.py:1009
 #, fuzzy
 msgid "title_landing-page"
 msgstr "Welcome to Hedy!"
 
-#: app.py:1038
+#: app.py:1011
 #, fuzzy
 msgid "not_user"
 msgstr "Looks like you are not logged in!"
 
-#: app.py:1053
+#: app.py:1026
 #, fuzzy
 msgid "title_for-teacher"
 msgstr "Hedy - For teachers"
 
-#: app.py:1064
+#: app.py:1037
 #, fuzzy
 msgid "title_start"
 msgstr "Hedy - A gradual programming language"
 
-#: app.py:1117
+#: app.py:1090
 #, fuzzy
 msgid "title_explore"
 msgstr "Hedy - Explore"
 
-#: app.py:1135 app.py:1137
+#: app.py:1108 app.py:1110
 #, fuzzy
 msgid "translate_error"
 msgstr ""
 "Something went wrong while translating the code. Try running the code to "
 "see if it has an error. Code with errors can not be translated."
 
-#: app.py:1246 website/auth.py:241 website/auth.py:290 website/auth.py:426
+#: app.py:1219 website/auth.py:241 website/auth.py:290 website/auth.py:426
 #: website/auth.py:451 website/auth.py:481 website/auth.py:587
 #: website/auth.py:619 website/auth.py:659 website/auth.py:686
 #: website/teacher.py:90 website/teacher.py:125 website/teacher.py:197
@@ -159,32 +159,32 @@ msgstr ""
 msgid "ajax_error"
 msgstr "There was an error, please try again."
 
-#: app.py:1249
+#: app.py:1222
 #, fuzzy
 msgid "image_invalid"
 msgstr "Your chosen image is invalid."
 
-#: app.py:1251
+#: app.py:1224
 #, fuzzy
 msgid "personal_text_invalid"
 msgstr "Your personal text is invalid."
 
-#: app.py:1253 app.py:1259
+#: app.py:1226 app.py:1232
 #, fuzzy
 msgid "favourite_program_invalid"
 msgstr "Your chosen favourite program is invalid."
 
-#: app.py:1271 app.py:1272
+#: app.py:1244 app.py:1245
 #, fuzzy
 msgid "public_profile_updated"
 msgstr "Public profile updated."
 
-#: app.py:1306 app.py:1330
+#: app.py:1279 app.py:1303
 #, fuzzy
 msgid "user_not_private"
 msgstr "This user doesn't exist or doesn't have a public profile"
 
-#: app.py:1339
+#: app.py:1312
 #, fuzzy
 msgid "invalid_teacher_invitation_code"
 msgstr ""
@@ -491,7 +491,7 @@ msgstr "Visible columns"
 
 #: templates/class-overview.html:21 templates/class-overview.html:64
 #: templates/class-overview.html:108 templates/create-accounts.html:16
-#: templates/login.html:12 templates/profile.html:93 templates/recover.html:8
+#: templates/login.html:12 templates/profile.html:86 templates/recover.html:8
 #: templates/signup.html:10
 #, fuzzy
 msgid "username"
@@ -508,7 +508,6 @@ msgid "highest_level_reached"
 msgstr "Highest level reached"
 
 #: templates/class-overview.html:35 templates/class-overview.html:67
-#: templates/profile.html:74
 #, fuzzy
 msgid "number_programs"
 msgstr "Number of programs"
@@ -524,8 +523,8 @@ msgid "latest_shared_program"
 msgstr "Latest shared program"
 
 #: templates/class-overview.html:49 templates/class-overview.html:70
-#: templates/class-overview.html:83 templates/profile.html:151
-#: templates/profile.html:153 templates/profile.html:166
+#: templates/class-overview.html:83 templates/profile.html:144
+#: templates/profile.html:146 templates/profile.html:159
 #, fuzzy
 msgid "change_password"
 msgstr "Change password"
@@ -700,7 +699,7 @@ msgid "create_accounts_prompt"
 msgstr "Are you sure you want to create these accounts?"
 
 #: templates/create-accounts.html:17 templates/learn-more.html:10
-#: templates/profile.html:96 templates/recover.html:8 templates/signup.html:13
+#: templates/profile.html:89 templates/recover.html:8 templates/signup.html:13
 #, fuzzy
 msgid "email"
 msgstr "Email"
@@ -909,8 +908,8 @@ msgid "select_own_adventures"
 msgstr "Select own adventures"
 
 #: templates/customize-class.html:95 templates/customize-class.html:121
-#: templates/profile.html:47 templates/profile.html:128
-#: templates/profile.html:137 templates/signup.html:26 templates/signup.html:45
+#: templates/profile.html:47 templates/profile.html:121
+#: templates/profile.html:130 templates/signup.html:26 templates/signup.html:45
 #: templates/signup.html:53
 #, fuzzy
 msgid "select"
@@ -998,8 +997,8 @@ msgstr "Creator"
 msgid "view_program"
 msgstr "View program"
 
-#: templates/for-teachers.html:5 templates/profile.html:78
-#: templates/profile.html:80
+#: templates/for-teachers.html:5 templates/profile.html:71
+#: templates/profile.html:73
 #, fuzzy
 msgid "my_classes"
 msgstr "My classes"
@@ -1244,14 +1243,7 @@ msgstr "Cancel"
 msgid "copy_link_to_share"
 msgstr "Copy link to share"
 
-#: templates/layout.html:78
-#, fuzzy
-msgid "set_preferred_lang"
-msgstr ""
-"Hedy now supports preferred user languages. You can set one for your "
-"profile in \"My profile\""
-
-#: templates/layout.html:86 templates/quiz/endquiz.html:18
+#: templates/layout.html:83 templates/quiz/endquiz.html:18
 #: templates/quiz/quiz.html:29
 #, fuzzy
 msgid "achievement_earned"
@@ -1272,7 +1264,7 @@ msgstr "First Name"
 msgid "lastname"
 msgstr "Last Name"
 
-#: templates/learn-more.html:22 templates/profile.html:135
+#: templates/learn-more.html:22 templates/profile.html:128
 #: templates/signup.html:52
 #, fuzzy
 msgid "country"
@@ -1421,7 +1413,7 @@ msgstr ""
 msgid "update_public"
 msgstr "Update public profile"
 
-#: templates/profile.html:61 templates/profile.html:148
+#: templates/profile.html:61 templates/profile.html:141
 #, fuzzy
 msgid "are_you_sure"
 msgstr "Are you sure? You cannot revert this action."
@@ -1431,82 +1423,77 @@ msgstr "Are you sure? You cannot revert this action."
 msgid "delete_public"
 msgstr "Delete public profile"
 
-#: templates/profile.html:70 templates/profile.html:72
-#, fuzzy
-msgid "statistics"
-msgstr "My statistics"
-
-#: templates/profile.html:83
+#: templates/profile.html:76
 #, fuzzy
 msgid "self_removal_prompt"
 msgstr "Are you sure you want to leave this class?"
 
-#: templates/profile.html:83
+#: templates/profile.html:76
 #, fuzzy
 msgid "leave_class"
 msgstr "Leave class"
 
-#: templates/profile.html:88 templates/profile.html:91
+#: templates/profile.html:81 templates/profile.html:84
 #, fuzzy
 msgid "settings"
 msgstr "My personal settings"
 
-#: templates/profile.html:99 templates/signup.html:41
+#: templates/profile.html:92 templates/signup.html:41
 #, fuzzy
 msgid "birth_year"
 msgstr "Birth year"
 
-#: templates/profile.html:102 templates/signup.html:25
+#: templates/profile.html:95 templates/signup.html:25
 #, fuzzy
 msgid "preferred_language"
 msgstr "Preferred language"
 
-#: templates/profile.html:112 templates/signup.html:34
+#: templates/profile.html:105 templates/signup.html:34
 #, fuzzy
 msgid "preferred_keyword_language"
 msgstr "Preferred keyword language"
 
-#: templates/profile.html:126 templates/signup.html:44
+#: templates/profile.html:119 templates/signup.html:44
 #, fuzzy
 msgid "gender"
 msgstr "Gender"
 
-#: templates/profile.html:129 templates/signup.html:46
+#: templates/profile.html:122 templates/signup.html:46
 #, fuzzy
 msgid "female"
 msgstr "Female"
 
-#: templates/profile.html:130 templates/signup.html:47
+#: templates/profile.html:123 templates/signup.html:47
 #, fuzzy
 msgid "male"
 msgstr "Male"
 
-#: templates/profile.html:131 templates/signup.html:48
+#: templates/profile.html:124 templates/signup.html:48
 #, fuzzy
 msgid "other"
 msgstr "Other"
 
-#: templates/profile.html:144
+#: templates/profile.html:137
 #, fuzzy
 msgid "update_profile"
 msgstr "Update profile"
 
-#: templates/profile.html:148
+#: templates/profile.html:141
 #, fuzzy
 msgid "destroy_profile"
 msgstr "Delete profile"
 
-#: templates/profile.html:155
+#: templates/profile.html:148
 #, fuzzy
 msgid "current_password"
 msgstr "Current password"
 
-#: templates/profile.html:159
+#: templates/profile.html:152
 #, fuzzy
 msgid "new_password"
 msgstr "New password"
 
-#: templates/profile.html:163
+#: templates/profile.html:156
 #, fuzzy
 msgid "repeat_new_password"
 msgstr "Repeat new password"
@@ -2202,4 +2189,13 @@ msgstr "The adventure has been updated!"
 #, fuzzy
 msgid "adventure_empty"
 msgstr "You didn't enter an adventure name!"
+
+#~ msgid "set_preferred_lang"
+#~ msgstr ""
+#~ "Hedy now supports preferred user "
+#~ "languages. You can set one for "
+#~ "your profile in \"My profile\""
+
+#~ msgid "statistics"
+#~ msgstr "My statistics"
 

--- a/translations/sw/LC_MESSAGES/messages.po
+++ b/translations/sw/LC_MESSAGES/messages.po
@@ -1,29 +1,29 @@
-#: app.py:497
+#: app.py:451
 #, fuzzy
 msgid "program_contains_error"
 msgstr "This program contains an error, are you sure you want to share it?"
 
-#: app.py:649
+#: app.py:604
 #, fuzzy
 msgid "title_achievements"
 msgstr "Hedy - My achievements"
 
-#: app.py:666 app.py:1057 website/teacher.py:363 website/teacher.py:372
+#: app.py:622 app.py:1030 website/teacher.py:363 website/teacher.py:372
 #, fuzzy
 msgid "not_teacher"
 msgstr "Looks like you are not a teacher!"
 
-#: app.py:669
+#: app.py:625
 #, fuzzy
 msgid "not_enrolled"
 msgstr "Looks like you are not in this class!"
 
-#: app.py:701
+#: app.py:657
 #, fuzzy
 msgid "title_programs"
 msgstr "Hedy - My programs"
 
-#: app.py:711 app.py:721 app.py:725 app.py:739 app.py:1000 app.py:1302
+#: app.py:667 app.py:677 app.py:681 app.py:695 app.py:956 app.py:1275
 #: website/admin.py:17 website/admin.py:25 website/admin.py:95
 #: website/admin.py:112 website/admin.py:130 website/auth.py:653
 #: website/auth.py:680 website/statistics.py:86
@@ -31,122 +31,122 @@ msgstr "Hedy - My programs"
 msgid "unauthorized"
 msgstr "You don't have access rights for this page"
 
-#: app.py:749
+#: app.py:705
 msgid "minutes"
 msgstr "dakika"
 
-#: app.py:752
+#: app.py:708
 msgid "hours"
 msgstr "Saa"
 
-#: app.py:755
+#: app.py:711
 msgid "days"
 msgstr "siku"
 
-#: app.py:758
+#: app.py:714
 #, fuzzy
 msgid "ago"
 msgstr "{time} ago"
 
-#: app.py:774 app.py:776 app.py:915 app.py:939 app.py:941
+#: app.py:730 app.py:732 app.py:871 app.py:895 app.py:897
 #, fuzzy
 msgid "no_such_level"
 msgstr "No such Hedy level!"
 
-#: app.py:784 app.py:791 app.py:865 app.py:871
+#: app.py:740 app.py:747 app.py:821 app.py:827
 #, fuzzy
 msgid "no_such_program"
 msgstr "No such Hedy program!"
 
-#: app.py:820
+#: app.py:776
 #, fuzzy
 msgid "level_not_translated"
 msgstr "This level is not translated in your language (yet)"
 
-#: app.py:822
+#: app.py:778
 #, fuzzy
 msgid "level_not_class"
 msgstr "You're in a class where this level has not been made available yet"
 
-#: app.py:925 website/teacher.py:430 website/teacher.py:446
+#: app.py:881 website/teacher.py:430 website/teacher.py:446
 #: website/teacher.py:475 website/teacher.py:501
 #, fuzzy
 msgid "no_such_adventure"
 msgstr "This adventure doesn't exist!"
 
-#: app.py:951
+#: app.py:907
 #, fuzzy
 msgid "page_not_found"
 msgstr "We could not find that page!"
 
-#: app.py:971
+#: app.py:927
 #, fuzzy
 msgid "title_signup"
 msgstr "Hedy - Create an account"
 
-#: app.py:978
+#: app.py:934
 #, fuzzy
 msgid "title_login"
 msgstr "Hedy - Login"
 
-#: app.py:985
+#: app.py:941
 #, fuzzy
 msgid "title_recover"
 msgstr "Hedy - Recover account"
 
-#: app.py:1001
+#: app.py:957
 #, fuzzy
 msgid "title_reset"
 msgstr "Hedy - Reset password"
 
-#: app.py:1010
+#: app.py:982
 #, fuzzy
 msgid "title_my-profile"
 msgstr "Hedy - My account"
 
-#: app.py:1024
+#: app.py:997
 #, fuzzy
 msgid "title_learn-more"
 msgstr "Hedy - Learn more"
 
-#: app.py:1029
+#: app.py:1002
 #, fuzzy
 msgid "title_privacy"
 msgstr "Hedy - Privacy terms"
 
-#: app.py:1036
+#: app.py:1009
 #, fuzzy
 msgid "title_landing-page"
 msgstr "Welcome to Hedy!"
 
-#: app.py:1038
+#: app.py:1011
 #, fuzzy
 msgid "not_user"
 msgstr "Looks like you are not logged in!"
 
-#: app.py:1053
+#: app.py:1026
 #, fuzzy
 msgid "title_for-teacher"
 msgstr "Hedy - For teachers"
 
-#: app.py:1064
+#: app.py:1037
 #, fuzzy
 msgid "title_start"
 msgstr "Hedy - A gradual programming language"
 
-#: app.py:1117
+#: app.py:1090
 #, fuzzy
 msgid "title_explore"
 msgstr "Hedy - Explore"
 
-#: app.py:1135 app.py:1137
+#: app.py:1108 app.py:1110
 #, fuzzy
 msgid "translate_error"
 msgstr ""
 "Something went wrong while translating the code. Try running the code to "
 "see if it has an error. Code with errors can not be translated."
 
-#: app.py:1246 website/auth.py:241 website/auth.py:290 website/auth.py:426
+#: app.py:1219 website/auth.py:241 website/auth.py:290 website/auth.py:426
 #: website/auth.py:451 website/auth.py:481 website/auth.py:587
 #: website/auth.py:619 website/auth.py:659 website/auth.py:686
 #: website/teacher.py:90 website/teacher.py:125 website/teacher.py:197
@@ -155,32 +155,32 @@ msgstr ""
 msgid "ajax_error"
 msgstr "Kulikuwa na hitilafu, tafadhali jaribu tena."
 
-#: app.py:1249
+#: app.py:1222
 #, fuzzy
 msgid "image_invalid"
 msgstr "Your chosen image is invalid."
 
-#: app.py:1251
+#: app.py:1224
 #, fuzzy
 msgid "personal_text_invalid"
 msgstr "Your personal text is invalid."
 
-#: app.py:1253 app.py:1259
+#: app.py:1226 app.py:1232
 #, fuzzy
 msgid "favourite_program_invalid"
 msgstr "Your chosen favourite program is invalid."
 
-#: app.py:1271 app.py:1272
+#: app.py:1244 app.py:1245
 #, fuzzy
 msgid "public_profile_updated"
 msgstr "Public profile updated."
 
-#: app.py:1306 app.py:1330
+#: app.py:1279 app.py:1303
 #, fuzzy
 msgid "user_not_private"
 msgstr "This user doesn't exist or doesn't have a public profile"
 
-#: app.py:1339
+#: app.py:1312
 #, fuzzy
 msgid "invalid_teacher_invitation_code"
 msgstr ""
@@ -469,7 +469,7 @@ msgstr "Visible columns"
 
 #: templates/class-overview.html:21 templates/class-overview.html:64
 #: templates/class-overview.html:108 templates/create-accounts.html:16
-#: templates/login.html:12 templates/profile.html:93 templates/recover.html:8
+#: templates/login.html:12 templates/profile.html:86 templates/recover.html:8
 #: templates/signup.html:10
 msgid "username"
 msgstr "Jina la mtumiaji"
@@ -485,7 +485,6 @@ msgid "highest_level_reached"
 msgstr "Highest level reached"
 
 #: templates/class-overview.html:35 templates/class-overview.html:67
-#: templates/profile.html:74
 #, fuzzy
 msgid "number_programs"
 msgstr "Number of programs"
@@ -501,8 +500,8 @@ msgid "latest_shared_program"
 msgstr "Latest shared program"
 
 #: templates/class-overview.html:49 templates/class-overview.html:70
-#: templates/class-overview.html:83 templates/profile.html:151
-#: templates/profile.html:153 templates/profile.html:166
+#: templates/class-overview.html:83 templates/profile.html:144
+#: templates/profile.html:146 templates/profile.html:159
 msgid "change_password"
 msgstr "Badilisha nenosiri"
 
@@ -675,7 +674,7 @@ msgid "create_accounts_prompt"
 msgstr "Are you sure you want to create these accounts?"
 
 #: templates/create-accounts.html:17 templates/learn-more.html:10
-#: templates/profile.html:96 templates/recover.html:8 templates/signup.html:13
+#: templates/profile.html:89 templates/recover.html:8 templates/signup.html:13
 msgid "email"
 msgstr "Barua pepe"
 
@@ -869,8 +868,8 @@ msgid "select_own_adventures"
 msgstr "Select own adventures"
 
 #: templates/customize-class.html:95 templates/customize-class.html:121
-#: templates/profile.html:47 templates/profile.html:128
-#: templates/profile.html:137 templates/signup.html:26 templates/signup.html:45
+#: templates/profile.html:47 templates/profile.html:121
+#: templates/profile.html:130 templates/signup.html:26 templates/signup.html:45
 #: templates/signup.html:53
 msgid "select"
 msgstr "Chagua"
@@ -957,8 +956,8 @@ msgstr "Creator"
 msgid "view_program"
 msgstr "View program"
 
-#: templates/for-teachers.html:5 templates/profile.html:78
-#: templates/profile.html:80
+#: templates/for-teachers.html:5 templates/profile.html:71
+#: templates/profile.html:73
 #, fuzzy
 msgid "my_classes"
 msgstr "My classes"
@@ -1191,14 +1190,7 @@ msgstr "Cancel"
 msgid "copy_link_to_share"
 msgstr "Copy link to share"
 
-#: templates/layout.html:78
-#, fuzzy
-msgid "set_preferred_lang"
-msgstr ""
-"Hedy now supports preferred user languages. You can set one for your "
-"profile in \"My profile\""
-
-#: templates/layout.html:86 templates/quiz/endquiz.html:18
+#: templates/layout.html:83 templates/quiz/endquiz.html:18
 #: templates/quiz/quiz.html:29
 #, fuzzy
 msgid "achievement_earned"
@@ -1219,7 +1211,7 @@ msgstr "Jina la mtumiaji"
 msgid "lastname"
 msgstr "Name"
 
-#: templates/learn-more.html:22 templates/profile.html:135
+#: templates/learn-more.html:22 templates/profile.html:128
 #: templates/signup.html:52
 msgid "country"
 msgstr "Nchi"
@@ -1358,7 +1350,7 @@ msgstr ""
 msgid "update_public"
 msgstr "Update public profile"
 
-#: templates/profile.html:61 templates/profile.html:148
+#: templates/profile.html:61 templates/profile.html:141
 msgid "are_you_sure"
 msgstr "Una uhakika? Huwezi kurudisha kitendo hiki."
 
@@ -1367,73 +1359,68 @@ msgstr "Una uhakika? Huwezi kurudisha kitendo hiki."
 msgid "delete_public"
 msgstr "Delete public profile"
 
-#: templates/profile.html:70 templates/profile.html:72
-#, fuzzy
-msgid "statistics"
-msgstr "My statistics"
-
-#: templates/profile.html:83
+#: templates/profile.html:76
 #, fuzzy
 msgid "self_removal_prompt"
 msgstr "Are you sure you want to leave this class?"
 
-#: templates/profile.html:83
+#: templates/profile.html:76
 #, fuzzy
 msgid "leave_class"
 msgstr "Leave class"
 
-#: templates/profile.html:88 templates/profile.html:91
+#: templates/profile.html:81 templates/profile.html:84
 #, fuzzy
 msgid "settings"
 msgstr "My personal settings"
 
-#: templates/profile.html:99 templates/signup.html:41
+#: templates/profile.html:92 templates/signup.html:41
 msgid "birth_year"
 msgstr "Mwaka wa kuzaliwa"
 
-#: templates/profile.html:102 templates/signup.html:25
+#: templates/profile.html:95 templates/signup.html:25
 #, fuzzy
 msgid "preferred_language"
 msgstr "Preferred language"
 
-#: templates/profile.html:112 templates/signup.html:34
+#: templates/profile.html:105 templates/signup.html:34
 #, fuzzy
 msgid "preferred_keyword_language"
 msgstr "Preferred keyword language"
 
-#: templates/profile.html:126 templates/signup.html:44
+#: templates/profile.html:119 templates/signup.html:44
 msgid "gender"
 msgstr "Jinsia"
 
-#: templates/profile.html:129 templates/signup.html:46
+#: templates/profile.html:122 templates/signup.html:46
 msgid "female"
 msgstr "Mwanamke"
 
-#: templates/profile.html:130 templates/signup.html:47
+#: templates/profile.html:123 templates/signup.html:47
 msgid "male"
 msgstr "Mwanaume"
 
-#: templates/profile.html:131 templates/signup.html:48
+#: templates/profile.html:124 templates/signup.html:48
 msgid "other"
 msgstr "Nyingine"
 
-#: templates/profile.html:144
+#: templates/profile.html:137
 msgid "update_profile"
 msgstr "Sasisha wasifu"
 
-#: templates/profile.html:148
+#: templates/profile.html:141
 msgid "destroy_profile"
 msgstr "Futa akaunti kabisa"
 
-#: templates/profile.html:155
+#: templates/profile.html:148
 msgid "current_password"
 msgstr "Nenosiri la sasa"
 
-#: templates/profile.html:159
+#: templates/profile.html:152
 msgid "new_password"
 msgstr "Nenosiri mpya"
 
-#: templates/profile.html:163
+#: templates/profile.html:156
 msgid "repeat_new_password"
 msgstr "Rudia nenosiri mpya"
 
@@ -2092,4 +2079,13 @@ msgstr "The adventure has been updated!"
 #, fuzzy
 msgid "adventure_empty"
 msgstr "You didn't enter an adventure name!"
+
+#~ msgid "set_preferred_lang"
+#~ msgstr ""
+#~ "Hedy now supports preferred user "
+#~ "languages. You can set one for "
+#~ "your profile in \"My profile\""
+
+#~ msgid "statistics"
+#~ msgstr "My statistics"
 

--- a/translations/tr/LC_MESSAGES/messages.po
+++ b/translations/tr/LC_MESSAGES/messages.po
@@ -1,29 +1,29 @@
-#: app.py:497
+#: app.py:451
 #, fuzzy
 msgid "program_contains_error"
 msgstr "This program contains an error, are you sure you want to share it?"
 
-#: app.py:649
+#: app.py:604
 #, fuzzy
 msgid "title_achievements"
 msgstr "Hedy - My achievements"
 
-#: app.py:666 app.py:1057 website/teacher.py:363 website/teacher.py:372
+#: app.py:622 app.py:1030 website/teacher.py:363 website/teacher.py:372
 #, fuzzy
 msgid "not_teacher"
 msgstr "Looks like you are not a teacher!"
 
-#: app.py:669
+#: app.py:625
 #, fuzzy
 msgid "not_enrolled"
 msgstr "Looks like you are not in this class!"
 
-#: app.py:701
+#: app.py:657
 #, fuzzy
 msgid "title_programs"
 msgstr "Hedy - My programs"
 
-#: app.py:711 app.py:721 app.py:725 app.py:739 app.py:1000 app.py:1302
+#: app.py:667 app.py:677 app.py:681 app.py:695 app.py:956 app.py:1275
 #: website/admin.py:17 website/admin.py:25 website/admin.py:95
 #: website/admin.py:112 website/admin.py:130 website/auth.py:653
 #: website/auth.py:680 website/statistics.py:86
@@ -31,125 +31,125 @@ msgstr "Hedy - My programs"
 msgid "unauthorized"
 msgstr "You don't have access rights for this page"
 
-#: app.py:749
+#: app.py:705
 #, fuzzy
 msgid "minutes"
 msgstr "minutes"
 
-#: app.py:752
+#: app.py:708
 #, fuzzy
 msgid "hours"
 msgstr "hours"
 
-#: app.py:755
+#: app.py:711
 #, fuzzy
 msgid "days"
 msgstr "days"
 
-#: app.py:758
+#: app.py:714
 #, fuzzy
 msgid "ago"
 msgstr "{time} ago"
 
-#: app.py:774 app.py:776 app.py:915 app.py:939 app.py:941
+#: app.py:730 app.py:732 app.py:871 app.py:895 app.py:897
 #, fuzzy
 msgid "no_such_level"
 msgstr "No such Hedy level!"
 
-#: app.py:784 app.py:791 app.py:865 app.py:871
+#: app.py:740 app.py:747 app.py:821 app.py:827
 #, fuzzy
 msgid "no_such_program"
 msgstr "No such Hedy program!"
 
-#: app.py:820
+#: app.py:776
 #, fuzzy
 msgid "level_not_translated"
 msgstr "This level is not translated in your language (yet)"
 
-#: app.py:822
+#: app.py:778
 #, fuzzy
 msgid "level_not_class"
 msgstr "You're in a class where this level has not been made available yet"
 
-#: app.py:925 website/teacher.py:430 website/teacher.py:446
+#: app.py:881 website/teacher.py:430 website/teacher.py:446
 #: website/teacher.py:475 website/teacher.py:501
 #, fuzzy
 msgid "no_such_adventure"
 msgstr "This adventure doesn't exist!"
 
-#: app.py:951
+#: app.py:907
 #, fuzzy
 msgid "page_not_found"
 msgstr "We could not find that page!"
 
-#: app.py:971
+#: app.py:927
 #, fuzzy
 msgid "title_signup"
 msgstr "Hedy - Create an account"
 
-#: app.py:978
+#: app.py:934
 #, fuzzy
 msgid "title_login"
 msgstr "Hedy - Login"
 
-#: app.py:985
+#: app.py:941
 #, fuzzy
 msgid "title_recover"
 msgstr "Hedy - Recover account"
 
-#: app.py:1001
+#: app.py:957
 #, fuzzy
 msgid "title_reset"
 msgstr "Hedy - Reset password"
 
-#: app.py:1010
+#: app.py:982
 #, fuzzy
 msgid "title_my-profile"
 msgstr "Hedy - My account"
 
-#: app.py:1024
+#: app.py:997
 #, fuzzy
 msgid "title_learn-more"
 msgstr "Hedy - Learn more"
 
-#: app.py:1029
+#: app.py:1002
 #, fuzzy
 msgid "title_privacy"
 msgstr "Hedy - Privacy terms"
 
-#: app.py:1036
+#: app.py:1009
 #, fuzzy
 msgid "title_landing-page"
 msgstr "Welcome to Hedy!"
 
-#: app.py:1038
+#: app.py:1011
 #, fuzzy
 msgid "not_user"
 msgstr "Looks like you are not logged in!"
 
-#: app.py:1053
+#: app.py:1026
 #, fuzzy
 msgid "title_for-teacher"
 msgstr "Hedy - For teachers"
 
-#: app.py:1064
+#: app.py:1037
 #, fuzzy
 msgid "title_start"
 msgstr "Hedy - A gradual programming language"
 
-#: app.py:1117
+#: app.py:1090
 #, fuzzy
 msgid "title_explore"
 msgstr "Hedy - Explore"
 
-#: app.py:1135 app.py:1137
+#: app.py:1108 app.py:1110
 #, fuzzy
 msgid "translate_error"
 msgstr ""
 "Something went wrong while translating the code. Try running the code to "
 "see if it has an error. Code with errors can not be translated."
 
-#: app.py:1246 website/auth.py:241 website/auth.py:290 website/auth.py:426
+#: app.py:1219 website/auth.py:241 website/auth.py:290 website/auth.py:426
 #: website/auth.py:451 website/auth.py:481 website/auth.py:587
 #: website/auth.py:619 website/auth.py:659 website/auth.py:686
 #: website/teacher.py:90 website/teacher.py:125 website/teacher.py:197
@@ -159,32 +159,32 @@ msgstr ""
 msgid "ajax_error"
 msgstr "There was an error, please try again."
 
-#: app.py:1249
+#: app.py:1222
 #, fuzzy
 msgid "image_invalid"
 msgstr "Your chosen image is invalid."
 
-#: app.py:1251
+#: app.py:1224
 #, fuzzy
 msgid "personal_text_invalid"
 msgstr "Your personal text is invalid."
 
-#: app.py:1253 app.py:1259
+#: app.py:1226 app.py:1232
 #, fuzzy
 msgid "favourite_program_invalid"
 msgstr "Your chosen favourite program is invalid."
 
-#: app.py:1271 app.py:1272
+#: app.py:1244 app.py:1245
 #, fuzzy
 msgid "public_profile_updated"
 msgstr "Public profile updated."
 
-#: app.py:1306 app.py:1330
+#: app.py:1279 app.py:1303
 #, fuzzy
 msgid "user_not_private"
 msgstr "This user doesn't exist or doesn't have a public profile"
 
-#: app.py:1339
+#: app.py:1312
 #, fuzzy
 msgid "invalid_teacher_invitation_code"
 msgstr ""
@@ -491,7 +491,7 @@ msgstr "Visible columns"
 
 #: templates/class-overview.html:21 templates/class-overview.html:64
 #: templates/class-overview.html:108 templates/create-accounts.html:16
-#: templates/login.html:12 templates/profile.html:93 templates/recover.html:8
+#: templates/login.html:12 templates/profile.html:86 templates/recover.html:8
 #: templates/signup.html:10
 msgid "username"
 msgstr "Kullanıcı adı"
@@ -507,7 +507,6 @@ msgid "highest_level_reached"
 msgstr "Highest level reached"
 
 #: templates/class-overview.html:35 templates/class-overview.html:67
-#: templates/profile.html:74
 #, fuzzy
 msgid "number_programs"
 msgstr "Number of programs"
@@ -523,8 +522,8 @@ msgid "latest_shared_program"
 msgstr "Latest shared program"
 
 #: templates/class-overview.html:49 templates/class-overview.html:70
-#: templates/class-overview.html:83 templates/profile.html:151
-#: templates/profile.html:153 templates/profile.html:166
+#: templates/class-overview.html:83 templates/profile.html:144
+#: templates/profile.html:146 templates/profile.html:159
 #, fuzzy
 msgid "change_password"
 msgstr "Change password"
@@ -699,7 +698,7 @@ msgid "create_accounts_prompt"
 msgstr "Are you sure you want to create these accounts?"
 
 #: templates/create-accounts.html:17 templates/learn-more.html:10
-#: templates/profile.html:96 templates/recover.html:8 templates/signup.html:13
+#: templates/profile.html:89 templates/recover.html:8 templates/signup.html:13
 #, fuzzy
 msgid "email"
 msgstr "Email"
@@ -895,8 +894,8 @@ msgid "select_own_adventures"
 msgstr "Select own adventures"
 
 #: templates/customize-class.html:95 templates/customize-class.html:121
-#: templates/profile.html:47 templates/profile.html:128
-#: templates/profile.html:137 templates/signup.html:26 templates/signup.html:45
+#: templates/profile.html:47 templates/profile.html:121
+#: templates/profile.html:130 templates/signup.html:26 templates/signup.html:45
 #: templates/signup.html:53
 #, fuzzy
 msgid "select"
@@ -984,8 +983,8 @@ msgstr "Creator"
 msgid "view_program"
 msgstr "View program"
 
-#: templates/for-teachers.html:5 templates/profile.html:78
-#: templates/profile.html:80
+#: templates/for-teachers.html:5 templates/profile.html:71
+#: templates/profile.html:73
 #, fuzzy
 msgid "my_classes"
 msgstr "My classes"
@@ -1229,14 +1228,7 @@ msgstr "Cancel"
 msgid "copy_link_to_share"
 msgstr "Copy link to share"
 
-#: templates/layout.html:78
-#, fuzzy
-msgid "set_preferred_lang"
-msgstr ""
-"Hedy now supports preferred user languages. You can set one for your "
-"profile in \"My profile\""
-
-#: templates/layout.html:86 templates/quiz/endquiz.html:18
+#: templates/layout.html:83 templates/quiz/endquiz.html:18
 #: templates/quiz/quiz.html:29
 #, fuzzy
 msgid "achievement_earned"
@@ -1257,7 +1249,7 @@ msgstr "Kullanıcı adı"
 msgid "lastname"
 msgstr "Name"
 
-#: templates/learn-more.html:22 templates/profile.html:135
+#: templates/learn-more.html:22 templates/profile.html:128
 #: templates/signup.html:52
 #, fuzzy
 msgid "country"
@@ -1402,7 +1394,7 @@ msgstr ""
 msgid "update_public"
 msgstr "Update public profile"
 
-#: templates/profile.html:61 templates/profile.html:148
+#: templates/profile.html:61 templates/profile.html:141
 #, fuzzy
 msgid "are_you_sure"
 msgstr "Are you sure? You cannot revert this action."
@@ -1412,82 +1404,77 @@ msgstr "Are you sure? You cannot revert this action."
 msgid "delete_public"
 msgstr "Delete public profile"
 
-#: templates/profile.html:70 templates/profile.html:72
-#, fuzzy
-msgid "statistics"
-msgstr "My statistics"
-
-#: templates/profile.html:83
+#: templates/profile.html:76
 #, fuzzy
 msgid "self_removal_prompt"
 msgstr "Are you sure you want to leave this class?"
 
-#: templates/profile.html:83
+#: templates/profile.html:76
 #, fuzzy
 msgid "leave_class"
 msgstr "Leave class"
 
-#: templates/profile.html:88 templates/profile.html:91
+#: templates/profile.html:81 templates/profile.html:84
 #, fuzzy
 msgid "settings"
 msgstr "My personal settings"
 
-#: templates/profile.html:99 templates/signup.html:41
+#: templates/profile.html:92 templates/signup.html:41
 #, fuzzy
 msgid "birth_year"
 msgstr "Birth year"
 
-#: templates/profile.html:102 templates/signup.html:25
+#: templates/profile.html:95 templates/signup.html:25
 #, fuzzy
 msgid "preferred_language"
 msgstr "Preferred language"
 
-#: templates/profile.html:112 templates/signup.html:34
+#: templates/profile.html:105 templates/signup.html:34
 #, fuzzy
 msgid "preferred_keyword_language"
 msgstr "Preferred keyword language"
 
-#: templates/profile.html:126 templates/signup.html:44
+#: templates/profile.html:119 templates/signup.html:44
 #, fuzzy
 msgid "gender"
 msgstr "Gender"
 
-#: templates/profile.html:129 templates/signup.html:46
+#: templates/profile.html:122 templates/signup.html:46
 #, fuzzy
 msgid "female"
 msgstr "Female"
 
-#: templates/profile.html:130 templates/signup.html:47
+#: templates/profile.html:123 templates/signup.html:47
 #, fuzzy
 msgid "male"
 msgstr "Male"
 
-#: templates/profile.html:131 templates/signup.html:48
+#: templates/profile.html:124 templates/signup.html:48
 #, fuzzy
 msgid "other"
 msgstr "Other"
 
-#: templates/profile.html:144
+#: templates/profile.html:137
 #, fuzzy
 msgid "update_profile"
 msgstr "Update profile"
 
-#: templates/profile.html:148
+#: templates/profile.html:141
 #, fuzzy
 msgid "destroy_profile"
 msgstr "Delete profile"
 
-#: templates/profile.html:155
+#: templates/profile.html:148
 #, fuzzy
 msgid "current_password"
 msgstr "Current password"
 
-#: templates/profile.html:159
+#: templates/profile.html:152
 #, fuzzy
 msgid "new_password"
 msgstr "New password"
 
-#: templates/profile.html:163
+#: templates/profile.html:156
 #, fuzzy
 msgid "repeat_new_password"
 msgstr "Repeat new password"
@@ -2183,4 +2170,13 @@ msgstr "The adventure has been updated!"
 #, fuzzy
 msgid "adventure_empty"
 msgstr "You didn't enter an adventure name!"
+
+#~ msgid "set_preferred_lang"
+#~ msgstr ""
+#~ "Hedy now supports preferred user "
+#~ "languages. You can set one for "
+#~ "your profile in \"My profile\""
+
+#~ msgid "statistics"
+#~ msgstr "My statistics"
 

--- a/translations/zh_Hans/LC_MESSAGES/messages.po
+++ b/translations/zh_Hans/LC_MESSAGES/messages.po
@@ -1,29 +1,29 @@
-#: app.py:497
+#: app.py:451
 #, fuzzy
 msgid "program_contains_error"
 msgstr "This program contains an error, are you sure you want to share it?"
 
-#: app.py:649
+#: app.py:604
 #, fuzzy
 msgid "title_achievements"
 msgstr "Hedy - My achievements"
 
-#: app.py:666 app.py:1057 website/teacher.py:363 website/teacher.py:372
+#: app.py:622 app.py:1030 website/teacher.py:363 website/teacher.py:372
 #, fuzzy
 msgid "not_teacher"
 msgstr "Looks like you are not a teacher!"
 
-#: app.py:669
+#: app.py:625
 #, fuzzy
 msgid "not_enrolled"
 msgstr "Looks like you are not in this class!"
 
-#: app.py:701
+#: app.py:657
 #, fuzzy
 msgid "title_programs"
 msgstr "Hedy - My programs"
 
-#: app.py:711 app.py:721 app.py:725 app.py:739 app.py:1000 app.py:1302
+#: app.py:667 app.py:677 app.py:681 app.py:695 app.py:956 app.py:1275
 #: website/admin.py:17 website/admin.py:25 website/admin.py:95
 #: website/admin.py:112 website/admin.py:130 website/auth.py:653
 #: website/auth.py:680 website/statistics.py:86
@@ -31,122 +31,122 @@ msgstr "Hedy - My programs"
 msgid "unauthorized"
 msgstr "You don't have access rights for this page"
 
-#: app.py:749
+#: app.py:705
 msgid "minutes"
 msgstr "分钟"
 
-#: app.py:752
+#: app.py:708
 msgid "hours"
 msgstr "小时"
 
-#: app.py:755
+#: app.py:711
 msgid "days"
 msgstr "天"
 
-#: app.py:758
+#: app.py:714
 #, fuzzy
 msgid "ago"
 msgstr "{time} ago"
 
-#: app.py:774 app.py:776 app.py:915 app.py:939 app.py:941
+#: app.py:730 app.py:732 app.py:871 app.py:895 app.py:897
 #, fuzzy
 msgid "no_such_level"
 msgstr "No such Hedy level!"
 
-#: app.py:784 app.py:791 app.py:865 app.py:871
+#: app.py:740 app.py:747 app.py:821 app.py:827
 #, fuzzy
 msgid "no_such_program"
 msgstr "No such Hedy program!"
 
-#: app.py:820
+#: app.py:776
 #, fuzzy
 msgid "level_not_translated"
 msgstr "This level is not translated in your language (yet)"
 
-#: app.py:822
+#: app.py:778
 #, fuzzy
 msgid "level_not_class"
 msgstr "You're in a class where this level has not been made available yet"
 
-#: app.py:925 website/teacher.py:430 website/teacher.py:446
+#: app.py:881 website/teacher.py:430 website/teacher.py:446
 #: website/teacher.py:475 website/teacher.py:501
 #, fuzzy
 msgid "no_such_adventure"
 msgstr "This adventure doesn't exist!"
 
-#: app.py:951
+#: app.py:907
 #, fuzzy
 msgid "page_not_found"
 msgstr "We could not find that page!"
 
-#: app.py:971
+#: app.py:927
 #, fuzzy
 msgid "title_signup"
 msgstr "Hedy - Create an account"
 
-#: app.py:978
+#: app.py:934
 #, fuzzy
 msgid "title_login"
 msgstr "Hedy - Login"
 
-#: app.py:985
+#: app.py:941
 #, fuzzy
 msgid "title_recover"
 msgstr "Hedy - Recover account"
 
-#: app.py:1001
+#: app.py:957
 #, fuzzy
 msgid "title_reset"
 msgstr "Hedy - Reset password"
 
-#: app.py:1010
+#: app.py:982
 #, fuzzy
 msgid "title_my-profile"
 msgstr "Hedy - My account"
 
-#: app.py:1024
+#: app.py:997
 #, fuzzy
 msgid "title_learn-more"
 msgstr "Hedy - Learn more"
 
-#: app.py:1029
+#: app.py:1002
 #, fuzzy
 msgid "title_privacy"
 msgstr "Hedy - Privacy terms"
 
-#: app.py:1036
+#: app.py:1009
 #, fuzzy
 msgid "title_landing-page"
 msgstr "Welcome to Hedy!"
 
-#: app.py:1038
+#: app.py:1011
 #, fuzzy
 msgid "not_user"
 msgstr "Looks like you are not logged in!"
 
-#: app.py:1053
+#: app.py:1026
 #, fuzzy
 msgid "title_for-teacher"
 msgstr "Hedy - For teachers"
 
-#: app.py:1064
+#: app.py:1037
 #, fuzzy
 msgid "title_start"
 msgstr "Hedy - A gradual programming language"
 
-#: app.py:1117
+#: app.py:1090
 #, fuzzy
 msgid "title_explore"
 msgstr "Hedy - Explore"
 
-#: app.py:1135 app.py:1137
+#: app.py:1108 app.py:1110
 #, fuzzy
 msgid "translate_error"
 msgstr ""
 "Something went wrong while translating the code. Try running the code to "
 "see if it has an error. Code with errors can not be translated."
 
-#: app.py:1246 website/auth.py:241 website/auth.py:290 website/auth.py:426
+#: app.py:1219 website/auth.py:241 website/auth.py:290 website/auth.py:426
 #: website/auth.py:451 website/auth.py:481 website/auth.py:587
 #: website/auth.py:619 website/auth.py:659 website/auth.py:686
 #: website/teacher.py:90 website/teacher.py:125 website/teacher.py:197
@@ -155,32 +155,32 @@ msgstr ""
 msgid "ajax_error"
 msgstr "出现错误，请再试一次."
 
-#: app.py:1249
+#: app.py:1222
 #, fuzzy
 msgid "image_invalid"
 msgstr "Your chosen image is invalid."
 
-#: app.py:1251
+#: app.py:1224
 #, fuzzy
 msgid "personal_text_invalid"
 msgstr "Your personal text is invalid."
 
-#: app.py:1253 app.py:1259
+#: app.py:1226 app.py:1232
 #, fuzzy
 msgid "favourite_program_invalid"
 msgstr "Your chosen favourite program is invalid."
 
-#: app.py:1271 app.py:1272
+#: app.py:1244 app.py:1245
 #, fuzzy
 msgid "public_profile_updated"
 msgstr "Public profile updated."
 
-#: app.py:1306 app.py:1330
+#: app.py:1279 app.py:1303
 #, fuzzy
 msgid "user_not_private"
 msgstr "This user doesn't exist or doesn't have a public profile"
 
-#: app.py:1339
+#: app.py:1312
 #, fuzzy
 msgid "invalid_teacher_invitation_code"
 msgstr ""
@@ -453,7 +453,7 @@ msgstr "Visible columns"
 
 #: templates/class-overview.html:21 templates/class-overview.html:64
 #: templates/class-overview.html:108 templates/create-accounts.html:16
-#: templates/login.html:12 templates/profile.html:93 templates/recover.html:8
+#: templates/login.html:12 templates/profile.html:86 templates/recover.html:8
 #: templates/signup.html:10
 msgid "username"
 msgstr "用户名"
@@ -469,7 +469,6 @@ msgid "highest_level_reached"
 msgstr "Highest level reached"
 
 #: templates/class-overview.html:35 templates/class-overview.html:67
-#: templates/profile.html:74
 #, fuzzy
 msgid "number_programs"
 msgstr "Number of programs"
@@ -485,8 +484,8 @@ msgid "latest_shared_program"
 msgstr "Latest shared program"
 
 #: templates/class-overview.html:49 templates/class-overview.html:70
-#: templates/class-overview.html:83 templates/profile.html:151
-#: templates/profile.html:153 templates/profile.html:166
+#: templates/class-overview.html:83 templates/profile.html:144
+#: templates/profile.html:146 templates/profile.html:159
 msgid "change_password"
 msgstr "修改密码"
 
@@ -659,7 +658,7 @@ msgid "create_accounts_prompt"
 msgstr "Are you sure you want to create these accounts?"
 
 #: templates/create-accounts.html:17 templates/learn-more.html:10
-#: templates/profile.html:96 templates/recover.html:8 templates/signup.html:13
+#: templates/profile.html:89 templates/recover.html:8 templates/signup.html:13
 msgid "email"
 msgstr "电子邮箱"
 
@@ -853,8 +852,8 @@ msgid "select_own_adventures"
 msgstr "Select own adventures"
 
 #: templates/customize-class.html:95 templates/customize-class.html:121
-#: templates/profile.html:47 templates/profile.html:128
-#: templates/profile.html:137 templates/signup.html:26 templates/signup.html:45
+#: templates/profile.html:47 templates/profile.html:121
+#: templates/profile.html:130 templates/signup.html:26 templates/signup.html:45
 #: templates/signup.html:53
 msgid "select"
 msgstr "选择"
@@ -941,8 +940,8 @@ msgstr "Creator"
 msgid "view_program"
 msgstr "View program"
 
-#: templates/for-teachers.html:5 templates/profile.html:78
-#: templates/profile.html:80
+#: templates/for-teachers.html:5 templates/profile.html:71
+#: templates/profile.html:73
 #, fuzzy
 msgid "my_classes"
 msgstr "My classes"
@@ -1174,14 +1173,7 @@ msgstr "Cancel"
 msgid "copy_link_to_share"
 msgstr "Copy link to share"
 
-#: templates/layout.html:78
-#, fuzzy
-msgid "set_preferred_lang"
-msgstr ""
-"Hedy now supports preferred user languages. You can set one for your "
-"profile in \"My profile\""
-
-#: templates/layout.html:86 templates/quiz/endquiz.html:18
+#: templates/layout.html:83 templates/quiz/endquiz.html:18
 #: templates/quiz/quiz.html:29
 #, fuzzy
 msgid "achievement_earned"
@@ -1201,7 +1193,7 @@ msgstr "用户名"
 msgid "lastname"
 msgstr "Name"
 
-#: templates/learn-more.html:22 templates/profile.html:135
+#: templates/learn-more.html:22 templates/profile.html:128
 #: templates/signup.html:52
 msgid "country"
 msgstr "国家"
@@ -1342,7 +1334,7 @@ msgstr ""
 msgid "update_public"
 msgstr "Update public profile"
 
-#: templates/profile.html:61 templates/profile.html:148
+#: templates/profile.html:61 templates/profile.html:141
 msgid "are_you_sure"
 msgstr "你确定吗？你无法撤回这个动作."
 
@@ -1351,73 +1343,68 @@ msgstr "你确定吗？你无法撤回这个动作."
 msgid "delete_public"
 msgstr "Delete public profile"
 
-#: templates/profile.html:70 templates/profile.html:72
-#, fuzzy
-msgid "statistics"
-msgstr "My statistics"
-
-#: templates/profile.html:83
+#: templates/profile.html:76
 #, fuzzy
 msgid "self_removal_prompt"
 msgstr "Are you sure you want to leave this class?"
 
-#: templates/profile.html:83
+#: templates/profile.html:76
 #, fuzzy
 msgid "leave_class"
 msgstr "Leave class"
 
-#: templates/profile.html:88 templates/profile.html:91
+#: templates/profile.html:81 templates/profile.html:84
 #, fuzzy
 msgid "settings"
 msgstr "My personal settings"
 
-#: templates/profile.html:99 templates/signup.html:41
+#: templates/profile.html:92 templates/signup.html:41
 msgid "birth_year"
 msgstr "你出生的年份"
 
-#: templates/profile.html:102 templates/signup.html:25
+#: templates/profile.html:95 templates/signup.html:25
 #, fuzzy
 msgid "preferred_language"
 msgstr "Preferred language"
 
-#: templates/profile.html:112 templates/signup.html:34
+#: templates/profile.html:105 templates/signup.html:34
 #, fuzzy
 msgid "preferred_keyword_language"
 msgstr "Preferred keyword language"
 
-#: templates/profile.html:126 templates/signup.html:44
+#: templates/profile.html:119 templates/signup.html:44
 msgid "gender"
 msgstr "性别"
 
-#: templates/profile.html:129 templates/signup.html:46
+#: templates/profile.html:122 templates/signup.html:46
 msgid "female"
 msgstr "女"
 
-#: templates/profile.html:130 templates/signup.html:47
+#: templates/profile.html:123 templates/signup.html:47
 msgid "male"
 msgstr "男"
 
-#: templates/profile.html:131 templates/signup.html:48
+#: templates/profile.html:124 templates/signup.html:48
 msgid "other"
 msgstr "其他"
 
-#: templates/profile.html:144
+#: templates/profile.html:137
 msgid "update_profile"
 msgstr "更新资料"
 
-#: templates/profile.html:148
+#: templates/profile.html:141
 msgid "destroy_profile"
 msgstr "永久的删除账号"
 
-#: templates/profile.html:155
+#: templates/profile.html:148
 msgid "current_password"
 msgstr "现在的密码"
 
-#: templates/profile.html:159
+#: templates/profile.html:152
 msgid "new_password"
 msgstr "新的密码"
 
-#: templates/profile.html:163
+#: templates/profile.html:156
 msgid "repeat_new_password"
 msgstr "再次输入新的密码"
 
@@ -2075,4 +2062,13 @@ msgstr "The adventure has been updated!"
 #, fuzzy
 msgid "adventure_empty"
 msgstr "You didn't enter an adventure name!"
+
+#~ msgid "set_preferred_lang"
+#~ msgstr ""
+#~ "Hedy now supports preferred user "
+#~ "languages. You can set one for "
+#~ "your profile in \"My profile\""
+
+#~ msgid "statistics"
+#~ msgstr "My statistics"
 


### PR DESCRIPTION
**Description**
In this PR we make some small fix to improve performance overall. We remove the `@app.context_processor` db calls. These calls where made at each template render to make sure the data was available, however in most cases this data was redundant. We now only make these db calls when rendering the actual relevant pages. We also remove some redundant Babel explanation as that is already mentioned (and improved) in CONTRIBUTING.md. Lastly we remove the "set a preferred language" header, which has become redundant as it's already over 6 months shown to users without a set language. We still catch the possible errors, so this is no longer an issue. And we remove the "Statistics" header on the profile page as it is not really relevant.

**Fixes**
This PR fixes #2445

**How to test**
This is a clean-up task, if nothing is broken it works.
