### PR TITLE
[BUG FIX] Error messages work again on program view page

### DIFF
--- a/templates/code-page.html
+++ b/templates/code-page.html
@@ -17,7 +17,7 @@
   <script src="{{static('/vendor/ace.js')}}" type="text/javascript" charset="utf-8" crossorigin="anonymous"></script>
   <script src="{{static('/vendor/ext-whitespace.js')}}" type="text/javascript" charset="utf-8" crossorigin="anonymous"></script>
   <script src="{{static('/vendor/ext-rtl.js')}}" type="text/javascript" charset="utf-8" crossorigin="anonymous"></script>
-  <script src="/client_messages.js?lang={{ g.lang }}" type="text/javascript" crossorigin="anonymous"></script>
+  <script src="/client_messages.js" type="text/javascript" crossorigin="anonymous"></script>
   <script>
     window.State = {};
     window.State.lang = "{{ g.lang }}";

--- a/templates/view-program-page.html
+++ b/templates/view-program-page.html
@@ -17,12 +17,10 @@
 </div>
 {% endblock %}
 {% block scripts %}
-  <script src="{{static('/vendor/jquery.min.js')}}" type="text/javascript" crossorigin="anonymous"></script>
   <script src="{{static('/vendor/ace.js')}}" type="text/javascript" charset="utf-8" crossorigin="anonymous"></script>
   <script src="{{static('/vendor/ext-whitespace.js')}}" type="text/javascript" charset="utf-8" crossorigin="anonymous"></script>
   <script src="{{static('/vendor/ext-rtl.js')}}" type="text/javascript" charset="utf-8" crossorigin="anonymous"></script>
-  <script src="{{static('/vendor/skulpt.min.js')}}" type="text/javascript" crossorigin="anonymous"></script>
-  <script src="{{static('/vendor/skulpt-stdlib.js')}}" type="text/javascript" crossorigin="anonymous"></script>
+  <script src="/client_messages.js" type="text/javascript" crossorigin="anonymous"></script>
   <script>
     window.State = {};
     window.State.lang = "{{ g.lang }}";
@@ -30,4 +28,7 @@
     window.State.level_title = "{{ _('level_title') }}";
   </script>
   <script src="{{static('/js/appbundle.js')}}" type="text/javascript" crossorigin="anonymous"></script>
+  <script src="{{static('/vendor/skulpt.min.js')}}" type="text/javascript" crossorigin="anonymous"></script>
+  <script src="{{static('/vendor/skulpt-stdlib.js')}}" type="text/javascript" crossorigin="anonymous"></script>
+  <script src="{{static('/vendor/jquery.min.js')}}" type="text/javascript" crossorigin="anonymous"></script>
 {% endblock %}


### PR DESCRIPTION
**Description**
In this PR we fix a small issue where the error messages on the program view page weren't working due to a missing include. The actual issue isn't the bug, but the weird structure we use with `window.State` to pass relevant info such as the current level. It would be nice of we perform some clean-up on the `{% block scripts %}` elements to ensure these bugs don't happen again.

**Fixes**
This PR fixes #2463.

**How to test**
Make sure there is a shared incorrect program. Navigate to the share link and verify that the error message is shown correctly when trying to run on the program view page.