### PR TITLE
Remove grammar ambiguity in if-statements at levels 5-7 #2471

### DIFF
--- a/grammars/level5-Additions.lark
+++ b/grammars/level5-Additions.lark
@@ -16,11 +16,12 @@ assign: var _IS textwithspaces
 error_print_no_quotes: _PRINT (textwithoutspaces | list_access | var_access) (_SPACE (textwithoutspaces | list_access | var_access))*  -> error_print_nq
 
 // new commands for level 5
-ifelse: _IF (condition (_SPACE|_EOL*) | condition_spaces _EOL*) command (_SPACE|_EOL*) _ELSE (_SPACE|_EOL*) command
-ifs: _IF (condition (_SPACE|_EOL*)) command //'if' cannot be used in Python, hence the name of the rule is 'ifs'
+ifelse: _IF (condition (_SPACE|_EOL*) | condition_spaces _SPACE* _EOL+ | illegal_condition) command (_SPACE|_EOL*) _ELSE (_SPACE|_EOL*) command
+ifs: _IF condition (_SPACE+ _EOL* | _EOL+) command //'if' cannot be used in Python, hence the name of the rule is 'ifs'
 
-condition_spaces: textwithoutspaces _IS textwithoutspaces (_SPACE textwithspaces)+
+condition_spaces: textwithoutspaces _IS textwithoutspaces (_SPACE textwithoutspaces)+
 condition: equality_check | in_list_check
+illegal_condition: condition_spaces _SPACE -> illegal_condition
 equality_check: textwithoutspaces _IS (quoted_text | textwithoutspaces) //TODO FH nov 2021: not super pretty that this is textwithoutquotes for both a var and also a textual constant, level 12 handles this nicer now, could be done here too
 
 

--- a/grammars/level6-Additions.lark
+++ b/grammars/level6-Additions.lark
@@ -19,4 +19,4 @@ assign: var (_IS | _EQUALS) expression | var ( _IS  | _EQUALS) textwithoutspaces
 ?atom: INT | var_access | error_unsupported_number | textwithoutspaces
 error_unsupported_number: /([-+]?(\d+[\.,]\d+))/ -> error_unsupported_number
 
-textwithoutspaces: /(?:[^\n،, *+\-\/ei]|e(?!lse)|i(?!f))+/ -> text //new cause in level 6 calculation elements need to be escaped too
+textwithoutspaces: /(?:[^#\n،, *+\-\/eias]|e(?!lse)|i(?!f)|s(?!i|inon|ino)|a(?!nders|ls))+/ -> text

--- a/hedy.py
+++ b/hedy.py
@@ -953,7 +953,9 @@ class IsValid(Filter):
         error = InvalidInfo('unsupported number', arguments=[str(args[0])], line=meta.line, column=meta.column)
         return False, error, meta
 
-
+    def illegal_condition(self, meta, args):
+        error = InvalidInfo('invalid condition', arguments=[str(args[0])], line=meta.line, column=meta.column)
+        return False, error, meta
 
     #other rules are inherited from Filter
 
@@ -2089,7 +2091,7 @@ def parse_input(input_string, level, lang):
     try:
         parse_result = parser.parse(input_string + '\n')
         return parse_result.children[0]  # getting rid of the root could also be done in the transformer would be nicer
-    except lark.UnexpectedEOF:
+    except lark.UnexpectedEOF as e:
         lines = input_string.split('\n')
         last_line = len(lines)
         raise exceptions.UnquotedEqualityCheck(line_number=last_line)
@@ -2139,6 +2141,8 @@ def is_program_valid(program_root, input_string, level, lang):
                     # The fixed code contains another error. Only report the original error for now.
                     pass
             raise exceptions.InvalidSpaceException(level=level, line_number=line, fixed_code=fixed_code, fixed_result=result)
+        elif invalid_info.error_type == 'invalid condition':
+            raise exceptions.UnquotedEqualityCheck(line_number=line)
         elif invalid_info.error_type == 'print without quotes':
             # grammar rule is agnostic of line number so we can't easily return that here
             raise exceptions.UnquotedTextException(level=level)

--- a/tests/test_level/test_level_05.py
+++ b/tests/test_level/test_level_05.py
@@ -12,7 +12,6 @@ class TestsLevel5(HedyTester):
 
   # is
 
-
   def test_print_var_1795(self):
     code = textwrap.dedent("""\
     naam is 'Daan'
@@ -47,217 +46,37 @@ class TestsLevel5(HedyTester):
     expected = f"message = '{eq}Hello welcome to Hedy.{eq}'"
     self.single_level_tester(code=code, expected=expected)
 
-  # if
-  def test_allow_space_after_else_line(self):
-    #this code has a space at the end of line 2
-    code = textwrap.dedent("""\
-    a is 2
-    if a is 1 print a  
-    else print 'nee'""")
-
-    expected = textwrap.dedent("""\
-    a = '2'
-    if a == '1':
-      print(f'{a}')
-    else:
-      print(f'nee')""")
-
-    self.single_level_tester(
-      code=code,
-      expected=expected,
-      expected_commands=['is', 'else', 'print', 'print']
-    )
-  def test_ifelse_should_go_before_assign(self):
-    code = textwrap.dedent("""\
-    kleur is geel
-    if kleur is groen antwoord is ok else antwoord is stom
-    print antwoord""")
-    expected = textwrap.dedent("""\
-      kleur = 'geel'
-      if kleur == 'groen':
-        antwoord = 'ok'
-      else:
-        antwoord = 'stom'
-      print(f'{antwoord}')""")
-
-    self.multi_level_tester(
-      max_level=5,
-      code=code,
-      expected=expected
-    )
-
-  def test_identifies_backtick_inside_conditional(self):
-    self.assertRaises(hedy.exceptions.UnquotedTextException, lambda: hedy.transpile("if 1 is 1 print `yay!` else print `nay`", self.level))
-
-
-  # turn forward
-  # no new tests, covered by lower levels.
-
-  # combined tests
-  def test_turn_forward(self):
-    result = hedy.transpile("forward 50\nturn\nforward 100", self.level)
-    expected = HedyTester.dedent(
-      HedyTester.forward_transpiled(50),
-      "t.right(90)",
-      HedyTester.forward_transpiled(100))
-    self.assertEqual(expected, result.code)
-    self.assertEqual(True, result.has_turtle)
-  def test_ask_print(self):
-    code = textwrap.dedent("""\
-    kleur is ask 'wat is je lievelingskleur?'
-    print 'jouw lievelingskleur is dus' kleur '!'""")
-
-    expected = textwrap.dedent("""\
-    kleur = input(f'wat is je lievelingskleur?')
-    print(f'jouw lievelingskleur is dus{kleur}!')""")
-
-    self.single_level_tester(code=code, expected=expected)
-  def test_print_if_else(self):
+  #
+  # if tests
+  #
+  def test_if_equality_linebreak_print(self):
+    # line breaks after if-condition are allowed
     code = textwrap.dedent("""\
     naam is Hedy
-    print 'ik heet' naam
-    if naam is Hedy print 'leuk' else print 'minder leuk'""")
-
-    expected = textwrap.dedent("""\
-    naam = 'Hedy'
-    print(f'ik heet{naam}')
-    if naam == 'Hedy':
-      print(f'leuk')
-    else:
-      print(f'minder leuk')""")
-
-    self.single_level_tester(code=code, expected=expected)
-
-  def test_print_if_else_ask(self):
-
-    code = textwrap.dedent("""\
-    kleur is ask 'Wat is je lievelingskleur?'
-    if kleur is groen print 'mooi!' else print 'niet zo mooi'""")
-
-    expected = textwrap.dedent("""\
-    kleur = input(f'Wat is je lievelingskleur?')
-    if kleur == 'groen':
-      print(f'mooi!')
-    else:
-      print(f'niet zo mooi')""")
-
-    self.single_level_tester(code=code, expected=expected)
-
-  def test_print_if_else_with_line_break(self):
-    # line breaks should be allowed in if-elses until level 7 when we start with indentation
-    code = textwrap.dedent("""\
-    naam is Hedy
-    print 'ik heet' naam
-    if naam is Hedy print 'leuk'
-    else print 'minder leuk'""")
-
-    expected = textwrap.dedent("""\
-    naam = 'Hedy'
-    print(f'ik heet{naam}')
-    if naam == 'Hedy':
-      print(f'leuk')
-    else:
-      print(f'minder leuk')""")
-
-    self.multi_level_tester(
-      max_level=5,
-      code=code,
-      expected=expected
-    )
-  def test_print_if_else_with_line_break_after_condition(self):
-    # line breaks after conditional should be allowed in if-elses until level 7 when we start with indentation
-    code = textwrap.dedent("""\
-    naam is Hedy
-    print 'ik heet' naam
     if naam is Hedy
-    print 'leuk'
-    else print 'minder leuk'""")
+    print 'leuk'""")
 
     expected = textwrap.dedent("""\
     naam = 'Hedy'
-    print(f'ik heet{naam}')
     if naam == 'Hedy':
-      print(f'leuk')
-    else:
-      print(f'minder leuk')""")
+      print(f'leuk')""")
 
-    self.multi_level_tester(
-      max_level=5,
-      code=code,
-      expected=expected
-    )
+    self.single_level_tester(code=code, expected=expected)
 
-  def test_if_else_newline_list_assigment_print(self):
-    # line breaks after conditional should be allowed in if-elses until level 7 when we start with indentation
+  def test_if_equality_trailing_space_linebreak_print(self):
     code = textwrap.dedent("""\
-    people is mom, dad, Emma, Sophie
-    dishwasher is people at random
-    if dishwasher is Sophie
-    print 'too bad I have to do the dishes'
-    else
-    print 'luckily no dishes because' dishwasher 'is already washing up'""")
+    naam is James
+    if naam is trailing_space 
+    print 'shaken'""")
 
     expected = textwrap.dedent("""\
-    people = ['mom', 'dad', 'Emma', 'Sophie']
-    dishwasher = random.choice(people)
-    if dishwasher == 'Sophie':
-      print(f'too bad I have to do the dishes')
-    else:
-      print(f'luckily no dishes because{dishwasher}is already washing up')""")
+    naam = 'James'
+    if naam == 'trailing_space':
+      print(f'shaken')""")
 
-    self.single_level_tester(
-      code=code,
-      expected=expected
-    )
+    self.single_level_tester(code=code, expected=expected)
 
-
-  def test_print_if_else_line_break_and_space(self):
-    # line breaks should be allowed in if-elses until level 7 when we start with indentation
-
-    code = textwrap.dedent("""\
-    naam is Hedy
-    print 'ik heet' naam
-    if naam is Hedy print 'leuk'
-    else print 'minder leuk'""")
-
-    expected = textwrap.dedent("""\
-    naam = 'Hedy'
-    print(f'ik heet{naam}')
-    if naam == 'Hedy':
-      print(f'leuk')
-    else:
-      print(f'minder leuk')""")
-
-    self.multi_level_tester(
-      max_level=5,
-      code=code,
-      expected=expected
-    )
-
-  def test_print_if_linebreak_statement(self):
-    # Breaking an if statement and its following statement should be
-    # permited until level 7
-
-    code = textwrap.dedent("""\
-    people is 1, 2, 3, 3
-    dishwasher is people at random
-    test is 1
-    if dishwasher is test
-    print 'too bad I have to do the dishes!'""")
-
-    expected = textwrap.dedent("""\
-    people = ['1', '2', '3', '3']
-    dishwasher = random.choice(people)
-    test = '1'
-    if dishwasher == test:
-      print(f'too bad I have to do the dishes!')""")
-
-    self.single_level_tester(
-      code=code,
-      expected=expected,
-      expected_commands=['is', 'random', 'is', 'if', 'print']
-    )
-  def test_print_if_assign(self):
+  def test_if_2_vars_equality_print(self):
     code = textwrap.dedent("""\
     jouwkeuze is schaar
     computerkeuze is schaar
@@ -271,7 +90,7 @@ class TestsLevel5(HedyTester):
 
     self.single_level_tester(code=code, expected=expected, output='gelijkspel!')
 
-  def test_if_in_list(self):
+  def test_if_in_list_print(self):
     code = textwrap.dedent("""\
     items is red, green
     selected is red
@@ -283,69 +102,37 @@ class TestsLevel5(HedyTester):
     if selected in items:
       print(f'found!')""")
 
-    #todo: whould be tested for higher levels too (FH, dec 21)
-    self.single_level_tester(code=code, expected=expected, output='found!', expected_commands=['is', 'is', 'if', 'in', 'print'])
+    self.multi_level_tester(
+      max_level=7,
+      code=code,
+      expected=expected,
+      output='found!',
+      expected_commands=['is', 'is', 'if', 'in', 'print']
+    )
 
-  def test_undefined_list_if_in_list(self):
+  def test_if_in_undefined_list(self):
     code = textwrap.dedent("""\
     selected is red
     if selected in items print 'found!'""")
 
-    self.single_level_tester(code=code, exception=hedy.exceptions.UndefinedVarException)
+    self.multi_level_tester(code=code, exception=hedy.exceptions.UndefinedVarException, max_level=7)
 
-  def test_unquoted_space_rhs(self):
-    code = textwrap.dedent("""\
-    naam is James
-    if naam is James Bond print 'shaken' else print 'biertje!'""")
-
-    self.single_level_tester(
-      code=code,
-      exception=hedy.exceptions.UnquotedEqualityCheck)
-
-  def test_unquoted_space_rhs_no_else(self):
+  def test_if_equality_unquoted_rhs_with_space_print_gives_error(self):
     code = textwrap.dedent("""\
     naam is James
     if naam is James Bond print 'shaken'""")
 
-    self.single_level_tester(
-      code=code,
-      exception=hedy.exceptions.UnquotedEqualityCheck)
+    self.multi_level_tester(code=code, exception=hedy.exceptions.UnquotedEqualityCheck, max_level=11)
 
-  def test_unquoted_space_rhs_assign(self):
+  def test_if_equality_unquoted_rhs_with_space_assign_gives_error(self):
     code = textwrap.dedent("""\
     naam is James
     if naam is James Bond naam is 'Pietjansma'""")
 
-    self.single_level_tester(
-      code=code,
-      exception=hedy.exceptions.UnquotedEqualityCheck)
-
-  def test_equality_single_quoted_rhs_with_inner_double_quote(self):
-    code = textwrap.dedent(f"""\
-       answer is no
-       if answer is 'He said "no"' print 'no'""")
-
-    expected = textwrap.dedent(f"""\
-       answer = 'no'
-       if answer == 'He said "no"':
-         print(f'no')""")
-
-    self.single_level_tester(code=code, expected=expected)
-
-  def test_equality_double_quoted_rhs_with_inner_single_quote(self):
-    code = textwrap.dedent(f"""\
-       answer is no
-       if answer is "He said 'no'" print 'no'""")
-
-    expected = textwrap.dedent(f"""\
-       answer = 'no'
-       if answer == 'He said \\'no\\'':
-         print(f'no')""")
-
-    self.single_level_tester(code=code, expected=expected)
+    self.multi_level_tester(code=code, exception=hedy.exceptions.UnquotedEqualityCheck, max_level=11)
 
   @parameterized.expand(HedyTester.quotes)
-  def test_one_space_in_rhs_if(self, q):
+  def test_if_equality_quoted_rhs_with_space(self, q):
     code = textwrap.dedent(f"""\
     naam is James
     if naam is {q}James Bond{q} print {q}shaken{q}""")
@@ -358,7 +145,7 @@ class TestsLevel5(HedyTester):
     self.single_level_tester(code=code, expected=expected)
 
   @parameterized.expand(HedyTester.quotes)
-  def test_multiple_spaces_in_rhs_if(self, q):
+  def test_if_equality_quoted_rhs_with_spaces(self, q):
     code = textwrap.dedent(f"""\
     naam is James
     if naam is {q}Bond James Bond{q} print 'shaken'""")
@@ -370,23 +157,29 @@ class TestsLevel5(HedyTester):
 
     self.single_level_tester(code=code, expected=expected)
 
-  @parameterized.expand(HedyTester.quotes)
-  def test_one_space_in_rhs_if_else(self, q):
+  def test_if_equality_single_quoted_rhs_with_inner_double_quote(self):
     code = textwrap.dedent(f"""\
-    naam is James
-    if naam is {q}James Bond{q} print {q}shaken{q} else print {q}biertje!{q}""")
+    answer is no
+    if answer is 'He said "no"' print 'no'""")
 
     expected = textwrap.dedent(f"""\
-    naam = 'James'
-    if naam == 'James Bond':
-      print(f'shaken')
-    else:
-      print(f'biertje!')""")
+    answer = 'no'
+    if answer == 'He said "no"':
+      print(f'no')""")
 
     self.single_level_tester(code=code, expected=expected)
 
+  def test_if_equality_double_quoted_rhs_with_inner_single_quote(self):
+    code = textwrap.dedent(f"""\
+    answer is no
+    if answer is "He said 'no'" print 'no'""")
 
-  # todo would be good to make combinations with if and turtle
+    expected = textwrap.dedent(f"""\
+    answer = 'no'
+    if answer == 'He said \\'no\\'':
+      print(f'no')""")
+
+    self.single_level_tester(code=code, expected=expected)
 
   def test_equality_promotes_int_to_string(self):
     code = textwrap.dedent("""\
@@ -433,58 +226,326 @@ class TestsLevel5(HedyTester):
       exception=hedy.exceptions.InvalidArgumentTypeException
     )
 
+  #
+  # if else tests
+  #
+  def test_if_equality_print_else_print(self):
+    code = textwrap.dedent("""\
+    naam is Hedy
+    if naam is Hedy print 'leuk' else print 'minder leuk'""")
+
+    expected = textwrap.dedent("""\
+    naam = 'Hedy'
+    if naam == 'Hedy':
+      print(f'leuk')
+    else:
+      print(f'minder leuk')""")
+
+    self.single_level_tester(code=code, expected=expected)
+
+  def test_if_ask_equality_print_else_print(self):
+    code = textwrap.dedent("""\
+    kleur is ask 'Wat is je lievelingskleur?'
+    if kleur is groen print 'mooi!' else print 'niet zo mooi'""")
+
+    expected = textwrap.dedent("""\
+    kleur = input(f'Wat is je lievelingskleur?')
+    if kleur == 'groen':
+      print(f'mooi!')
+    else:
+      print(f'niet zo mooi')""")
+
+    self.single_level_tester(code=code, expected=expected)
+
+  def test_if_else_followed_by_print(self):
+    code = textwrap.dedent("""\
+    kleur is geel
+    if kleur is groen antwoord is ok else antwoord is stom
+    print antwoord""")
+
+    expected = textwrap.dedent("""\
+    kleur = 'geel'
+    if kleur == 'groen':
+      antwoord = 'ok'
+    else:
+      antwoord = 'stom'
+    print(f'{antwoord}')""")
+
+    self.single_level_tester(code=code, expected=expected)
+
+  def test_if_equality_trailing_space_linebreak_print_else(self):
+    # this code has a space at the end of line 2
+    code = textwrap.dedent("""\
+    naam is James
+    if naam is trailing space  
+    print 'shaken' else print 'biertje!'""")
+
+    expected = textwrap.dedent("""\
+    naam = 'James'
+    if naam == 'trailing space':
+      print(f'shaken')
+    else:
+      print(f'biertje!')""")
+
+    self.multi_level_tester(max_level=7, code=code, expected=expected)
+
+  def test_if_equality_print_linebreak_else_print(self):
+    # line break before else is allowed
+    code = textwrap.dedent("""\
+    naam is Hedy
+    if naam is Hedy print 'leuk'
+    else print 'minder leuk'""")
+
+    expected = textwrap.dedent("""\
+    naam = 'Hedy'
+    if naam == 'Hedy':
+      print(f'leuk')
+    else:
+      print(f'minder leuk')""")
+
+    self.single_level_tester(code=code, expected=expected)
+
+  def test_if_equality_linebreak_print_else_print(self):
+    # line break after if-condition is allowed
+    code = textwrap.dedent("""\
+    naam is Hedy
+    if naam is Hedy
+    print 'leuk' else print 'minder leuk'""")
+
+    expected = textwrap.dedent("""\
+    naam = 'Hedy'
+    if naam == 'Hedy':
+      print(f'leuk')
+    else:
+      print(f'minder leuk')""")
+
+    self.single_level_tester(code=code, expected=expected)
+
+  def test_if_equality_unquoted_with_space_linebreak_print_else_print(self):
+    code = textwrap.dedent("""\
+    naam is James
+    if naam is James Bond
+    print 'shaken' else print 'biertje!'""")
+
+    expected = textwrap.dedent("""\
+    naam = 'James'
+    if naam == 'James Bond':
+      print(f'shaken')
+    else:
+      print(f'biertje!')""")
+
+    self.multi_level_tester(max_level=7, code=code, expected=expected)
+
+  def test_if_equality_print_else_linebreak_print(self):
+    # line break after else is allowed
+    code = textwrap.dedent("""\
+    naam is Hedy
+    if naam is Hedy print 'leuk' else
+    print 'minder leuk'""")
+
+    expected = textwrap.dedent("""\
+    naam = 'Hedy'
+    if naam == 'Hedy':
+      print(f'leuk')
+    else:
+      print(f'minder leuk')""")
+
+    self.single_level_tester(code=code, expected=expected)
+
+  def test_if_equality_linebreak_print_linebreak_else_print(self):
+    # line breaks after if-condition and before else are allowed
+    code = textwrap.dedent("""\
+    naam is Hedy
+    if naam is Hedy
+    print 'leuk'
+    else print 'minder leuk'""")
+
+    expected = textwrap.dedent("""\
+    naam = 'Hedy'
+    if naam == 'Hedy':
+      print(f'leuk')
+    else:
+      print(f'minder leuk')""")
+
+    self.single_level_tester(code=code, expected=expected)
+
+  def test_if_equality_linebreak_print_linebreak_else_linebreak_print(self):
+    # line breaks after if-condition, before else and after else are allowed
+    code = textwrap.dedent("""\
+    naam is Hedy
+    if naam is Hedy
+    print 'leuk'
+    else
+    print 'minder leuk'""")
+
+    expected = textwrap.dedent("""\
+    naam = 'Hedy'
+    if naam == 'Hedy':
+      print(f'leuk')
+    else:
+      print(f'minder leuk')""")
+
+    self.single_level_tester(code=code, expected=expected)
+
+  def test_if_equality_linebreak_print_else_linebreak_print(self):
+    # line breaks after if-condition and after else are allowed
+    code = textwrap.dedent("""\
+    naam is Hedy
+    if naam is Hedy
+    print 'leuk' else
+    print 'minder leuk'""")
+
+    expected = textwrap.dedent("""\
+    naam = 'Hedy'
+    if naam == 'Hedy':
+      print(f'leuk')
+    else:
+      print(f'minder leuk')""")
+
+    self.single_level_tester(code=code, expected=expected)
+
+  def test_if_list_assignment_else_print(self):
+    code = textwrap.dedent("""\
+    people is mom, dad, Emma, Sophie
+    dishwasher is people at random
+    if dishwasher is Sophie
+    print 'too bad I have to do the dishes'
+    else
+    print 'luckily no dishes because' dishwasher 'is already washing up'""")
+
+    expected = textwrap.dedent("""\
+    people = ['mom', 'dad', 'Emma', 'Sophie']
+    dishwasher = random.choice(people)
+    if dishwasher == 'Sophie':
+      print(f'too bad I have to do the dishes')
+    else:
+      print(f'luckily no dishes because{dishwasher}is already washing up')""")
+
+    self.single_level_tester(code=code, expected=expected)
+
+  @parameterized.expand(HedyTester.quotes)
+  def test_if_equality_quoted_rhs_with_space_else(self, q):
+    code = textwrap.dedent(f"""\
+    naam is James
+    if naam is {q}James Bond{q} print {q}shaken{q} else print {q}biertje!{q}""")
+
+    expected = textwrap.dedent(f"""\
+    naam = 'James'
+    if naam == 'James Bond':
+      print(f'shaken')
+    else:
+      print(f'biertje!')""")
+
+    self.single_level_tester(code=code, expected=expected)
+
+  def test_if_equality_print_else_print_bengali(self):
+    code = textwrap.dedent("""\
+    নাম is ask 'আপনার নাম কি?'
+    if নাম is হেডি print 'ভালো!' else print 'মন্দ'""")
+
+    expected = textwrap.dedent("""\
+    veb9b5c786e8cde0910df4197f630ee75 = input(f'আপনার নাম কি?')
+    if veb9b5c786e8cde0910df4197f630ee75 == 'হেডি':
+      print(f'ভালো!')
+    else:
+      print(f'মন্দ')""")
+
+    self.single_level_tester(code=code, expected=expected)
+
+  # todo would be good to make combinations with if and turtle
+
+  # turn forward
+  # no new tests, covered by lower levels.
+
+  # combined tests
+  def test_turn_forward(self):
+    result = hedy.transpile("forward 50\nturn\nforward 100", self.level)
+    expected = HedyTester.dedent(
+      HedyTester.forward_transpiled(50),
+      "t.right(90)",
+      HedyTester.forward_transpiled(100))
+    self.assertEqual(expected, result.code)
+    self.assertEqual(True, result.has_turtle)
+  def test_ask_print(self):
+    code = textwrap.dedent("""\
+    kleur is ask 'wat is je lievelingskleur?'
+    print 'jouw lievelingskleur is dus' kleur '!'""")
+
+    expected = textwrap.dedent("""\
+    kleur = input(f'wat is je lievelingskleur?')
+    print(f'jouw lievelingskleur is dus{kleur}!')""")
+
+    self.single_level_tester(code=code, expected=expected)
+
+  def test_consecutive_if_statements(self):
+    code = textwrap.dedent("""\
+    names is Hedy, Lamar
+    name is ask 'What is a name you like?'
+    if name is Hedy print 'nice!'
+    if name in names print 'nice!'""")
+
+    expected = textwrap.dedent("""\
+    names = ['Hedy', 'Lamar']
+    name = input(f'What is a name you like?')
+    if name == 'Hedy':
+      print(f'nice!')
+    if name in names:
+      print(f'nice!')""")
+
+    self.single_level_tester(code=code, expected=expected)
+
+  def test_consecutive_if_else_statements(self):
+    code = textwrap.dedent("""\
+    names is Hedy, Lamar
+    name is ask 'What is a name you like?'
+    if name is Hedy print 'nice!' else print 'meh'
+    if name in names print 'nice!' else print 'meh'""")
+
+    expected = textwrap.dedent("""\
+    names = ['Hedy', 'Lamar']
+    name = input(f'What is a name you like?')
+    if name == 'Hedy':
+      print(f'nice!')
+    else:
+      print(f'meh')
+    if name in names:
+      print(f'nice!')
+    else:
+      print(f'meh')""")
+
+    self.single_level_tester(code=code, expected=expected)
+
   #negative tests
-  def test_indent_gives_parse_error(self):
+  def test_if_indent_gives_parse_error(self):
     code = textwrap.dedent("""\
     option is ask 'Rock Paper or Scissors?'
-    print 'Player 2 ' option
     if option is Scissors
         print 'Its a tie!'""")
 
-    with self.assertRaises(hedy.exceptions.ParseException) as context:
-      result = hedy.transpile(code, self.level)
-    self.assertEqual('Parse', context.exception.error_code)
-    self.assertEqual(4, context.exception.error_location[0])
-    self.assertEqual(1, context.exception.error_location[1])
+    self.multi_level_tester(
+      max_level=7,
+      code=code,
+      exception=hedy.exceptions.ParseException,
+      extra_check_function=lambda c: c.exception.error_location[0] == 3 and c.exception.error_location[1] == 1
+    )
 
-  def test_if_print_has_no_turtle(self):
-    code = textwrap.dedent("""\
-    jouwkeuze is schaar
-    computerkeuze is schaar
-    if computerkeuze is jouwkeuze print 'gelijkspel!'""")
-    result = hedy.transpile_inner(code, self.level)
-    self.assertEqual(False, result.has_turtle)
-
-    #we don't have a function now for testing more exceptoion logic
-    # self.assertEqual('print', str(context.exception.arguments['guessed_command']))
   def test_pront_should_suggest_print(self):
     code = "pront 'Hedy is leuk!'"
 
-    with self.assertRaises(hedy.exceptions.InvalidCommandException) as context:
-        result = hedy.transpile(code, self.level)
-    self.assertEqual('Invalid', context.exception.error_code)
-    self.assertEqual('print', str(context.exception.arguments['guessed_command']))
+    self.multi_level_tester(
+      code=code,
+      exception=hedy.exceptions.InvalidCommandException,
+      extra_check_function=lambda c: str(c.exception.arguments['guessed_command']) == 'print'
+    )
 
-  def test_if_with_print_backtick(self):
-    code = textwrap.dedent("""\
-    name is ask 'ποιό είναι το όνομά σου;'
-    if name is Hedy print `ωραία` else print `μπου!`""")
+  def test_if_equality_print_backtick_text_gives_error(self):
+    code = "if 1 is 1 print `yay!` else print `nay`"
 
     self.multi_level_tester(
-      max_level=5,
+      max_level=6,
       code=code,
       exception=hedy.exceptions.UnquotedTextException
     )
-
-  # def test_list_find_issue(self):
-  #   #'list' object has no attribute 'find'?
-  # add 'TODO' for searchability, not sure this is still a thing?
-  #   # FH dd sept 2021 for later fixing!
-  #   code = textwrap.dedent("""\
-  #     নাম is ask আপনার নাম কি?
-  #     if নাম is হেডি print 'ভালো!' else print 'মন্দ'\"""")
-  #
-  #
 
   def test_meta_column_missing_quote(self):
     code = textwrap.dedent("""\

--- a/tests/test_level/test_level_06.py
+++ b/tests/test_level/test_level_06.py
@@ -94,18 +94,254 @@ class TestsLevel6(HedyTester):
 
     self.single_level_tester(code=code, expected=expected)
 
-  #if tests
-  def test_print_if_else_with_line_break(self):
-    # line breaks should be allowed in if-elses until level 7 when we start with indentation
+  #
+  # if tests
+  #
+  def test_if_equality_linebreak_print(self):
+    # line breaks after if-condition are allowed
     code = textwrap.dedent("""\
     naam is Hedy
-    print 'ik heet' naam
+    if naam is Hedy
+    print 'leuk'""")
+
+    expected = textwrap.dedent("""\
+    naam = 'Hedy'
+    if str(naam) == str('Hedy'):
+      print(f'leuk')""")
+
+    self.multi_level_tester(max_level=7, code=code, expected=expected)
+
+  def test_if_equality_trailing_space_linebreak_print(self):
+    code = textwrap.dedent("""\
+    naam is James
+    if naam is trailing_space 
+    print 'shaken'""")
+
+    expected = textwrap.dedent("""\
+    naam = 'James'
+    if str(naam) == str('trailing_space'):
+      print(f'shaken')""")
+
+    self.multi_level_tester(max_level=7, code=code, expected=expected)
+
+  def test_if_2_vars_equality_print(self):
+    code = textwrap.dedent("""\
+    jouwkeuze is schaar
+    computerkeuze is schaar
+    if computerkeuze is jouwkeuze print 'gelijkspel!'""")
+
+    expected = textwrap.dedent("""\
+    jouwkeuze = 'schaar'
+    computerkeuze = 'schaar'
+    if str(computerkeuze) == str(jouwkeuze):
+      print(f'gelijkspel!')""")
+
+    self.multi_level_tester(max_level=7, code=code, expected=expected, output='gelijkspel!')
+
+  @parameterized.expand(HedyTester.quotes)
+  def test_if_equality_quoted_rhs_with_space(self, q):
+    code = textwrap.dedent(f"""\
+    naam is James
+    if naam is {q}James Bond{q} print {q}shaken{q}""")
+
+    expected = textwrap.dedent(f"""\
+    naam = 'James'
+    if str(naam) == str('James Bond'):
+      print(f'shaken')""")
+
+    self.multi_level_tester(max_level=7, code=code, expected=expected)
+
+  @parameterized.expand(HedyTester.quotes)
+  def test_if_equality_quoted_rhs_with_spaces(self, q):
+    code = textwrap.dedent(f"""\
+    naam is James
+    if naam is {q}Bond James Bond{q} print 'shaken'""")
+
+    expected = textwrap.dedent(f"""\
+    naam = 'James'
+    if str(naam) == str('Bond James Bond'):
+      print(f'shaken')""")
+
+    self.multi_level_tester(max_level=7, code=code, expected=expected)
+
+  def test_if_equality_single_quoted_rhs_with_inner_double_quote(self):
+    code = textwrap.dedent(f"""\
+    answer is no
+    if answer is 'He said "no"' print 'no'""")
+
+    expected = textwrap.dedent(f"""\
+    answer = 'no'
+    if str(answer) == str('He said "no"'):
+      print(f'no')""")
+
+    self.multi_level_tester(max_level=7, code=code, expected=expected)
+
+  def test_equality_double_quoted_rhs_with_inner_single_quote(self):
+    code = textwrap.dedent(f"""\
+    answer is no
+    if answer is "He said 'no'" print 'no'""")
+
+    expected = textwrap.dedent(f"""\
+    answer = 'no'
+    if str(answer) == str('He said \\'no\\''):
+      print(f'no')""")
+
+    self.multi_level_tester(max_level=7, code=code, expected=expected)
+
+  def test_equality_promotes_int_to_string(self):
+    code = textwrap.dedent("""\
+    a is test
+    b is 15
+    if a is b c is 1""")
+
+    expected = textwrap.dedent("""\
+    a = 'test'
+    b = '15'
+    if str(a) == str(b):
+      c = '1'""")
+
+    self.multi_level_tester(max_level=7, code=code, expected=expected)
+
+  def test_if_equality_assign_calc(self):
+    code = textwrap.dedent("""\
+    cmp is 1
+    test is 2
+    acu is 0
+    if test is cmp acu is acu + 1""")
+
+    expected = textwrap.dedent("""\
+    cmp = '1'
+    test = '2'
+    acu = '0'
+    if str(test) == str(cmp):
+      acu = int(acu) + int(1)""")
+
+    self.multi_level_tester(max_level=7, code=code, expected=expected)
+
+  def test_if_equality_with_ise(self):
+    code = textwrap.dedent("""\
+    naam is Hedy
+    if naam is Hedy print 'leuk'""")
+
+    expected = textwrap.dedent("""\
+    naam = 'Hedy'
+    if str(naam) == str('Hedy'):
+      print(f'leuk')""")
+
+    self.multi_level_tester(
+      code=code,
+      expected=expected,
+      max_level=7)
+
+  def test_if_equality_with_equals_sign(self):
+    code = textwrap.dedent("""\
+    naam is Hedy
+    if naam = Hedy print 'leuk'""")
+
+    expected = textwrap.dedent("""\
+    naam = 'Hedy'
+    if str(naam) == str('Hedy'):
+      print(f'leuk')""")
+
+    self.multi_level_tester(
+      code=code,
+      expected=expected,
+      max_level=7
+    )
+
+  #
+  # if else tests
+  #
+  def test_if_equality_print_else_print(self):
+    code = textwrap.dedent("""\
+    naam is Hedy
+    if naam is Hedy print 'leuk' else print 'minder leuk'""")
+
+    expected = textwrap.dedent("""\
+    naam = 'Hedy'
+    if str(naam) == str('Hedy'):
+      print(f'leuk')
+    else:
+      print(f'minder leuk')""")
+
+    self.multi_level_tester(max_level=7, code=code, expected=expected)
+
+  def test_if_ask_equality_print_else_print(self):
+    code = textwrap.dedent("""\
+    kleur is ask 'Wat is je lievelingskleur?'
+    if kleur is groen print 'mooi!' else print 'niet zo mooi'""")
+
+    expected = textwrap.dedent("""\
+    kleur = input(f'Wat is je lievelingskleur?')
+    if str(kleur) == str('groen'):
+      print(f'mooi!')
+    else:
+      print(f'niet zo mooi')""")
+
+    self.multi_level_tester(max_level=7, code=code, expected=expected)
+
+  def test_if_else_followed_by_print(self):
+    code = textwrap.dedent("""\
+    kleur is geel
+    if kleur is groen antwoord is ok else antwoord is stom
+    print antwoord""")
+
+    expected = textwrap.dedent("""\
+    kleur = 'geel'
+    if str(kleur) == str('groen'):
+      antwoord = 'ok'
+    else:
+      antwoord = 'stom'
+    print(f'{antwoord}')""")
+
+    self.multi_level_tester(max_level=7, code=code, expected=expected)
+
+  def test_if_equality_assign_else_assign(self):
+    code = textwrap.dedent("""\
+    cmp is 1
+    test is 2
+    acu is 0
+    if test is cmp
+    acu is acu + 1
+    else
+    acu is acu + 5""")
+
+    expected = textwrap.dedent("""\
+    cmp = '1'
+    test = '2'
+    acu = '0'
+    if str(test) == str(cmp):
+      acu = int(acu) + int(1)
+    else:
+      acu = int(acu) + int(5)""")
+
+    self.multi_level_tester(
+      max_level=7,
+      code=code,
+      expected=expected
+    )
+
+  # Legal syntax:
+  #
+  # if name is Hedy print 'hello'
+  # if name is 'Hedy' print 'hello'
+  # if name is 'Hedy is het beste' print 'hello'
+  # if name is Hedy c is 5
+
+  # Illegal syntax:
+  #
+  # if name is Hedy is het beste print 'hello'
+  # if name is Hedy is het beste x is 5
+
+  def test_if_equality_print_linebreak_else_print(self):
+    # line break before else is allowed
+    code = textwrap.dedent("""\
+    naam is Hedy
     if naam is Hedy print 'leuk'
     else print 'minder leuk'""")
 
     expected = textwrap.dedent("""\
     naam = 'Hedy'
-    print(f'ik heet{naam}')
     if str(naam) == str('Hedy'):
       print(f'leuk')
     else:
@@ -115,110 +351,107 @@ class TestsLevel6(HedyTester):
       max_level=7,
       code=code,
       expected=expected,
-      expected_commands=['is', 'print', 'else', 'print', 'print']
+      expected_commands=['is', 'else', 'print', 'print']
     )
-  def test_print_if_else_with_line_break_and_space(self):
-    # line breaks should be allowed in if-elses until level 7 when we start with indentation
 
+  def test_if_equality_linebreak_print_else_print(self):
+    # line break after if-condition is allowed
     code = textwrap.dedent("""\
     naam is Hedy
-    print 'ik heet' naam
-    if naam is Hedy print 'leuk'
+    if naam is Hedy
+    print 'leuk' else print 'minder leuk'""")
+
+    expected = textwrap.dedent("""\
+    naam = 'Hedy'
+    if str(naam) == str('Hedy'):
+      print(f'leuk')
+    else:
+      print(f'minder leuk')""")
+
+    self.multi_level_tester(max_level=7, code=code, expected=expected)
+
+  def test_if_equality_print_else_linebreak_print(self):
+    # line break after else is allowed
+    code = textwrap.dedent("""\
+    naam is Hedy
+    if naam is Hedy print 'leuk' else
+    print 'minder leuk'""")
+
+    expected = textwrap.dedent("""\
+    naam = 'Hedy'
+    if str(naam) == str('Hedy'):
+      print(f'leuk')
+    else:
+      print(f'minder leuk')""")
+
+    self.multi_level_tester(max_level=7, code=code, expected=expected)
+
+  def test_if_equality_linebreak_print_linebreak_else_print(self):
+    # line breaks after if-condition and before else are allowed
+    code = textwrap.dedent("""\
+    naam is Hedy
+    if naam is Hedy
+    print 'leuk'
     else print 'minder leuk'""")
 
     expected = textwrap.dedent("""\
     naam = 'Hedy'
-    print(f'ik heet{naam}')
     if str(naam) == str('Hedy'):
       print(f'leuk')
     else:
       print(f'minder leuk')""")
 
-    self.multi_level_tester(
-      max_level=6,
-      code=code,
-      expected=expected
-    )
-  def test_if_else_with_space(self):
-    code = textwrap.dedent("""\
-    a is 2
-    if a is 1 print a
-    else print 'nee'""")
+    self.multi_level_tester(max_level=7, code=code, expected=expected)
 
-    expected = textwrap.dedent("""\
-    a = '2'
-    if str(a) == str('1'):
-      print(f'{a}')
-    else:
-      print(f'nee')""")
-
-    self.multi_level_tester(
-      max_level=6,
-      code=code,
-      expected=expected
-    )
-  def test_print_if_else_with_is(self):
+  def test_if_equality_linebreak_print_linebreak_else_linebreak_print(self):
+    # line breaks after if-condition, before else and after else are allowed
     code = textwrap.dedent("""\
     naam is Hedy
-    print 'ik heet' naam
-    if naam is Hedy print 'leuk' else print 'minder leuk'""")
+    if naam is Hedy
+    print 'leuk'
+    else
+    print 'minder leuk'""")
 
     expected = textwrap.dedent("""\
     naam = 'Hedy'
-    print(f'ik heet{naam}')
     if str(naam) == str('Hedy'):
       print(f'leuk')
     else:
       print(f'minder leuk')""")
 
-    self.multi_level_tester(
-      code=code,
-      expected=expected,
-      max_level=7)
+    self.multi_level_tester(max_level=7, code=code, expected=expected)
 
-  def test_print_if_else_with_equals_sign(self):
+  def test_if_equality_linebreak_print_else_linebreak_print(self):
+    # line breaks after if-condition and after else are allowed
     code = textwrap.dedent("""\
     naam is Hedy
-    print 'ik heet' naam
-    if naam = Hedy print 'leuk' else print 'minder leuk'""")
+    if naam is Hedy
+    print 'leuk' else
+    print 'minder leuk'""")
 
     expected = textwrap.dedent("""\
     naam = 'Hedy'
-    print(f'ik heet{naam}')
     if str(naam) == str('Hedy'):
       print(f'leuk')
     else:
       print(f'minder leuk')""")
 
-    self.multi_level_tester(
-      code=code,
-      expected=expected,
-      max_level=7
-    )
+    self.multi_level_tester(max_level=7, code=code, expected=expected)
 
-  def test_equality_single_quoted_rhs_with_inner_double_quote(self):
+  @parameterized.expand(HedyTester.quotes)
+  def test_if_equality_quoted_rhs_with_space_else(self, q):
     code = textwrap.dedent(f"""\
-      answer is no
-      if answer is 'He said "no"' print 'no'""")
+      naam is James
+      if naam is {q}James Bond{q} print {q}shaken{q} else print {q}biertje!{q}""")
 
     expected = textwrap.dedent(f"""\
-      answer = 'no'
-      if str(answer) == str('He said "no"'):
-        print(f'no')""")
+      naam = 'James'
+      if str(naam) == str('James Bond'):
+        print(f'shaken')
+      else:
+        print(f'biertje!')""")
 
-    self.multi_level_tester(code=code, expected=expected, max_level=7)
-
-  def test_equality_double_quoted_rhs_with_inner_single_quote(self):
-    code = textwrap.dedent(f"""\
-      answer is no
-      if answer is "He said 'no'" print 'no'""")
-
-    expected = textwrap.dedent(f"""\
-      answer = 'no'
-      if str(answer) == str('He said \\'no\\''):
-        print(f'no')""")
-
-    self.multi_level_tester(code=code, expected=expected, max_level=7)
+    self.multi_level_tester(max_level=7, code=code, expected=expected)
 
   # calculation tests
   # todo should all be tested for higher levels too!
@@ -437,199 +670,43 @@ class TestsLevel6(HedyTester):
 
       self.single_level_tester(code=code, expected=expected)
 
-  def test_ifelse_should_go_before_assign(self):
+  def test_consecutive_if_statements(self):
     code = textwrap.dedent("""\
-    kleur is geel
-    if kleur is groen antwoord is ok else antwoord is stom
-    print antwoord""")
+    names is Hedy, Lamar
+    name is ask 'What is a name you like?'
+    if name is Hedy print 'nice!'
+    if name in names print 'nice!'""")
+
     expected = textwrap.dedent("""\
-    kleur = 'geel'
-    if str(kleur) == str('groen'):
-      antwoord = 'ok'
+    names = ['Hedy', 'Lamar']
+    name = input(f'What is a name you like?')
+    if str(name) == str('Hedy'):
+      print(f'nice!')
+    if name in names:
+      print(f'nice!')""")
+
+    self.multi_level_tester(max_level=7, code=code, expected=expected)
+
+  def test_consecutive_if_else_statements(self):
+    code = textwrap.dedent("""\
+    names is Hedy, Lamar
+    name is ask 'What is a name you like?'
+    if name is Hedy print 'nice!' else print 'meh'
+    if name in names print 'nice!' else print 'meh'""")
+
+    expected = textwrap.dedent("""\
+    names = ['Hedy', 'Lamar']
+    name = input(f'What is a name you like?')
+    if str(name) == str('Hedy'):
+      print(f'nice!')
     else:
-      antwoord = 'stom'
-    print(f'{antwoord}')""")
-
-    self.multi_level_tester(
-      max_level=6,
-      code=code,
-      expected=expected
-    )
-  def test_ifelse_calc_vars(self):
-    code = textwrap.dedent("""\
-    cmp is 1
-    test is 2
-    acu is 0
-    if test is cmp
-    acu is acu + 1
-    else acu is acu + 5""")
-    # @TODO: Felienne, if the above line starts with "else\nacu", then the test fails intermittently due to ambiguity
-    expected = textwrap.dedent("""\
-    cmp = '1'
-    test = '2'
-    acu = '0'
-    if str(test) == str(cmp):
-      acu = int(acu) + int(1)
+      print(f'meh')
+    if name in names:
+      print(f'nice!')
     else:
-      acu = int(acu) + int(5)""")
-    self.multi_level_tester(
-      max_level=6,
-      code=code,
-      expected=expected
-    )
+      print(f'meh')""")
 
-  def test_if_calc_vars(self):
-    code =  textwrap.dedent("""\
-    cmp is 1
-    test is 2
-    acu is 0
-    if test is cmp acu is acu + 1""")
-    expected = textwrap.dedent("""\
-    cmp = '1'
-    test = '2'
-    acu = '0'
-    if str(test) == str(cmp):
-      acu = int(acu) + int(1)""")
-    self.single_level_tester(
-      code=code,
-      expected=expected
-    )
-
-  # So legal are:
-  #
-  # if name is Hedy print 'hello'
-  # if name is 'Hedy' print 'hello'
-  # if name is 'Hedy is het beste' print 'hello'
-  # if name is Hedy c is 5
-
-  # Illegal is:
-  #
-  # if name is Hedy is het beste print 'hello'
-  # if name is Hedy is het beste x is 5
-
-  def test_equality_promotes_int_to_string(self):
-    code = textwrap.dedent("""\
-    a is test
-    b is 15
-    if a is b c is 1""")
-    expected = textwrap.dedent("""\
-    a = 'test'
-    b = '15'
-    if str(a) == str(b):
-      c = '1'""")
-    self.multi_level_tester(
-      max_level=7,
-      code=code,
-      expected=expected
-    )
-
-  def test_one_space_in_rhs_if(self):
-    code = textwrap.dedent("""\
-    naam is James
-    if naam is 'James Bond' print 'shaken'""")
-
-    expected = textwrap.dedent("""\
-    naam = 'James'
-    if str(naam) == str('James Bond'):
-      print(f'shaken')""")
-
-    self.multi_level_tester(
-      code=code,
-      expected=expected,
-      max_level=7)
-
-  def test_no_space_nor_quotes_in_rhs(self):
-    code = textwrap.dedent("""\
-    warna = ask 'Apa warna favorit kamu?'
-    if warna is hijau print 'cantik!' else print 'meh!'""")
-
-    expected = textwrap.dedent("""\
-    warna = input(f'Apa warna favorit kamu?')
-    if str(warna) == str('hijau'):
-      print(f'cantik!')
-    else:
-      print(f'meh!')""")
-
-    self.multi_level_tester(
-      code=code,
-      expected=expected,
-      max_level=7)
-
-  def test_one_space_in_rhs_if_else(self):
-    code = textwrap.dedent("""\
-    naam is James
-    if naam is 'James Bond' print 'shaken' else print 'biertje!'""")
-
-    expected = textwrap.dedent("""\
-    naam = 'James'
-    if str(naam) == str('James Bond'):
-      print(f'shaken')
-    else:
-      print(f'biertje!')""")
-
-    self.multi_level_tester(
-      code=code,
-      expected=expected,
-      max_level=7)
-
-  @parameterized.expand(HedyTester.quotes)
-  def test_quoted_space_rhs(self, q):
-    code = textwrap.dedent(f"""\
-    naam is James
-    if naam is {q}James Bond{q} print {q}shaken{q} else print {q}biertje!{q}""")
-
-    expected = textwrap.dedent(f"""\
-    naam = 'James'
-    if str(naam) == str('James Bond'):
-      print(f'shaken')
-    else:
-      print(f'biertje!')""")
-    self.single_level_tester(
-      code=code,
-      expected=expected)
-
-
-  def test_space_enter_rhs_ifelse(self):
-    code = textwrap.dedent("""\
-    naam is James
-    if naam is James Bond
-    print 'shaken' else print 'biertje!'""")
-
-    expected = textwrap.dedent("""\
-    naam = 'James'
-    if naam == 'James Bond':
-      print(f'shaken')
-    else:
-      print(f'biertje!')""")
-
-    self.single_level_tester(
-      code=code,
-      expected=expected)
-
-  def test_space_enter_rhs_if(self):
-    code = textwrap.dedent("""\
-    naam is James
-    if naam is James Bond print 'shaken'""")
-
-    self.single_level_tester(
-      code=code,
-      exception=hedy.exceptions.UnquotedEqualityCheck)
-
-
-  def test_multiple_spaces_in_rhs_if(self):
-    code = textwrap.dedent("""\
-    naam is James
-    if naam is 'Bond James Bond' print 'shaken'""")
-
-    expected = textwrap.dedent("""\
-    naam = 'James'
-    if str(naam) == str('Bond James Bond'):
-      print(f'shaken')""")
-
-    self.multi_level_tester(
-      code=code,
-      expected=expected,
-      max_level=7)
+    self.multi_level_tester(max_level=6, code=code, expected=expected)
 
   def test_calc_chained_vars(self):
     code = textwrap.dedent("""\


### PR DESCRIPTION
**Please fill out this template by replacing all content between < >**

< Remove grammar ambiguity with consecutive if-statements at levels 5-7; Refactor tests for if and if-else statements >

**Description**

< Remove grammar ambiguity with consecutive if-statements at levels 5-7; Refactor tests for if and if-else statements > Use present tense without a subject to describe your PR, for example: "Adds translations of levels 1 to 12 to Polish"

**Fixes < #2471  >**

< Always link the number of the issue or of the discussion that your pr concerns. >
Notable exception: adding content may be done without an accompanying issue 

**How to test**

< All changes are covered with tests. The tests are refactored, so that the same test has the same name across multiple levels. Examine the tests and whether they define the expected behaviour.  >

**Checklist**
Done? Check if you have it all in place using this list*
  
- [ ] Describes changes in the format above (present tense)
- [ ] Links to an existing issue or discussion 
- [ ] Has a "How to test" section

* If you're unsure about any of these, don't hesitate to ask. We're here to help!
