### PR TITLE
[REVERSE FIX] Removes double Dynamo index key dependency

### DIFF
--- a/website/database.py
+++ b/website/database.py
@@ -9,7 +9,7 @@ storage = dynamo.AwsDynamoStorage.from_env() or dynamo.MemoryStorage('dev_databa
 
 USERS = dynamo.Table(storage, 'users', 'username', indexed_fields=[dynamo.IndexKey('email')])
 TOKENS = dynamo.Table(storage, 'tokens', 'id', indexed_fields=[dynamo.IndexKey(v) for v in ['id', 'username']])
-PROGRAMS = dynamo.Table(storage, 'programs', 'id', indexed_fields=[dynamo.IndexKey(v) for v in ['username', 'level', 'public']])
+PROGRAMS = dynamo.Table(storage, 'programs', 'id', indexed_fields=[dynamo.IndexKey(v) for v in ['username', 'public']])
 CLASSES = dynamo.Table(storage, 'classes', 'id', indexed_fields=[dynamo.IndexKey(v) for v in ['teacher', 'link']])
 ADVENTURES = dynamo.Table(storage, 'adventures', 'id', indexed_fields=[dynamo.IndexKey('creator')])
 INVITATIONS = dynamo.Table(storage, 'class_invitations', partition_key='username', indexed_fields=[dynamo.IndexKey('class_id')])
@@ -93,7 +93,8 @@ class Database:
 
         Returns: [{ code, name, program, level, adventure_name, date }]
         """
-        return PROGRAMS.get_many({'username': username, 'level': level}, reverse=True)
+        programs = PROGRAMS.get_many({'username': username}, reverse=True)
+        return [x for x in programs if x.get('level') == int(level)]
 
     def programs_for_user(self, username):
         """List programs for the given user, newest first.


### PR DESCRIPTION
**Description**
In this PR we reverse a fix made in #2479 that depends on two index keys and a sort key to automatically retrieve all user programs for a specific level. This works fine with the local database, but does seem impossible to work around with the actual Dynamo db. Therefore we reverse this and use a list comprehension to filter the correct programs.

**Fixes**
No related issue.

**How to test**
Locally everything should work exactly the same. Verify that on alpha the `/hedy` page is working again after merging this PR.