### PR TITLE
Fix incorrect parsing of ask in level 6 #2497

### DIFF
--- a/grammars/level6-Additions.lark
+++ b/grammars/level6-Additions.lark
@@ -1,8 +1,9 @@
 _print_argument: (_SPACE | quoted_text | list_access | print_expression)*
 ?print_expression: INT | var_access | error_unsupported_number | expression
 
-command:+= ask | list_access_var | assign -= ask | list_access | list_access_var | assign
-_if_less_command:+= ask | list_access_var | assign -= ask | list_access | list_access_var | assign
+// redefining it entirely since it has many order-depending rules
+command: print | turtle | add | remove | sleep | error_print_no_quotes | ifelse | ifs | ask | list_access_var | assign | assign_list
+_if_less_command: print | turtle | add | remove | sleep | error_print_no_quotes | ask | list_access_var | assign | assign_list
 
 //splitting  these commands into two rules, one for equals and one for is so they can be properly handled in the translator
 ask: var (_IS | _EQUALS) _ASK (_print_argument)?

--- a/tests/test_level/test_level_06.py
+++ b/tests/test_level/test_level_06.py
@@ -94,6 +94,21 @@ class TestsLevel6(HedyTester):
 
     self.single_level_tester(code=code, expected=expected)
 
+  def test_ask_comma(self):
+    code = textwrap.dedent("""\
+    name = Hedy
+    mood = ask 'Hey, ' name '! How are you, ' name '?'""")
+
+    expected = textwrap.dedent("""\
+    name = 'Hedy'
+    mood = input(f'Hey, {name}! How are you, {name}?')""")
+
+    self.multi_level_tester(
+      code=code,
+      max_level=11,
+      expected=expected
+    )
+
   #
   # if tests
   #


### PR DESCRIPTION
Fix incorrect parsing of ask in level 6

**Description**

In the grammar level 6 creating lists had priority over the ask command. As a result, an ask statement with quoted commas would be parsed as a list assignment instead.

**Fixes #2497**

**How to test**

Run Hedy locally, go to level 6 and run the following code:
```
naam is Hedy
gang is something
eten is ask naam ', Wat wil jij bestellen als ' gang '?'
print eten
```
Ensure there are no errors and that the ask statement actually asks you for input that is printed afterwards.

**Checklist**
Done? Check if you have it all in place using this list:*
  
- [X] Describes changes in the format above (present tense)
- [X] Links to an existing issue or discussion 
- [X] Has a "How to test" section

If you're unsure about any of these, don't hesitate to ask. We're here to help!
