### PR TITLE
[BUG FIX] Fixes faulty link creation for password reset

### DIFF
--- a/translations/nl/LC_MESSAGES/messages.po
+++ b/translations/nl/LC_MESSAGES/messages.po
@@ -1677,11 +1677,11 @@ msgstr "Jouw Hedy wachtwoord is veranderd"
 
 #: website/auth.py:770
 msgid "mail_recover_password_subject"
-msgstr "Jouw Hedy wachtwood is ge-reset"
+msgstr "Reset jouw Hedy wachtwoord"
 
 #: website/auth.py:772
 msgid "mail_reset_password_subject"
-msgstr "Reset jouw Hedy wachtwoord"
+msgstr "Jouw Hedy wachtwood is ge-reset"
 
 #: website/auth.py:774
 msgid "mail_welcome_teacher_subject"

--- a/website/auth.py
+++ b/website/auth.py
@@ -226,6 +226,12 @@ def store_new_account(account, email):
     return user, resp
 
 
+def create_recover_link(username, token):
+    email = email_base_url() + '/reset?username='
+    email += urllib.parse.quote_plus(username) + '&token=' + urllib.parse.quote_plus(token)
+    return email
+
+
 def create_verify_link(username, token):
     email = email_base_url() + '/auth/verify?username='
     email += urllib.parse.quote_plus(username) + '&token=' + urllib.parse.quote_plus(token)
@@ -609,7 +615,7 @@ def routes(app, database):
             return jsonify({'username': user['username'], 'token': token}), 200
         else:
             send_email_template(template='recover_password', email=user['email'],
-                                link=create_verify_link(user['username'], token), username=user['username'])
+                                link=create_recover_link(user['username'], token), username=user['username'])
             return jsonify({'message':gettext('sent_password_recovery')}), 200
 
     @app.route('/auth/reset', methods=['POST'])


### PR DESCRIPTION
**Description**
In this PR we fix the password reset where an invalid link was created as well as an invalid mail template. This might be introduced due to the mail template clean-up, but should work again. We should merge this to Alpha with some priority to verify that it is all working as well as currently users that forgot their password are stuck.

**Fixes**
This PR fixes #2574

**How to test**
Merge to Alpha and test the password reset. The mail template (in Dutch) should be current again with a valid link.
