### PR TITLE
[TESTS] Catches keyErrors when testing snippets

### DIFF
--- a/tests/test_snippets/test_adventures.py
+++ b/tests/test_snippets/test_adventures.py
@@ -60,7 +60,11 @@ Hedy_snippets = [(s.name, s) for s in collect_snippets(path='../../content/adven
 # We replace the code snippet placeholders with actual keywords to the code is valid: {print} -> print
 keywords = YamlFile.for_file('../../content/keywords/en.yaml').to_dict()
 for snippet in Hedy_snippets:
-    snippet[1].code = snippet[1].code.format(**keywords)
+    try:
+        snippet[1].code = snippet[1].code.format(**keywords)
+    except KeyError:
+        print("This following snippet contains an invalid placeholder ...")
+        print(snippet)
 
 class TestsAdventurePrograms(unittest.TestCase):
 

--- a/tests/test_snippets/test_level_commands.py
+++ b/tests/test_snippets/test_level_commands.py
@@ -48,7 +48,11 @@ if lang:
 # We replace the code snippet placeholders with actual keywords to the code is valid: {print} -> print
 keywords = YamlFile.for_file('../../content/keywords/en.yaml').to_dict()
 for snippet in Hedy_snippets:
-    snippet[1].code = snippet[1].code.format(**keywords)
+    try:
+        snippet[1].code = snippet[1].code.format(**keywords)
+    except KeyError:
+        print("This following snippet contains an invalid placeholder ...")
+        print(snippet)
 
 
 class TestsCommandPrograms(unittest.TestCase):


### PR DESCRIPTION
**Description**
In this PR we add a `try/except` block around the snippet parsing to catch possible faulty placeholders. This way the testing will no longer crash but instead show a nice error of the faulty placeholder. 

**Note**: The tests will no longer crash, but we do have to fix the placeholder!

**Fixes**
This PR fixes #2584.

**How to test**
Github does the testing, no fails? No problem!