### PR TITLE
[REVERSE FIX] Enables fuzzy compiling of Babel again

### DIFF
--- a/build-tools/heroku/on-deploy.sh
+++ b/build-tools/heroku/on-deploy.sh
@@ -30,4 +30,4 @@ echo '-----> Compiling TypeScript'
 echo '-----> Compiling Babel translations'
 cd ..
 cd ..
-pybabel compile -d translations
+pybabel compile -f -d translations


### PR DESCRIPTION
**Description**
Removing the fuzzy compiling of Babel results in some languages not being compiled at all. This is unexpected and undesirable behavior. We reverse this change in this PR.