### PR TITLE
[BUG FIX] Common mistakes on nl/en for-teachers is working again

### DIFF
--- a/content/pages/en.yaml
+++ b/content/pages/en.yaml
@@ -85,7 +85,7 @@ sections:
             How did they learn from their mistakes? And of course: What did they create?
             Students are often very proud of their own creations, so it's nice to save a little time and gove your students the opportunity to show their work to their classmates.
 -   title: "Frequently made mistakes"
-    key: Common mistakes
+    key: "common_mistakes"
     intro: |
         You can learn from your mistakes, especially in coding!
         Making mistakes is unavoidable, and a great opportunity to learn, but for teachers it can be a challenge to find the correct fix for a mistake!

--- a/content/pages/nl.yaml
+++ b/content/pages/nl.yaml
@@ -87,7 +87,7 @@ sections:
             Om te testen of uw leerlingen de nieuwe concepten en commando's volledig begrepen hebben, kunt u de leerlingen de quiz laten invullen.
             Dit zijn 10 multiple-choice vragen over de leerstof van het desbetreffende level.
 -   title: "Veelgemaakte fouten"
-    key: Veel gemaakte fouten
+    key: "common_mistakes"
     intro: |
         Van fouten kun je leren en dat geldt al helemaal bij programmeren!
         Fouten maken is onvermijdelijk en helemaal niet erg, maar het kan als leerkracht soms nog knap lastig zijn om foutjes van leerlingen op te sporen en op te lossen.


### PR DESCRIPTION
**Description**
In this PR we fix the common mistakes section on the for-teachers Hedy documentation. This was broken due to a translated key that shouldn't have been translated. This is the second time this happened so we might want to dive into re-structuring the YAMLs to prevent these types of errors.

**Fixes**
This PR fixes #2677

**How to test**
Make sure you are a teacher and your profile is set to either English or Dutch. Verify that the common mistakes section is working on the for-teachers page.
