### PR TITLE
[IMPROVEMENT] Redirects user to login when trying to visit /tutorial

### DIFF
--- a/app.py
+++ b/app.py
@@ -741,8 +741,9 @@ def get_user_formatted_age(now, date):
 
 
 @app.route('/tutorial', methods=['GET'])
-@requires_login
-def tutorial_index(user):
+def tutorial_index():
+    if not current_user()['username']:
+        return redirect('/login')
     level = 1
     commands = COMMANDS[g.lang].get_commands_for_level(level, g.keyword_lang)
     adventures = load_adventures_per_level(level)


### PR DESCRIPTION
**Description**
In this PR we improve the error handling when a non-logged in user tries to start the tutorial. Instead of the currently empty error page that is returned we redirect the user to the login page.

**Fixes**
This PR fixes #2791

**How to test**
Make sure you are not logged in and visit the `/tutorial` page. Verify that you are being re-directed to the login page.
