### PR TITLE
[BUG] Skip numerical values in check_var_usage

### DIFF
--- a/hedy.py
+++ b/hedy.py
@@ -1099,7 +1099,12 @@ class ConvertToPython(Transformer):
         # this function checks whether arguments are valid
         # we can proceed if all arguments are either quoted OR all variables
 
-        args_to_process = [a for a in args if not isinstance(a, Tree)]#we do not check trees (calcs) they are always ok
+        def is_var_candidate(arg) -> bool:
+            return not isinstance(arg, Tree) and \
+                    not ConvertToPython.is_int(arg) and \
+                    not ConvertToPython.is_float(arg)
+
+        args_to_process = [a for a in args if is_var_candidate(a)]#we do not check trees (calcs) they are always ok
 
         unquoted_args = [a for a in args_to_process if not ConvertToPython.is_quoted(a)]
         unquoted_in_lookup = [self.is_variable(a) for a in unquoted_args]

--- a/tests/test_level/test_level_06.py
+++ b/tests/test_level/test_level_06.py
@@ -787,3 +787,12 @@ class TestsLevel6(HedyTester):
           print(f'meh')""")
 
         self.multi_level_tester(max_level=7, code=code, expected=expected)
+
+    def test_print_single_number(self):
+        code = textwrap.dedent("""\
+                print 5""")
+
+        expected = textwrap.dedent("""\
+                print(f'5')""")
+
+        self.multi_level_tester(max_level=6, code=code, expected=expected)


### PR DESCRIPTION
Level 6 was failing to print single digits in a print statement due to
the fact that check_var_usage was considering numerical strings as
candidates for variables.

This commit will also filter out numerical values from the arguments to
be processed for print statements.

Fixes #2794

**How to test**

Print a single digit in level 6.
