### PR TITLE
Adds Discord link to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Other project boards are student projects that keep track of their own issues, t
 
 **Discord**
 
-We also run a Discord channel to enable contributors to get in touch with us, ask any questions and show off awesome Hedy related content. It is a great way for you as a contributor to stay connected and up-to-date with the Hedy project. Feel free to join the channel to get in touch with us! You can join the channel through [this](https://discord.gg/8yY7dEme9r) Discord link.
+We also run a Discord channel to enable users and contributors to get in touch with us, ask any questions and show off awesome Hedy related content. It is a great way for you as a contributor to stay connected and up-to-date with the Hedy project. Feel free to join the channel to get in touch with us! You can join the channel through [this](https://discord.gg/8yY7dEme9r) Discord link.
 
 **Discussions**
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,10 @@ The core team (currently consisting of [Felienne](https://github.com/Felienne), 
 
 Other project boards are student projects that keep track of their own issues, these are typically not open for contributors to work on since we want the students to do their own projects :)
 
+**Discord**
+
+We also run a Discord channel to enable contributors to get in touch with us, ask any questions and show off awesome Hedy related content. It is a great way for you as a contributor to stay connected and up-to-date with the Hedy project. Feel free to join the channel to get in touch with us! You can join the channel through [this](https://discord.gg/8yY7dEme9r) Discord link.
+
 **Discussions**
 
 The [Discussion board](https://github.com/Felienne/hedy/discussions) has ideas that are not yet detailed enough to be put into issue, like big new features or overhuals of the language or architecture. If you are interested in picking up such a large feature do [let us know](mailto:hedy@felienne.com) and read the corresponding discussion to see what has alrady been considered.

--- a/TRANSLATING.md
+++ b/TRANSLATING.md
@@ -59,7 +59,7 @@ One important thing to notice is the **grayed pieces of tekst**. This is compute
 
 
 
-That's all for now, any problems, let us know so we can address them here for future translators. You can reach us at [hedy@felienne.com](mailto:hedy@felienne.com). Or you can join our [Slack channel](https://join.slack.com/share/enQtMzUxNzkyNzUxMTAxMy1hYzA1NzRkODU2M2Y1YjliZThjODgyZTQwZGMyMThmYmVlYTcyMjAxNTUyYmYxODdjZjBkOWJkYjQwNGYyMzFl?cdn_fallback=1)
+If you run into any problems, let us know, so we can address them here for future translators. You can reach us at [hedy@felienne.com](mailto:hedy@felienne.com), or you can join our [Discord #translators channel](https://discord.gg/aQqDWFbk)
 
 Fixing Weblate issues
 ================


### PR DESCRIPTION
**Description**
We add the newly created Discord channel link to `CONTRIBUTING.md` to enable external contributors to get in touch with us.

**Fixes**
No related issue.

**How to test**
Nothing to test.