### PR TITLE
[BUG FIX] Keywords are always correctly localized on /explore page

### DIFF
--- a/app.py
+++ b/app.py
@@ -885,10 +885,14 @@ def view_program(id):
     result['public_profile'] = True if DATABASE.get_public_profile_settings(
         result['username']) else None
 
-    # If the language doesn't match the user -> parse the keywords
-    if result.get("lang", "en") not in [g.lang, "en"] and g.lang in ALL_KEYWORD_LANGUAGES:
-        result['code'] = hedy_translation.translate_keywords(result.get(
-            'code'), result.get('lang', 'en'), g.lang, level=int(result.get('level', 1)))
+    code = result['code']
+    if result.get("lang") != "en" and result.get("lang") in ALL_KEYWORD_LANGUAGES.keys():
+        code = hedy_translation.translate_keywords(code, from_lang=result.get('lang'), to_lang="en", level=int(result.get('level', 1)))
+    # If the keyword language is non-English -> parse again to guarantee completely localized keywords
+    if g.keyword_lang != "en":
+        code = hedy_translation.translate_keywords(code, from_lang="en", to_lang=g.keyword_lang, level=int(result.get('level', 1)))
+
+    result['code'] = code
 
     arguments_dict = {}
     arguments_dict['program_id'] = id


### PR DESCRIPTION
**Description**
In this PR we fix an issue where not all keywords where correctly localized on the `/explore` page. This was due to some programs being partly with English and partly with non-english keywords. As we only parsed the code once to the set user keyword language this introduced bugs. We fix this by parsing twice if the user set keyword language is non-english. First to English, then to the selected user language. This is the only way we can guarantee that all keywords are translated, see the following example:

A dutch user might create a program containing both dutch and English keywords. In the original situation we didn't parse the program if our profile was also set to dutch. As the program language is the same as our keyword language. So, the following program would be shown identical on the explore page:
```
vraag Hoe gaat het?
sleep 2
echo Dus het gaat 
```
However, the second line contains and English keyword. To prevent this issue we **always** parse for any non-english language like this: `original program -> English -> User keyword language`. Using this double parsing the loaded program will be shown as follows:
```
vraag Hoe gaat het?
slaap 2
echo Dus het gaat 
```

**Fixes**
This PR fixes #2769.

**How to test**
Verify that all programs are correctly shown in your set keyword language on the `/explore` page. Independent of the original keyword language and language of the program it should always be shown correctly.