### PR TITLE
[BUG FIX] Fixes quiz lvl 6 question 2

### DIFF
--- a/templates/quiz/feedback.html
+++ b/templates/quiz/feedback.html
@@ -41,7 +41,7 @@
                             <pre class="no-copy-button" level="{{ level_source }}">{{correct_option.option|commonmark}}</pre>
                         </div>
                     {% else %}
-                        <div class="pt-8 px-2 mx-auto mb-2 text-lg">{{ correct_option.option }}</div>
+                        <div class="pt-8 px-2 mx-auto mb-2 text-lg">{% if correct_option|length < 2 %}{{ correct_option.option }}{% else %}{{ correct_option.option|commonmark }}{% endif %}</div>
                     {% endif %}
                 </div>
             </div>

--- a/templates/quiz/feedback.html
+++ b/templates/quiz/feedback.html
@@ -41,7 +41,7 @@
                             <pre class="no-copy-button" level="{{ level_source }}">{{correct_option.option|commonmark}}</pre>
                         </div>
                     {% else %}
-                        <div class="pt-8 px-2 mx-auto mb-2 text-lg">{% if correct_option|length < 2 %}{{ correct_option.option }}{% else %}{{ correct_option.option|commonmark }}{% endif %}</div>
+                        <div class="pt-8 px-2 mx-auto mb-2 text-lg">{% if correct_option.option|length < 2 %}{{ correct_option.option }}{% else %}{{ correct_option.option|commonmark }}{% endif %}</div>
                     {% endif %}
                 </div>
             </div>

--- a/templates/quiz/feedback.html
+++ b/templates/quiz/feedback.html
@@ -41,7 +41,7 @@
                             <pre class="no-copy-button" level="{{ level_source }}">{{correct_option.option|commonmark}}</pre>
                         </div>
                     {% else %}
-                        <div class="pt-8 px-2 mx-auto mb-2 text-lg">{{ correct_option.option|commonmark }}</div>
+                        <div class="pt-8 px-2 mx-auto mb-2 text-lg">{{ correct_option.option }}</div>
                     {% endif %}
                 </div>
             </div>

--- a/templates/quiz/quiz_question.html
+++ b/templates/quiz/quiz_question.html
@@ -54,7 +54,7 @@
                                     <pre class="no-copy-button" level="{{ level_source }}">{{question_options[counter.value].option|commonmark}}</pre>
                                 </div>
                             {% else %}
-                                <div class="pt-8 px-2 mx-2 mb-2 text-lg">{{ question_options[counter.value].option|commonmark }}</div>
+                                <div class="pt-8 px-2 mx-2 mb-2 text-lg">{{ question_options[counter.value].option }}</div>
                             {% endif %}
                         </div>
                         <button class="submit-button" type="submit" name="submit-button" value="{{ question_options[counter.value].char_index }}">

--- a/templates/quiz/quiz_question.html
+++ b/templates/quiz/quiz_question.html
@@ -54,7 +54,9 @@
                                     <pre class="no-copy-button" level="{{ level_source }}">{{question_options[counter.value].option|commonmark}}</pre>
                                 </div>
                             {% else %}
-                                <div class="pt-8 px-2 mx-2 mb-2 text-lg">{{ question_options[counter.value].option }}</div>
+                                <!-- Not a really nice solution but if the option is only one char it might be a mathematical operation like "+"
+                                    When using common mark this is replaced in HTML by a empty black dot marker, so we make a bucket fix -->
+                                <div class="pt-8 px-2 mx-2 mb-2 text-lg">{% if question_options[counter.value].option|length < 2  %}{{ question_options[counter.value].option }}{% else %}{{ question_options[counter.value].option|commonmark }}{% endif %}</div>
                             {% endif %}
                         </div>
                         <button class="submit-button" type="submit" name="submit-button" value="{{ question_options[counter.value].char_index }}">

--- a/website/quiz.py
+++ b/website/quiz.py
@@ -96,6 +96,7 @@ def routes(app, database, achievements, quizzes):
 
         quiz_answers = DATABASE.get_quiz_answer(username, level_source, session['quiz-attempt-id'])
 
+        print(question)
         # Todo TB -> We have to do some magic here to format() the keywords into the quiz
 
         return render_template('quiz/quiz_question.html',


### PR DESCRIPTION
**Description**
Question 2 of level 6 of the quiz contained some one character answers. Due to using the `|commonmark` parser on the front-end the options are parsed into HTML from the Markdown format. However, for some reason single mathematical symbols are in this case replaced by a black dot marker. To prevent this we create a bit of a bucket-workaround-fix, if and only if the option is only one character: don't use common mark but show as plain text instead. This solves our bug.

**Fixes**
This PR fixes #2807.

**How to test**
Navigate to level 6 -> quiz -> question 2. Verify that the mathematical symbols are shown as expected.