### PR TITLE
Adds explanation on localhost

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,7 @@ If you want to run the website version locally, run:
 ```bash
 (.env)$ python app.py
 ```
+Your local Hedy version should be available on address `http://0.0.0.0:8080/`. It appears that on some Windows machines this address does not work, make sure the server is still running and try visiting the website on `http://localhost:8080/`.
 
 To run the unit tests:
 


### PR DESCRIPTION
**Description**
In this PR we update `CONTRIBUTING.md` to add an explanation to use localhost in the case that 0.0.0.0 is not working as address. The cause is unknown, but this bug seems to appear on several Windows machines.

**Fixes**
This PR fixes #2815.

**How to test**
Nothing to test, verify that CONTRIBUTING.md is updated.
