### PR TITLE
[BUG FIX] Tutorial works again and improve e2e tests

### DIFF
--- a/templates/quiz.html
+++ b/templates/quiz.html
@@ -15,13 +15,15 @@
 </div>
 <div id="quiz_container" class="hidden">
     <div class="arrow-steps clearfix">
-        {% for i in range(1, quiz_questions + 1)%}
-           {% if i == 1 %}
-               <div class="step current" id="question_header_{{i}}"><span><a class="step-text"><span class="question_header_text_container" id="question_header_text_{{i}}">{{_('question')}}</span> {{ i }}</a></span></div>
-           {% else %}
-               <div class="step" id="question_header_{{i}}"><span><a class="step-text"><span class="question_header_text_container" id="question_header_text_{{i}}" style="display: none;">{{_('question')}}</span> {{ i }}</a></span></div>
-           {% endif %}
-        {% endfor %}
+        {%  if quiz_questions %}
+            {% for i in range(1, quiz_questions + 1)%}
+               {% if i == 1 %}
+                   <div class="step current" id="question_header_{{i}}"><span><a class="step-text"><span class="question_header_text_container" id="question_header_text_{{i}}">{{_('question')}}</span> {{ i }}</a></span></div>
+               {% else %}
+                   <div class="step" id="question_header_{{i}}"><span><a class="step-text"><span class="question_header_text_container" id="question_header_text_{{i}}" style="display: none;">{{_('question')}}</span> {{ i }}</a></span></div>
+               {% endif %}
+            {% endfor %}
+        {% endif %}
     </div>
     <div id="quiz_question_container">
         <p class="italic text-3xl font-bold text-blue-900 text-center font-slab" id="quiz_question_title"></p> <!-- question -->

--- a/tests_e2e.py
+++ b/tests_e2e.py
@@ -288,7 +288,7 @@ class TestPages(AuthHelper):
         self.given_fresh_user_is_logged_in()
 
         body = {'email': self.user['email'], 'keyword_language': self.user['keyword_language']}
-        pages = ['/', '/hedy', '/explore', '/learn-more', '/programs', '/my-achievements', '/my-profile']
+        pages = ['/', '/hedy', '/tutorial', '/explore', '/learn-more', '/programs', '/my-achievements', '/my-profile']
 
         for language in ALL_LANGUAGES.keys():
             body['language'] = language


### PR DESCRIPTION
**Description**
In this PR we fix an issue where the tutorial would crash due to a missing variable that was expected by the .html template. However, this mistake should never have been merged in the first place. This is our own mistake by not updating the e2e tests to also verify that the `/tutorial` route is still valid in all languages. To prevent this we also fix the e2e tests for the tutorial.

**Fixes**
This PR fixes #2840.

**How to test**
Login and navigate to `/tutorial`. Verify that it is working again.
