### PR TITLE
[UI IMPROVEMENT] Replaces all datetimes with localized versions

### DIFF
--- a/app.py
+++ b/app.py
@@ -743,7 +743,7 @@ def teacher_tutorial(user):
         adventures.append(
             {'id': adventure.get('id'),
              'name': adventure.get('name'),
-             'date': utils.datetotimeordate(utils.mstoisostring(adventure.get('date'))),
+             'date': utils.localized_date_format(adventure.get('date')),
              'level': adventure.get('level')
              }
         )
@@ -889,8 +889,7 @@ def view_program(id):
         now = timems()
         arguments_dict['program_age'] = get_user_formatted_age(
             now, result['date'])
-        arguments_dict[
-            'program_timestamp'] = f"{datetime.datetime.fromtimestamp(result['date'] / 1000.0).strftime('%d-%m-%Y, %H:%M:%S')} GMT"
+        arguments_dict['program_timestamp'] = utils.localized_date_format(result['date'])
     else:
         arguments_dict['show_edit_button'] = True
 
@@ -1085,7 +1084,7 @@ def for_teachers_page(user):
         adventures.append(
           {'id': adventure.get('id'),
            'name': adventure.get('name'),
-           'date': utils.datetotimeordate(utils.mstoisostring(adventure.get('date'))),
+           'date': utils.localized_date_format(adventure.get('date')),
            'level': adventure.get('level')
            }
         )

--- a/app.py
+++ b/app.py
@@ -32,6 +32,7 @@ import collections
 import datetime
 import sys
 
+# Todo TB: This can introduce a possible app breaking bug when switching to Python 4 -> e.g. Python 4.0.1 is invalid
 if (sys.version_info.major < 3 or sys.version_info.minor < 7):
     print('Hedy requires Python 3.7 or newer to run. However, your version of Python is',
           '.'.join([str(sys.version_info.major), str(sys.version_info.minor), str(sys.version_info.micro)]))

--- a/app.py
+++ b/app.py
@@ -1,13 +1,10 @@
 # coding=utf-8
-import random
-
 from website import auth
 from website import statistics
 from website import quiz
 from website import admin
 from website import teacher
 from website import programs
-import textwrap
 import utils
 from utils import timems, load_yaml_rt, dump_yaml_rt, version, is_debug_mode
 from website.log_fetcher import log_fetcher
@@ -18,7 +15,7 @@ import hedy_translation
 from hedy_content import COUNTRIES, ALL_LANGUAGES, ALL_KEYWORD_LANGUAGES, NON_LATIN_LANGUAGES
 import hedyweb
 import hedy_content
-from flask_babel import gettext, format_timedelta
+from flask_babel import gettext
 from flask_babel import Babel
 from flask_compress import Compress
 from flask_helpers import render_template

--- a/app.py
+++ b/app.py
@@ -18,7 +18,7 @@ import hedy_translation
 from hedy_content import COUNTRIES, ALL_LANGUAGES, ALL_KEYWORD_LANGUAGES, NON_LATIN_LANGUAGES
 import hedyweb
 import hedy_content
-from flask_babel import gettext
+from flask_babel import gettext, format_timedelta
 from flask_babel import Babel
 from flask_compress import Compress
 from flask_helpers import render_template
@@ -643,7 +643,7 @@ def programs_page(user):
     programs = []
     now = timems()
     for item in result:
-        date = get_user_formatted_age(now, item['date'])
+        date = utils.delta_timestamp(item['date'])
         # This way we only keep the first 4 lines to show as preview to the user
         code = "\n".join(item['code'].split("\n")[:4])
         programs.append(
@@ -703,21 +703,6 @@ def get_log_results():
         query_execution_id, next_token)
     response = {'data': data, 'next_token': next_token}
     return jsonify(response)
-
-
-def get_user_formatted_age(now, date):
-    program_age = now - date
-    if program_age < 1000 * 60 * 60:
-        measure = gettext('minutes')
-        date = round(program_age / (1000 * 60))
-    elif program_age < 1000 * 60 * 60 * 24:
-        measure = gettext('hours')
-        date = round(program_age / (1000 * 60 * 60))
-    else:
-        measure = gettext('days')
-        date = round(program_age / (1000 * 60 * 60 * 24))
-    age = {'time': str(date) + " " + measure}
-    return gettext('ago').format(**age)
 
 
 @app.route('/tutorial', methods=['GET'])
@@ -886,9 +871,6 @@ def view_program(id):
 
     if "submitted" in result and result['submitted']:
         arguments_dict['show_edit_button'] = False
-        now = timems()
-        arguments_dict['program_age'] = get_user_formatted_age(
-            now, result['date'])
         arguments_dict['program_timestamp'] = utils.localized_date_format(result['date'])
     else:
         arguments_dict['show_edit_button'] = True

--- a/templates/view-program-page.html
+++ b/templates/view-program-page.html
@@ -5,7 +5,7 @@
   {% if loaded_program.submitted %}
       <div class="text-center">
         <h2>{{_('submitted_header')}}</h2>
-        <h3 class="inline-block mt-0">{{_('last_edited')}}: {{program_timestamp}}</h3> - {{program_age}}
+        <h3 class="inline-block mt-0">{{_('last_edited')}}: {{program_timestamp}}</h3>
       </div>
   {% endif %}
   <h1>{{loaded_program.name}}</h1>

--- a/utils.py
+++ b/utils.py
@@ -9,7 +9,7 @@ import string
 import random
 import uuid
 
-from flask_babel import gettext, format_date, format_datetime
+from flask_babel import gettext, format_date, format_datetime, format_timedelta
 from ruamel import yaml
 from website import querylog
 import commonmark
@@ -249,6 +249,13 @@ def atomic_write_file(filename, mode='wb'):
 # and then invoking the `isoformat` date function on it
 def mstoisostring(date):
     return datetime.datetime.fromtimestamp(int(str(date)[:-3])).isoformat()
+
+def delta_timestamp(date, short_format=False):
+    if short_format:
+        delta = datetime.datetime.now() - datetime.datetime.fromtimestamp(int(str(date)))
+    else:
+        delta = datetime.datetime.now() - datetime.datetime.fromtimestamp(int(str(date)[:-3]))
+    return format_timedelta(delta)
 
 def stoisostring(date):
     return datetime.datetime.fromtimestamp(date)

--- a/utils.py
+++ b/utils.py
@@ -253,9 +253,12 @@ def mstoisostring(date):
 def stoisostring(date):
     return datetime.datetime.fromtimestamp(date)
 
-def localized_date_format(date):
+def localized_date_format(date, short_format=False):
     # Improve the date by using the Flask Babel library and return timestamp as expected by language
-    timestamp = datetime.datetime.fromtimestamp(int(str(date)[:-3]))
+    if short_format:
+        timestamp = datetime.datetime.fromtimestamp(int(str(date)))
+    else:
+        timestamp = datetime.datetime.fromtimestamp(int(str(date)[:-3]))
     return format_date(timestamp, format='medium') + " " + format_datetime(timestamp, "H:mm")
 
 def datetotimeordate(date):

--- a/website/admin.py
+++ b/website/admin.py
@@ -59,7 +59,7 @@ def routes(app, database):
             data = pick(user, *fields)
             data['email_verified'] = not bool(data['verification_pending'])
             data['is_teacher'] = bool(data['is_teacher'])
-            data['created'] = utils.datetotimeordate (utils.mstoisostring(data['created'])) if data['created'] else '?'
+            data['created'] = utils.localized_date_format(data.get('created')) if data.get('created') else '-'
             if filtering and category == "language":
                 if language != data['language']:
                     continue
@@ -73,7 +73,7 @@ def routes(app, database):
                 if (start_date and utils.datetotimeordate(start_date) >= data['created']) or (end_date and utils.datetotimeordate(end_date) <= data['created']):
                     continue
             if data['last_login']:
-                data['last_login'] = utils.datetotimeordate(utils.mstoisostring(data['last_login'])) if data['last_login'] else '?'
+                data['last_login'] = utils.localized_date_format(data['last_login']) if data.get('last_login') else '-'
                 if filtering and category == "last_login":
                     if (start_date and utils.datetotimeordate(start_date) >= data['last_login']) or (end_date and utils.datetotimeordate(end_date) <= data['last_login']):
                         continue
@@ -113,7 +113,7 @@ def routes(app, database):
             "name": adventure.get('name'),
             "level": adventure.get('level'),
             "public": "Yes" if adventure.get('public') else "No",
-            "date": utils.datetotimeordate(utils.mstoisostring(adventure.get('date')))
+            "date": utils.localized_date_format(adventure.get('date'))
         } for adventure in DATABASE.all_adventures()]
         adventures = sorted(adventures, key=lambda d: d['date'], reverse=True)
 

--- a/website/teacher.py
+++ b/website/teacher.py
@@ -67,8 +67,8 @@ def routes(app, database, achievements):
         invites = []
         for invite in DATABASE.get_class_invites(Class['id']):
             invites.append({'username': invite['username'],
-                            'timestamp': utils.stoisostring(invite['timestamp']),
-                            'expire_timestamp': utils.stoisostring(invite['ttl'])})
+                            'timestamp': utils.localized_date_format(invite['timestamp']),
+                            'expire_timestamp': utils.localized_date_format(invite['ttl'])})
 
         return render_template('class-overview.html', current_page='my-profile',
                                 page_title=gettext('title_class-overview'),

--- a/website/teacher.py
+++ b/website/teacher.py
@@ -67,8 +67,8 @@ def routes(app, database, achievements):
         invites = []
         for invite in DATABASE.get_class_invites(Class['id']):
             invites.append({'username': invite['username'],
-                            'timestamp': utils.localized_date_format(invite['timestamp']),
-                            'expire_timestamp': utils.localized_date_format(invite['ttl'])})
+                            'timestamp': utils.localized_date_format(invite['timestamp'], short_format=True),
+                            'expire_timestamp': utils.localized_date_format(invite['ttl'], short_format=True)})
 
         return render_template('class-overview.html', current_page='my-profile',
                                 page_title=gettext('title_class-overview'),


### PR DESCRIPTION
**Description**
In this PR we replace all currently manually formatted date times into formats suggested by Babel. The Babel library automatically selects the expected format corresponding to the current language. The new function `localized_date_format()` takes a date object as well as a `short_format` boolean as we store some values in ms and some in s. In the first case we have to remove the last three characters before parsing to a date object, in the second case we can directly parse.

**Fixes**
This PR fixes #2868.

**How to test**
The formatting is changed in several spots, verify that it is shown as expected in all places:
- The submitted program page
- The class overview page (last login as well as invites)
- Admin page (created, last login)
