### PR TITLE
All image alt attributes are translatable

### DIFF
--- a/messages.pot
+++ b/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-06-21 10:36+0200\n"
+"POT-Creation-Date: 2022-06-23 14:02+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -26,7 +26,7 @@ msgid "title_achievements"
 msgstr ""
 
 #: app.py:639 app.py:743 app.py:1085 website/teacher.py:361
-#: website/teacher.py:370
+#: website/teacher.py:372
 msgid "not_teacher"
 msgstr ""
 
@@ -62,8 +62,8 @@ msgstr ""
 msgid "level_not_class"
 msgstr ""
 
-#: app.py:923 website/teacher.py:419 website/teacher.py:435
-#: website/teacher.py:464 website/teacher.py:490
+#: app.py:923 website/teacher.py:421 website/teacher.py:437
+#: website/teacher.py:466 website/teacher.py:492
 msgid "no_such_adventure"
 msgstr ""
 
@@ -296,8 +296,8 @@ msgstr ""
 #: website/auth.py:671 website/auth.py:718 website/auth.py:745
 #: website/quiz.py:43 website/quiz.py:69 website/teacher.py:88
 #: website/teacher.py:123 website/teacher.py:195 website/teacher.py:251
-#: website/teacher.py:298 website/teacher.py:339 website/teacher.py:375
-#: website/teacher.py:446 website/teacher.py:504
+#: website/teacher.py:298 website/teacher.py:339 website/teacher.py:377
+#: website/teacher.py:448 website/teacher.py:506
 msgid "ajax_error"
 msgstr ""
 
@@ -541,6 +541,21 @@ msgstr ""
 msgid "hedy_achievements"
 msgstr ""
 
+#: templates/achievements.html:36 templates/achievements.html:50
+#: templates/landing-page.html:89 templates/layout.html:92
+#: templates/public-page.html:51
+msgid "achievements_logo_alt"
+msgstr ""
+
+#: templates/achievements.html:37
+msgid "achievements_check_icon_alt"
+msgstr ""
+
+#: templates/base_email.html:3 templates/cheatsheet.html:15
+#: templates/incl-menubar.html:4
+msgid "hedy_logo_alt"
+msgstr ""
+
 #: templates/cheatsheet.html:14
 msgid "cheatsheet_title"
 msgstr ""
@@ -642,7 +657,7 @@ msgstr ""
 msgid "invite_by_username"
 msgstr ""
 
-#: templates/class-overview.html:55 templates/create-accounts.html:49
+#: templates/class-overview.html:55 templates/create-accounts.html:45
 msgid "create_accounts"
 msgstr ""
 
@@ -666,6 +681,10 @@ msgstr ""
 msgid "class_already_joined"
 msgstr ""
 
+#: templates/class-prejoin.html:9 templates/error-page.html:6
+msgid "error_logo_alt"
+msgstr ""
+
 #: templates/class-prejoin.html:11
 msgid "goto_profile"
 msgstr ""
@@ -682,7 +701,8 @@ msgstr ""
 msgid "join_class"
 msgstr ""
 
-#: templates/class-stats.html:22 templates/customize-class.html:166
+#: templates/class-stats.html:22 templates/create-accounts.html:41
+#: templates/customize-class.html:166
 msgid "back_to_class"
 msgstr ""
 
@@ -711,25 +731,21 @@ msgstr ""
 msgid "create_accounts_prompt"
 msgstr ""
 
-#: templates/create-accounts.html:19
-msgid "select_class"
-msgstr ""
-
-#: templates/create-accounts.html:30
+#: templates/create-accounts.html:25
 msgid "download_login_credentials"
 msgstr ""
 
-#: templates/create-accounts.html:34 templates/layout.html:22
+#: templates/create-accounts.html:29 templates/layout.html:22
 #: templates/signup.html:64
 msgid "yes"
 msgstr ""
 
-#: templates/create-accounts.html:38 templates/layout.html:23
+#: templates/create-accounts.html:33 templates/layout.html:23
 #: templates/signup.html:68
 msgid "no"
 msgstr ""
 
-#: templates/create-accounts.html:48 templates/programs.html:24
+#: templates/create-accounts.html:44 templates/programs.html:24
 msgid "reset_view"
 msgstr ""
 
@@ -977,7 +993,7 @@ msgstr ""
 msgid "adventure_prompt"
 msgstr ""
 
-#: templates/for-teachers.html:59 website/teacher.py:499
+#: templates/for-teachers.html:59 website/teacher.py:501
 msgid "create_adventure"
 msgstr ""
 
@@ -1031,6 +1047,10 @@ msgstr ""
 
 #: templates/incl-editor-and-output.html:144
 msgid "edit_code_button"
+msgstr ""
+
+#: templates/incl-editor-and-output.html:146
+msgid "repair_program_logo_alt"
 msgstr ""
 
 #: templates/incl-editor-and-output.html:150
@@ -1112,20 +1132,42 @@ msgstr ""
 msgid "welcome_back"
 msgstr ""
 
+#: templates/landing-page.html:11
+msgid "teacher_tutorial_logo_alt"
+msgstr ""
+
 #: templates/landing-page.html:13
 msgid "start_teacher_tutorial"
+msgstr ""
+
+#: templates/landing-page.html:18
+msgid "hedy_tutorial_logo_alt"
 msgstr ""
 
 #: templates/landing-page.html:20
 msgid "start_hedy_tutorial"
 msgstr ""
 
+#: templates/landing-page.html:25
+msgid "start_programming_logo_alt"
+msgstr ""
+
 #: templates/landing-page.html:27
 msgid "start_programming"
 msgstr ""
 
+#: templates/landing-page.html:31
+msgid "explore_programs_logo_alt"
+msgstr ""
+
 #: templates/landing-page.html:39
 msgid "your_account"
+msgstr ""
+
+#: templates/landing-page.html:43 templates/landing-page.html:45
+#: templates/profile.html:33 templates/public-page.html:7
+#: templates/public-page.html:9
+msgid "profile_logo_alt"
 msgstr ""
 
 #: templates/landing-page.html:52 templates/public-page.html:16
@@ -1461,6 +1503,10 @@ msgstr ""
 
 #: templates/public-page.html:85
 msgid "no_shared_programs"
+msgstr ""
+
+#: templates/quiz.html:4
+msgid "quiz_logo_alt"
 msgstr ""
 
 #: templates/quiz.html:7
@@ -1815,7 +1861,7 @@ msgstr ""
 msgid "favourite_success"
 msgstr ""
 
-#: website/quiz.py:45 website/quiz.py:71 website/teacher.py:452
+#: website/quiz.py:45 website/quiz.py:71 website/teacher.py:454
 msgid "level_invalid"
 msgstr ""
 
@@ -1844,6 +1890,7 @@ msgstr ""
 #: website/statistics.py:41 website/teacher.py:38 website/teacher.py:131
 #: website/teacher.py:150 website/teacher.py:212 website/teacher.py:234
 #: website/teacher.py:246 website/teacher.py:313 website/teacher.py:352
+#: website/teacher.py:364
 msgid "no_such_class"
 msgstr ""
 
@@ -1871,7 +1918,7 @@ msgstr ""
 msgid "class_name_duplicate"
 msgstr ""
 
-#: website/teacher.py:162 website/teacher.py:178 website/teacher.py:531
+#: website/teacher.py:162 website/teacher.py:178 website/teacher.py:533
 msgid "invalid_class_link"
 msgstr ""
 
@@ -1907,64 +1954,64 @@ msgstr ""
 msgid "student_already_invite"
 msgstr ""
 
-#: website/teacher.py:380
+#: website/teacher.py:382
 msgid "no_accounts"
 msgstr ""
 
-#: website/teacher.py:390
+#: website/teacher.py:392
 msgid "unique_usernames"
 msgstr ""
 
-#: website/teacher.py:399
+#: website/teacher.py:401
 msgid "usernames_exist"
 msgstr ""
 
-#: website/teacher.py:410
+#: website/teacher.py:412
 msgid "accounts_created"
 msgstr ""
 
-#: website/teacher.py:416 website/teacher.py:421 website/teacher.py:432
-#: website/teacher.py:461 website/teacher.py:487
+#: website/teacher.py:418 website/teacher.py:423 website/teacher.py:434
+#: website/teacher.py:463 website/teacher.py:489
 msgid "retrieve_adventure_error"
 msgstr ""
 
-#: website/teacher.py:426
+#: website/teacher.py:428
 msgid "title_view-adventure"
 msgstr ""
 
-#: website/teacher.py:437
+#: website/teacher.py:439
 msgid "title_customize-adventure"
 msgstr ""
 
-#: website/teacher.py:448
+#: website/teacher.py:450
 msgid "adventure_id_invalid"
 msgstr ""
 
-#: website/teacher.py:450 website/teacher.py:506
+#: website/teacher.py:452 website/teacher.py:508
 msgid "adventure_name_invalid"
 msgstr ""
 
-#: website/teacher.py:454
+#: website/teacher.py:456
 msgid "content_invalid"
 msgstr ""
 
-#: website/teacher.py:456
+#: website/teacher.py:458
 msgid "adventure_length"
 msgstr ""
 
-#: website/teacher.py:458
+#: website/teacher.py:460
 msgid "public_invalid"
 msgstr ""
 
-#: website/teacher.py:469 website/teacher.py:513
+#: website/teacher.py:471 website/teacher.py:515
 msgid "adventure_duplicate"
 msgstr ""
 
-#: website/teacher.py:481
+#: website/teacher.py:483
 msgid "adventure_updated"
 msgstr ""
 
-#: website/teacher.py:508
+#: website/teacher.py:510
 msgid "adventure_empty"
 msgstr ""
 

--- a/templates/achievements.html
+++ b/templates/achievements.html
@@ -47,7 +47,7 @@
                     {% else %}
                         <div class="w-40 rounded-lg ltr:mr-4 rtl:ml-4 mt-4 relative bg-gray-500">
                             <div class="flex items-center justify-center h-40">
-                                <img src="{{static('/images/achievement.png')}}" class="px-2" alt="Achievement logo">
+                                <img src="{{static('/images/achievement.png')}}" class="px-2" alt="{{_('achievements_logo_alt')}}">
                             </div>
                             <div class="w-40 h-full opacity-0 hover:opacity-75 bg-black rounded-lg inset-0 absolute z-10 text-center text-white px-4 pt-10">
                                 <p class="font-semibold">{% if title == _('hidden') %}???{% else %}{{ translations[achievement].text }}{% endif %}</p>

--- a/templates/achievements.html
+++ b/templates/achievements.html
@@ -33,8 +33,8 @@
                         <div class="w-40 rounded-lg ltr:mr-4 rtl:ml-4 mt-4 relative bg-blue-200">
                             <div class="relative h-40">
                                 <div class="flex items-center justify-center h-40">
-                                    <img src="{{static('/images/achievement.png')}}" class="px-2" alt="Achievement logo">
-                                    <img src="{{static('/images/check.png')}}" class="absolute w-3/4 mt-2 block" alt="Achievement check icon">
+                                    <img src="{{static('/images/achievement.png')}}" class="px-2" alt="{{_('achievements_logo_alt')}}">
+                                    <img src="{{static('/images/check.png')}}" class="absolute w-3/4 mt-2 block" alt="{{_('achievements_check_icon_alt')}}">
                                 </div>
                             </div>
                             <div class="w-40 h-full opacity-0 hover:opacity-75 bg-black rounded-lg inset-0 absolute z-10 text-center text-white px-4 pt-10">

--- a/templates/base_email.html
+++ b/templates/base_email.html
@@ -1,6 +1,6 @@
 <div style='border: solid; border-radius: 5px; border-color: #4299e1; background: #4299e1; font-size: 1.2em; font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";'>
   <div style="margin: 30px 20px; padding: 30px; background-color: white; border: solid; border-color: white; border-radius: 5px;">
-    <img style="max-width: 120px;" src="http://www.hedycode.com/images/Hedy-logo.png" alt="Hedy logo">
+    <img style="max-width: 120px;" src="http://www.hedycode.com/images/Hedy-logo.png" alt="{{_('hedy_logo_alt')}}">
     <div id="content" style="margin-top: 30px; margin-bottom: 20px; white-space: pre-line;">
         {content}
     </div>

--- a/templates/cheatsheet.html
+++ b/templates/cheatsheet.html
@@ -12,7 +12,7 @@
         <div class="container min-w-min mx-auto bg-gray-100 min-h-screen shadow-md flex flex-col">
             <div id="cheatsheet_header" class="bg-blue-500 h-32 flex flex-row items-center">
                 <h1 class="text-white text-5xl font-light font-serif mx-16">{{_('cheatsheet_title')}}</h1>
-                <img src="{{static('/images/Hedy-logo.png')}}" class="z-10 w-40 ltr:ml-auto rtl:mr-auto ltr:mr-24 rtl:ml-24 mt-28" alt="Hedy logo">
+                <img src="{{static('/images/Hedy-logo.png')}}" class="z-10 w-40 ltr:ml-auto rtl:mr-auto ltr:mr-24 rtl:ml-24 mt-28" alt="{{_('hedy_logo_alt')}}">
             </div>
             <div id="cheatsheet_body" class="bg-blue-200 min-h-screen px-16 py-8">
                 <h2 class="text-black text-4xl font-sans font-light mb-8">Level {{ level }}</h2>

--- a/templates/class-prejoin.html
+++ b/templates/class-prejoin.html
@@ -6,7 +6,7 @@
         <div class="flex flex-col w-full items-center">
             <h1>{{_('class_already_joined')}} <i>"{{class_info.name}}"</i></h1>
             <div class="w-1/2 mt-2">
-                <img class="w-full" src="/images/500.png" alt="Error 500 logo">
+                <img class="w-full" src="/images/500.png" alt="{{_('error_logo_alt')}}">
             </div>
             <button class="green-btn" onclick="window.open('/my-profile','_self')">{{_('goto_profile')}}</button>
         </div>

--- a/templates/error-page.html
+++ b/templates/error-page.html
@@ -3,7 +3,7 @@
 {% block body %}
   <div class="flex flex-col items-center">
       <div class="w-1/2 mt-8">
-          <img class="w-full" src="/images/{{ error }}.png" alt="Error logo">
+          <img class="w-full" src="/images/{{ error }}.png" alt="{{_('error_logo_alt')}}">
       </div>
       <div class="mb-6 -mt-8 text-lg font-bold">
           {{page_error}}

--- a/templates/incl-editor-and-output.html
+++ b/templates/incl-editor-and-output.html
@@ -143,7 +143,7 @@
         {% if show_edit_button %}
             <button onclick="window.location = '/hedy/{{level}}/{{program_id}}'" class="blue-btn ltr:ml-4 rtl:mr-4">{{_('edit_code_button')}}</button>
         {% else %}
-            <img src="/images/Hedylightbulb_1.svg" onclick="hedyApp.modalStepOne()" class="hidden h-28 -mt-2" id="repair_button" alt="Repair program logo">
+            <img src="/images/Hedylightbulb_1.svg" onclick="hedyApp.modalStepOne()" class="hidden h-28 -mt-2" id="repair_button" alt="{{_('repair_program_logo_alt')}}">
         {% endif %}
       </div>
       <div id="speak_container" class="hidden mt-4 flex flex-row items-center w-max overflow-visible">

--- a/templates/incl-menubar.html
+++ b/templates/incl-menubar.html
@@ -1,7 +1,7 @@
 <nav class="bg-blue-500 px-4 text-white flex flex-row items-center">
     <div class="py-1 ltr:mr-6 rtl:ml-6">
       <a href="/">
-        <img src="{{static('/images/Hedy-logo.png')}}" style="width: 2.5em;" alt="Hedy logo">
+        <img src="{{static('/images/Hedy-logo.png')}}" style="width: 2.5em;" alt="{{_('hedy_logo_alt')}}">
       </a>
     </div>
     {% block menu %}

--- a/templates/landing-page.html
+++ b/templates/landing-page.html
@@ -8,27 +8,27 @@
     <div class="mt-8 mx-auto flex justify-around">
         {% if is_teacher %}
             <div class="border-2 rounded-lg flex flex-col items-center mx-4 px-4 bg-white text-center border-green-400 bg-gray-200 hover:bg-green-400 cursor-pointer" onclick="window.location = '/teacher-tutorial'">
-              <img src="/images/profile_images/3.png" class="h-32 mt-8" alt="Teacher tutorial logo">
+              <img src="/images/profile_images/3.png" class="h-32 mt-8" alt="{{_('teacher_tutorial_logo_alt')}}">
               <div class="my-4">
                 <p class="text-xl">{{_('start_teacher_tutorial')}}</p>
               </div>
             </div>
         {% else %}
             <div class="border-2 rounded-lg flex flex-col items-center mx-4 px-4 bg-white text-center border-green-400 bg-gray-200 hover:bg-green-400 cursor-pointer" onclick="window.location = '/tutorial'">
-              <img src="/images/profile_images/3.png" class="h-32 mt-8" alt="Hedy tutorial logo">
+              <img src="/images/profile_images/3.png" class="h-32 mt-8" alt="{{_('hedy_tutorial_logo_alt')}}">
               <div class="my-4">
                 <p class="text-xl">{{_('start_hedy_tutorial')}}</p>
               </div>
             </div>
         {% endif %}
         <div class="border-2 rounded-lg flex flex-col items-center mx-4 px-4 bg-white text-center border-green-400 bg-gray-200 hover:bg-green-400 cursor-pointer" onclick="window.location = '/hedy'">
-            <img src="/images/Hedy-logo.png" class="h-32 mt-8" alt="Start programming logo">
+            <img src="/images/Hedy-logo.png" class="h-32 mt-8" alt="{{_('start_programming_logo_alt')}}">
             <div class="mt-4">
               <p class="text-xl">{{_('start_programming')}}</p>
             </div>
         </div>
         <div class="border-2 rounded-lg flex flex-col items-center mx-4 px-4 bg-white text-center border-green-500 bg-gray-200 hover:bg-green-400 cursor-pointer" onclick="window.location = '/explore'">
-            <img src="/images/profile_images/5.png" class="h-32 mt-8" alt="Explore programs logo">
+            <img src="/images/profile_images/5.png" class="h-32 mt-8" alt="{{_('explore_programs_logo_alt')}}">
             <div class="mt-4">
               <p class="text-xl">{{_('explore_programs')}}</p>
             </div>
@@ -40,9 +40,9 @@
             <div id="general_info" class="flex flex-row items-center h-64 mt-8 mx-2">
                 <div class="w-1/3 mr-4 h-full flex items-center justify-center">
                     {% if user_info.image %}
-                        <img src="{{static('/images/profile_images/' + user_info.image + '.png')}}" class="w-64" alt="Your profile logo">
+                        <img src="{{static('/images/profile_images/' + user_info.image + '.png')}}" class="w-64" alt="{{_('profile_logo_alt')}}">
                     {% else %}
-                        <img src="{{static('/images/Hedy-logo.png')}}" class="w-64" alt="Your profile logo">
+                        <img src="{{static('/images/Hedy-logo.png')}}" class="w-64" alt="{{_('profile_logo_alt')}}">
                     {% endif %}
                 </div>
                 <div class="w-full h-full bg-blue-200 flex flex-col rounded-lg border border-black">
@@ -86,7 +86,7 @@
                 {% if last_achieved %}
                     <div class="text-center rounded-lg bg-yellow-400 w-1/3 ml-4 mr-4 border border-black">
                         <h3>{{_('last_achievement')}}</h3>
-                        <img class="w-full px-8 mt-2" src="{{static('/images/achievement.png')}}" alt="Achievement logo">
+                        <img class="w-full px-8 mt-2" src="{{static('/images/achievement.png')}}" alt="{{_('achievements_logo_alt')}}">
                         <h4>{{ achievements[last_achieved].title }}</h4>
                     </div>
                 {% endif %}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -89,7 +89,7 @@
         </div>
         <div class="bg-blue-600 border-2 border-black rounded-lg px-8 pt-0 pb-4 text-center">
             <h3 class="text-white">{{_('achievement_earned')}}</h3>
-            <img id="achievement_reached_image" src="{{static('/images/achievement.png')}}" class="h-32 mx-auto" alt="Achievement logo">
+            <img id="achievement_reached_image" src="{{static('/images/achievement.png')}}" class="h-32 mx-auto" alt="{{_('achievements_logo_alt')}}">
             <h4 class="text-white italic" id="achievement_reached_title"></h4>
             <p id="achievement_reached_text"></p>
             <p id="achievement_reached_statics" class="text-white italic"></p>

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -30,7 +30,7 @@
             {% for i in range(1, 13) %}
                 <div class="w-32 h-32 rounded-lg mr-4 relative profile_image {% if (public_settings.image and public_settings.image == i|string()) or (not public_settings.image and i == 1) %}border-2 border-blue-600{% endif %}" id="profile_image_{{ i }}" onclick="hedyApp.select_profile_image({{ i }});">
                     <div class="relative h-full">
-                        <img src="{{static('/images/profile_images/' + i|string() + '.png')}}" class="absolute p-1" alt="Profile logo">
+                        <img src="{{static('/images/profile_images/' + i|string() + '.png')}}" class="absolute p-1" alt="{{_('profile_logo_alt')}}">
                     </div>
                 </div>
             {% endfor %}

--- a/templates/public-page.html
+++ b/templates/public-page.html
@@ -4,9 +4,9 @@
     <div id="general_info" class="flex flex-row items-center h-64 mt-8 mx-2">
         <div class="w-1/3 mr-4 h-full flex items-center justify-center">
             {% if user_info.image %}
-                <img src="{{static('/images/profile_images/' + user_info.image + '.png')}}" class="w-64" alt="Profile logo">
+                <img src="{{static('/images/profile_images/' + user_info.image + '.png')}}" class="w-64" alt="{{_('profile_logo_alt')}}">
             {% else %}
-                <img src="{{static('/images/Hedy-logo.png')}}" class="w-64" alt="Profile logo">
+                <img src="{{static('/images/Hedy-logo.png')}}" class="w-64" alt="{{_('profile_logo_alt')}}">
             {% endif %}
         </div>
         <div class="w-full h-full bg-blue-200 flex flex-col rounded-lg border border-black">
@@ -48,7 +48,7 @@
         {% if last_achieved %}
         <div class="text-center rounded-lg bg-yellow-400 w-1/3 ml-4 mr-4 border border-black">
             <h3>{{_('last_achievement')}}</h3>
-            <img class="w-full px-8 mt-2" src="{{static('/images/achievement.png')}}" alt="Achievement logo">
+            <img class="w-full px-8 mt-2" src="{{static('/images/achievement.png')}}" alt="{{_('achievements_logo_alt')}}">
             <h4>{{ achievements[last_achieved].title }}</h4>
         </div>
         {% endif %}

--- a/templates/quiz.html
+++ b/templates/quiz.html
@@ -1,7 +1,7 @@
 <div id="start_quiz_container">
     <div class="flex flex-col">
         <div class="flex items-center justify-center bg-blue-200 p-10">
-            <img class="rounded-full border-green-600 border-8 w-80" src="{{ static('/images/quiz_logo.jpg') }}" alt="Quiz logo">
+            <img class="rounded-full border-green-600 border-8 w-80" src="{{ static('/images/quiz_logo.jpg') }}" alt="{{_('quiz_logo_alt')}}">
         </div>
         <div class="p-8 border-t-8 bg-blue-400 border-blue-600">
             <h1 class="text-center text-white font-bold font-slab">{{_('start_quiz')}}</h1>

--- a/translations/ar/LC_MESSAGES/messages.po
+++ b/translations/ar/LC_MESSAGES/messages.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-21 10:36+0200\n"
+"POT-Creation-Date: 2022-06-23 14:02+0200\n"
 "PO-Revision-Date: 2022-06-18 14:19+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: ar\n"
@@ -24,7 +24,7 @@ msgid "title_achievements"
 msgstr "هيدي - انجازاتي"
 
 #: app.py:639 app.py:743 app.py:1085 website/teacher.py:361
-#: website/teacher.py:370
+#: website/teacher.py:372
 msgid "not_teacher"
 msgstr "يبدو أنك لست معلم أو معلمة!"
 
@@ -60,8 +60,8 @@ msgstr "لا يوجد هذا البرنامج في هيدي!"
 msgid "level_not_class"
 msgstr "هذا المستوى ليس متاحا لصفك الدراسي بعد"
 
-#: app.py:923 website/teacher.py:419 website/teacher.py:435
-#: website/teacher.py:464 website/teacher.py:490
+#: app.py:923 website/teacher.py:421 website/teacher.py:437
+#: website/teacher.py:466 website/teacher.py:492
 msgid "no_such_adventure"
 msgstr "هذه المغامرة غير موجودة!"
 
@@ -332,8 +332,8 @@ msgstr ""
 #: website/auth.py:671 website/auth.py:718 website/auth.py:745
 #: website/quiz.py:43 website/quiz.py:69 website/teacher.py:88
 #: website/teacher.py:123 website/teacher.py:195 website/teacher.py:251
-#: website/teacher.py:298 website/teacher.py:339 website/teacher.py:375
-#: website/teacher.py:446 website/teacher.py:504
+#: website/teacher.py:298 website/teacher.py:339 website/teacher.py:377
+#: website/teacher.py:448 website/teacher.py:506
 msgid "ajax_error"
 msgstr "لقد حدث خطأ ما، يرجى المحاولة مرة أخرى."
 
@@ -634,6 +634,23 @@ msgstr "مخفي"
 msgid "hedy_achievements"
 msgstr "انجازات هيدي"
 
+#: templates/achievements.html:36 templates/achievements.html:50
+#: templates/landing-page.html:89 templates/layout.html:92
+#: templates/public-page.html:51
+#, fuzzy
+msgid "achievements_logo_alt"
+msgstr "انجازات"
+
+#: templates/achievements.html:37
+#, fuzzy
+msgid "achievements_check_icon_alt"
+msgstr "لقد ا حصلت على انجاز!"
+
+#: templates/base_email.html:3 templates/cheatsheet.html:15
+#: templates/incl-menubar.html:4
+msgid "hedy_logo_alt"
+msgstr ""
+
 #: templates/cheatsheet.html:14
 msgid "cheatsheet_title"
 msgstr "ورقة غش"
@@ -740,7 +757,7 @@ msgstr "أدخل اسم مستخدم"
 msgid "invite_by_username"
 msgstr "يجب أن تكون جميع أسماء المستخدمين لا نظير لها."
 
-#: templates/class-overview.html:55 templates/create-accounts.html:49
+#: templates/class-overview.html:55 templates/create-accounts.html:45
 msgid "create_accounts"
 msgstr "انشاء عدة حسابات"
 
@@ -764,6 +781,10 @@ msgstr "هل أنت متأكد أنك تريد حذف الدعوة الى هذا
 msgid "class_already_joined"
 msgstr "أنت بالفعل تلميذ في صف"
 
+#: templates/class-prejoin.html:9 templates/error-page.html:6
+msgid "error_logo_alt"
+msgstr ""
+
 #: templates/class-prejoin.html:11
 msgid "goto_profile"
 msgstr "الذهاب الى ملفي الشخصي"
@@ -780,7 +801,8 @@ msgstr "يجب أن يكون لديك حساب لتنضم الى صف. هل تر
 msgid "join_class"
 msgstr "انضم الى صف"
 
-#: templates/class-stats.html:22 templates/customize-class.html:166
+#: templates/class-stats.html:22 templates/create-accounts.html:41
+#: templates/customize-class.html:166
 msgid "back_to_class"
 msgstr "الرجوع الى صف"
 
@@ -816,26 +838,22 @@ msgstr ""
 msgid "create_accounts_prompt"
 msgstr "هل أنت متأكد أنك تريد انشاء هذه الحسابات؟"
 
-#: templates/create-accounts.html:19
-msgid "select_class"
-msgstr "اختر الصف"
-
-#: templates/create-accounts.html:30
+#: templates/create-accounts.html:25
 #, fuzzy
 msgid "download_login_credentials"
 msgstr ""
 
-#: templates/create-accounts.html:34 templates/layout.html:22
+#: templates/create-accounts.html:29 templates/layout.html:22
 #: templates/signup.html:64
 msgid "yes"
 msgstr "نعم"
 
-#: templates/create-accounts.html:38 templates/layout.html:23
+#: templates/create-accounts.html:33 templates/layout.html:23
 #: templates/signup.html:68
 msgid "no"
 msgstr "لا"
 
-#: templates/create-accounts.html:48 templates/programs.html:24
+#: templates/create-accounts.html:44 templates/programs.html:24
 msgid "reset_view"
 msgstr "اعادة ضبط"
 
@@ -1118,7 +1136,7 @@ msgstr "عرض"
 msgid "adventure_prompt"
 msgstr "الرجاء إدخال اسم المغامرة"
 
-#: templates/for-teachers.html:59 website/teacher.py:499
+#: templates/for-teachers.html:59 website/teacher.py:501
 msgid "create_adventure"
 msgstr "انشاء مغامرة"
 
@@ -1177,6 +1195,10 @@ msgstr "Next exercise"
 #: templates/incl-editor-and-output.html:144
 msgid "edit_code_button"
 msgstr "تعديل البرنامج"
+
+#: templates/incl-editor-and-output.html:146
+msgid "repair_program_logo_alt"
+msgstr ""
 
 #: templates/incl-editor-and-output.html:150
 msgid "read_code_label"
@@ -1257,21 +1279,48 @@ msgstr "مرحباً"
 msgid "welcome_back"
 msgstr "مرحباً بعودتك"
 
+#: templates/landing-page.html:11
+#, fuzzy
+msgid "teacher_tutorial_logo_alt"
+msgstr "اضغط على \"الخطوة التالية\" لتبدأ كمعلم أو معلمة في هيدي!"
+
 #: templates/landing-page.html:13
 msgid "start_teacher_tutorial"
 msgstr "بدء الدليل التوجيهي للمعلم"
+
+#: templates/landing-page.html:18
+#, fuzzy
+msgid "hedy_tutorial_logo_alt"
+msgstr "بدء الدليل التوجيهي"
 
 #: templates/landing-page.html:20
 msgid "start_hedy_tutorial"
 msgstr "بدء الدليل التوجيهي"
 
+#: templates/landing-page.html:25
+#, fuzzy
+msgid "start_programming_logo_alt"
+msgstr "ابدأ البرمجة"
+
 #: templates/landing-page.html:27
 msgid "start_programming"
 msgstr "ابدأ البرمجة"
 
+#: templates/landing-page.html:31
+#, fuzzy
+msgid "explore_programs_logo_alt"
+msgstr "استكشف البرامج"
+
 #: templates/landing-page.html:39
 msgid "your_account"
 msgstr "ملفك الشخصي"
+
+#: templates/landing-page.html:43 templates/landing-page.html:45
+#: templates/profile.html:33 templates/public-page.html:7
+#: templates/public-page.html:9
+#, fuzzy
+msgid "profile_logo_alt"
+msgstr "تم تحديث الملف الشخصي."
 
 #: templates/landing-page.html:52 templates/public-page.html:16
 msgid "achievements"
@@ -1611,6 +1660,10 @@ msgstr "اكتب أول برامجك!"
 #: templates/public-page.html:85
 msgid "no_shared_programs"
 msgstr "ليس لديه برامج تم مشاركتها..."
+
+#: templates/quiz.html:4
+msgid "quiz_logo_alt"
+msgstr ""
 
 #: templates/quiz.html:7
 msgid "start_quiz"
@@ -2015,7 +2068,7 @@ msgstr "تم التراجع عن مشاركة البرنامج بنجاح."
 msgid "favourite_success"
 msgstr "تم ضبط البرنامج كمفضل."
 
-#: website/quiz.py:45 website/quiz.py:71 website/teacher.py:452
+#: website/quiz.py:45 website/quiz.py:71 website/teacher.py:454
 msgid "level_invalid"
 msgstr "هذا المستوى من هيدي غير صحيح."
 
@@ -2046,6 +2099,7 @@ msgstr "يمكن للمعلمين فقط استرجاع الصفوف"
 #: website/statistics.py:41 website/teacher.py:38 website/teacher.py:131
 #: website/teacher.py:150 website/teacher.py:212 website/teacher.py:234
 #: website/teacher.py:246 website/teacher.py:313 website/teacher.py:352
+#: website/teacher.py:364
 msgid "no_such_class"
 msgstr "لا وجود لهذا الصف في هيدي"
 
@@ -2073,7 +2127,7 @@ msgstr "لم تدخل اسم الصف!"
 msgid "class_name_duplicate"
 msgstr "لديك بالفعل صف بهذا الإسم."
 
-#: website/teacher.py:162 website/teacher.py:178 website/teacher.py:531
+#: website/teacher.py:162 website/teacher.py:178 website/teacher.py:533
 msgid "invalid_class_link"
 msgstr "رابط الانضمام للصف غير صالح."
 
@@ -2109,64 +2163,64 @@ msgstr "هذا التلميذ بالفعل موجود في الصف الخاص �
 msgid "student_already_invite"
 msgstr "هذا التلميذ بالفعل لديه دعوة قيد الإنتظار."
 
-#: website/teacher.py:380
+#: website/teacher.py:382
 msgid "no_accounts"
 msgstr "لا يوجد حسابات ليتم انشاءها."
 
-#: website/teacher.py:390
+#: website/teacher.py:392
 msgid "unique_usernames"
 msgstr "يجب أن تكون جميع أسماء المستخدمين لا نظير لها."
 
-#: website/teacher.py:399
+#: website/teacher.py:401
 msgid "usernames_exist"
 msgstr "اسم مستخدم واحد أو أكثر قيد الاستخدام بالفعل."
 
-#: website/teacher.py:410
+#: website/teacher.py:412
 msgid "accounts_created"
 msgstr "تم إنشاء الحسابات بنجاح."
 
-#: website/teacher.py:416 website/teacher.py:421 website/teacher.py:432
-#: website/teacher.py:461 website/teacher.py:487
+#: website/teacher.py:418 website/teacher.py:423 website/teacher.py:434
+#: website/teacher.py:463 website/teacher.py:489
 msgid "retrieve_adventure_error"
 msgstr "لا يسمح لك بعرض هذه المغامرة!"
 
-#: website/teacher.py:426
+#: website/teacher.py:428
 msgid "title_view-adventure"
 msgstr "هيدي - عرض مغامرة"
 
-#: website/teacher.py:437
+#: website/teacher.py:439
 msgid "title_customize-adventure"
 msgstr "هيدي - تخصيص مغامرة"
 
-#: website/teacher.py:448
+#: website/teacher.py:450
 msgid "adventure_id_invalid"
 msgstr "رمز المغامرة هذا غير صالح."
 
-#: website/teacher.py:450 website/teacher.py:506
+#: website/teacher.py:452 website/teacher.py:508
 msgid "adventure_name_invalid"
 msgstr "اسم المغامرة غير صالح."
 
-#: website/teacher.py:454
+#: website/teacher.py:456
 msgid "content_invalid"
 msgstr "هذه المغامرة غير صالحة"
 
-#: website/teacher.py:456
+#: website/teacher.py:458
 msgid "adventure_length"
 msgstr "المغامرة يجب أن تحتوي على ٢٠ حرفاً على الأقل."
 
-#: website/teacher.py:458
+#: website/teacher.py:460
 msgid "public_invalid"
 msgstr "اختيار الاتفاقية هذا غير صالح"
 
-#: website/teacher.py:469 website/teacher.py:513
+#: website/teacher.py:471 website/teacher.py:515
 msgid "adventure_duplicate"
 msgstr "لديك بالفعل مغامرة بنفس هذا الإسم."
 
-#: website/teacher.py:481
+#: website/teacher.py:483
 msgid "adventure_updated"
 msgstr "تم تحديث المغامرة!"
 
-#: website/teacher.py:508
+#: website/teacher.py:510
 msgid "adventure_empty"
 msgstr "لم تدخل اسم المغامرة!"
 
@@ -2324,4 +2378,7 @@ msgstr "لم تدخل اسم المغامرة!"
 
 #~ msgid "go_to_first_exercise"
 #~ msgstr "الذهاب الى السؤال ١"
+
+#~ msgid "select_class"
+#~ msgstr "اختر الصف"
 

--- a/translations/bg/LC_MESSAGES/messages.po
+++ b/translations/bg/LC_MESSAGES/messages.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-21 10:36+0200\n"
+"POT-Creation-Date: 2022-06-23 14:02+0200\n"
 "PO-Revision-Date: 2022-06-18 14:19+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: bg\n"
@@ -23,7 +23,7 @@ msgid "title_achievements"
 msgstr "Хеди - Мойте постижения"
 
 #: app.py:639 app.py:743 app.py:1085 website/teacher.py:361
-#: website/teacher.py:370
+#: website/teacher.py:372
 msgid "not_teacher"
 msgstr "Изглежда, че ти не си учител!"
 
@@ -59,8 +59,8 @@ msgstr "Няма такава Хеди програма!"
 msgid "level_not_class"
 msgstr "Това ниво не е налично в твоя клас все още"
 
-#: app.py:923 website/teacher.py:419 website/teacher.py:435
-#: website/teacher.py:464 website/teacher.py:490
+#: app.py:923 website/teacher.py:421 website/teacher.py:437
+#: website/teacher.py:466 website/teacher.py:492
 msgid "no_such_adventure"
 msgstr "Това приключение не съществува!"
 
@@ -342,8 +342,8 @@ msgstr ""
 #: website/auth.py:671 website/auth.py:718 website/auth.py:745
 #: website/quiz.py:43 website/quiz.py:69 website/teacher.py:88
 #: website/teacher.py:123 website/teacher.py:195 website/teacher.py:251
-#: website/teacher.py:298 website/teacher.py:339 website/teacher.py:375
-#: website/teacher.py:446 website/teacher.py:504
+#: website/teacher.py:298 website/teacher.py:339 website/teacher.py:377
+#: website/teacher.py:448 website/teacher.py:506
 #, fuzzy
 msgid "ajax_error"
 msgstr "There was an error, please try again."
@@ -678,6 +678,23 @@ msgstr "Hint?"
 msgid "hedy_achievements"
 msgstr "My achievements"
 
+#: templates/achievements.html:36 templates/achievements.html:50
+#: templates/landing-page.html:89 templates/layout.html:92
+#: templates/public-page.html:51
+#, fuzzy
+msgid "achievements_logo_alt"
+msgstr "achievements"
+
+#: templates/achievements.html:37
+#, fuzzy
+msgid "achievements_check_icon_alt"
+msgstr "You've earned an achievement!"
+
+#: templates/base_email.html:3 templates/cheatsheet.html:15
+#: templates/incl-menubar.html:4
+msgid "hedy_logo_alt"
+msgstr ""
+
 #: templates/cheatsheet.html:14
 #, fuzzy
 msgid "cheatsheet_title"
@@ -801,7 +818,7 @@ msgstr "Enter a username"
 msgid "invite_by_username"
 msgstr "All usernames need to be unique."
 
-#: templates/class-overview.html:55 templates/create-accounts.html:49
+#: templates/class-overview.html:55 templates/create-accounts.html:45
 #, fuzzy
 msgid "create_accounts"
 msgstr "Create multiple accounts"
@@ -831,6 +848,10 @@ msgstr "Are you sure you want to remove this class invitation?"
 msgid "class_already_joined"
 msgstr "You are already a student of class"
 
+#: templates/class-prejoin.html:9 templates/error-page.html:6
+msgid "error_logo_alt"
+msgstr ""
+
 #: templates/class-prejoin.html:11
 #, fuzzy
 msgid "goto_profile"
@@ -851,7 +872,8 @@ msgstr "You need to have an account to join a class. Would you like to login now
 msgid "join_class"
 msgstr "Join class"
 
-#: templates/class-stats.html:22 templates/customize-class.html:166
+#: templates/class-stats.html:22 templates/create-accounts.html:41
+#: templates/customize-class.html:166
 #, fuzzy
 msgid "back_to_class"
 msgstr "Go back to class"
@@ -892,27 +914,22 @@ msgstr ""
 msgid "create_accounts_prompt"
 msgstr "Are you sure you want to create these accounts?"
 
-#: templates/create-accounts.html:19
-#, fuzzy
-msgid "select_class"
-msgstr "Select class"
-
-#: templates/create-accounts.html:30
+#: templates/create-accounts.html:25
 #, fuzzy
 msgid "download_login_credentials"
 msgstr ""
 
-#: templates/create-accounts.html:34 templates/layout.html:22
+#: templates/create-accounts.html:29 templates/layout.html:22
 #: templates/signup.html:64
 msgid "yes"
 msgstr "Да"
 
-#: templates/create-accounts.html:38 templates/layout.html:23
+#: templates/create-accounts.html:33 templates/layout.html:23
 #: templates/signup.html:68
 msgid "no"
 msgstr "Не"
 
-#: templates/create-accounts.html:48 templates/programs.html:24
+#: templates/create-accounts.html:44 templates/programs.html:24
 #, fuzzy
 msgid "reset_view"
 msgstr "Reset"
@@ -1241,7 +1258,7 @@ msgstr "View"
 msgid "adventure_prompt"
 msgstr "Please enter the name of the adventure"
 
-#: templates/for-teachers.html:59 website/teacher.py:499
+#: templates/for-teachers.html:59 website/teacher.py:501
 #, fuzzy
 msgid "create_adventure"
 msgstr "Create adventure"
@@ -1309,6 +1326,10 @@ msgstr "Next exercise"
 #: templates/incl-editor-and-output.html:144
 msgid "edit_code_button"
 msgstr "Промени кода"
+
+#: templates/incl-editor-and-output.html:146
+msgid "repair_program_logo_alt"
+msgstr ""
 
 #: templates/incl-editor-and-output.html:150
 msgid "read_code_label"
@@ -1404,25 +1425,52 @@ msgstr ""
 "Welcome to Hedy! Your are now the proud owner of a teachers account which"
 " allows you to create classes and invite students."
 
+#: templates/landing-page.html:11
+#, fuzzy
+msgid "teacher_tutorial_logo_alt"
+msgstr "You have received an invitation to join class"
+
 #: templates/landing-page.html:13
 #, fuzzy
 msgid "start_teacher_tutorial"
 msgstr "Start teacher tutorial"
+
+#: templates/landing-page.html:18
+#, fuzzy
+msgid "hedy_tutorial_logo_alt"
+msgstr "Start hedy tutorial"
 
 #: templates/landing-page.html:20
 #, fuzzy
 msgid "start_hedy_tutorial"
 msgstr "Start hedy tutorial"
 
+#: templates/landing-page.html:25
+#, fuzzy
+msgid "start_programming_logo_alt"
+msgstr "Directly start programming"
+
 #: templates/landing-page.html:27
 #, fuzzy
 msgid "start_programming"
 msgstr "Directly start programming"
 
+#: templates/landing-page.html:31
+#, fuzzy
+msgid "explore_programs_logo_alt"
+msgstr "Explore programs"
+
 #: templates/landing-page.html:39
 #, fuzzy
 msgid "your_account"
 msgstr "Нямаш акаунт?"
+
+#: templates/landing-page.html:43 templates/landing-page.html:45
+#: templates/profile.html:33 templates/public-page.html:7
+#: templates/public-page.html:9
+#, fuzzy
+msgid "profile_logo_alt"
+msgstr "Profile updated."
 
 #: templates/landing-page.html:52 templates/public-page.html:16
 #, fuzzy
@@ -1815,6 +1863,10 @@ msgstr "Напиши първата си програма!"
 #, fuzzy
 msgid "no_shared_programs"
 msgstr "has no shared programs..."
+
+#: templates/quiz.html:4
+msgid "quiz_logo_alt"
+msgstr ""
 
 #: templates/quiz.html:7
 msgid "start_quiz"
@@ -2277,7 +2329,7 @@ msgstr "Program unshared successfully."
 msgid "favourite_success"
 msgstr "Your program is set as favourite."
 
-#: website/quiz.py:45 website/quiz.py:71 website/teacher.py:452
+#: website/quiz.py:45 website/quiz.py:71 website/teacher.py:454
 #, fuzzy
 msgid "level_invalid"
 msgstr "This Hedy level in invalid."
@@ -2310,6 +2362,7 @@ msgstr "Only teachers can retrieve classes"
 #: website/statistics.py:41 website/teacher.py:38 website/teacher.py:131
 #: website/teacher.py:150 website/teacher.py:212 website/teacher.py:234
 #: website/teacher.py:246 website/teacher.py:313 website/teacher.py:352
+#: website/teacher.py:364
 #, fuzzy
 msgid "no_such_class"
 msgstr "No such Hedy class"
@@ -2344,7 +2397,7 @@ msgstr "You didn't enter a class name!"
 msgid "class_name_duplicate"
 msgstr "You already have a class with this name."
 
-#: website/teacher.py:162 website/teacher.py:178 website/teacher.py:531
+#: website/teacher.py:162 website/teacher.py:178 website/teacher.py:533
 #, fuzzy
 msgid "invalid_class_link"
 msgstr "Invalid link for joining the class."
@@ -2389,78 +2442,78 @@ msgstr "This student is already in your class."
 msgid "student_already_invite"
 msgstr "This student already has a pending invitation."
 
-#: website/teacher.py:380
+#: website/teacher.py:382
 #, fuzzy
 msgid "no_accounts"
 msgstr "There are no accounts to create."
 
-#: website/teacher.py:390
+#: website/teacher.py:392
 #, fuzzy
 msgid "unique_usernames"
 msgstr "All usernames need to be unique."
 
-#: website/teacher.py:399
+#: website/teacher.py:401
 #, fuzzy
 msgid "usernames_exist"
 msgstr "One or more usernames is already in use."
 
-#: website/teacher.py:410
+#: website/teacher.py:412
 #, fuzzy
 msgid "accounts_created"
 msgstr "Accounts where successfully created."
 
-#: website/teacher.py:416 website/teacher.py:421 website/teacher.py:432
-#: website/teacher.py:461 website/teacher.py:487
+#: website/teacher.py:418 website/teacher.py:423 website/teacher.py:434
+#: website/teacher.py:463 website/teacher.py:489
 #, fuzzy
 msgid "retrieve_adventure_error"
 msgstr "You're not allowed to view this adventure!"
 
-#: website/teacher.py:426
+#: website/teacher.py:428
 #, fuzzy
 msgid "title_view-adventure"
 msgstr "Hedy - View adventure"
 
-#: website/teacher.py:437
+#: website/teacher.py:439
 #, fuzzy
 msgid "title_customize-adventure"
 msgstr "Hedy - Customize adventure"
 
-#: website/teacher.py:448
+#: website/teacher.py:450
 #, fuzzy
 msgid "adventure_id_invalid"
 msgstr "This adventure id is invalid."
 
-#: website/teacher.py:450 website/teacher.py:506
+#: website/teacher.py:452 website/teacher.py:508
 #, fuzzy
 msgid "adventure_name_invalid"
 msgstr "This adventure name is invalid."
 
-#: website/teacher.py:454
+#: website/teacher.py:456
 #, fuzzy
 msgid "content_invalid"
 msgstr "This adventure is invalid."
 
-#: website/teacher.py:456
+#: website/teacher.py:458
 #, fuzzy
 msgid "adventure_length"
 msgstr "Your adventure has to be at least 20 characters."
 
-#: website/teacher.py:458
+#: website/teacher.py:460
 #, fuzzy
 msgid "public_invalid"
 msgstr "This agreement selection is invalid"
 
-#: website/teacher.py:469 website/teacher.py:513
+#: website/teacher.py:471 website/teacher.py:515
 #, fuzzy
 msgid "adventure_duplicate"
 msgstr "You already have an adventure with this name."
 
-#: website/teacher.py:481
+#: website/teacher.py:483
 #, fuzzy
 msgid "adventure_updated"
 msgstr "The adventure has been updated!"
 
-#: website/teacher.py:508
+#: website/teacher.py:510
 #, fuzzy
 msgid "adventure_empty"
 msgstr "You didn't enter an adventure name!"
@@ -2598,4 +2651,7 @@ msgstr "You didn't enter an adventure name!"
 
 #~ msgid "go_to_first_exercise"
 #~ msgstr "Go to question 1"
+
+#~ msgid "select_class"
+#~ msgstr "Select class"
 

--- a/translations/bn/LC_MESSAGES/messages.po
+++ b/translations/bn/LC_MESSAGES/messages.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-21 10:36+0200\n"
+"POT-Creation-Date: 2022-06-23 14:02+0200\n"
 "PO-Revision-Date: 2022-06-18 14:19+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: bn\n"
@@ -25,7 +25,7 @@ msgid "title_achievements"
 msgstr "Hedy - My achievements"
 
 #: app.py:639 app.py:743 app.py:1085 website/teacher.py:361
-#: website/teacher.py:370
+#: website/teacher.py:372
 #, fuzzy
 msgid "not_teacher"
 msgstr "Looks like you are not a teacher!"
@@ -69,8 +69,8 @@ msgstr "No such Hedy program!"
 msgid "level_not_class"
 msgstr "You're in a class where this level has not been made available yet"
 
-#: app.py:923 website/teacher.py:419 website/teacher.py:435
-#: website/teacher.py:464 website/teacher.py:490
+#: app.py:923 website/teacher.py:421 website/teacher.py:437
+#: website/teacher.py:466 website/teacher.py:492
 #, fuzzy
 msgid "no_such_adventure"
 msgstr "This adventure doesn't exist!"
@@ -367,8 +367,8 @@ msgstr ""
 #: website/auth.py:671 website/auth.py:718 website/auth.py:745
 #: website/quiz.py:43 website/quiz.py:69 website/teacher.py:88
 #: website/teacher.py:123 website/teacher.py:195 website/teacher.py:251
-#: website/teacher.py:298 website/teacher.py:339 website/teacher.py:375
-#: website/teacher.py:446 website/teacher.py:504
+#: website/teacher.py:298 website/teacher.py:339 website/teacher.py:377
+#: website/teacher.py:448 website/teacher.py:506
 #, fuzzy
 msgid "ajax_error"
 msgstr "There was an error, please try again."
@@ -731,6 +731,23 @@ msgstr "Hint?"
 msgid "hedy_achievements"
 msgstr "My achievements"
 
+#: templates/achievements.html:36 templates/achievements.html:50
+#: templates/landing-page.html:89 templates/layout.html:92
+#: templates/public-page.html:51
+#, fuzzy
+msgid "achievements_logo_alt"
+msgstr "achievements"
+
+#: templates/achievements.html:37
+#, fuzzy
+msgid "achievements_check_icon_alt"
+msgstr "You've earned an achievement!"
+
+#: templates/base_email.html:3 templates/cheatsheet.html:15
+#: templates/incl-menubar.html:4
+msgid "hedy_logo_alt"
+msgstr ""
+
 #: templates/cheatsheet.html:14
 #, fuzzy
 msgid "cheatsheet_title"
@@ -856,7 +873,7 @@ msgstr "Enter a username"
 msgid "invite_by_username"
 msgstr "All usernames need to be unique."
 
-#: templates/class-overview.html:55 templates/create-accounts.html:49
+#: templates/class-overview.html:55 templates/create-accounts.html:45
 #, fuzzy
 msgid "create_accounts"
 msgstr "Create multiple accounts"
@@ -886,6 +903,10 @@ msgstr "Are you sure you want to remove this class invitation?"
 msgid "class_already_joined"
 msgstr "You are already a student of class"
 
+#: templates/class-prejoin.html:9 templates/error-page.html:6
+msgid "error_logo_alt"
+msgstr ""
+
 #: templates/class-prejoin.html:11
 #, fuzzy
 msgid "goto_profile"
@@ -906,7 +927,8 @@ msgstr "You need to have an account to join a class. Would you like to login now
 msgid "join_class"
 msgstr "Join class"
 
-#: templates/class-stats.html:22 templates/customize-class.html:166
+#: templates/class-stats.html:22 templates/create-accounts.html:41
+#: templates/customize-class.html:166
 #, fuzzy
 msgid "back_to_class"
 msgstr "Go back to class"
@@ -948,29 +970,24 @@ msgstr ""
 msgid "create_accounts_prompt"
 msgstr "Are you sure you want to create these accounts?"
 
-#: templates/create-accounts.html:19
-#, fuzzy
-msgid "select_class"
-msgstr "Select class"
-
-#: templates/create-accounts.html:30
+#: templates/create-accounts.html:25
 #, fuzzy
 msgid "download_login_credentials"
 msgstr ""
 
-#: templates/create-accounts.html:34 templates/layout.html:22
+#: templates/create-accounts.html:29 templates/layout.html:22
 #: templates/signup.html:64
 #, fuzzy
 msgid "yes"
 msgstr "Yes"
 
-#: templates/create-accounts.html:38 templates/layout.html:23
+#: templates/create-accounts.html:33 templates/layout.html:23
 #: templates/signup.html:68
 #, fuzzy
 msgid "no"
 msgstr "No"
 
-#: templates/create-accounts.html:48 templates/programs.html:24
+#: templates/create-accounts.html:44 templates/programs.html:24
 #, fuzzy
 msgid "reset_view"
 msgstr "Reset"
@@ -1302,7 +1319,7 @@ msgstr "View"
 msgid "adventure_prompt"
 msgstr "Please enter the name of the adventure"
 
-#: templates/for-teachers.html:59 website/teacher.py:499
+#: templates/for-teachers.html:59 website/teacher.py:501
 #, fuzzy
 msgid "create_adventure"
 msgstr "Create adventure"
@@ -1375,6 +1392,10 @@ msgstr "Next exercise"
 #, fuzzy
 msgid "edit_code_button"
 msgstr "Edit code"
+
+#: templates/incl-editor-and-output.html:146
+msgid "repair_program_logo_alt"
+msgstr ""
 
 #: templates/incl-editor-and-output.html:150
 #, fuzzy
@@ -1478,25 +1499,52 @@ msgstr ""
 "Welcome to Hedy! Your are now the proud owner of a teachers account which"
 " allows you to create classes and invite students."
 
+#: templates/landing-page.html:11
+#, fuzzy
+msgid "teacher_tutorial_logo_alt"
+msgstr "You have received an invitation to join class"
+
 #: templates/landing-page.html:13
 #, fuzzy
 msgid "start_teacher_tutorial"
 msgstr "Start teacher tutorial"
+
+#: templates/landing-page.html:18
+#, fuzzy
+msgid "hedy_tutorial_logo_alt"
+msgstr "Start hedy tutorial"
 
 #: templates/landing-page.html:20
 #, fuzzy
 msgid "start_hedy_tutorial"
 msgstr "Start hedy tutorial"
 
+#: templates/landing-page.html:25
+#, fuzzy
+msgid "start_programming_logo_alt"
+msgstr "Directly start programming"
+
 #: templates/landing-page.html:27
 #, fuzzy
 msgid "start_programming"
 msgstr "Directly start programming"
 
+#: templates/landing-page.html:31
+#, fuzzy
+msgid "explore_programs_logo_alt"
+msgstr "Explore programs"
+
 #: templates/landing-page.html:39
 #, fuzzy
 msgid "your_account"
 msgstr "No account?"
+
+#: templates/landing-page.html:43 templates/landing-page.html:45
+#: templates/profile.html:33 templates/public-page.html:7
+#: templates/public-page.html:9
+#, fuzzy
+msgid "profile_logo_alt"
+msgstr "Profile updated."
 
 #: templates/landing-page.html:52 templates/public-page.html:16
 #, fuzzy
@@ -1917,6 +1965,10 @@ msgstr "Write your first program!"
 #, fuzzy
 msgid "no_shared_programs"
 msgstr "has no shared programs..."
+
+#: templates/quiz.html:4
+msgid "quiz_logo_alt"
+msgstr ""
 
 #: templates/quiz.html:7
 #, fuzzy
@@ -2392,7 +2444,7 @@ msgstr "Program unshared successfully."
 msgid "favourite_success"
 msgstr "Your program is set as favourite."
 
-#: website/quiz.py:45 website/quiz.py:71 website/teacher.py:452
+#: website/quiz.py:45 website/quiz.py:71 website/teacher.py:454
 #, fuzzy
 msgid "level_invalid"
 msgstr "This Hedy level in invalid."
@@ -2425,6 +2477,7 @@ msgstr "Only teachers can retrieve classes"
 #: website/statistics.py:41 website/teacher.py:38 website/teacher.py:131
 #: website/teacher.py:150 website/teacher.py:212 website/teacher.py:234
 #: website/teacher.py:246 website/teacher.py:313 website/teacher.py:352
+#: website/teacher.py:364
 #, fuzzy
 msgid "no_such_class"
 msgstr "No such Hedy class"
@@ -2459,7 +2512,7 @@ msgstr "You didn't enter a class name!"
 msgid "class_name_duplicate"
 msgstr "You already have a class with this name."
 
-#: website/teacher.py:162 website/teacher.py:178 website/teacher.py:531
+#: website/teacher.py:162 website/teacher.py:178 website/teacher.py:533
 #, fuzzy
 msgid "invalid_class_link"
 msgstr "Invalid link for joining the class."
@@ -2504,78 +2557,78 @@ msgstr "This student is already in your class."
 msgid "student_already_invite"
 msgstr "This student already has a pending invitation."
 
-#: website/teacher.py:380
+#: website/teacher.py:382
 #, fuzzy
 msgid "no_accounts"
 msgstr "There are no accounts to create."
 
-#: website/teacher.py:390
+#: website/teacher.py:392
 #, fuzzy
 msgid "unique_usernames"
 msgstr "All usernames need to be unique."
 
-#: website/teacher.py:399
+#: website/teacher.py:401
 #, fuzzy
 msgid "usernames_exist"
 msgstr "One or more usernames is already in use."
 
-#: website/teacher.py:410
+#: website/teacher.py:412
 #, fuzzy
 msgid "accounts_created"
 msgstr "Accounts where successfully created."
 
-#: website/teacher.py:416 website/teacher.py:421 website/teacher.py:432
-#: website/teacher.py:461 website/teacher.py:487
+#: website/teacher.py:418 website/teacher.py:423 website/teacher.py:434
+#: website/teacher.py:463 website/teacher.py:489
 #, fuzzy
 msgid "retrieve_adventure_error"
 msgstr "You're not allowed to view this adventure!"
 
-#: website/teacher.py:426
+#: website/teacher.py:428
 #, fuzzy
 msgid "title_view-adventure"
 msgstr "Hedy - View adventure"
 
-#: website/teacher.py:437
+#: website/teacher.py:439
 #, fuzzy
 msgid "title_customize-adventure"
 msgstr "Hedy - Customize adventure"
 
-#: website/teacher.py:448
+#: website/teacher.py:450
 #, fuzzy
 msgid "adventure_id_invalid"
 msgstr "This adventure id is invalid."
 
-#: website/teacher.py:450 website/teacher.py:506
+#: website/teacher.py:452 website/teacher.py:508
 #, fuzzy
 msgid "adventure_name_invalid"
 msgstr "This adventure name is invalid."
 
-#: website/teacher.py:454
+#: website/teacher.py:456
 #, fuzzy
 msgid "content_invalid"
 msgstr "This adventure is invalid."
 
-#: website/teacher.py:456
+#: website/teacher.py:458
 #, fuzzy
 msgid "adventure_length"
 msgstr "Your adventure has to be at least 20 characters."
 
-#: website/teacher.py:458
+#: website/teacher.py:460
 #, fuzzy
 msgid "public_invalid"
 msgstr "This agreement selection is invalid"
 
-#: website/teacher.py:469 website/teacher.py:513
+#: website/teacher.py:471 website/teacher.py:515
 #, fuzzy
 msgid "adventure_duplicate"
 msgstr "You already have an adventure with this name."
 
-#: website/teacher.py:481
+#: website/teacher.py:483
 #, fuzzy
 msgid "adventure_updated"
 msgstr "The adventure has been updated!"
 
-#: website/teacher.py:508
+#: website/teacher.py:510
 #, fuzzy
 msgid "adventure_empty"
 msgstr "You didn't enter an adventure name!"
@@ -2734,4 +2787,7 @@ msgstr "You didn't enter an adventure name!"
 
 #~ msgid "go_to_first_exercise"
 #~ msgstr "Go to question 1"
+
+#~ msgid "select_class"
+#~ msgstr "Select class"
 

--- a/translations/cs/LC_MESSAGES/messages.po
+++ b/translations/cs/LC_MESSAGES/messages.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-21 10:36+0200\n"
+"POT-Creation-Date: 2022-06-23 14:02+0200\n"
 "PO-Revision-Date: 2022-06-18 14:19+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: cs\n"
@@ -23,7 +23,7 @@ msgid "title_achievements"
 msgstr "Hedy - Moje úspěchy"
 
 #: app.py:639 app.py:743 app.py:1085 website/teacher.py:361
-#: website/teacher.py:370
+#: website/teacher.py:372
 msgid "not_teacher"
 msgstr "Zdá se, že nejste učitel!"
 
@@ -59,8 +59,8 @@ msgstr "Neexistující program jazyka Hedy!"
 msgid "level_not_class"
 msgstr "Jste ve třídě, kde tato úroveň ještě nebyla zpřístupněna"
 
-#: app.py:923 website/teacher.py:419 website/teacher.py:435
-#: website/teacher.py:464 website/teacher.py:490
+#: app.py:923 website/teacher.py:421 website/teacher.py:437
+#: website/teacher.py:466 website/teacher.py:492
 msgid "no_such_adventure"
 msgstr "Toto dobrodružství neexistuje!"
 
@@ -344,8 +344,8 @@ msgstr ""
 #: website/auth.py:671 website/auth.py:718 website/auth.py:745
 #: website/quiz.py:43 website/quiz.py:69 website/teacher.py:88
 #: website/teacher.py:123 website/teacher.py:195 website/teacher.py:251
-#: website/teacher.py:298 website/teacher.py:339 website/teacher.py:375
-#: website/teacher.py:446 website/teacher.py:504
+#: website/teacher.py:298 website/teacher.py:339 website/teacher.py:377
+#: website/teacher.py:448 website/teacher.py:506
 msgid "ajax_error"
 msgstr "Nastala chyba, prosím zkus to znova."
 
@@ -686,6 +686,23 @@ msgstr "Hint?"
 msgid "hedy_achievements"
 msgstr "My achievements"
 
+#: templates/achievements.html:36 templates/achievements.html:50
+#: templates/landing-page.html:89 templates/layout.html:92
+#: templates/public-page.html:51
+#, fuzzy
+msgid "achievements_logo_alt"
+msgstr "achievements"
+
+#: templates/achievements.html:37
+#, fuzzy
+msgid "achievements_check_icon_alt"
+msgstr "You've earned an achievement!"
+
+#: templates/base_email.html:3 templates/cheatsheet.html:15
+#: templates/incl-menubar.html:4
+msgid "hedy_logo_alt"
+msgstr ""
+
 #: templates/cheatsheet.html:14
 #, fuzzy
 msgid "cheatsheet_title"
@@ -809,7 +826,7 @@ msgstr "Enter a username"
 msgid "invite_by_username"
 msgstr "All usernames need to be unique."
 
-#: templates/class-overview.html:55 templates/create-accounts.html:49
+#: templates/class-overview.html:55 templates/create-accounts.html:45
 #, fuzzy
 msgid "create_accounts"
 msgstr "Create multiple accounts"
@@ -839,6 +856,10 @@ msgstr "Are you sure you want to remove this class invitation?"
 msgid "class_already_joined"
 msgstr "You are already a student of class"
 
+#: templates/class-prejoin.html:9 templates/error-page.html:6
+msgid "error_logo_alt"
+msgstr ""
+
 #: templates/class-prejoin.html:11
 #, fuzzy
 msgid "goto_profile"
@@ -859,7 +880,8 @@ msgstr "You need to have an account to join a class. Would you like to login now
 msgid "join_class"
 msgstr "Join class"
 
-#: templates/class-stats.html:22 templates/customize-class.html:166
+#: templates/class-stats.html:22 templates/create-accounts.html:41
+#: templates/customize-class.html:166
 #, fuzzy
 msgid "back_to_class"
 msgstr "Go back to class"
@@ -900,27 +922,22 @@ msgstr ""
 msgid "create_accounts_prompt"
 msgstr "Are you sure you want to create these accounts?"
 
-#: templates/create-accounts.html:19
-#, fuzzy
-msgid "select_class"
-msgstr "Select class"
-
-#: templates/create-accounts.html:30
+#: templates/create-accounts.html:25
 #, fuzzy
 msgid "download_login_credentials"
 msgstr "Do you want to download the login credentials after the accounts creation?"
 
-#: templates/create-accounts.html:34 templates/layout.html:22
+#: templates/create-accounts.html:29 templates/layout.html:22
 #: templates/signup.html:64
 msgid "yes"
 msgstr "Ano"
 
-#: templates/create-accounts.html:38 templates/layout.html:23
+#: templates/create-accounts.html:33 templates/layout.html:23
 #: templates/signup.html:68
 msgid "no"
 msgstr "Ne"
 
-#: templates/create-accounts.html:48 templates/programs.html:24
+#: templates/create-accounts.html:44 templates/programs.html:24
 #, fuzzy
 msgid "reset_view"
 msgstr "Reset"
@@ -1250,7 +1267,7 @@ msgstr "View"
 msgid "adventure_prompt"
 msgstr "Please enter the name of the adventure"
 
-#: templates/for-teachers.html:59 website/teacher.py:499
+#: templates/for-teachers.html:59 website/teacher.py:501
 #, fuzzy
 msgid "create_adventure"
 msgstr "Create adventure"
@@ -1319,6 +1336,10 @@ msgstr "Next exercise"
 #: templates/incl-editor-and-output.html:144
 msgid "edit_code_button"
 msgstr "Upravit kód"
+
+#: templates/incl-editor-and-output.html:146
+msgid "repair_program_logo_alt"
+msgstr ""
 
 #: templates/incl-editor-and-output.html:150
 msgid "read_code_label"
@@ -1414,25 +1435,52 @@ msgstr ""
 "Welcome to Hedy! Your are now the proud owner of a teachers account which"
 " allows you to create classes and invite students."
 
+#: templates/landing-page.html:11
+#, fuzzy
+msgid "teacher_tutorial_logo_alt"
+msgstr "You have received an invitation to join class"
+
 #: templates/landing-page.html:13
 #, fuzzy
 msgid "start_teacher_tutorial"
 msgstr "Start teacher tutorial"
+
+#: templates/landing-page.html:18
+#, fuzzy
+msgid "hedy_tutorial_logo_alt"
+msgstr "Start hedy tutorial"
 
 #: templates/landing-page.html:20
 #, fuzzy
 msgid "start_hedy_tutorial"
 msgstr "Start hedy tutorial"
 
+#: templates/landing-page.html:25
+#, fuzzy
+msgid "start_programming_logo_alt"
+msgstr "Directly start programming"
+
 #: templates/landing-page.html:27
 #, fuzzy
 msgid "start_programming"
 msgstr "Directly start programming"
 
+#: templates/landing-page.html:31
+#, fuzzy
+msgid "explore_programs_logo_alt"
+msgstr "Explore programs"
+
 #: templates/landing-page.html:39
 #, fuzzy
 msgid "your_account"
 msgstr "Zatím nemáš svů účet?"
+
+#: templates/landing-page.html:43 templates/landing-page.html:45
+#: templates/profile.html:33 templates/public-page.html:7
+#: templates/public-page.html:9
+#, fuzzy
+msgid "profile_logo_alt"
+msgstr "Profil byl upraven."
 
 #: templates/landing-page.html:52 templates/public-page.html:16
 #, fuzzy
@@ -1819,6 +1867,10 @@ msgstr "Write your first program!"
 #, fuzzy
 msgid "no_shared_programs"
 msgstr "has no shared programs..."
+
+#: templates/quiz.html:4
+msgid "quiz_logo_alt"
+msgstr ""
 
 #: templates/quiz.html:7
 #, fuzzy
@@ -2262,7 +2314,7 @@ msgstr "Program už dále není sdílený"
 msgid "favourite_success"
 msgstr "Your program is set as favourite."
 
-#: website/quiz.py:45 website/quiz.py:71 website/teacher.py:452
+#: website/quiz.py:45 website/quiz.py:71 website/teacher.py:454
 #, fuzzy
 msgid "level_invalid"
 msgstr "This Hedy level in invalid."
@@ -2295,6 +2347,7 @@ msgstr "Only teachers can retrieve classes"
 #: website/statistics.py:41 website/teacher.py:38 website/teacher.py:131
 #: website/teacher.py:150 website/teacher.py:212 website/teacher.py:234
 #: website/teacher.py:246 website/teacher.py:313 website/teacher.py:352
+#: website/teacher.py:364
 #, fuzzy
 msgid "no_such_class"
 msgstr "No such Hedy class"
@@ -2329,7 +2382,7 @@ msgstr "You didn't enter a class name!"
 msgid "class_name_duplicate"
 msgstr "You already have a class with this name."
 
-#: website/teacher.py:162 website/teacher.py:178 website/teacher.py:531
+#: website/teacher.py:162 website/teacher.py:178 website/teacher.py:533
 #, fuzzy
 msgid "invalid_class_link"
 msgstr "Invalid link for joining the class."
@@ -2374,78 +2427,78 @@ msgstr "This student is already in your class."
 msgid "student_already_invite"
 msgstr "This student already has a pending invitation."
 
-#: website/teacher.py:380
+#: website/teacher.py:382
 #, fuzzy
 msgid "no_accounts"
 msgstr "There are no accounts to create."
 
-#: website/teacher.py:390
+#: website/teacher.py:392
 #, fuzzy
 msgid "unique_usernames"
 msgstr "All usernames need to be unique."
 
-#: website/teacher.py:399
+#: website/teacher.py:401
 #, fuzzy
 msgid "usernames_exist"
 msgstr "One or more usernames is already in use."
 
-#: website/teacher.py:410
+#: website/teacher.py:412
 #, fuzzy
 msgid "accounts_created"
 msgstr "Accounts where successfully created."
 
-#: website/teacher.py:416 website/teacher.py:421 website/teacher.py:432
-#: website/teacher.py:461 website/teacher.py:487
+#: website/teacher.py:418 website/teacher.py:423 website/teacher.py:434
+#: website/teacher.py:463 website/teacher.py:489
 #, fuzzy
 msgid "retrieve_adventure_error"
 msgstr "You're not allowed to view this adventure!"
 
-#: website/teacher.py:426
+#: website/teacher.py:428
 #, fuzzy
 msgid "title_view-adventure"
 msgstr "Hedy - View adventure"
 
-#: website/teacher.py:437
+#: website/teacher.py:439
 #, fuzzy
 msgid "title_customize-adventure"
 msgstr "Hedy - Customize adventure"
 
-#: website/teacher.py:448
+#: website/teacher.py:450
 #, fuzzy
 msgid "adventure_id_invalid"
 msgstr "This adventure id is invalid."
 
-#: website/teacher.py:450 website/teacher.py:506
+#: website/teacher.py:452 website/teacher.py:508
 #, fuzzy
 msgid "adventure_name_invalid"
 msgstr "This adventure name is invalid."
 
-#: website/teacher.py:454
+#: website/teacher.py:456
 #, fuzzy
 msgid "content_invalid"
 msgstr "This adventure is invalid."
 
-#: website/teacher.py:456
+#: website/teacher.py:458
 #, fuzzy
 msgid "adventure_length"
 msgstr "Your adventure has to be at least 20 characters."
 
-#: website/teacher.py:458
+#: website/teacher.py:460
 #, fuzzy
 msgid "public_invalid"
 msgstr "This agreement selection is invalid"
 
-#: website/teacher.py:469 website/teacher.py:513
+#: website/teacher.py:471 website/teacher.py:515
 #, fuzzy
 msgid "adventure_duplicate"
 msgstr "You already have an adventure with this name."
 
-#: website/teacher.py:481
+#: website/teacher.py:483
 #, fuzzy
 msgid "adventure_updated"
 msgstr "The adventure has been updated!"
 
-#: website/teacher.py:508
+#: website/teacher.py:510
 #, fuzzy
 msgid "adventure_empty"
 msgstr "You didn't enter an adventure name!"
@@ -2613,4 +2666,7 @@ msgstr "You didn't enter an adventure name!"
 
 #~ msgid "go_to_first_exercise"
 #~ msgstr "Go to question 1"
+
+#~ msgid "select_class"
+#~ msgstr "Select class"
 

--- a/translations/de/LC_MESSAGES/messages.po
+++ b/translations/de/LC_MESSAGES/messages.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-21 10:36+0200\n"
+"POT-Creation-Date: 2022-06-23 14:02+0200\n"
 "PO-Revision-Date: 2022-06-18 14:19+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: de\n"
@@ -25,7 +25,7 @@ msgid "title_achievements"
 msgstr "Hedy - My achievements"
 
 #: app.py:639 app.py:743 app.py:1085 website/teacher.py:361
-#: website/teacher.py:370
+#: website/teacher.py:372
 #, fuzzy
 msgid "not_teacher"
 msgstr "Looks like you are not a teacher!"
@@ -69,8 +69,8 @@ msgstr "No such Hedy program!"
 msgid "level_not_class"
 msgstr "You're in a class where this level has not been made available yet"
 
-#: app.py:923 website/teacher.py:419 website/teacher.py:435
-#: website/teacher.py:464 website/teacher.py:490
+#: app.py:923 website/teacher.py:421 website/teacher.py:437
+#: website/teacher.py:466 website/teacher.py:492
 #, fuzzy
 msgid "no_such_adventure"
 msgstr "This adventure doesn't exist!"
@@ -367,8 +367,8 @@ msgstr ""
 #: website/auth.py:671 website/auth.py:718 website/auth.py:745
 #: website/quiz.py:43 website/quiz.py:69 website/teacher.py:88
 #: website/teacher.py:123 website/teacher.py:195 website/teacher.py:251
-#: website/teacher.py:298 website/teacher.py:339 website/teacher.py:375
-#: website/teacher.py:446 website/teacher.py:504
+#: website/teacher.py:298 website/teacher.py:339 website/teacher.py:377
+#: website/teacher.py:448 website/teacher.py:506
 msgid "ajax_error"
 msgstr "Ein Fehler ist aufgetreten. Bitte nochmal versuchen."
 
@@ -693,6 +693,23 @@ msgstr "Hint?"
 msgid "hedy_achievements"
 msgstr "Meine Leistungen"
 
+#: templates/achievements.html:36 templates/achievements.html:50
+#: templates/landing-page.html:89 templates/layout.html:92
+#: templates/public-page.html:51
+#, fuzzy
+msgid "achievements_logo_alt"
+msgstr "achievements"
+
+#: templates/achievements.html:37
+#, fuzzy
+msgid "achievements_check_icon_alt"
+msgstr "Du hast eine Leistung erbracht!"
+
+#: templates/base_email.html:3 templates/cheatsheet.html:15
+#: templates/incl-menubar.html:4
+msgid "hedy_logo_alt"
+msgstr ""
+
 #: templates/cheatsheet.html:14
 #, fuzzy
 msgid "cheatsheet_title"
@@ -805,7 +822,7 @@ msgstr "Enter a username"
 msgid "invite_by_username"
 msgstr "All usernames need to be unique."
 
-#: templates/class-overview.html:55 templates/create-accounts.html:49
+#: templates/class-overview.html:55 templates/create-accounts.html:45
 #, fuzzy
 msgid "create_accounts"
 msgstr "Create multiple accounts"
@@ -834,6 +851,10 @@ msgstr "Are you sure you want to remove this class invitation?"
 msgid "class_already_joined"
 msgstr "Du bist schon in dieser Klasse"
 
+#: templates/class-prejoin.html:9 templates/error-page.html:6
+msgid "error_logo_alt"
+msgstr ""
+
 #: templates/class-prejoin.html:11
 msgid "goto_profile"
 msgstr "Mein Profil"
@@ -850,7 +871,8 @@ msgstr "Zum beitreten benötigst du einen Account. Möchtest du dich einloggen?"
 msgid "join_class"
 msgstr "Klasse beitreten"
 
-#: templates/class-stats.html:22 templates/customize-class.html:166
+#: templates/class-stats.html:22 templates/create-accounts.html:41
+#: templates/customize-class.html:166
 msgid "back_to_class"
 msgstr "Gehe zurück zur Klasse"
 
@@ -890,27 +912,22 @@ msgstr ""
 msgid "create_accounts_prompt"
 msgstr "Are you sure you want to create these accounts?"
 
-#: templates/create-accounts.html:19
-#, fuzzy
-msgid "select_class"
-msgstr "Select class"
-
-#: templates/create-accounts.html:30
+#: templates/create-accounts.html:25
 #, fuzzy
 msgid "download_login_credentials"
 msgstr ""
 
-#: templates/create-accounts.html:34 templates/layout.html:22
+#: templates/create-accounts.html:29 templates/layout.html:22
 #: templates/signup.html:64
 msgid "yes"
 msgstr "Ja"
 
-#: templates/create-accounts.html:38 templates/layout.html:23
+#: templates/create-accounts.html:33 templates/layout.html:23
 #: templates/signup.html:68
 msgid "no"
 msgstr "Nein"
 
-#: templates/create-accounts.html:48 templates/programs.html:24
+#: templates/create-accounts.html:44 templates/programs.html:24
 #, fuzzy
 msgid "reset_view"
 msgstr "Reset"
@@ -1231,7 +1248,7 @@ msgstr "View"
 msgid "adventure_prompt"
 msgstr "Please enter the name of the adventure"
 
-#: templates/for-teachers.html:59 website/teacher.py:499
+#: templates/for-teachers.html:59 website/teacher.py:501
 #, fuzzy
 msgid "create_adventure"
 msgstr "Create adventure"
@@ -1298,6 +1315,10 @@ msgstr "Next exercise"
 #: templates/incl-editor-and-output.html:144
 msgid "edit_code_button"
 msgstr "Programm ändern"
+
+#: templates/incl-editor-and-output.html:146
+msgid "repair_program_logo_alt"
+msgstr ""
 
 #: templates/incl-editor-and-output.html:150
 msgid "read_code_label"
@@ -1387,25 +1408,52 @@ msgstr ""
 "Willkommen bei Hedy! Du bist nun eine stolze BesitzerIn eines LehrerIn "
 "Kontos, welches dir erlaubt Klassen zu erstellen und Schüler einzuladen."
 
+#: templates/landing-page.html:11
+#, fuzzy
+msgid "teacher_tutorial_logo_alt"
+msgstr "You have received an invitation to join class"
+
 #: templates/landing-page.html:13
 #, fuzzy
 msgid "start_teacher_tutorial"
 msgstr "Start teacher tutorial"
+
+#: templates/landing-page.html:18
+#, fuzzy
+msgid "hedy_tutorial_logo_alt"
+msgstr "Start hedy tutorial"
 
 #: templates/landing-page.html:20
 #, fuzzy
 msgid "start_hedy_tutorial"
 msgstr "Start hedy tutorial"
 
+#: templates/landing-page.html:25
+#, fuzzy
+msgid "start_programming_logo_alt"
+msgstr "Directly start programming"
+
 #: templates/landing-page.html:27
 #, fuzzy
 msgid "start_programming"
 msgstr "Directly start programming"
 
+#: templates/landing-page.html:31
+#, fuzzy
+msgid "explore_programs_logo_alt"
+msgstr "Entdecke die Programme"
+
 #: templates/landing-page.html:39
 #, fuzzy
 msgid "your_account"
 msgstr "Hast du noch kein Konto?"
+
+#: templates/landing-page.html:43 templates/landing-page.html:45
+#: templates/profile.html:33 templates/public-page.html:7
+#: templates/public-page.html:9
+#, fuzzy
+msgid "profile_logo_alt"
+msgstr "Das Profil wurde aktualisiert."
 
 #: templates/landing-page.html:52 templates/public-page.html:16
 #, fuzzy
@@ -1778,6 +1826,10 @@ msgstr "Schreibe dein erstes Programm!"
 #, fuzzy
 msgid "no_shared_programs"
 msgstr "has no shared programs..."
+
+#: templates/quiz.html:4
+msgid "quiz_logo_alt"
+msgstr ""
 
 #: templates/quiz.html:7
 #, fuzzy
@@ -2214,7 +2266,7 @@ msgstr "Programm wieder verborgen"
 msgid "favourite_success"
 msgstr "Your program is set as favourite."
 
-#: website/quiz.py:45 website/quiz.py:71 website/teacher.py:452
+#: website/quiz.py:45 website/quiz.py:71 website/teacher.py:454
 #, fuzzy
 msgid "level_invalid"
 msgstr "This Hedy level in invalid."
@@ -2247,6 +2299,7 @@ msgstr "Only teachers can retrieve classes"
 #: website/statistics.py:41 website/teacher.py:38 website/teacher.py:131
 #: website/teacher.py:150 website/teacher.py:212 website/teacher.py:234
 #: website/teacher.py:246 website/teacher.py:313 website/teacher.py:352
+#: website/teacher.py:364
 #, fuzzy
 msgid "no_such_class"
 msgstr "No such Hedy class"
@@ -2279,7 +2332,7 @@ msgstr "Du hast keinen Namen für die Klasse eingegeben!"
 msgid "class_name_duplicate"
 msgstr "Du hast bereits eine Klasse mit diesem Namen!"
 
-#: website/teacher.py:162 website/teacher.py:178 website/teacher.py:531
+#: website/teacher.py:162 website/teacher.py:178 website/teacher.py:533
 #, fuzzy
 msgid "invalid_class_link"
 msgstr "Invalid link for joining the class."
@@ -2324,78 +2377,78 @@ msgstr "This student is already in your class."
 msgid "student_already_invite"
 msgstr "This student already has a pending invitation."
 
-#: website/teacher.py:380
+#: website/teacher.py:382
 #, fuzzy
 msgid "no_accounts"
 msgstr "There are no accounts to create."
 
-#: website/teacher.py:390
+#: website/teacher.py:392
 #, fuzzy
 msgid "unique_usernames"
 msgstr "All usernames need to be unique."
 
-#: website/teacher.py:399
+#: website/teacher.py:401
 #, fuzzy
 msgid "usernames_exist"
 msgstr "One or more usernames is already in use."
 
-#: website/teacher.py:410
+#: website/teacher.py:412
 #, fuzzy
 msgid "accounts_created"
 msgstr "Accounts where successfully created."
 
-#: website/teacher.py:416 website/teacher.py:421 website/teacher.py:432
-#: website/teacher.py:461 website/teacher.py:487
+#: website/teacher.py:418 website/teacher.py:423 website/teacher.py:434
+#: website/teacher.py:463 website/teacher.py:489
 #, fuzzy
 msgid "retrieve_adventure_error"
 msgstr "You're not allowed to view this adventure!"
 
-#: website/teacher.py:426
+#: website/teacher.py:428
 #, fuzzy
 msgid "title_view-adventure"
 msgstr "Hedy - View adventure"
 
-#: website/teacher.py:437
+#: website/teacher.py:439
 #, fuzzy
 msgid "title_customize-adventure"
 msgstr "Welches Abenteuer möchtest du verfügbar machen?"
 
-#: website/teacher.py:448
+#: website/teacher.py:450
 #, fuzzy
 msgid "adventure_id_invalid"
 msgstr "This adventure id is invalid."
 
-#: website/teacher.py:450 website/teacher.py:506
+#: website/teacher.py:452 website/teacher.py:508
 #, fuzzy
 msgid "adventure_name_invalid"
 msgstr "This adventure name is invalid."
 
-#: website/teacher.py:454
+#: website/teacher.py:456
 #, fuzzy
 msgid "content_invalid"
 msgstr "This adventure is invalid."
 
-#: website/teacher.py:456
+#: website/teacher.py:458
 #, fuzzy
 msgid "adventure_length"
 msgstr "Your adventure has to be at least 20 characters."
 
-#: website/teacher.py:458
+#: website/teacher.py:460
 #, fuzzy
 msgid "public_invalid"
 msgstr "This agreement selection is invalid"
 
-#: website/teacher.py:469 website/teacher.py:513
+#: website/teacher.py:471 website/teacher.py:515
 #, fuzzy
 msgid "adventure_duplicate"
 msgstr "You already have an adventure with this name."
 
-#: website/teacher.py:481
+#: website/teacher.py:483
 #, fuzzy
 msgid "adventure_updated"
 msgstr "The adventure has been updated!"
 
-#: website/teacher.py:508
+#: website/teacher.py:510
 #, fuzzy
 msgid "adventure_empty"
 msgstr "You didn't enter an adventure name!"
@@ -2560,4 +2613,7 @@ msgstr "You didn't enter an adventure name!"
 
 #~ msgid "go_to_first_exercise"
 #~ msgstr "Go to question 1"
+
+#~ msgid "select_class"
+#~ msgstr "Select class"
 

--- a/translations/el/LC_MESSAGES/messages.po
+++ b/translations/el/LC_MESSAGES/messages.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-21 10:36+0200\n"
+"POT-Creation-Date: 2022-06-23 14:02+0200\n"
 "PO-Revision-Date: 2022-06-18 14:19+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: el\n"
@@ -25,7 +25,7 @@ msgid "title_achievements"
 msgstr "Hedy - My achievements"
 
 #: app.py:639 app.py:743 app.py:1085 website/teacher.py:361
-#: website/teacher.py:370
+#: website/teacher.py:372
 msgid "not_teacher"
 msgstr "Φαίνεται πως δεν είσαι καθηγητής!"
 
@@ -64,8 +64,8 @@ msgstr "Δεν υπάρχει τέτοιο πρόγραμμα Hedy!"
 msgid "level_not_class"
 msgstr "Είσαι σε μια τάξη στην οποία δεν είναι ακόμα διαθέσιμο αυτό το επίπεδο"
 
-#: app.py:923 website/teacher.py:419 website/teacher.py:435
-#: website/teacher.py:464 website/teacher.py:490
+#: app.py:923 website/teacher.py:421 website/teacher.py:437
+#: website/teacher.py:466 website/teacher.py:492
 msgid "no_such_adventure"
 msgstr "Αυτή η περιπέτεια δεν υπάρχει!"
 
@@ -360,8 +360,8 @@ msgstr ""
 #: website/auth.py:671 website/auth.py:718 website/auth.py:745
 #: website/quiz.py:43 website/quiz.py:69 website/teacher.py:88
 #: website/teacher.py:123 website/teacher.py:195 website/teacher.py:251
-#: website/teacher.py:298 website/teacher.py:339 website/teacher.py:375
-#: website/teacher.py:446 website/teacher.py:504
+#: website/teacher.py:298 website/teacher.py:339 website/teacher.py:377
+#: website/teacher.py:448 website/teacher.py:506
 msgid "ajax_error"
 msgstr "Παρουσιάστηκε κάποιο σφάλμα, παρακαλώ ξαναπροσπάθησε."
 
@@ -668,6 +668,23 @@ msgstr "Κρυμμένο"
 msgid "hedy_achievements"
 msgstr "Επιτεύγματα Hedy"
 
+#: templates/achievements.html:36 templates/achievements.html:50
+#: templates/landing-page.html:89 templates/layout.html:92
+#: templates/public-page.html:51
+#, fuzzy
+msgid "achievements_logo_alt"
+msgstr "επιτεύγματα"
+
+#: templates/achievements.html:37
+#, fuzzy
+msgid "achievements_check_icon_alt"
+msgstr "Κέρδισες ένα επίτευγμα!"
+
+#: templates/base_email.html:3 templates/cheatsheet.html:15
+#: templates/incl-menubar.html:4
+msgid "hedy_logo_alt"
+msgstr ""
+
 #: templates/cheatsheet.html:14
 #, fuzzy
 msgid "cheatsheet_title"
@@ -775,7 +792,7 @@ msgstr "Δώσε όνομα χρήστη"
 msgid "invite_by_username"
 msgstr "Όλα τα ονόματα χρηστών πρέπει να είναι μοναδικά."
 
-#: templates/class-overview.html:55 templates/create-accounts.html:49
+#: templates/class-overview.html:55 templates/create-accounts.html:45
 msgid "create_accounts"
 msgstr "Δημιουργία πολλών λογαριασμών"
 
@@ -800,6 +817,10 @@ msgstr "Είσαι βέβαιος ότι θέλεις να καταργήσει�
 msgid "class_already_joined"
 msgstr "Είσαι ήδη μαθητής της τάξης"
 
+#: templates/class-prejoin.html:9 templates/error-page.html:6
+msgid "error_logo_alt"
+msgstr ""
+
 #: templates/class-prejoin.html:11
 msgid "goto_profile"
 msgstr "Πήγαινε στο προφίλ μου"
@@ -818,7 +839,8 @@ msgstr ""
 msgid "join_class"
 msgstr "Συμμετοχή σε τάξη"
 
-#: templates/class-stats.html:22 templates/customize-class.html:166
+#: templates/class-stats.html:22 templates/create-accounts.html:41
+#: templates/customize-class.html:166
 msgid "back_to_class"
 msgstr "Επιστροφή στην τάξη"
 
@@ -859,26 +881,22 @@ msgstr ""
 msgid "create_accounts_prompt"
 msgstr "Είσαι σίγουρος ότι θέλεις να δημιουργήσεις αυτούς τους λογαριασμούς;"
 
-#: templates/create-accounts.html:19
-msgid "select_class"
-msgstr "Επίλεξε τάξη"
-
-#: templates/create-accounts.html:30
+#: templates/create-accounts.html:25
 #, fuzzy
 msgid "download_login_credentials"
 msgstr ""
 
-#: templates/create-accounts.html:34 templates/layout.html:22
+#: templates/create-accounts.html:29 templates/layout.html:22
 #: templates/signup.html:64
 msgid "yes"
 msgstr "Ναι"
 
-#: templates/create-accounts.html:38 templates/layout.html:23
+#: templates/create-accounts.html:33 templates/layout.html:23
 #: templates/signup.html:68
 msgid "no"
 msgstr "Όχι"
 
-#: templates/create-accounts.html:48 templates/programs.html:24
+#: templates/create-accounts.html:44 templates/programs.html:24
 msgid "reset_view"
 msgstr "Επαναφορά"
 
@@ -1188,7 +1206,7 @@ msgstr "Προβολή"
 msgid "adventure_prompt"
 msgstr "Παρακαλώ δώσε το όνομα της περιπέτειας"
 
-#: templates/for-teachers.html:59 website/teacher.py:499
+#: templates/for-teachers.html:59 website/teacher.py:501
 msgid "create_adventure"
 msgstr "Δημιουργία περιπέτειας"
 
@@ -1255,6 +1273,10 @@ msgstr "Next exercise"
 #: templates/incl-editor-and-output.html:144
 msgid "edit_code_button"
 msgstr "Επεξεργασία κώδικα"
+
+#: templates/incl-editor-and-output.html:146
+msgid "repair_program_logo_alt"
+msgstr ""
 
 #: templates/incl-editor-and-output.html:150
 msgid "read_code_label"
@@ -1345,25 +1367,52 @@ msgstr ""
 "καθηγητή που σου επιτρέπει να δημιουργείς μαθήματα και να προσκαλείς "
 "μαθητές."
 
+#: templates/landing-page.html:11
+#, fuzzy
+msgid "teacher_tutorial_logo_alt"
+msgstr "Έλαβες μια πρόσκληση για να συμμετάσχεις στην τάξη"
+
 #: templates/landing-page.html:13
 #, fuzzy
 msgid "start_teacher_tutorial"
 msgstr "Start teacher tutorial"
+
+#: templates/landing-page.html:18
+#, fuzzy
+msgid "hedy_tutorial_logo_alt"
+msgstr "Start hedy tutorial"
 
 #: templates/landing-page.html:20
 #, fuzzy
 msgid "start_hedy_tutorial"
 msgstr "Start hedy tutorial"
 
+#: templates/landing-page.html:25
+#, fuzzy
+msgid "start_programming_logo_alt"
+msgstr "Directly start programming"
+
 #: templates/landing-page.html:27
 #, fuzzy
 msgid "start_programming"
 msgstr "Directly start programming"
 
+#: templates/landing-page.html:31
+#, fuzzy
+msgid "explore_programs_logo_alt"
+msgstr "Εξερεύνηση προγραμμάτων"
+
 #: templates/landing-page.html:39
 #, fuzzy
 msgid "your_account"
 msgstr "Ακόμα χωρίς λογαριασμό;"
+
+#: templates/landing-page.html:43 templates/landing-page.html:45
+#: templates/profile.html:33 templates/public-page.html:7
+#: templates/public-page.html:9
+#, fuzzy
+msgid "profile_logo_alt"
+msgstr "Το προφίλ ενημερώθηκε."
 
 #: templates/landing-page.html:52 templates/public-page.html:16
 msgid "achievements"
@@ -1709,6 +1758,10 @@ msgstr "Γράψε το πρώτο σου πρόγραμμα!"
 #: templates/public-page.html:85
 msgid "no_shared_programs"
 msgstr "δεν έχει κοινά προγράμματα..."
+
+#: templates/quiz.html:4
+msgid "quiz_logo_alt"
+msgstr ""
 
 #: templates/quiz.html:7
 msgid "start_quiz"
@@ -2126,7 +2179,7 @@ msgstr "Το πρόγραμμα καταργήθηκε με επιτυχία"
 msgid "favourite_success"
 msgstr "Το πρόγραμμά σου έχει οριστεί ως αγαπημένο"
 
-#: website/quiz.py:45 website/quiz.py:71 website/teacher.py:452
+#: website/quiz.py:45 website/quiz.py:71 website/teacher.py:454
 msgid "level_invalid"
 msgstr "Αυτό το επίπεδο Hedy δεν είναι έγκυρο"
 
@@ -2157,6 +2210,7 @@ msgstr "Μόνο οι καθηγητές μπορούν να ανακτήσου�
 #: website/statistics.py:41 website/teacher.py:38 website/teacher.py:131
 #: website/teacher.py:150 website/teacher.py:212 website/teacher.py:234
 #: website/teacher.py:246 website/teacher.py:313 website/teacher.py:352
+#: website/teacher.py:364
 msgid "no_such_class"
 msgstr "Δεν υπάρχει τέτοια τάξη Hedy!"
 
@@ -2188,7 +2242,7 @@ msgstr "Δεν δώσατε όνομα τάξης!"
 msgid "class_name_duplicate"
 msgstr "Έχεις ήδη μια τάξη με αυτό το όνομα!"
 
-#: website/teacher.py:162 website/teacher.py:178 website/teacher.py:531
+#: website/teacher.py:162 website/teacher.py:178 website/teacher.py:533
 msgid "invalid_class_link"
 msgstr "Μη έγκυρος σύνδεσμος για συμμετοχή στην τάξη."
 
@@ -2226,66 +2280,66 @@ msgstr "Αυτός ο μαθητής είναι ήδη στη τάξη σου"
 msgid "student_already_invite"
 msgstr "Αυτός ο μαθητής έχει ήδη μια πρόσκληση σε αναμονή"
 
-#: website/teacher.py:380
+#: website/teacher.py:382
 msgid "no_accounts"
 msgstr "Δεν υπάρχουν λογαριασμοί για δημιουργία."
 
-#: website/teacher.py:390
+#: website/teacher.py:392
 msgid "unique_usernames"
 msgstr "Όλα τα ονόματα χρηστών πρέπει να είναι μοναδικά."
 
-#: website/teacher.py:399
+#: website/teacher.py:401
 msgid "usernames_exist"
 msgstr "Ένα ή περισσότερα ονόματα χρηστών ήδη χρησιμοποιούνται."
 
-#: website/teacher.py:410
+#: website/teacher.py:412
 msgid "accounts_created"
 msgstr "Οι λογαριασμοί δημιουργήθηκαν με επιτυχία."
 
-#: website/teacher.py:416 website/teacher.py:421 website/teacher.py:432
-#: website/teacher.py:461 website/teacher.py:487
+#: website/teacher.py:418 website/teacher.py:423 website/teacher.py:434
+#: website/teacher.py:463 website/teacher.py:489
 msgid "retrieve_adventure_error"
 msgstr "Δεν επιτρέπεται να δεις αυτήν την περιπέτεια!"
 
-#: website/teacher.py:426
+#: website/teacher.py:428
 #, fuzzy
 msgid "title_view-adventure"
 msgstr "Hedy - View adventure"
 
-#: website/teacher.py:437
+#: website/teacher.py:439
 #, fuzzy
 msgid "title_customize-adventure"
 msgstr "Hedy - Customize adventure"
 
-#: website/teacher.py:448
+#: website/teacher.py:450
 msgid "adventure_id_invalid"
 msgstr "Αυτό το αναγνωριστικό περιπέτειας δεν είναι έγκυρο"
 
-#: website/teacher.py:450 website/teacher.py:506
+#: website/teacher.py:452 website/teacher.py:508
 msgid "adventure_name_invalid"
 msgstr "Αυτό το όνομα περιπέτειας δεν είναι έγκυρο"
 
-#: website/teacher.py:454
+#: website/teacher.py:456
 msgid "content_invalid"
 msgstr "Αυτή η περιπέτεια δεν είναι έγκυρη"
 
-#: website/teacher.py:456
+#: website/teacher.py:458
 msgid "adventure_length"
 msgstr "Η περιπέτειά σου πρέπει να είναι τουλάχιστον 20 χαρακτήρες"
 
-#: website/teacher.py:458
+#: website/teacher.py:460
 msgid "public_invalid"
 msgstr "Αυτή η επιλογή συμφωνίας δεν είναι έγκυρη"
 
-#: website/teacher.py:469 website/teacher.py:513
+#: website/teacher.py:471 website/teacher.py:515
 msgid "adventure_duplicate"
 msgstr "Έχεις ήδη μια περιπέτεια με αυτό το όνομα"
 
-#: website/teacher.py:481
+#: website/teacher.py:483
 msgid "adventure_updated"
 msgstr "Η περιπέτεια έχει ενημερωθεί!"
 
-#: website/teacher.py:508
+#: website/teacher.py:510
 msgid "adventure_empty"
 msgstr "Δεν έδωσες όνομα περιπέτειας!"
 
@@ -2454,4 +2508,7 @@ msgstr "Δεν έδωσες όνομα περιπέτειας!"
 
 #~ msgid "go_to_first_exercise"
 #~ msgstr "Πήγαινε στην ερώτηση 1"
+
+#~ msgid "select_class"
+#~ msgstr "Επίλεξε τάξη"
 

--- a/translations/en/LC_MESSAGES/messages.po
+++ b/translations/en/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-06-21 10:36+0200\n"
+"POT-Creation-Date: 2022-06-23 14:02+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: en\n"
@@ -28,7 +28,7 @@ msgid "title_achievements"
 msgstr "Hedy - My achievements"
 
 #: app.py:639 app.py:743 app.py:1085 website/teacher.py:361
-#: website/teacher.py:370
+#: website/teacher.py:372
 msgid "not_teacher"
 msgstr "Looks like you are not a teacher!"
 
@@ -64,8 +64,8 @@ msgstr "No such Hedy program!"
 msgid "level_not_class"
 msgstr "This level has not been made available in your class yet"
 
-#: app.py:923 website/teacher.py:419 website/teacher.py:435
-#: website/teacher.py:464 website/teacher.py:490
+#: app.py:923 website/teacher.py:421 website/teacher.py:437
+#: website/teacher.py:466 website/teacher.py:492
 msgid "no_such_adventure"
 msgstr "This adventure doesn't exist!"
 
@@ -339,8 +339,8 @@ msgstr ""
 #: website/auth.py:671 website/auth.py:718 website/auth.py:745
 #: website/quiz.py:43 website/quiz.py:69 website/teacher.py:88
 #: website/teacher.py:123 website/teacher.py:195 website/teacher.py:251
-#: website/teacher.py:298 website/teacher.py:339 website/teacher.py:375
-#: website/teacher.py:446 website/teacher.py:504
+#: website/teacher.py:298 website/teacher.py:339 website/teacher.py:377
+#: website/teacher.py:448 website/teacher.py:506
 msgid "ajax_error"
 msgstr "There was an error, please try again."
 
@@ -640,6 +640,21 @@ msgstr "Hidden"
 msgid "hedy_achievements"
 msgstr "Hedy achievements"
 
+#: templates/achievements.html:36 templates/achievements.html:50
+#: templates/landing-page.html:89 templates/layout.html:92
+#: templates/public-page.html:51
+msgid "achievements_logo_alt"
+msgstr "Achievement logo"
+
+#: templates/achievements.html:37
+msgid "achievements_check_icon_alt"
+msgstr "Achievement check icon"
+
+#: templates/base_email.html:3 templates/cheatsheet.html:15
+#: templates/incl-menubar.html:4
+msgid "hedy_logo_alt"
+msgstr "Hedy logo"
+
 #: templates/cheatsheet.html:14
 msgid "cheatsheet_title"
 msgstr "Cheatsheet"
@@ -698,7 +713,6 @@ msgid "remove_student_prompt"
 msgstr "Are you sure you want to remove the student from the class?"
 
 #: templates/class-overview.html:44
-
 msgid "add_students"
 msgstr "Add students"
 
@@ -742,7 +756,7 @@ msgstr "Enter a username"
 msgid "invite_by_username"
 msgstr "Invite by username"
 
-#: templates/class-overview.html:55 templates/create-accounts.html:49
+#: templates/class-overview.html:55 templates/create-accounts.html:45
 msgid "create_accounts"
 msgstr "Create accounts"
 
@@ -766,6 +780,10 @@ msgstr "Are you sure you want to remove this class invitation?"
 msgid "class_already_joined"
 msgstr "You are already a student of class"
 
+#: templates/class-prejoin.html:9 templates/error-page.html:6
+msgid "error_logo_alt"
+msgstr "Error logo"
+
 #: templates/class-prejoin.html:11
 msgid "goto_profile"
 msgstr "Go to my profile"
@@ -782,7 +800,8 @@ msgstr "You need to have an account to join a class. Would you like to login now
 msgid "join_class"
 msgstr "Join class"
 
-#: templates/class-stats.html:22 templates/customize-class.html:166
+#: templates/class-stats.html:22 templates/create-accounts.html:41
+#: templates/customize-class.html:166
 msgid "back_to_class"
 msgstr "Go back to class"
 
@@ -807,36 +826,32 @@ msgstr "Create multiple accounts"
 msgid "accounts_intro"
 msgstr ""
 "On this page you can create accounts for multiple students at the same "
-"time. There are autoamtically added to the current class, make sure the selected class is correct!. By "
-"pressing the green + on the bottom right of the page you can add extra "
-"rows. You can delete a row by pressing the corresponding red cross. Make "
-"sure no rows are empty when you press \"Create accounts\". Please keep in"
-" mind that every username needs to be unique and the password needs to be"
-" <b>at least</b> 6 characters."
+"time. There are autoamtically added to the current class, make sure the "
+"selected class is correct!. By pressing the green + on the bottom right "
+"of the page you can add extra rows. You can delete a row by pressing the "
+"corresponding red cross. Make sure no rows are empty when you press "
+"\"Create accounts\". Please keep in mind that every username needs to be "
+"unique and the password needs to be <b>at least</b> 6 characters."
 
 #: templates/create-accounts.html:10
 msgid "create_accounts_prompt"
 msgstr "Are you sure you want to create these accounts?"
 
-#: templates/create-accounts.html:19
-msgid "select_class"
-msgstr "Select class"
-
-#: templates/create-accounts.html:30
+#: templates/create-accounts.html:25
 msgid "download_login_credentials"
 msgstr "Do you want to download the login credentials after the accounts creation?"
 
-#: templates/create-accounts.html:34 templates/layout.html:22
+#: templates/create-accounts.html:29 templates/layout.html:22
 #: templates/signup.html:64
 msgid "yes"
 msgstr "Yes"
 
-#: templates/create-accounts.html:38 templates/layout.html:23
+#: templates/create-accounts.html:33 templates/layout.html:23
 #: templates/signup.html:68
 msgid "no"
 msgstr "No"
 
-#: templates/create-accounts.html:48 templates/programs.html:24
+#: templates/create-accounts.html:44 templates/programs.html:24
 msgid "reset_view"
 msgstr "Reset"
 
@@ -1122,7 +1137,7 @@ msgstr "View"
 msgid "adventure_prompt"
 msgstr "Please enter the name of the adventure"
 
-#: templates/for-teachers.html:59 website/teacher.py:499
+#: templates/for-teachers.html:59 website/teacher.py:501
 msgid "create_adventure"
 msgstr "Create adventure"
 
@@ -1181,6 +1196,10 @@ msgstr "Next exercise"
 #: templates/incl-editor-and-output.html:144
 msgid "edit_code_button"
 msgstr "Edit code"
+
+#: templates/incl-editor-and-output.html:146
+msgid "repair_program_logo_alt"
+msgstr "Repair program icon"
 
 #: templates/incl-editor-and-output.html:150
 msgid "read_code_label"
@@ -1261,21 +1280,43 @@ msgstr "Welcome"
 msgid "welcome_back"
 msgstr "Welcome back"
 
+#: templates/landing-page.html:11
+msgid "teacher_tutorial_logo_alt"
+msgstr "Teacher tutorial icon"
+
 #: templates/landing-page.html:13
 msgid "start_teacher_tutorial"
 msgstr "Start teacher tutorial"
+
+#: templates/landing-page.html:18
+msgid "hedy_tutorial_logo_alt"
+msgstr "Hedy tutorial icon"
 
 #: templates/landing-page.html:20
 msgid "start_hedy_tutorial"
 msgstr "Start hedy tutorial"
 
+#: templates/landing-page.html:25
+msgid "start_programming_logo_alt"
+msgstr "Start programming icon"
+
 #: templates/landing-page.html:27
 msgid "start_programming"
 msgstr "Start programming"
 
+#: templates/landing-page.html:31
+msgid "explore_programs_logo_alt"
+msgstr "Explore programs icon"
+
 #: templates/landing-page.html:39
 msgid "your_account"
 msgstr "Your profile"
+
+#: templates/landing-page.html:43 templates/landing-page.html:45
+#: templates/profile.html:33 templates/public-page.html:7
+#: templates/public-page.html:9
+msgid "profile_logo_alt"
+msgstr "Profile icon."
 
 #: templates/landing-page.html:52 templates/public-page.html:16
 msgid "achievements"
@@ -1614,6 +1655,10 @@ msgstr "Write your first program!"
 #: templates/public-page.html:85
 msgid "no_shared_programs"
 msgstr "has no shared programs..."
+
+#: templates/quiz.html:4
+msgid "quiz_logo_alt"
+msgstr "Quiz logo"
 
 #: templates/quiz.html:7
 msgid "start_quiz"
@@ -2018,7 +2063,7 @@ msgstr "Program unshared successfully."
 msgid "favourite_success"
 msgstr "Your program is set as favourite."
 
-#: website/quiz.py:45 website/quiz.py:71 website/teacher.py:452
+#: website/quiz.py:45 website/quiz.py:71 website/teacher.py:454
 msgid "level_invalid"
 msgstr "This Hedy level in invalid."
 
@@ -2049,6 +2094,7 @@ msgstr "Only teachers can retrieve classes"
 #: website/statistics.py:41 website/teacher.py:38 website/teacher.py:131
 #: website/teacher.py:150 website/teacher.py:212 website/teacher.py:234
 #: website/teacher.py:246 website/teacher.py:313 website/teacher.py:352
+#: website/teacher.py:364
 msgid "no_such_class"
 msgstr "No such Hedy class."
 
@@ -2076,7 +2122,7 @@ msgstr "You didn't enter a class name!"
 msgid "class_name_duplicate"
 msgstr "You already have a class with this name."
 
-#: website/teacher.py:162 website/teacher.py:178 website/teacher.py:531
+#: website/teacher.py:162 website/teacher.py:178 website/teacher.py:533
 msgid "invalid_class_link"
 msgstr "Invalid link for joining the class."
 
@@ -2112,64 +2158,64 @@ msgstr "This student is already in your class."
 msgid "student_already_invite"
 msgstr "This student already has a pending invitation."
 
-#: website/teacher.py:380
+#: website/teacher.py:382
 msgid "no_accounts"
 msgstr "There are no accounts to create."
 
-#: website/teacher.py:390
+#: website/teacher.py:392
 msgid "unique_usernames"
 msgstr "All usernames need to be unique."
 
-#: website/teacher.py:399
+#: website/teacher.py:401
 msgid "usernames_exist"
 msgstr "One or more usernames is already in use."
 
-#: website/teacher.py:410
+#: website/teacher.py:412
 msgid "accounts_created"
 msgstr "Accounts where successfully created."
 
-#: website/teacher.py:416 website/teacher.py:421 website/teacher.py:432
-#: website/teacher.py:461 website/teacher.py:487
+#: website/teacher.py:418 website/teacher.py:423 website/teacher.py:434
+#: website/teacher.py:463 website/teacher.py:489
 msgid "retrieve_adventure_error"
 msgstr "You're not allowed to view this adventure!"
 
-#: website/teacher.py:426
+#: website/teacher.py:428
 msgid "title_view-adventure"
 msgstr "Hedy - View adventure"
 
-#: website/teacher.py:437
+#: website/teacher.py:439
 msgid "title_customize-adventure"
 msgstr "Hedy - Customize adventure"
 
-#: website/teacher.py:448
+#: website/teacher.py:450
 msgid "adventure_id_invalid"
 msgstr "This adventure id is invalid."
 
-#: website/teacher.py:450 website/teacher.py:506
+#: website/teacher.py:452 website/teacher.py:508
 msgid "adventure_name_invalid"
 msgstr "This adventure name is invalid."
 
-#: website/teacher.py:454
+#: website/teacher.py:456
 msgid "content_invalid"
 msgstr "This adventure is invalid."
 
-#: website/teacher.py:456
+#: website/teacher.py:458
 msgid "adventure_length"
 msgstr "Your adventure has to be at least 20 characters."
 
-#: website/teacher.py:458
+#: website/teacher.py:460
 msgid "public_invalid"
 msgstr "This agreement selection is invalid"
 
-#: website/teacher.py:469 website/teacher.py:513
+#: website/teacher.py:471 website/teacher.py:515
 msgid "adventure_duplicate"
 msgstr "You already have an adventure with this name."
 
-#: website/teacher.py:481
+#: website/teacher.py:483
 msgid "adventure_updated"
 msgstr "The adventure has been updated!"
 
-#: website/teacher.py:508
+#: website/teacher.py:510
 msgid "adventure_empty"
 msgstr "You didn't enter an adventure name!"
 
@@ -2243,4 +2289,7 @@ msgstr "You didn't enter an adventure name!"
 
 #~ msgid "go_to_first_exercise"
 #~ msgstr "Go to exercise 1"
+
+#~ msgid "select_class"
+#~ msgstr "Select class"
 

--- a/translations/eo/LC_MESSAGES/messages.po
+++ b/translations/eo/LC_MESSAGES/messages.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-06-21 10:36+0200\n"
+"POT-Creation-Date: 2022-06-23 14:02+0200\n"
 "PO-Revision-Date: 2022-06-18 14:19+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: eo\n"
@@ -25,7 +25,7 @@ msgid "title_achievements"
 msgstr "Hedy - Miaj premioj"
 
 #: app.py:639 app.py:743 app.py:1085 website/teacher.py:361
-#: website/teacher.py:370
+#: website/teacher.py:372
 #, fuzzy
 msgid "not_teacher"
 msgstr "Looks like you are not a teacher!"
@@ -67,8 +67,8 @@ msgstr "Programo ne ekzistas!"
 msgid "level_not_class"
 msgstr "This level has not been made available in your class yet"
 
-#: app.py:923 website/teacher.py:419 website/teacher.py:435
-#: website/teacher.py:464 website/teacher.py:490
+#: app.py:923 website/teacher.py:421 website/teacher.py:437
+#: website/teacher.py:466 website/teacher.py:492
 #, fuzzy
 msgid "no_such_adventure"
 msgstr "This adventure doesn't exist!"
@@ -366,8 +366,8 @@ msgstr ""
 #: website/auth.py:671 website/auth.py:718 website/auth.py:745
 #: website/quiz.py:43 website/quiz.py:69 website/teacher.py:88
 #: website/teacher.py:123 website/teacher.py:195 website/teacher.py:251
-#: website/teacher.py:298 website/teacher.py:339 website/teacher.py:375
-#: website/teacher.py:446 website/teacher.py:504
+#: website/teacher.py:298 website/teacher.py:339 website/teacher.py:377
+#: website/teacher.py:448 website/teacher.py:506
 #, fuzzy
 msgid "ajax_error"
 msgstr "There was an error, please try again."
@@ -727,6 +727,23 @@ msgstr "Hidden"
 msgid "hedy_achievements"
 msgstr "Hedy achievements"
 
+#: templates/achievements.html:36 templates/achievements.html:50
+#: templates/landing-page.html:89 templates/layout.html:92
+#: templates/public-page.html:51
+#, fuzzy
+msgid "achievements_logo_alt"
+msgstr "premioj"
+
+#: templates/achievements.html:37
+#, fuzzy
+msgid "achievements_check_icon_alt"
+msgstr "You've earned an achievement!"
+
+#: templates/base_email.html:3 templates/cheatsheet.html:15
+#: templates/incl-menubar.html:4
+msgid "hedy_logo_alt"
+msgstr ""
+
 #: templates/cheatsheet.html:14
 #, fuzzy
 msgid "cheatsheet_title"
@@ -852,7 +869,7 @@ msgstr "Enter a username"
 msgid "invite_by_username"
 msgstr "All usernames need to be unique."
 
-#: templates/class-overview.html:55 templates/create-accounts.html:49
+#: templates/class-overview.html:55 templates/create-accounts.html:45
 #, fuzzy
 msgid "create_accounts"
 msgstr "Create multiple accounts"
@@ -882,6 +899,10 @@ msgstr "Are you sure you want to remove this class invitation?"
 msgid "class_already_joined"
 msgstr "You are already a student of class"
 
+#: templates/class-prejoin.html:9 templates/error-page.html:6
+msgid "error_logo_alt"
+msgstr ""
+
 #: templates/class-prejoin.html:11
 #, fuzzy
 msgid "goto_profile"
@@ -902,7 +923,8 @@ msgstr "You need to have an account to join a class. Would you like to login now
 msgid "join_class"
 msgstr "Join class"
 
-#: templates/class-stats.html:22 templates/customize-class.html:166
+#: templates/class-stats.html:22 templates/create-accounts.html:41
+#: templates/customize-class.html:166
 #, fuzzy
 msgid "back_to_class"
 msgstr "Go back to class"
@@ -944,27 +966,22 @@ msgstr ""
 msgid "create_accounts_prompt"
 msgstr "Are you sure you want to create these accounts?"
 
-#: templates/create-accounts.html:19
-#, fuzzy
-msgid "select_class"
-msgstr "Select class"
-
-#: templates/create-accounts.html:30
+#: templates/create-accounts.html:25
 #, fuzzy
 msgid "download_login_credentials"
 msgstr ""
 
-#: templates/create-accounts.html:34 templates/layout.html:22
+#: templates/create-accounts.html:29 templates/layout.html:22
 #: templates/signup.html:64
 msgid "yes"
 msgstr "Jes"
 
-#: templates/create-accounts.html:38 templates/layout.html:23
+#: templates/create-accounts.html:33 templates/layout.html:23
 #: templates/signup.html:68
 msgid "no"
 msgstr "Ne"
 
-#: templates/create-accounts.html:48 templates/programs.html:24
+#: templates/create-accounts.html:44 templates/programs.html:24
 #, fuzzy
 msgid "reset_view"
 msgstr "Reset"
@@ -1300,7 +1317,7 @@ msgstr "Vidi"
 msgid "adventure_prompt"
 msgstr "Please enter the name of the adventure"
 
-#: templates/for-teachers.html:59 website/teacher.py:499
+#: templates/for-teachers.html:59 website/teacher.py:501
 #, fuzzy
 msgid "create_adventure"
 msgstr "Create adventure"
@@ -1366,6 +1383,10 @@ msgstr "Next exercise"
 #: templates/incl-editor-and-output.html:144
 msgid "edit_code_button"
 msgstr "Redakti kodon"
+
+#: templates/incl-editor-and-output.html:146
+msgid "repair_program_logo_alt"
+msgstr ""
 
 #: templates/incl-editor-and-output.html:150
 #, fuzzy
@@ -1455,25 +1476,52 @@ msgstr "Welcome"
 msgid "welcome_back"
 msgstr "Bonvenon ree"
 
+#: templates/landing-page.html:11
+#, fuzzy
+msgid "teacher_tutorial_logo_alt"
+msgstr "Click on 'next step' to get started as a Hedy teacher!"
+
 #: templates/landing-page.html:13
 #, fuzzy
 msgid "start_teacher_tutorial"
 msgstr "Start teacher tutorial"
+
+#: templates/landing-page.html:18
+#, fuzzy
+msgid "hedy_tutorial_logo_alt"
+msgstr "Start hedy tutorial"
 
 #: templates/landing-page.html:20
 #, fuzzy
 msgid "start_hedy_tutorial"
 msgstr "Start hedy tutorial"
 
+#: templates/landing-page.html:25
+#, fuzzy
+msgid "start_programming_logo_alt"
+msgstr "Ekprogrami"
+
 #: templates/landing-page.html:27
 #, fuzzy
 msgid "start_programming"
 msgstr "Ekprogrami"
 
+#: templates/landing-page.html:31
+#, fuzzy
+msgid "explore_programs_logo_alt"
+msgstr "Esplori programojn"
+
 #: templates/landing-page.html:39
 #, fuzzy
 msgid "your_account"
 msgstr "Via profilo?"
+
+#: templates/landing-page.html:43 templates/landing-page.html:45
+#: templates/profile.html:33 templates/public-page.html:7
+#: templates/public-page.html:9
+#, fuzzy
+msgid "profile_logo_alt"
+msgstr "Profile updated."
 
 #: templates/landing-page.html:52 templates/public-page.html:16
 #, fuzzy
@@ -1864,6 +1912,10 @@ msgstr "Write your first program!"
 #, fuzzy
 msgid "no_shared_programs"
 msgstr "has no shared programs..."
+
+#: templates/quiz.html:4
+msgid "quiz_logo_alt"
+msgstr ""
 
 #: templates/quiz.html:7
 #, fuzzy
@@ -2346,7 +2398,7 @@ msgstr "Program unshared successfully."
 msgid "favourite_success"
 msgstr "Your program is set as favourite."
 
-#: website/quiz.py:45 website/quiz.py:71 website/teacher.py:452
+#: website/quiz.py:45 website/quiz.py:71 website/teacher.py:454
 #, fuzzy
 msgid "level_invalid"
 msgstr "This Hedy level in invalid."
@@ -2379,6 +2431,7 @@ msgstr "Only teachers can retrieve classes"
 #: website/statistics.py:41 website/teacher.py:38 website/teacher.py:131
 #: website/teacher.py:150 website/teacher.py:212 website/teacher.py:234
 #: website/teacher.py:246 website/teacher.py:313 website/teacher.py:352
+#: website/teacher.py:364
 #, fuzzy
 msgid "no_such_class"
 msgstr "No such Hedy class."
@@ -2412,7 +2465,7 @@ msgstr "You didn't enter a class name!"
 msgid "class_name_duplicate"
 msgstr "You already have a class with this name."
 
-#: website/teacher.py:162 website/teacher.py:178 website/teacher.py:531
+#: website/teacher.py:162 website/teacher.py:178 website/teacher.py:533
 #, fuzzy
 msgid "invalid_class_link"
 msgstr "Invalid link for joining the class."
@@ -2457,78 +2510,78 @@ msgstr "This student is already in your class."
 msgid "student_already_invite"
 msgstr "This student already has a pending invitation."
 
-#: website/teacher.py:380
+#: website/teacher.py:382
 #, fuzzy
 msgid "no_accounts"
 msgstr "There are no accounts to create."
 
-#: website/teacher.py:390
+#: website/teacher.py:392
 #, fuzzy
 msgid "unique_usernames"
 msgstr "All usernames need to be unique."
 
-#: website/teacher.py:399
+#: website/teacher.py:401
 #, fuzzy
 msgid "usernames_exist"
 msgstr "One or more usernames is already in use."
 
-#: website/teacher.py:410
+#: website/teacher.py:412
 #, fuzzy
 msgid "accounts_created"
 msgstr "Accounts where successfully created."
 
-#: website/teacher.py:416 website/teacher.py:421 website/teacher.py:432
-#: website/teacher.py:461 website/teacher.py:487
+#: website/teacher.py:418 website/teacher.py:423 website/teacher.py:434
+#: website/teacher.py:463 website/teacher.py:489
 #, fuzzy
 msgid "retrieve_adventure_error"
 msgstr "You're not allowed to view this adventure!"
 
-#: website/teacher.py:426
+#: website/teacher.py:428
 #, fuzzy
 msgid "title_view-adventure"
 msgstr "Hedy - View adventure"
 
-#: website/teacher.py:437
+#: website/teacher.py:439
 #, fuzzy
 msgid "title_customize-adventure"
 msgstr "Hedy - Customize adventure"
 
-#: website/teacher.py:448
+#: website/teacher.py:450
 #, fuzzy
 msgid "adventure_id_invalid"
 msgstr "This adventure id is invalid."
 
-#: website/teacher.py:450 website/teacher.py:506
+#: website/teacher.py:452 website/teacher.py:508
 #, fuzzy
 msgid "adventure_name_invalid"
 msgstr "This adventure name is invalid."
 
-#: website/teacher.py:454
+#: website/teacher.py:456
 #, fuzzy
 msgid "content_invalid"
 msgstr "This adventure is invalid."
 
-#: website/teacher.py:456
+#: website/teacher.py:458
 #, fuzzy
 msgid "adventure_length"
 msgstr "Your adventure has to be at least 20 characters."
 
-#: website/teacher.py:458
+#: website/teacher.py:460
 #, fuzzy
 msgid "public_invalid"
 msgstr "This agreement selection is invalid"
 
-#: website/teacher.py:469 website/teacher.py:513
+#: website/teacher.py:471 website/teacher.py:515
 #, fuzzy
 msgid "adventure_duplicate"
 msgstr "You already have an adventure with this name."
 
-#: website/teacher.py:481
+#: website/teacher.py:483
 #, fuzzy
 msgid "adventure_updated"
 msgstr "The adventure has been updated!"
 
-#: website/teacher.py:508
+#: website/teacher.py:510
 #, fuzzy
 msgid "adventure_empty"
 msgstr "Vi ne tajpis nomon de aventuro!"
@@ -2621,4 +2674,7 @@ msgstr "Vi ne tajpis nomon de aventuro!"
 
 #~ msgid "go_to_first_exercise"
 #~ msgstr "Go to question 1"
+
+#~ msgid "select_class"
+#~ msgstr "Select class"
 

--- a/translations/es/LC_MESSAGES/messages.po
+++ b/translations/es/LC_MESSAGES/messages.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-21 10:36+0200\n"
+"POT-Creation-Date: 2022-06-23 14:02+0200\n"
 "PO-Revision-Date: 2022-06-18 14:19+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: es\n"
@@ -25,7 +25,7 @@ msgid "title_achievements"
 msgstr "Hedy - My achievements"
 
 #: app.py:639 app.py:743 app.py:1085 website/teacher.py:361
-#: website/teacher.py:370
+#: website/teacher.py:372
 msgid "not_teacher"
 msgstr "Parece que no eres un instructor."
 
@@ -65,8 +65,8 @@ msgstr "No se encontró el programa de Hedy"
 msgid "level_not_class"
 msgstr "You're in a class where this level has not been made available yet"
 
-#: app.py:923 website/teacher.py:419 website/teacher.py:435
-#: website/teacher.py:464 website/teacher.py:490
+#: app.py:923 website/teacher.py:421 website/teacher.py:437
+#: website/teacher.py:466 website/teacher.py:492
 #, fuzzy
 msgid "no_such_adventure"
 msgstr "This adventure doesn't exist!"
@@ -362,8 +362,8 @@ msgstr ""
 #: website/auth.py:671 website/auth.py:718 website/auth.py:745
 #: website/quiz.py:43 website/quiz.py:69 website/teacher.py:88
 #: website/teacher.py:123 website/teacher.py:195 website/teacher.py:251
-#: website/teacher.py:298 website/teacher.py:339 website/teacher.py:375
-#: website/teacher.py:446 website/teacher.py:504
+#: website/teacher.py:298 website/teacher.py:339 website/teacher.py:377
+#: website/teacher.py:448 website/teacher.py:506
 msgid "ajax_error"
 msgstr "Hubo un error, por favor intenta nuevamente."
 
@@ -698,6 +698,23 @@ msgstr "Oculto"
 msgid "hedy_achievements"
 msgstr "My achievements"
 
+#: templates/achievements.html:36 templates/achievements.html:50
+#: templates/landing-page.html:89 templates/layout.html:92
+#: templates/public-page.html:51
+#, fuzzy
+msgid "achievements_logo_alt"
+msgstr "achievements"
+
+#: templates/achievements.html:37
+#, fuzzy
+msgid "achievements_check_icon_alt"
+msgstr "You've earned an achievement!"
+
+#: templates/base_email.html:3 templates/cheatsheet.html:15
+#: templates/incl-menubar.html:4
+msgid "hedy_logo_alt"
+msgstr ""
+
 #: templates/cheatsheet.html:14
 #, fuzzy
 msgid "cheatsheet_title"
@@ -817,7 +834,7 @@ msgstr "Enter a username"
 msgid "invite_by_username"
 msgstr "All usernames need to be unique."
 
-#: templates/class-overview.html:55 templates/create-accounts.html:49
+#: templates/class-overview.html:55 templates/create-accounts.html:45
 #, fuzzy
 msgid "create_accounts"
 msgstr "Create multiple accounts"
@@ -846,6 +863,10 @@ msgstr "Are you sure you want to remove this class invitation?"
 msgid "class_already_joined"
 msgstr "Ya eres parte de la clase"
 
+#: templates/class-prejoin.html:9 templates/error-page.html:6
+msgid "error_logo_alt"
+msgstr ""
+
 #: templates/class-prejoin.html:11
 msgid "goto_profile"
 msgstr "Ir a mi perfil"
@@ -864,7 +885,8 @@ msgstr ""
 msgid "join_class"
 msgstr "Unirse a la clase"
 
-#: templates/class-stats.html:22 templates/customize-class.html:166
+#: templates/class-stats.html:22 templates/create-accounts.html:41
+#: templates/customize-class.html:166
 #, fuzzy
 msgid "back_to_class"
 msgstr "Go back to class"
@@ -905,27 +927,22 @@ msgstr ""
 msgid "create_accounts_prompt"
 msgstr "Are you sure you want to create these accounts?"
 
-#: templates/create-accounts.html:19
-#, fuzzy
-msgid "select_class"
-msgstr "Select class"
-
-#: templates/create-accounts.html:30
+#: templates/create-accounts.html:25
 #, fuzzy
 msgid "download_login_credentials"
 msgstr ""
 
-#: templates/create-accounts.html:34 templates/layout.html:22
+#: templates/create-accounts.html:29 templates/layout.html:22
 #: templates/signup.html:64
 msgid "yes"
 msgstr "Sí"
 
-#: templates/create-accounts.html:38 templates/layout.html:23
+#: templates/create-accounts.html:33 templates/layout.html:23
 #: templates/signup.html:68
 msgid "no"
 msgstr "No"
 
-#: templates/create-accounts.html:48 templates/programs.html:24
+#: templates/create-accounts.html:44 templates/programs.html:24
 #, fuzzy
 msgid "reset_view"
 msgstr "Reset"
@@ -1249,7 +1266,7 @@ msgstr "View"
 msgid "adventure_prompt"
 msgstr "Please enter the name of the adventure"
 
-#: templates/for-teachers.html:59 website/teacher.py:499
+#: templates/for-teachers.html:59 website/teacher.py:501
 #, fuzzy
 msgid "create_adventure"
 msgstr "Create adventure"
@@ -1317,6 +1334,10 @@ msgstr "Next exercise"
 #: templates/incl-editor-and-output.html:144
 msgid "edit_code_button"
 msgstr "Editar código"
+
+#: templates/incl-editor-and-output.html:146
+msgid "repair_program_logo_alt"
+msgstr ""
 
 #: templates/incl-editor-and-output.html:150
 msgid "read_code_label"
@@ -1408,25 +1429,52 @@ msgstr ""
 "Welcome to Hedy! Your are now the proud owner of a teachers account which"
 " allows you to create classes and invite students."
 
+#: templates/landing-page.html:11
+#, fuzzy
+msgid "teacher_tutorial_logo_alt"
+msgstr "You have received an invitation to join class"
+
 #: templates/landing-page.html:13
 #, fuzzy
 msgid "start_teacher_tutorial"
 msgstr "Start teacher tutorial"
+
+#: templates/landing-page.html:18
+#, fuzzy
+msgid "hedy_tutorial_logo_alt"
+msgstr "Start hedy tutorial"
 
 #: templates/landing-page.html:20
 #, fuzzy
 msgid "start_hedy_tutorial"
 msgstr "Start hedy tutorial"
 
+#: templates/landing-page.html:25
+#, fuzzy
+msgid "start_programming_logo_alt"
+msgstr "Directly start programming"
+
 #: templates/landing-page.html:27
 #, fuzzy
 msgid "start_programming"
 msgstr "Directly start programming"
 
+#: templates/landing-page.html:31
+#, fuzzy
+msgid "explore_programs_logo_alt"
+msgstr "Explore programs"
+
 #: templates/landing-page.html:39
 #, fuzzy
 msgid "your_account"
 msgstr "¿Todavía no tienes una cuenta?"
+
+#: templates/landing-page.html:43 templates/landing-page.html:45
+#: templates/profile.html:33 templates/public-page.html:7
+#: templates/public-page.html:9
+#, fuzzy
+msgid "profile_logo_alt"
+msgstr "Perfil actualizado."
 
 #: templates/landing-page.html:52 templates/public-page.html:16
 #, fuzzy
@@ -1807,6 +1855,10 @@ msgstr "¡Escribe tu primer programa!"
 #, fuzzy
 msgid "no_shared_programs"
 msgstr "has no shared programs..."
+
+#: templates/quiz.html:4
+msgid "quiz_logo_alt"
+msgstr ""
 
 #: templates/quiz.html:7
 msgid "start_quiz"
@@ -2239,7 +2291,7 @@ msgstr "Tu programa es ahora privado"
 msgid "favourite_success"
 msgstr "Your program is set as favourite."
 
-#: website/quiz.py:45 website/quiz.py:71 website/teacher.py:452
+#: website/quiz.py:45 website/quiz.py:71 website/teacher.py:454
 #, fuzzy
 msgid "level_invalid"
 msgstr "This Hedy level in invalid."
@@ -2271,6 +2323,7 @@ msgstr "Solo los instructores pueden ver clases"
 #: website/statistics.py:41 website/teacher.py:38 website/teacher.py:131
 #: website/teacher.py:150 website/teacher.py:212 website/teacher.py:234
 #: website/teacher.py:246 website/teacher.py:313 website/teacher.py:352
+#: website/teacher.py:364
 msgid "no_such_class"
 msgstr "No se encontró esa clase de Hedy"
 
@@ -2304,7 +2357,7 @@ msgstr "You didn't enter a class name!"
 msgid "class_name_duplicate"
 msgstr "You already have a class with this name."
 
-#: website/teacher.py:162 website/teacher.py:178 website/teacher.py:531
+#: website/teacher.py:162 website/teacher.py:178 website/teacher.py:533
 msgid "invalid_class_link"
 msgstr "Enlace incorrecto para unirse a la clase"
 
@@ -2348,78 +2401,78 @@ msgstr "This student is already in your class."
 msgid "student_already_invite"
 msgstr "This student already has a pending invitation."
 
-#: website/teacher.py:380
+#: website/teacher.py:382
 #, fuzzy
 msgid "no_accounts"
 msgstr "There are no accounts to create."
 
-#: website/teacher.py:390
+#: website/teacher.py:392
 #, fuzzy
 msgid "unique_usernames"
 msgstr "All usernames need to be unique."
 
-#: website/teacher.py:399
+#: website/teacher.py:401
 #, fuzzy
 msgid "usernames_exist"
 msgstr "One or more usernames is already in use."
 
-#: website/teacher.py:410
+#: website/teacher.py:412
 #, fuzzy
 msgid "accounts_created"
 msgstr "Accounts where successfully created."
 
-#: website/teacher.py:416 website/teacher.py:421 website/teacher.py:432
-#: website/teacher.py:461 website/teacher.py:487
+#: website/teacher.py:418 website/teacher.py:423 website/teacher.py:434
+#: website/teacher.py:463 website/teacher.py:489
 #, fuzzy
 msgid "retrieve_adventure_error"
 msgstr "You're not allowed to view this adventure!"
 
-#: website/teacher.py:426
+#: website/teacher.py:428
 #, fuzzy
 msgid "title_view-adventure"
 msgstr "Hedy - View adventure"
 
-#: website/teacher.py:437
+#: website/teacher.py:439
 #, fuzzy
 msgid "title_customize-adventure"
 msgstr "Hedy - Customize adventure"
 
-#: website/teacher.py:448
+#: website/teacher.py:450
 #, fuzzy
 msgid "adventure_id_invalid"
 msgstr "This adventure id is invalid."
 
-#: website/teacher.py:450 website/teacher.py:506
+#: website/teacher.py:452 website/teacher.py:508
 #, fuzzy
 msgid "adventure_name_invalid"
 msgstr "This adventure name is invalid."
 
-#: website/teacher.py:454
+#: website/teacher.py:456
 #, fuzzy
 msgid "content_invalid"
 msgstr "This adventure is invalid."
 
-#: website/teacher.py:456
+#: website/teacher.py:458
 #, fuzzy
 msgid "adventure_length"
 msgstr "Your adventure has to be at least 20 characters."
 
-#: website/teacher.py:458
+#: website/teacher.py:460
 #, fuzzy
 msgid "public_invalid"
 msgstr "This agreement selection is invalid"
 
-#: website/teacher.py:469 website/teacher.py:513
+#: website/teacher.py:471 website/teacher.py:515
 #, fuzzy
 msgid "adventure_duplicate"
 msgstr "You already have an adventure with this name."
 
-#: website/teacher.py:481
+#: website/teacher.py:483
 #, fuzzy
 msgid "adventure_updated"
 msgstr "The adventure has been updated!"
 
-#: website/teacher.py:508
+#: website/teacher.py:510
 #, fuzzy
 msgid "adventure_empty"
 msgstr "You didn't enter an adventure name!"
@@ -2578,4 +2631,7 @@ msgstr "You didn't enter an adventure name!"
 
 #~ msgid "go_to_first_exercise"
 #~ msgstr "Ir a la pregunta primera"
+
+#~ msgid "select_class"
+#~ msgstr "Select class"
 

--- a/translations/et/LC_MESSAGES/messages.po
+++ b/translations/et/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-06-21 10:36+0200\n"
+"POT-Creation-Date: 2022-06-23 14:02+0200\n"
 "PO-Revision-Date: 2022-06-20 05:52+0000\n"
 "Last-Translator: Elvia Sober <elvia.sober@gmail.com>\n"
 "Language: et\n"
@@ -27,7 +27,7 @@ msgid "title_achievements"
 msgstr "Hedy - Minu saavutused"
 
 #: app.py:639 app.py:743 app.py:1085 website/teacher.py:361
-#: website/teacher.py:370
+#: website/teacher.py:372
 msgid "not_teacher"
 msgstr "Sa ei ole õpetaja!"
 
@@ -63,8 +63,8 @@ msgstr "Sellist programmi ei ole!"
 msgid "level_not_class"
 msgstr "See tase pole veel sinu klassile avatud"
 
-#: app.py:923 website/teacher.py:419 website/teacher.py:435
-#: website/teacher.py:464 website/teacher.py:490
+#: app.py:923 website/teacher.py:421 website/teacher.py:437
+#: website/teacher.py:466 website/teacher.py:492
 msgid "no_such_adventure"
 msgstr "Seda seiklust ei ole olemas!"
 
@@ -349,8 +349,8 @@ msgstr ""
 #: website/auth.py:671 website/auth.py:718 website/auth.py:745
 #: website/quiz.py:43 website/quiz.py:69 website/teacher.py:88
 #: website/teacher.py:123 website/teacher.py:195 website/teacher.py:251
-#: website/teacher.py:298 website/teacher.py:339 website/teacher.py:375
-#: website/teacher.py:446 website/teacher.py:504
+#: website/teacher.py:298 website/teacher.py:339 website/teacher.py:377
+#: website/teacher.py:448 website/teacher.py:506
 #, fuzzy
 msgid "ajax_error"
 msgstr "There was an error, please try again."
@@ -711,6 +711,23 @@ msgstr "Hidden"
 msgid "hedy_achievements"
 msgstr "Hedy achievements"
 
+#: templates/achievements.html:36 templates/achievements.html:50
+#: templates/landing-page.html:89 templates/layout.html:92
+#: templates/public-page.html:51
+#, fuzzy
+msgid "achievements_logo_alt"
+msgstr "achievements"
+
+#: templates/achievements.html:37
+#, fuzzy
+msgid "achievements_check_icon_alt"
+msgstr "You've earned an achievement!"
+
+#: templates/base_email.html:3 templates/cheatsheet.html:15
+#: templates/incl-menubar.html:4
+msgid "hedy_logo_alt"
+msgstr ""
+
 #: templates/cheatsheet.html:14
 #, fuzzy
 msgid "cheatsheet_title"
@@ -836,7 +853,7 @@ msgstr "Enter a username"
 msgid "invite_by_username"
 msgstr "All usernames need to be unique."
 
-#: templates/class-overview.html:55 templates/create-accounts.html:49
+#: templates/class-overview.html:55 templates/create-accounts.html:45
 #, fuzzy
 msgid "create_accounts"
 msgstr "Create multiple accounts"
@@ -866,6 +883,10 @@ msgstr "Are you sure you want to remove this class invitation?"
 msgid "class_already_joined"
 msgstr "You are already a student of class"
 
+#: templates/class-prejoin.html:9 templates/error-page.html:6
+msgid "error_logo_alt"
+msgstr ""
+
 #: templates/class-prejoin.html:11
 #, fuzzy
 msgid "goto_profile"
@@ -886,7 +907,8 @@ msgstr "You need to have an account to join a class. Would you like to login now
 msgid "join_class"
 msgstr "Join class"
 
-#: templates/class-stats.html:22 templates/customize-class.html:166
+#: templates/class-stats.html:22 templates/create-accounts.html:41
+#: templates/customize-class.html:166
 #, fuzzy
 msgid "back_to_class"
 msgstr "Go back to class"
@@ -928,29 +950,24 @@ msgstr ""
 msgid "create_accounts_prompt"
 msgstr "Are you sure you want to create these accounts?"
 
-#: templates/create-accounts.html:19
-#, fuzzy
-msgid "select_class"
-msgstr "Select class"
-
-#: templates/create-accounts.html:30
+#: templates/create-accounts.html:25
 #, fuzzy
 msgid "download_login_credentials"
 msgstr "Do you want to download the login credentials after the accounts creation?"
 
-#: templates/create-accounts.html:34 templates/layout.html:22
+#: templates/create-accounts.html:29 templates/layout.html:22
 #: templates/signup.html:64
 #, fuzzy
 msgid "yes"
 msgstr "Yes"
 
-#: templates/create-accounts.html:38 templates/layout.html:23
+#: templates/create-accounts.html:33 templates/layout.html:23
 #: templates/signup.html:68
 #, fuzzy
 msgid "no"
 msgstr "No"
 
-#: templates/create-accounts.html:48 templates/programs.html:24
+#: templates/create-accounts.html:44 templates/programs.html:24
 #, fuzzy
 msgid "reset_view"
 msgstr "Reset"
@@ -1295,7 +1312,7 @@ msgstr "View"
 msgid "adventure_prompt"
 msgstr "Please enter the name of the adventure"
 
-#: templates/for-teachers.html:59 website/teacher.py:499
+#: templates/for-teachers.html:59 website/teacher.py:501
 #, fuzzy
 msgid "create_adventure"
 msgstr "Create adventure"
@@ -1367,6 +1384,10 @@ msgstr "Next exercise"
 #, fuzzy
 msgid "edit_code_button"
 msgstr "Edit code"
+
+#: templates/incl-editor-and-output.html:146
+msgid "repair_program_logo_alt"
+msgstr ""
 
 #: templates/incl-editor-and-output.html:150
 #, fuzzy
@@ -1466,25 +1487,52 @@ msgstr "Welcome"
 msgid "welcome_back"
 msgstr "Welcome back"
 
+#: templates/landing-page.html:11
+#, fuzzy
+msgid "teacher_tutorial_logo_alt"
+msgstr "Click on 'next step' to get started as a Hedy teacher!"
+
 #: templates/landing-page.html:13
 #, fuzzy
 msgid "start_teacher_tutorial"
 msgstr "Start teacher tutorial"
+
+#: templates/landing-page.html:18
+#, fuzzy
+msgid "hedy_tutorial_logo_alt"
+msgstr "Start hedy tutorial"
 
 #: templates/landing-page.html:20
 #, fuzzy
 msgid "start_hedy_tutorial"
 msgstr "Start hedy tutorial"
 
+#: templates/landing-page.html:25
+#, fuzzy
+msgid "start_programming_logo_alt"
+msgstr "Start programming"
+
 #: templates/landing-page.html:27
 #, fuzzy
 msgid "start_programming"
 msgstr "Start programming"
 
+#: templates/landing-page.html:31
+#, fuzzy
+msgid "explore_programs_logo_alt"
+msgstr "Explore programs"
+
 #: templates/landing-page.html:39
 #, fuzzy
 msgid "your_account"
 msgstr "Your profile"
+
+#: templates/landing-page.html:43 templates/landing-page.html:45
+#: templates/profile.html:33 templates/public-page.html:7
+#: templates/public-page.html:9
+#, fuzzy
+msgid "profile_logo_alt"
+msgstr "Profile updated."
 
 #: templates/landing-page.html:52 templates/public-page.html:16
 #, fuzzy
@@ -1905,6 +1953,10 @@ msgstr "Write your first program!"
 #, fuzzy
 msgid "no_shared_programs"
 msgstr "has no shared programs..."
+
+#: templates/quiz.html:4
+msgid "quiz_logo_alt"
+msgstr ""
 
 #: templates/quiz.html:7
 #, fuzzy
@@ -2394,7 +2446,7 @@ msgstr "Program unshared successfully."
 msgid "favourite_success"
 msgstr "Your program is set as favourite."
 
-#: website/quiz.py:45 website/quiz.py:71 website/teacher.py:452
+#: website/quiz.py:45 website/quiz.py:71 website/teacher.py:454
 #, fuzzy
 msgid "level_invalid"
 msgstr "This Hedy level in invalid."
@@ -2425,6 +2477,7 @@ msgstr "Only teachers can retrieve classes"
 #: website/statistics.py:41 website/teacher.py:38 website/teacher.py:131
 #: website/teacher.py:150 website/teacher.py:212 website/teacher.py:234
 #: website/teacher.py:246 website/teacher.py:313 website/teacher.py:352
+#: website/teacher.py:364
 #, fuzzy
 msgid "no_such_class"
 msgstr "No such Hedy class."
@@ -2459,7 +2512,7 @@ msgstr "You didn't enter a class name!"
 msgid "class_name_duplicate"
 msgstr "You already have a class with this name."
 
-#: website/teacher.py:162 website/teacher.py:178 website/teacher.py:531
+#: website/teacher.py:162 website/teacher.py:178 website/teacher.py:533
 #, fuzzy
 msgid "invalid_class_link"
 msgstr "Invalid link for joining the class."
@@ -2504,78 +2557,78 @@ msgstr "This student is already in your class."
 msgid "student_already_invite"
 msgstr "This student already has a pending invitation."
 
-#: website/teacher.py:380
+#: website/teacher.py:382
 #, fuzzy
 msgid "no_accounts"
 msgstr "There are no accounts to create."
 
-#: website/teacher.py:390
+#: website/teacher.py:392
 #, fuzzy
 msgid "unique_usernames"
 msgstr "All usernames need to be unique."
 
-#: website/teacher.py:399
+#: website/teacher.py:401
 #, fuzzy
 msgid "usernames_exist"
 msgstr "One or more usernames is already in use."
 
-#: website/teacher.py:410
+#: website/teacher.py:412
 #, fuzzy
 msgid "accounts_created"
 msgstr "Accounts where successfully created."
 
-#: website/teacher.py:416 website/teacher.py:421 website/teacher.py:432
-#: website/teacher.py:461 website/teacher.py:487
+#: website/teacher.py:418 website/teacher.py:423 website/teacher.py:434
+#: website/teacher.py:463 website/teacher.py:489
 #, fuzzy
 msgid "retrieve_adventure_error"
 msgstr "You're not allowed to view this adventure!"
 
-#: website/teacher.py:426
+#: website/teacher.py:428
 #, fuzzy
 msgid "title_view-adventure"
 msgstr "Hedy - View adventure"
 
-#: website/teacher.py:437
+#: website/teacher.py:439
 #, fuzzy
 msgid "title_customize-adventure"
 msgstr "Hedy - Customize adventure"
 
-#: website/teacher.py:448
+#: website/teacher.py:450
 #, fuzzy
 msgid "adventure_id_invalid"
 msgstr "This adventure id is invalid."
 
-#: website/teacher.py:450 website/teacher.py:506
+#: website/teacher.py:452 website/teacher.py:508
 #, fuzzy
 msgid "adventure_name_invalid"
 msgstr "This adventure name is invalid."
 
-#: website/teacher.py:454
+#: website/teacher.py:456
 #, fuzzy
 msgid "content_invalid"
 msgstr "This adventure is invalid."
 
-#: website/teacher.py:456
+#: website/teacher.py:458
 #, fuzzy
 msgid "adventure_length"
 msgstr "Your adventure has to be at least 20 characters."
 
-#: website/teacher.py:458
+#: website/teacher.py:460
 #, fuzzy
 msgid "public_invalid"
 msgstr "This agreement selection is invalid"
 
-#: website/teacher.py:469 website/teacher.py:513
+#: website/teacher.py:471 website/teacher.py:515
 #, fuzzy
 msgid "adventure_duplicate"
 msgstr "You already have an adventure with this name."
 
-#: website/teacher.py:481
+#: website/teacher.py:483
 #, fuzzy
 msgid "adventure_updated"
 msgstr "The adventure has been updated!"
 
-#: website/teacher.py:508
+#: website/teacher.py:510
 #, fuzzy
 msgid "adventure_empty"
 msgstr "You didn't enter an adventure name!"
@@ -2591,4 +2644,7 @@ msgstr "You didn't enter an adventure name!"
 
 #~ msgid "go_to_first_exercise"
 #~ msgstr "Go to exercise 1"
+
+#~ msgid "select_class"
+#~ msgstr "Select class"
 

--- a/translations/fa/LC_MESSAGES/messages.po
+++ b/translations/fa/LC_MESSAGES/messages.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-21 10:36+0200\n"
+"POT-Creation-Date: 2022-06-23 14:02+0200\n"
 "PO-Revision-Date: 2022-06-18 14:19+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: fa\n"
@@ -24,7 +24,7 @@ msgid "title_achievements"
 msgstr "Hedy - My achievements"
 
 #: app.py:639 app.py:743 app.py:1085 website/teacher.py:361
-#: website/teacher.py:370
+#: website/teacher.py:372
 msgid "not_teacher"
 msgstr "به نظر میاد که شما معلم نیستی!"
 
@@ -65,8 +65,8 @@ msgstr "No such Hedy program!"
 msgid "level_not_class"
 msgstr "You're in a class where this level has not been made available yet"
 
-#: app.py:923 website/teacher.py:419 website/teacher.py:435
-#: website/teacher.py:464 website/teacher.py:490
+#: app.py:923 website/teacher.py:421 website/teacher.py:437
+#: website/teacher.py:466 website/teacher.py:492
 #, fuzzy
 msgid "no_such_adventure"
 msgstr "This adventure doesn't exist!"
@@ -363,8 +363,8 @@ msgstr ""
 #: website/auth.py:671 website/auth.py:718 website/auth.py:745
 #: website/quiz.py:43 website/quiz.py:69 website/teacher.py:88
 #: website/teacher.py:123 website/teacher.py:195 website/teacher.py:251
-#: website/teacher.py:298 website/teacher.py:339 website/teacher.py:375
-#: website/teacher.py:446 website/teacher.py:504
+#: website/teacher.py:298 website/teacher.py:339 website/teacher.py:377
+#: website/teacher.py:448 website/teacher.py:506
 #, fuzzy
 msgid "ajax_error"
 msgstr "There was an error, please try again."
@@ -720,6 +720,23 @@ msgstr "مخفی"
 msgid "hedy_achievements"
 msgstr "دستاوردهای هِدی"
 
+#: templates/achievements.html:36 templates/achievements.html:50
+#: templates/landing-page.html:89 templates/layout.html:92
+#: templates/public-page.html:51
+#, fuzzy
+msgid "achievements_logo_alt"
+msgstr "achievements"
+
+#: templates/achievements.html:37
+#, fuzzy
+msgid "achievements_check_icon_alt"
+msgstr "You've earned an achievement!"
+
+#: templates/base_email.html:3 templates/cheatsheet.html:15
+#: templates/incl-menubar.html:4
+msgid "hedy_logo_alt"
+msgstr ""
+
 #: templates/cheatsheet.html:14
 #, fuzzy
 msgid "cheatsheet_title"
@@ -845,7 +862,7 @@ msgstr "Enter a username"
 msgid "invite_by_username"
 msgstr "All usernames need to be unique."
 
-#: templates/class-overview.html:55 templates/create-accounts.html:49
+#: templates/class-overview.html:55 templates/create-accounts.html:45
 #, fuzzy
 msgid "create_accounts"
 msgstr "Create multiple accounts"
@@ -875,6 +892,10 @@ msgstr "Are you sure you want to remove this class invitation?"
 msgid "class_already_joined"
 msgstr "You are already a student of class"
 
+#: templates/class-prejoin.html:9 templates/error-page.html:6
+msgid "error_logo_alt"
+msgstr ""
+
 #: templates/class-prejoin.html:11
 #, fuzzy
 msgid "goto_profile"
@@ -895,7 +916,8 @@ msgstr "You need to have an account to join a class. Would you like to login now
 msgid "join_class"
 msgstr "Join class"
 
-#: templates/class-stats.html:22 templates/customize-class.html:166
+#: templates/class-stats.html:22 templates/create-accounts.html:41
+#: templates/customize-class.html:166
 #, fuzzy
 msgid "back_to_class"
 msgstr "Go back to class"
@@ -937,29 +959,24 @@ msgstr ""
 msgid "create_accounts_prompt"
 msgstr "Are you sure you want to create these accounts?"
 
-#: templates/create-accounts.html:19
-#, fuzzy
-msgid "select_class"
-msgstr "Select class"
-
-#: templates/create-accounts.html:30
+#: templates/create-accounts.html:25
 #, fuzzy
 msgid "download_login_credentials"
 msgstr ""
 
-#: templates/create-accounts.html:34 templates/layout.html:22
+#: templates/create-accounts.html:29 templates/layout.html:22
 #: templates/signup.html:64
 #, fuzzy
 msgid "yes"
 msgstr "Yes"
 
-#: templates/create-accounts.html:38 templates/layout.html:23
+#: templates/create-accounts.html:33 templates/layout.html:23
 #: templates/signup.html:68
 #, fuzzy
 msgid "no"
 msgstr "No"
 
-#: templates/create-accounts.html:48 templates/programs.html:24
+#: templates/create-accounts.html:44 templates/programs.html:24
 #, fuzzy
 msgid "reset_view"
 msgstr "Reset"
@@ -1303,7 +1320,7 @@ msgstr "View"
 msgid "adventure_prompt"
 msgstr "Please enter the name of the adventure"
 
-#: templates/for-teachers.html:59 website/teacher.py:499
+#: templates/for-teachers.html:59 website/teacher.py:501
 #, fuzzy
 msgid "create_adventure"
 msgstr "Create adventure"
@@ -1375,6 +1392,10 @@ msgstr "Next exercise"
 #, fuzzy
 msgid "edit_code_button"
 msgstr "Edit code"
+
+#: templates/incl-editor-and-output.html:146
+msgid "repair_program_logo_alt"
+msgstr ""
 
 #: templates/incl-editor-and-output.html:150
 #, fuzzy
@@ -1478,25 +1499,52 @@ msgstr ""
 "Welcome to Hedy! Your are now the proud owner of a teachers account which"
 " allows you to create classes and invite students."
 
+#: templates/landing-page.html:11
+#, fuzzy
+msgid "teacher_tutorial_logo_alt"
+msgstr "You have received an invitation to join class"
+
 #: templates/landing-page.html:13
 #, fuzzy
 msgid "start_teacher_tutorial"
 msgstr "Start teacher tutorial"
+
+#: templates/landing-page.html:18
+#, fuzzy
+msgid "hedy_tutorial_logo_alt"
+msgstr "Start hedy tutorial"
 
 #: templates/landing-page.html:20
 #, fuzzy
 msgid "start_hedy_tutorial"
 msgstr "Start hedy tutorial"
 
+#: templates/landing-page.html:25
+#, fuzzy
+msgid "start_programming_logo_alt"
+msgstr "Directly start programming"
+
 #: templates/landing-page.html:27
 #, fuzzy
 msgid "start_programming"
 msgstr "Directly start programming"
 
+#: templates/landing-page.html:31
+#, fuzzy
+msgid "explore_programs_logo_alt"
+msgstr "Explore programs"
+
 #: templates/landing-page.html:39
 #, fuzzy
 msgid "your_account"
 msgstr "No account?"
+
+#: templates/landing-page.html:43 templates/landing-page.html:45
+#: templates/profile.html:33 templates/public-page.html:7
+#: templates/public-page.html:9
+#, fuzzy
+msgid "profile_logo_alt"
+msgstr "Profile updated."
 
 #: templates/landing-page.html:52 templates/public-page.html:16
 #, fuzzy
@@ -1917,6 +1965,10 @@ msgstr "Write your first program!"
 #, fuzzy
 msgid "no_shared_programs"
 msgstr "has no shared programs..."
+
+#: templates/quiz.html:4
+msgid "quiz_logo_alt"
+msgstr ""
 
 #: templates/quiz.html:7
 #, fuzzy
@@ -2392,7 +2444,7 @@ msgstr "Program unshared successfully."
 msgid "favourite_success"
 msgstr "Your program is set as favourite."
 
-#: website/quiz.py:45 website/quiz.py:71 website/teacher.py:452
+#: website/quiz.py:45 website/quiz.py:71 website/teacher.py:454
 #, fuzzy
 msgid "level_invalid"
 msgstr "This Hedy level in invalid."
@@ -2425,6 +2477,7 @@ msgstr "Only teachers can retrieve classes"
 #: website/statistics.py:41 website/teacher.py:38 website/teacher.py:131
 #: website/teacher.py:150 website/teacher.py:212 website/teacher.py:234
 #: website/teacher.py:246 website/teacher.py:313 website/teacher.py:352
+#: website/teacher.py:364
 #, fuzzy
 msgid "no_such_class"
 msgstr "No such Hedy class"
@@ -2459,7 +2512,7 @@ msgstr "You didn't enter a class name!"
 msgid "class_name_duplicate"
 msgstr "You already have a class with this name."
 
-#: website/teacher.py:162 website/teacher.py:178 website/teacher.py:531
+#: website/teacher.py:162 website/teacher.py:178 website/teacher.py:533
 #, fuzzy
 msgid "invalid_class_link"
 msgstr "Invalid link for joining the class."
@@ -2504,78 +2557,78 @@ msgstr "This student is already in your class."
 msgid "student_already_invite"
 msgstr "This student already has a pending invitation."
 
-#: website/teacher.py:380
+#: website/teacher.py:382
 #, fuzzy
 msgid "no_accounts"
 msgstr "There are no accounts to create."
 
-#: website/teacher.py:390
+#: website/teacher.py:392
 #, fuzzy
 msgid "unique_usernames"
 msgstr "All usernames need to be unique."
 
-#: website/teacher.py:399
+#: website/teacher.py:401
 #, fuzzy
 msgid "usernames_exist"
 msgstr "One or more usernames is already in use."
 
-#: website/teacher.py:410
+#: website/teacher.py:412
 #, fuzzy
 msgid "accounts_created"
 msgstr "Accounts where successfully created."
 
-#: website/teacher.py:416 website/teacher.py:421 website/teacher.py:432
-#: website/teacher.py:461 website/teacher.py:487
+#: website/teacher.py:418 website/teacher.py:423 website/teacher.py:434
+#: website/teacher.py:463 website/teacher.py:489
 #, fuzzy
 msgid "retrieve_adventure_error"
 msgstr "You're not allowed to view this adventure!"
 
-#: website/teacher.py:426
+#: website/teacher.py:428
 #, fuzzy
 msgid "title_view-adventure"
 msgstr "Hedy - View adventure"
 
-#: website/teacher.py:437
+#: website/teacher.py:439
 #, fuzzy
 msgid "title_customize-adventure"
 msgstr "Hedy - Customize adventure"
 
-#: website/teacher.py:448
+#: website/teacher.py:450
 #, fuzzy
 msgid "adventure_id_invalid"
 msgstr "This adventure id is invalid."
 
-#: website/teacher.py:450 website/teacher.py:506
+#: website/teacher.py:452 website/teacher.py:508
 #, fuzzy
 msgid "adventure_name_invalid"
 msgstr "This adventure name is invalid."
 
-#: website/teacher.py:454
+#: website/teacher.py:456
 #, fuzzy
 msgid "content_invalid"
 msgstr "This adventure is invalid."
 
-#: website/teacher.py:456
+#: website/teacher.py:458
 #, fuzzy
 msgid "adventure_length"
 msgstr "Your adventure has to be at least 20 characters."
 
-#: website/teacher.py:458
+#: website/teacher.py:460
 #, fuzzy
 msgid "public_invalid"
 msgstr "This agreement selection is invalid"
 
-#: website/teacher.py:469 website/teacher.py:513
+#: website/teacher.py:471 website/teacher.py:515
 #, fuzzy
 msgid "adventure_duplicate"
 msgstr "You already have an adventure with this name."
 
-#: website/teacher.py:481
+#: website/teacher.py:483
 #, fuzzy
 msgid "adventure_updated"
 msgstr "The adventure has been updated!"
 
-#: website/teacher.py:508
+#: website/teacher.py:510
 #, fuzzy
 msgid "adventure_empty"
 msgstr "You didn't enter an adventure name!"
@@ -2734,4 +2787,7 @@ msgstr "You didn't enter an adventure name!"
 
 #~ msgid "go_to_first_exercise"
 #~ msgstr "Go to question 1"
+
+#~ msgid "select_class"
+#~ msgstr "Select class"
 

--- a/translations/fr/LC_MESSAGES/messages.po
+++ b/translations/fr/LC_MESSAGES/messages.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-21 10:36+0200\n"
+"POT-Creation-Date: 2022-06-23 14:02+0200\n"
 "PO-Revision-Date: 2022-06-18 14:19+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: fr\n"
@@ -23,7 +23,7 @@ msgid "title_achievements"
 msgstr "Hedy - Mes réalisations"
 
 #: app.py:639 app.py:743 app.py:1085 website/teacher.py:361
-#: website/teacher.py:370
+#: website/teacher.py:372
 msgid "not_teacher"
 msgstr "On dirait que vous n'êtes pas enseignant !"
 
@@ -61,8 +61,8 @@ msgstr "No such Hedy program!"
 msgid "level_not_class"
 msgstr "Ce niveau n'a pas encore été rendu disponible dans votre classe."
 
-#: app.py:923 website/teacher.py:419 website/teacher.py:435
-#: website/teacher.py:464 website/teacher.py:490
+#: app.py:923 website/teacher.py:421 website/teacher.py:437
+#: website/teacher.py:466 website/teacher.py:492
 msgid "no_such_adventure"
 msgstr "Cette aventure n’existe pas !"
 
@@ -345,8 +345,8 @@ msgstr ""
 #: website/auth.py:671 website/auth.py:718 website/auth.py:745
 #: website/quiz.py:43 website/quiz.py:69 website/teacher.py:88
 #: website/teacher.py:123 website/teacher.py:195 website/teacher.py:251
-#: website/teacher.py:298 website/teacher.py:339 website/teacher.py:375
-#: website/teacher.py:446 website/teacher.py:504
+#: website/teacher.py:298 website/teacher.py:339 website/teacher.py:377
+#: website/teacher.py:448 website/teacher.py:506
 #, fuzzy
 msgid "ajax_error"
 msgstr "There was an error, please try again."
@@ -699,6 +699,23 @@ msgstr "masqués"
 msgid "hedy_achievements"
 msgstr "Succès d'Hedy"
 
+#: templates/achievements.html:36 templates/achievements.html:50
+#: templates/landing-page.html:89 templates/layout.html:92
+#: templates/public-page.html:51
+#, fuzzy
+msgid "achievements_logo_alt"
+msgstr "achievements"
+
+#: templates/achievements.html:37
+#, fuzzy
+msgid "achievements_check_icon_alt"
+msgstr "You've earned an achievement!"
+
+#: templates/base_email.html:3 templates/cheatsheet.html:15
+#: templates/incl-menubar.html:4
+msgid "hedy_logo_alt"
+msgstr ""
+
 #: templates/cheatsheet.html:14
 #, fuzzy
 msgid "cheatsheet_title"
@@ -824,7 +841,7 @@ msgstr "Enter a username"
 msgid "invite_by_username"
 msgstr "All usernames need to be unique."
 
-#: templates/class-overview.html:55 templates/create-accounts.html:49
+#: templates/class-overview.html:55 templates/create-accounts.html:45
 #, fuzzy
 msgid "create_accounts"
 msgstr "Create multiple accounts"
@@ -854,6 +871,10 @@ msgstr "Are you sure you want to remove this class invitation?"
 msgid "class_already_joined"
 msgstr "You are already a student of class"
 
+#: templates/class-prejoin.html:9 templates/error-page.html:6
+msgid "error_logo_alt"
+msgstr ""
+
 #: templates/class-prejoin.html:11
 #, fuzzy
 msgid "goto_profile"
@@ -874,7 +895,8 @@ msgstr "You need to have an account to join a class. Would you like to login now
 msgid "join_class"
 msgstr "Join class"
 
-#: templates/class-stats.html:22 templates/customize-class.html:166
+#: templates/class-stats.html:22 templates/create-accounts.html:41
+#: templates/customize-class.html:166
 #, fuzzy
 msgid "back_to_class"
 msgstr "Go back to class"
@@ -916,29 +938,24 @@ msgstr ""
 msgid "create_accounts_prompt"
 msgstr "Are you sure you want to create these accounts?"
 
-#: templates/create-accounts.html:19
-#, fuzzy
-msgid "select_class"
-msgstr "Select class"
-
-#: templates/create-accounts.html:30
+#: templates/create-accounts.html:25
 #, fuzzy
 msgid "download_login_credentials"
 msgstr ""
 
-#: templates/create-accounts.html:34 templates/layout.html:22
+#: templates/create-accounts.html:29 templates/layout.html:22
 #: templates/signup.html:64
 #, fuzzy
 msgid "yes"
 msgstr "Yes"
 
-#: templates/create-accounts.html:38 templates/layout.html:23
+#: templates/create-accounts.html:33 templates/layout.html:23
 #: templates/signup.html:68
 #, fuzzy
 msgid "no"
 msgstr "No"
 
-#: templates/create-accounts.html:48 templates/programs.html:24
+#: templates/create-accounts.html:44 templates/programs.html:24
 #, fuzzy
 msgid "reset_view"
 msgstr "Reset"
@@ -1283,7 +1300,7 @@ msgstr "View"
 msgid "adventure_prompt"
 msgstr "Please enter the name of the adventure"
 
-#: templates/for-teachers.html:59 website/teacher.py:499
+#: templates/for-teachers.html:59 website/teacher.py:501
 #, fuzzy
 msgid "create_adventure"
 msgstr "Create adventure"
@@ -1355,6 +1372,10 @@ msgstr "Next exercise"
 #, fuzzy
 msgid "edit_code_button"
 msgstr "Edit code"
+
+#: templates/incl-editor-and-output.html:146
+msgid "repair_program_logo_alt"
+msgstr ""
 
 #: templates/incl-editor-and-output.html:150
 #, fuzzy
@@ -1458,25 +1479,52 @@ msgstr ""
 "Welcome to Hedy! Your are now the proud owner of a teachers account which"
 " allows you to create classes and invite students."
 
+#: templates/landing-page.html:11
+#, fuzzy
+msgid "teacher_tutorial_logo_alt"
+msgstr "You have received an invitation to join class"
+
 #: templates/landing-page.html:13
 #, fuzzy
 msgid "start_teacher_tutorial"
 msgstr "Start teacher tutorial"
+
+#: templates/landing-page.html:18
+#, fuzzy
+msgid "hedy_tutorial_logo_alt"
+msgstr "Start hedy tutorial"
 
 #: templates/landing-page.html:20
 #, fuzzy
 msgid "start_hedy_tutorial"
 msgstr "Start hedy tutorial"
 
+#: templates/landing-page.html:25
+#, fuzzy
+msgid "start_programming_logo_alt"
+msgstr "Directly start programming"
+
 #: templates/landing-page.html:27
 #, fuzzy
 msgid "start_programming"
 msgstr "Directly start programming"
 
+#: templates/landing-page.html:31
+#, fuzzy
+msgid "explore_programs_logo_alt"
+msgstr "Explore programs"
+
 #: templates/landing-page.html:39
 #, fuzzy
 msgid "your_account"
 msgstr "No account?"
+
+#: templates/landing-page.html:43 templates/landing-page.html:45
+#: templates/profile.html:33 templates/public-page.html:7
+#: templates/public-page.html:9
+#, fuzzy
+msgid "profile_logo_alt"
+msgstr "Profile updated."
 
 #: templates/landing-page.html:52 templates/public-page.html:16
 #, fuzzy
@@ -1897,6 +1945,10 @@ msgstr "Write your first program!"
 #, fuzzy
 msgid "no_shared_programs"
 msgstr "has no shared programs..."
+
+#: templates/quiz.html:4
+msgid "quiz_logo_alt"
+msgstr ""
 
 #: templates/quiz.html:7
 #, fuzzy
@@ -2386,7 +2438,7 @@ msgstr "Program unshared successfully."
 msgid "favourite_success"
 msgstr "Your program is set as favourite."
 
-#: website/quiz.py:45 website/quiz.py:71 website/teacher.py:452
+#: website/quiz.py:45 website/quiz.py:71 website/teacher.py:454
 #, fuzzy
 msgid "level_invalid"
 msgstr "This Hedy level in invalid."
@@ -2419,6 +2471,7 @@ msgstr "Only teachers can retrieve classes"
 #: website/statistics.py:41 website/teacher.py:38 website/teacher.py:131
 #: website/teacher.py:150 website/teacher.py:212 website/teacher.py:234
 #: website/teacher.py:246 website/teacher.py:313 website/teacher.py:352
+#: website/teacher.py:364
 #, fuzzy
 msgid "no_such_class"
 msgstr "No such Hedy class."
@@ -2453,7 +2506,7 @@ msgstr "You didn't enter a class name!"
 msgid "class_name_duplicate"
 msgstr "You already have a class with this name."
 
-#: website/teacher.py:162 website/teacher.py:178 website/teacher.py:531
+#: website/teacher.py:162 website/teacher.py:178 website/teacher.py:533
 #, fuzzy
 msgid "invalid_class_link"
 msgstr "Invalid link for joining the class."
@@ -2498,78 +2551,78 @@ msgstr "This student is already in your class."
 msgid "student_already_invite"
 msgstr "This student already has a pending invitation."
 
-#: website/teacher.py:380
+#: website/teacher.py:382
 #, fuzzy
 msgid "no_accounts"
 msgstr "There are no accounts to create."
 
-#: website/teacher.py:390
+#: website/teacher.py:392
 #, fuzzy
 msgid "unique_usernames"
 msgstr "All usernames need to be unique."
 
-#: website/teacher.py:399
+#: website/teacher.py:401
 #, fuzzy
 msgid "usernames_exist"
 msgstr "One or more usernames is already in use."
 
-#: website/teacher.py:410
+#: website/teacher.py:412
 #, fuzzy
 msgid "accounts_created"
 msgstr "Accounts where successfully created."
 
-#: website/teacher.py:416 website/teacher.py:421 website/teacher.py:432
-#: website/teacher.py:461 website/teacher.py:487
+#: website/teacher.py:418 website/teacher.py:423 website/teacher.py:434
+#: website/teacher.py:463 website/teacher.py:489
 #, fuzzy
 msgid "retrieve_adventure_error"
 msgstr "You're not allowed to view this adventure!"
 
-#: website/teacher.py:426
+#: website/teacher.py:428
 #, fuzzy
 msgid "title_view-adventure"
 msgstr "Hedy - View adventure"
 
-#: website/teacher.py:437
+#: website/teacher.py:439
 #, fuzzy
 msgid "title_customize-adventure"
 msgstr "Hedy - Customize adventure"
 
-#: website/teacher.py:448
+#: website/teacher.py:450
 #, fuzzy
 msgid "adventure_id_invalid"
 msgstr "This adventure id is invalid."
 
-#: website/teacher.py:450 website/teacher.py:506
+#: website/teacher.py:452 website/teacher.py:508
 #, fuzzy
 msgid "adventure_name_invalid"
 msgstr "This adventure name is invalid."
 
-#: website/teacher.py:454
+#: website/teacher.py:456
 #, fuzzy
 msgid "content_invalid"
 msgstr "This adventure is invalid."
 
-#: website/teacher.py:456
+#: website/teacher.py:458
 #, fuzzy
 msgid "adventure_length"
 msgstr "Your adventure has to be at least 20 characters."
 
-#: website/teacher.py:458
+#: website/teacher.py:460
 #, fuzzy
 msgid "public_invalid"
 msgstr "This agreement selection is invalid"
 
-#: website/teacher.py:469 website/teacher.py:513
+#: website/teacher.py:471 website/teacher.py:515
 #, fuzzy
 msgid "adventure_duplicate"
 msgstr "You already have an adventure with this name."
 
-#: website/teacher.py:481
+#: website/teacher.py:483
 #, fuzzy
 msgid "adventure_updated"
 msgstr "The adventure has been updated!"
 
-#: website/teacher.py:508
+#: website/teacher.py:510
 #, fuzzy
 msgid "adventure_empty"
 msgstr "You didn't enter an adventure name!"
@@ -2710,4 +2763,7 @@ msgstr "You didn't enter an adventure name!"
 
 #~ msgid "go_to_first_exercise"
 #~ msgstr "Go to question 1"
+
+#~ msgid "select_class"
+#~ msgstr "Select class"
 

--- a/translations/fy/LC_MESSAGES/messages.po
+++ b/translations/fy/LC_MESSAGES/messages.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-21 10:36+0200\n"
+"POT-Creation-Date: 2022-06-23 14:02+0200\n"
 "PO-Revision-Date: 2022-06-18 14:19+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: fy\n"
@@ -25,7 +25,7 @@ msgid "title_achievements"
 msgstr "Hedy - My achievements"
 
 #: app.py:639 app.py:743 app.py:1085 website/teacher.py:361
-#: website/teacher.py:370
+#: website/teacher.py:372
 #, fuzzy
 msgid "not_teacher"
 msgstr "Looks like you are not a teacher!"
@@ -69,8 +69,8 @@ msgstr "No such Hedy program!"
 msgid "level_not_class"
 msgstr "You're in a class where this level has not been made available yet"
 
-#: app.py:923 website/teacher.py:419 website/teacher.py:435
-#: website/teacher.py:464 website/teacher.py:490
+#: app.py:923 website/teacher.py:421 website/teacher.py:437
+#: website/teacher.py:466 website/teacher.py:492
 #, fuzzy
 msgid "no_such_adventure"
 msgstr "This adventure doesn't exist!"
@@ -367,8 +367,8 @@ msgstr ""
 #: website/auth.py:671 website/auth.py:718 website/auth.py:745
 #: website/quiz.py:43 website/quiz.py:69 website/teacher.py:88
 #: website/teacher.py:123 website/teacher.py:195 website/teacher.py:251
-#: website/teacher.py:298 website/teacher.py:339 website/teacher.py:375
-#: website/teacher.py:446 website/teacher.py:504
+#: website/teacher.py:298 website/teacher.py:339 website/teacher.py:377
+#: website/teacher.py:448 website/teacher.py:506
 msgid "ajax_error"
 msgstr "Der gong wat mis, besykje it nochris."
 
@@ -706,6 +706,23 @@ msgstr "Hint?"
 msgid "hedy_achievements"
 msgstr "My achievements"
 
+#: templates/achievements.html:36 templates/achievements.html:50
+#: templates/landing-page.html:89 templates/layout.html:92
+#: templates/public-page.html:51
+#, fuzzy
+msgid "achievements_logo_alt"
+msgstr "achievements"
+
+#: templates/achievements.html:37
+#, fuzzy
+msgid "achievements_check_icon_alt"
+msgstr "You've earned an achievement!"
+
+#: templates/base_email.html:3 templates/cheatsheet.html:15
+#: templates/incl-menubar.html:4
+msgid "hedy_logo_alt"
+msgstr ""
+
 #: templates/cheatsheet.html:14
 #, fuzzy
 msgid "cheatsheet_title"
@@ -822,7 +839,7 @@ msgstr "Enter a username"
 msgid "invite_by_username"
 msgstr "All usernames need to be unique."
 
-#: templates/class-overview.html:55 templates/create-accounts.html:49
+#: templates/class-overview.html:55 templates/create-accounts.html:45
 #, fuzzy
 msgid "create_accounts"
 msgstr "Create multiple accounts"
@@ -851,6 +868,10 @@ msgstr "Are you sure you want to remove this class invitation?"
 msgid "class_already_joined"
 msgstr "Dochst al mei oan de klas"
 
+#: templates/class-prejoin.html:9 templates/error-page.html:6
+msgid "error_logo_alt"
+msgstr ""
+
 #: templates/class-prejoin.html:11
 msgid "goto_profile"
 msgstr "Nei myn profyl"
@@ -870,7 +891,8 @@ msgstr ""
 msgid "join_class"
 msgstr "Join class"
 
-#: templates/class-stats.html:22 templates/customize-class.html:166
+#: templates/class-stats.html:22 templates/create-accounts.html:41
+#: templates/customize-class.html:166
 #, fuzzy
 msgid "back_to_class"
 msgstr "Go back to class"
@@ -912,27 +934,22 @@ msgstr ""
 msgid "create_accounts_prompt"
 msgstr "Are you sure you want to create these accounts?"
 
-#: templates/create-accounts.html:19
-#, fuzzy
-msgid "select_class"
-msgstr "Select class"
-
-#: templates/create-accounts.html:30
+#: templates/create-accounts.html:25
 #, fuzzy
 msgid "download_login_credentials"
 msgstr ""
 
-#: templates/create-accounts.html:34 templates/layout.html:22
+#: templates/create-accounts.html:29 templates/layout.html:22
 #: templates/signup.html:64
 msgid "yes"
 msgstr "Ja"
 
-#: templates/create-accounts.html:38 templates/layout.html:23
+#: templates/create-accounts.html:33 templates/layout.html:23
 #: templates/signup.html:68
 msgid "no"
 msgstr "Nee"
 
-#: templates/create-accounts.html:48 templates/programs.html:24
+#: templates/create-accounts.html:44 templates/programs.html:24
 #, fuzzy
 msgid "reset_view"
 msgstr "Reset"
@@ -1257,7 +1274,7 @@ msgstr "View"
 msgid "adventure_prompt"
 msgstr "Please enter the name of the adventure"
 
-#: templates/for-teachers.html:59 website/teacher.py:499
+#: templates/for-teachers.html:59 website/teacher.py:501
 #, fuzzy
 msgid "create_adventure"
 msgstr "Create adventure"
@@ -1326,6 +1343,10 @@ msgstr "Next exercise"
 #: templates/incl-editor-and-output.html:144
 msgid "edit_code_button"
 msgstr "Koade oanpasse"
+
+#: templates/incl-editor-and-output.html:146
+msgid "repair_program_logo_alt"
+msgstr ""
 
 #: templates/incl-editor-and-output.html:150
 msgid "read_code_label"
@@ -1418,25 +1439,52 @@ msgstr ""
 "Welcome to Hedy! Your are now the proud owner of a teachers account which"
 " allows you to create classes and invite students."
 
+#: templates/landing-page.html:11
+#, fuzzy
+msgid "teacher_tutorial_logo_alt"
+msgstr "You have received an invitation to join class"
+
 #: templates/landing-page.html:13
 #, fuzzy
 msgid "start_teacher_tutorial"
 msgstr "Start teacher tutorial"
+
+#: templates/landing-page.html:18
+#, fuzzy
+msgid "hedy_tutorial_logo_alt"
+msgstr "Start hedy tutorial"
 
 #: templates/landing-page.html:20
 #, fuzzy
 msgid "start_hedy_tutorial"
 msgstr "Start hedy tutorial"
 
+#: templates/landing-page.html:25
+#, fuzzy
+msgid "start_programming_logo_alt"
+msgstr "Directly start programming"
+
 #: templates/landing-page.html:27
 #, fuzzy
 msgid "start_programming"
 msgstr "Directly start programming"
 
+#: templates/landing-page.html:31
+#, fuzzy
+msgid "explore_programs_logo_alt"
+msgstr "Explore programs"
+
 #: templates/landing-page.html:39
 #, fuzzy
 msgid "your_account"
 msgstr "Noch gjin akkount?"
+
+#: templates/landing-page.html:43 templates/landing-page.html:45
+#: templates/profile.html:33 templates/public-page.html:7
+#: templates/public-page.html:9
+#, fuzzy
+msgid "profile_logo_alt"
+msgstr "Dyn profyl is oanpast."
 
 #: templates/landing-page.html:52 templates/public-page.html:16
 #, fuzzy
@@ -1821,6 +1869,10 @@ msgstr "Skreau dyn earste programma!"
 #, fuzzy
 msgid "no_shared_programs"
 msgstr "has no shared programs..."
+
+#: templates/quiz.html:4
+msgid "quiz_logo_alt"
+msgstr ""
 
 #: templates/quiz.html:7
 msgid "start_quiz"
@@ -2260,7 +2312,7 @@ msgstr "It programma wurd net mear dield"
 msgid "favourite_success"
 msgstr "Your program is set as favourite."
 
-#: website/quiz.py:45 website/quiz.py:71 website/teacher.py:452
+#: website/quiz.py:45 website/quiz.py:71 website/teacher.py:454
 #, fuzzy
 msgid "level_invalid"
 msgstr "This Hedy level in invalid."
@@ -2293,6 +2345,7 @@ msgstr "Only teachers can retrieve classes"
 #: website/statistics.py:41 website/teacher.py:38 website/teacher.py:131
 #: website/teacher.py:150 website/teacher.py:212 website/teacher.py:234
 #: website/teacher.py:246 website/teacher.py:313 website/teacher.py:352
+#: website/teacher.py:364
 #, fuzzy
 msgid "no_such_class"
 msgstr "No such Hedy class"
@@ -2327,7 +2380,7 @@ msgstr "You didn't enter a class name!"
 msgid "class_name_duplicate"
 msgstr "You already have a class with this name."
 
-#: website/teacher.py:162 website/teacher.py:178 website/teacher.py:531
+#: website/teacher.py:162 website/teacher.py:178 website/teacher.py:533
 #, fuzzy
 msgid "invalid_class_link"
 msgstr "Invalid link for joining the class."
@@ -2372,78 +2425,78 @@ msgstr "This student is already in your class."
 msgid "student_already_invite"
 msgstr "This student already has a pending invitation."
 
-#: website/teacher.py:380
+#: website/teacher.py:382
 #, fuzzy
 msgid "no_accounts"
 msgstr "There are no accounts to create."
 
-#: website/teacher.py:390
+#: website/teacher.py:392
 #, fuzzy
 msgid "unique_usernames"
 msgstr "All usernames need to be unique."
 
-#: website/teacher.py:399
+#: website/teacher.py:401
 #, fuzzy
 msgid "usernames_exist"
 msgstr "One or more usernames is already in use."
 
-#: website/teacher.py:410
+#: website/teacher.py:412
 #, fuzzy
 msgid "accounts_created"
 msgstr "Accounts where successfully created."
 
-#: website/teacher.py:416 website/teacher.py:421 website/teacher.py:432
-#: website/teacher.py:461 website/teacher.py:487
+#: website/teacher.py:418 website/teacher.py:423 website/teacher.py:434
+#: website/teacher.py:463 website/teacher.py:489
 #, fuzzy
 msgid "retrieve_adventure_error"
 msgstr "You're not allowed to view this adventure!"
 
-#: website/teacher.py:426
+#: website/teacher.py:428
 #, fuzzy
 msgid "title_view-adventure"
 msgstr "Hedy - View adventure"
 
-#: website/teacher.py:437
+#: website/teacher.py:439
 #, fuzzy
 msgid "title_customize-adventure"
 msgstr "Hedy - Customize adventure"
 
-#: website/teacher.py:448
+#: website/teacher.py:450
 #, fuzzy
 msgid "adventure_id_invalid"
 msgstr "This adventure id is invalid."
 
-#: website/teacher.py:450 website/teacher.py:506
+#: website/teacher.py:452 website/teacher.py:508
 #, fuzzy
 msgid "adventure_name_invalid"
 msgstr "This adventure name is invalid."
 
-#: website/teacher.py:454
+#: website/teacher.py:456
 #, fuzzy
 msgid "content_invalid"
 msgstr "This adventure is invalid."
 
-#: website/teacher.py:456
+#: website/teacher.py:458
 #, fuzzy
 msgid "adventure_length"
 msgstr "Your adventure has to be at least 20 characters."
 
-#: website/teacher.py:458
+#: website/teacher.py:460
 #, fuzzy
 msgid "public_invalid"
 msgstr "This agreement selection is invalid"
 
-#: website/teacher.py:469 website/teacher.py:513
+#: website/teacher.py:471 website/teacher.py:515
 #, fuzzy
 msgid "adventure_duplicate"
 msgstr "You already have an adventure with this name."
 
-#: website/teacher.py:481
+#: website/teacher.py:483
 #, fuzzy
 msgid "adventure_updated"
 msgstr "The adventure has been updated!"
 
-#: website/teacher.py:508
+#: website/teacher.py:510
 #, fuzzy
 msgid "adventure_empty"
 msgstr "You didn't enter an adventure name!"
@@ -2602,4 +2655,7 @@ msgstr "You didn't enter an adventure name!"
 
 #~ msgid "go_to_first_exercise"
 #~ msgstr "Go to question 1"
+
+#~ msgid "select_class"
+#~ msgstr "Select class"
 

--- a/translations/hi/LC_MESSAGES/messages.po
+++ b/translations/hi/LC_MESSAGES/messages.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-21 10:36+0200\n"
+"POT-Creation-Date: 2022-06-23 14:02+0200\n"
 "PO-Revision-Date: 2022-06-18 14:19+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: hi\n"
@@ -25,7 +25,7 @@ msgid "title_achievements"
 msgstr "Hedy - My achievements"
 
 #: app.py:639 app.py:743 app.py:1085 website/teacher.py:361
-#: website/teacher.py:370
+#: website/teacher.py:372
 msgid "not_teacher"
 msgstr "लगता है आप शिक्षक नहीं हैं!"
 
@@ -65,8 +65,8 @@ msgstr "ऐसा कोई हेडी प्रोग्राम नही�
 msgid "level_not_class"
 msgstr "You're in a class where this level has not been made available yet"
 
-#: app.py:923 website/teacher.py:419 website/teacher.py:435
-#: website/teacher.py:464 website/teacher.py:490
+#: app.py:923 website/teacher.py:421 website/teacher.py:437
+#: website/teacher.py:466 website/teacher.py:492
 #, fuzzy
 msgid "no_such_adventure"
 msgstr "This adventure doesn't exist!"
@@ -362,8 +362,8 @@ msgstr ""
 #: website/auth.py:671 website/auth.py:718 website/auth.py:745
 #: website/quiz.py:43 website/quiz.py:69 website/teacher.py:88
 #: website/teacher.py:123 website/teacher.py:195 website/teacher.py:251
-#: website/teacher.py:298 website/teacher.py:339 website/teacher.py:375
-#: website/teacher.py:446 website/teacher.py:504
+#: website/teacher.py:298 website/teacher.py:339 website/teacher.py:377
+#: website/teacher.py:448 website/teacher.py:506
 msgid "ajax_error"
 msgstr "एक त्रुटि थी, कृपया पुनः प्रयास करें।"
 
@@ -672,6 +672,23 @@ msgstr "संकेत?"
 msgid "hedy_achievements"
 msgstr "मेरी उपलब्धियां"
 
+#: templates/achievements.html:36 templates/achievements.html:50
+#: templates/landing-page.html:89 templates/layout.html:92
+#: templates/public-page.html:51
+#, fuzzy
+msgid "achievements_logo_alt"
+msgstr "उपलब्धियां"
+
+#: templates/achievements.html:37
+#, fuzzy
+msgid "achievements_check_icon_alt"
+msgstr "आपने एक उपलब्धि अर्जित की है!"
+
+#: templates/base_email.html:3 templates/cheatsheet.html:15
+#: templates/incl-menubar.html:4
+msgid "hedy_logo_alt"
+msgstr ""
+
 #: templates/cheatsheet.html:14
 #, fuzzy
 msgid "cheatsheet_title"
@@ -779,7 +796,7 @@ msgstr "एक उपयोगकर्ता नाम दर्ज करे�
 msgid "invite_by_username"
 msgstr "All usernames need to be unique."
 
-#: templates/class-overview.html:55 templates/create-accounts.html:49
+#: templates/class-overview.html:55 templates/create-accounts.html:45
 #, fuzzy
 msgid "create_accounts"
 msgstr "Create multiple accounts"
@@ -805,6 +822,10 @@ msgstr "क्या आप वाकई इस कक्षा आमंत्�
 msgid "class_already_joined"
 msgstr "आप पहले से ही कक्षा के छात्र हैं"
 
+#: templates/class-prejoin.html:9 templates/error-page.html:6
+msgid "error_logo_alt"
+msgstr ""
+
 #: templates/class-prejoin.html:11
 msgid "goto_profile"
 msgstr "मेरी प्रोफ़ाइल पर जाएँ"
@@ -823,7 +844,8 @@ msgstr ""
 msgid "join_class"
 msgstr "कक्षा में शामिल हों"
 
-#: templates/class-stats.html:22 templates/customize-class.html:166
+#: templates/class-stats.html:22 templates/create-accounts.html:41
+#: templates/customize-class.html:166
 msgid "back_to_class"
 msgstr "कक्षा में वापस जाएं"
 
@@ -863,27 +885,22 @@ msgstr ""
 msgid "create_accounts_prompt"
 msgstr "Are you sure you want to create these accounts?"
 
-#: templates/create-accounts.html:19
-#, fuzzy
-msgid "select_class"
-msgstr "Select class"
-
-#: templates/create-accounts.html:30
+#: templates/create-accounts.html:25
 #, fuzzy
 msgid "download_login_credentials"
 msgstr ""
 
-#: templates/create-accounts.html:34 templates/layout.html:22
+#: templates/create-accounts.html:29 templates/layout.html:22
 #: templates/signup.html:64
 msgid "yes"
 msgstr "हां"
 
-#: templates/create-accounts.html:38 templates/layout.html:23
+#: templates/create-accounts.html:33 templates/layout.html:23
 #: templates/signup.html:68
 msgid "no"
 msgstr "नहीं"
 
-#: templates/create-accounts.html:48 templates/programs.html:24
+#: templates/create-accounts.html:44 templates/programs.html:24
 #, fuzzy
 msgid "reset_view"
 msgstr "Reset"
@@ -1186,7 +1203,7 @@ msgstr "नज़र डालें"
 msgid "adventure_prompt"
 msgstr "कृपया adventure का नाम दर्ज करें"
 
-#: templates/for-teachers.html:59 website/teacher.py:499
+#: templates/for-teachers.html:59 website/teacher.py:501
 msgid "create_adventure"
 msgstr "adventure बनाएं"
 
@@ -1252,6 +1269,10 @@ msgstr "Next exercise"
 #: templates/incl-editor-and-output.html:144
 msgid "edit_code_button"
 msgstr "कोड को संपादित करें"
+
+#: templates/incl-editor-and-output.html:146
+msgid "repair_program_logo_alt"
+msgstr ""
 
 #: templates/incl-editor-and-output.html:150
 msgid "read_code_label"
@@ -1344,25 +1365,52 @@ msgstr ""
 "हेडी में आपका स्वागत है! अब आप एक शिक्षक खाते के गर्वित स्वामी हैं जो "
 "आपको कक्षाएं बनाने और छात्रों को आमंत्रित करने की अनुमति देता है।"
 
+#: templates/landing-page.html:11
+#, fuzzy
+msgid "teacher_tutorial_logo_alt"
+msgstr "आपको कक्षा में शामिल होने का निमंत्रण मिला है"
+
 #: templates/landing-page.html:13
 #, fuzzy
 msgid "start_teacher_tutorial"
 msgstr "Start teacher tutorial"
+
+#: templates/landing-page.html:18
+#, fuzzy
+msgid "hedy_tutorial_logo_alt"
+msgstr "Start hedy tutorial"
 
 #: templates/landing-page.html:20
 #, fuzzy
 msgid "start_hedy_tutorial"
 msgstr "Start hedy tutorial"
 
+#: templates/landing-page.html:25
+#, fuzzy
+msgid "start_programming_logo_alt"
+msgstr "Directly start programming"
+
 #: templates/landing-page.html:27
 #, fuzzy
 msgid "start_programming"
 msgstr "Directly start programming"
 
+#: templates/landing-page.html:31
+#, fuzzy
+msgid "explore_programs_logo_alt"
+msgstr "्रोग्राम्स का अन्वेषण करें"
+
 #: templates/landing-page.html:39
 #, fuzzy
 msgid "your_account"
 msgstr "अभी तक कोई खाता नहीं?"
+
+#: templates/landing-page.html:43 templates/landing-page.html:45
+#: templates/profile.html:33 templates/public-page.html:7
+#: templates/public-page.html:9
+#, fuzzy
+msgid "profile_logo_alt"
+msgstr "प्रोफ़ाइल अद्यतन की गई|"
 
 #: templates/landing-page.html:52 templates/public-page.html:16
 msgid "achievements"
@@ -1715,6 +1763,10 @@ msgstr "अपना पहला प्रोग्राम लिखें!"
 #: templates/public-page.html:85
 msgid "no_shared_programs"
 msgstr "कोई साझा प्रोग्राम नहीं है ..."
+
+#: templates/quiz.html:4
+msgid "quiz_logo_alt"
+msgstr ""
 
 #: templates/quiz.html:7
 msgid "start_quiz"
@@ -2134,7 +2186,7 @@ msgstr "प्रोग्राम सफलतापूर्वक साझ�
 msgid "favourite_success"
 msgstr "आपका प्रोग्राम पसंदीदा के रूप में सेट है"
 
-#: website/quiz.py:45 website/quiz.py:71 website/teacher.py:452
+#: website/quiz.py:45 website/quiz.py:71 website/teacher.py:454
 msgid "level_invalid"
 msgstr "यह हेडी स्तर अमान्य है"
 
@@ -2165,6 +2217,7 @@ msgstr "केवल शिक्षक ही कक्षाएं पुन�
 #: website/statistics.py:41 website/teacher.py:38 website/teacher.py:131
 #: website/teacher.py:150 website/teacher.py:212 website/teacher.py:234
 #: website/teacher.py:246 website/teacher.py:313 website/teacher.py:352
+#: website/teacher.py:364
 msgid "no_such_class"
 msgstr "ऐसी कोई हेडी कक्षा नहीं!"
 
@@ -2196,7 +2249,7 @@ msgstr "आपने कक्षा का नाम नहीं डाला!
 msgid "class_name_duplicate"
 msgstr "आपके पास पहले से ही इस नाम की एक कक्षा है!"
 
-#: website/teacher.py:162 website/teacher.py:178 website/teacher.py:531
+#: website/teacher.py:162 website/teacher.py:178 website/teacher.py:533
 msgid "invalid_class_link"
 msgstr "कक्षा में शामिल होने के लिए अमान्य लिंक|"
 
@@ -2234,71 +2287,71 @@ msgstr "यह छात्र पहले से ही आपकी कक्
 msgid "student_already_invite"
 msgstr "इस छात्र के पास पहले से ही एक आमंत्रण लंबित है"
 
-#: website/teacher.py:380
+#: website/teacher.py:382
 #, fuzzy
 msgid "no_accounts"
 msgstr "There are no accounts to create."
 
-#: website/teacher.py:390
+#: website/teacher.py:392
 #, fuzzy
 msgid "unique_usernames"
 msgstr "All usernames need to be unique."
 
-#: website/teacher.py:399
+#: website/teacher.py:401
 #, fuzzy
 msgid "usernames_exist"
 msgstr "One or more usernames is already in use."
 
-#: website/teacher.py:410
+#: website/teacher.py:412
 #, fuzzy
 msgid "accounts_created"
 msgstr "Accounts where successfully created."
 
-#: website/teacher.py:416 website/teacher.py:421 website/teacher.py:432
-#: website/teacher.py:461 website/teacher.py:487
+#: website/teacher.py:418 website/teacher.py:423 website/teacher.py:434
+#: website/teacher.py:463 website/teacher.py:489
 #, fuzzy
 msgid "retrieve_adventure_error"
 msgstr "You're not allowed to view this adventure!"
 
-#: website/teacher.py:426
+#: website/teacher.py:428
 #, fuzzy
 msgid "title_view-adventure"
 msgstr "Hedy - View adventure"
 
-#: website/teacher.py:437
+#: website/teacher.py:439
 #, fuzzy
 msgid "title_customize-adventure"
 msgstr "Hedy - Customize adventure"
 
-#: website/teacher.py:448
+#: website/teacher.py:450
 msgid "adventure_id_invalid"
 msgstr "यह adventure आईडी अमान्य है"
 
-#: website/teacher.py:450 website/teacher.py:506
+#: website/teacher.py:452 website/teacher.py:508
 msgid "adventure_name_invalid"
 msgstr "यह adventure नाम अमान्य है"
 
-#: website/teacher.py:454
+#: website/teacher.py:456
 msgid "content_invalid"
 msgstr "यह adventure अमान्य है"
 
-#: website/teacher.py:456
+#: website/teacher.py:458
 msgid "adventure_length"
 msgstr "आपका adventure कम से कम 20 वर्णों का होना चाहिए"
 
-#: website/teacher.py:458
+#: website/teacher.py:460
 msgid "public_invalid"
 msgstr "यह अनुबंध चयन अमान्य है"
 
-#: website/teacher.py:469 website/teacher.py:513
+#: website/teacher.py:471 website/teacher.py:515
 msgid "adventure_duplicate"
 msgstr "आपके पास पहले से ही इस नाम का एक adventure है"
 
-#: website/teacher.py:481
+#: website/teacher.py:483
 msgid "adventure_updated"
 msgstr "adventure अद्यतन किया गया है!"
 
-#: website/teacher.py:508
+#: website/teacher.py:510
 msgid "adventure_empty"
 msgstr "आपने एक adventure नाम दर्ज नहीं किया!"
 
@@ -2467,4 +2520,7 @@ msgstr "आपने एक adventure नाम दर्ज नहीं कि
 
 #~ msgid "go_to_first_exercise"
 #~ msgstr "प्रश्न 1 पर जाएं"
+
+#~ msgid "select_class"
+#~ msgstr "Select class"
 

--- a/translations/hu/LC_MESSAGES/messages.po
+++ b/translations/hu/LC_MESSAGES/messages.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-21 10:36+0200\n"
+"POT-Creation-Date: 2022-06-23 14:02+0200\n"
 "PO-Revision-Date: 2022-06-18 14:19+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: hu\n"
@@ -25,7 +25,7 @@ msgid "title_achievements"
 msgstr "Hedy - My achievements"
 
 #: app.py:639 app.py:743 app.py:1085 website/teacher.py:361
-#: website/teacher.py:370
+#: website/teacher.py:372
 #, fuzzy
 msgid "not_teacher"
 msgstr "Looks like you are not a teacher!"
@@ -69,8 +69,8 @@ msgstr "No such Hedy program!"
 msgid "level_not_class"
 msgstr "You're in a class where this level has not been made available yet"
 
-#: app.py:923 website/teacher.py:419 website/teacher.py:435
-#: website/teacher.py:464 website/teacher.py:490
+#: app.py:923 website/teacher.py:421 website/teacher.py:437
+#: website/teacher.py:466 website/teacher.py:492
 #, fuzzy
 msgid "no_such_adventure"
 msgstr "This adventure doesn't exist!"
@@ -367,8 +367,8 @@ msgstr ""
 #: website/auth.py:671 website/auth.py:718 website/auth.py:745
 #: website/quiz.py:43 website/quiz.py:69 website/teacher.py:88
 #: website/teacher.py:123 website/teacher.py:195 website/teacher.py:251
-#: website/teacher.py:298 website/teacher.py:339 website/teacher.py:375
-#: website/teacher.py:446 website/teacher.py:504
+#: website/teacher.py:298 website/teacher.py:339 website/teacher.py:377
+#: website/teacher.py:448 website/teacher.py:506
 msgid "ajax_error"
 msgstr "Hiba történt, próbálkozz újra."
 
@@ -704,6 +704,23 @@ msgstr "Hint?"
 msgid "hedy_achievements"
 msgstr "My achievements"
 
+#: templates/achievements.html:36 templates/achievements.html:50
+#: templates/landing-page.html:89 templates/layout.html:92
+#: templates/public-page.html:51
+#, fuzzy
+msgid "achievements_logo_alt"
+msgstr "achievements"
+
+#: templates/achievements.html:37
+#, fuzzy
+msgid "achievements_check_icon_alt"
+msgstr "You've earned an achievement!"
+
+#: templates/base_email.html:3 templates/cheatsheet.html:15
+#: templates/incl-menubar.html:4
+msgid "hedy_logo_alt"
+msgstr ""
+
 #: templates/cheatsheet.html:14
 #, fuzzy
 msgid "cheatsheet_title"
@@ -819,7 +836,7 @@ msgstr "Enter a username"
 msgid "invite_by_username"
 msgstr "All usernames need to be unique."
 
-#: templates/class-overview.html:55 templates/create-accounts.html:49
+#: templates/class-overview.html:55 templates/create-accounts.html:45
 #, fuzzy
 msgid "create_accounts"
 msgstr "Create multiple accounts"
@@ -848,6 +865,10 @@ msgstr "Are you sure you want to remove this class invitation?"
 msgid "class_already_joined"
 msgstr "Már az osztály tagja vagy"
 
+#: templates/class-prejoin.html:9 templates/error-page.html:6
+msgid "error_logo_alt"
+msgstr ""
+
 #: templates/class-prejoin.html:11
 msgid "goto_profile"
 msgstr "A profilomhoz"
@@ -866,7 +887,8 @@ msgstr ""
 msgid "join_class"
 msgstr "Belépés az osztályba"
 
-#: templates/class-stats.html:22 templates/customize-class.html:166
+#: templates/class-stats.html:22 templates/create-accounts.html:41
+#: templates/customize-class.html:166
 #, fuzzy
 msgid "back_to_class"
 msgstr "Go back to class"
@@ -907,27 +929,22 @@ msgstr ""
 msgid "create_accounts_prompt"
 msgstr "Are you sure you want to create these accounts?"
 
-#: templates/create-accounts.html:19
-#, fuzzy
-msgid "select_class"
-msgstr "Select class"
-
-#: templates/create-accounts.html:30
+#: templates/create-accounts.html:25
 #, fuzzy
 msgid "download_login_credentials"
 msgstr ""
 
-#: templates/create-accounts.html:34 templates/layout.html:22
+#: templates/create-accounts.html:29 templates/layout.html:22
 #: templates/signup.html:64
 msgid "yes"
 msgstr "Igen"
 
-#: templates/create-accounts.html:38 templates/layout.html:23
+#: templates/create-accounts.html:33 templates/layout.html:23
 #: templates/signup.html:68
 msgid "no"
 msgstr "Nem"
 
-#: templates/create-accounts.html:48 templates/programs.html:24
+#: templates/create-accounts.html:44 templates/programs.html:24
 #, fuzzy
 msgid "reset_view"
 msgstr "Reset"
@@ -1252,7 +1269,7 @@ msgstr "View"
 msgid "adventure_prompt"
 msgstr "Please enter the name of the adventure"
 
-#: templates/for-teachers.html:59 website/teacher.py:499
+#: templates/for-teachers.html:59 website/teacher.py:501
 #, fuzzy
 msgid "create_adventure"
 msgstr "Create adventure"
@@ -1321,6 +1338,10 @@ msgstr "Next exercise"
 #: templates/incl-editor-and-output.html:144
 msgid "edit_code_button"
 msgstr "Kód szerkesztése"
+
+#: templates/incl-editor-and-output.html:146
+msgid "repair_program_logo_alt"
+msgstr ""
 
 #: templates/incl-editor-and-output.html:150
 msgid "read_code_label"
@@ -1414,25 +1435,52 @@ msgstr ""
 "Welcome to Hedy! Your are now the proud owner of a teachers account which"
 " allows you to create classes and invite students."
 
+#: templates/landing-page.html:11
+#, fuzzy
+msgid "teacher_tutorial_logo_alt"
+msgstr "You have received an invitation to join class"
+
 #: templates/landing-page.html:13
 #, fuzzy
 msgid "start_teacher_tutorial"
 msgstr "Start teacher tutorial"
+
+#: templates/landing-page.html:18
+#, fuzzy
+msgid "hedy_tutorial_logo_alt"
+msgstr "Start hedy tutorial"
 
 #: templates/landing-page.html:20
 #, fuzzy
 msgid "start_hedy_tutorial"
 msgstr "Start hedy tutorial"
 
+#: templates/landing-page.html:25
+#, fuzzy
+msgid "start_programming_logo_alt"
+msgstr "Directly start programming"
+
 #: templates/landing-page.html:27
 #, fuzzy
 msgid "start_programming"
 msgstr "Directly start programming"
 
+#: templates/landing-page.html:31
+#, fuzzy
+msgid "explore_programs_logo_alt"
+msgstr "Explore programs"
+
 #: templates/landing-page.html:39
 #, fuzzy
 msgid "your_account"
 msgstr "Nincs még fiókod?"
+
+#: templates/landing-page.html:43 templates/landing-page.html:45
+#: templates/profile.html:33 templates/public-page.html:7
+#: templates/public-page.html:9
+#, fuzzy
+msgid "profile_logo_alt"
+msgstr "Profil frissítve."
 
 #: templates/landing-page.html:52 templates/public-page.html:16
 #, fuzzy
@@ -1815,6 +1863,10 @@ msgstr "Írd meg az első programot!"
 #, fuzzy
 msgid "no_shared_programs"
 msgstr "has no shared programs..."
+
+#: templates/quiz.html:4
+msgid "quiz_logo_alt"
+msgstr ""
 
 #: templates/quiz.html:7
 msgid "start_quiz"
@@ -2258,7 +2310,7 @@ msgstr "Program megosztása megszüntetve"
 msgid "favourite_success"
 msgstr "Your program is set as favourite."
 
-#: website/quiz.py:45 website/quiz.py:71 website/teacher.py:452
+#: website/quiz.py:45 website/quiz.py:71 website/teacher.py:454
 #, fuzzy
 msgid "level_invalid"
 msgstr "This Hedy level in invalid."
@@ -2291,6 +2343,7 @@ msgstr "Only teachers can retrieve classes"
 #: website/statistics.py:41 website/teacher.py:38 website/teacher.py:131
 #: website/teacher.py:150 website/teacher.py:212 website/teacher.py:234
 #: website/teacher.py:246 website/teacher.py:313 website/teacher.py:352
+#: website/teacher.py:364
 #, fuzzy
 msgid "no_such_class"
 msgstr "No such Hedy class"
@@ -2325,7 +2378,7 @@ msgstr "You didn't enter a class name!"
 msgid "class_name_duplicate"
 msgstr "You already have a class with this name."
 
-#: website/teacher.py:162 website/teacher.py:178 website/teacher.py:531
+#: website/teacher.py:162 website/teacher.py:178 website/teacher.py:533
 #, fuzzy
 msgid "invalid_class_link"
 msgstr "Invalid link for joining the class."
@@ -2370,78 +2423,78 @@ msgstr "This student is already in your class."
 msgid "student_already_invite"
 msgstr "This student already has a pending invitation."
 
-#: website/teacher.py:380
+#: website/teacher.py:382
 #, fuzzy
 msgid "no_accounts"
 msgstr "There are no accounts to create."
 
-#: website/teacher.py:390
+#: website/teacher.py:392
 #, fuzzy
 msgid "unique_usernames"
 msgstr "All usernames need to be unique."
 
-#: website/teacher.py:399
+#: website/teacher.py:401
 #, fuzzy
 msgid "usernames_exist"
 msgstr "One or more usernames is already in use."
 
-#: website/teacher.py:410
+#: website/teacher.py:412
 #, fuzzy
 msgid "accounts_created"
 msgstr "Accounts where successfully created."
 
-#: website/teacher.py:416 website/teacher.py:421 website/teacher.py:432
-#: website/teacher.py:461 website/teacher.py:487
+#: website/teacher.py:418 website/teacher.py:423 website/teacher.py:434
+#: website/teacher.py:463 website/teacher.py:489
 #, fuzzy
 msgid "retrieve_adventure_error"
 msgstr "You're not allowed to view this adventure!"
 
-#: website/teacher.py:426
+#: website/teacher.py:428
 #, fuzzy
 msgid "title_view-adventure"
 msgstr "Hedy - View adventure"
 
-#: website/teacher.py:437
+#: website/teacher.py:439
 #, fuzzy
 msgid "title_customize-adventure"
 msgstr "Hedy - Customize adventure"
 
-#: website/teacher.py:448
+#: website/teacher.py:450
 #, fuzzy
 msgid "adventure_id_invalid"
 msgstr "This adventure id is invalid."
 
-#: website/teacher.py:450 website/teacher.py:506
+#: website/teacher.py:452 website/teacher.py:508
 #, fuzzy
 msgid "adventure_name_invalid"
 msgstr "This adventure name is invalid."
 
-#: website/teacher.py:454
+#: website/teacher.py:456
 #, fuzzy
 msgid "content_invalid"
 msgstr "This adventure is invalid."
 
-#: website/teacher.py:456
+#: website/teacher.py:458
 #, fuzzy
 msgid "adventure_length"
 msgstr "Your adventure has to be at least 20 characters."
 
-#: website/teacher.py:458
+#: website/teacher.py:460
 #, fuzzy
 msgid "public_invalid"
 msgstr "This agreement selection is invalid"
 
-#: website/teacher.py:469 website/teacher.py:513
+#: website/teacher.py:471 website/teacher.py:515
 #, fuzzy
 msgid "adventure_duplicate"
 msgstr "You already have an adventure with this name."
 
-#: website/teacher.py:481
+#: website/teacher.py:483
 #, fuzzy
 msgid "adventure_updated"
 msgstr "The adventure has been updated!"
 
-#: website/teacher.py:508
+#: website/teacher.py:510
 #, fuzzy
 msgid "adventure_empty"
 msgstr "You didn't enter an adventure name!"
@@ -2600,4 +2653,7 @@ msgstr "You didn't enter an adventure name!"
 
 #~ msgid "go_to_first_exercise"
 #~ msgstr "Go to question 1"
+
+#~ msgid "select_class"
+#~ msgstr "Select class"
 

--- a/translations/id/LC_MESSAGES/messages.po
+++ b/translations/id/LC_MESSAGES/messages.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-21 10:36+0200\n"
+"POT-Creation-Date: 2022-06-23 14:02+0200\n"
 "PO-Revision-Date: 2022-06-18 14:19+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: id\n"
@@ -23,7 +23,7 @@ msgid "title_achievements"
 msgstr "Hedy - Prestasi saya"
 
 #: app.py:639 app.py:743 app.py:1085 website/teacher.py:361
-#: website/teacher.py:370
+#: website/teacher.py:372
 msgid "not_teacher"
 msgstr "Sepertinya Anda bukan seorang guru!"
 
@@ -64,8 +64,8 @@ msgstr "No such Hedy program!"
 msgid "level_not_class"
 msgstr "You're in a class where this level has not been made available yet"
 
-#: app.py:923 website/teacher.py:419 website/teacher.py:435
-#: website/teacher.py:464 website/teacher.py:490
+#: app.py:923 website/teacher.py:421 website/teacher.py:437
+#: website/teacher.py:466 website/teacher.py:492
 #, fuzzy
 msgid "no_such_adventure"
 msgstr "This adventure doesn't exist!"
@@ -362,8 +362,8 @@ msgstr ""
 #: website/auth.py:671 website/auth.py:718 website/auth.py:745
 #: website/quiz.py:43 website/quiz.py:69 website/teacher.py:88
 #: website/teacher.py:123 website/teacher.py:195 website/teacher.py:251
-#: website/teacher.py:298 website/teacher.py:339 website/teacher.py:375
-#: website/teacher.py:446 website/teacher.py:504
+#: website/teacher.py:298 website/teacher.py:339 website/teacher.py:377
+#: website/teacher.py:448 website/teacher.py:506
 msgid "ajax_error"
 msgstr "Ditemukan sebuah error. Silakan coba lagi."
 
@@ -703,6 +703,23 @@ msgstr "Hint?"
 msgid "hedy_achievements"
 msgstr "My achievements"
 
+#: templates/achievements.html:36 templates/achievements.html:50
+#: templates/landing-page.html:89 templates/layout.html:92
+#: templates/public-page.html:51
+#, fuzzy
+msgid "achievements_logo_alt"
+msgstr "achievements"
+
+#: templates/achievements.html:37
+#, fuzzy
+msgid "achievements_check_icon_alt"
+msgstr "You've earned an achievement!"
+
+#: templates/base_email.html:3 templates/cheatsheet.html:15
+#: templates/incl-menubar.html:4
+msgid "hedy_logo_alt"
+msgstr ""
+
 #: templates/cheatsheet.html:14
 #, fuzzy
 msgid "cheatsheet_title"
@@ -819,7 +836,7 @@ msgstr "Enter a username"
 msgid "invite_by_username"
 msgstr "All usernames need to be unique."
 
-#: templates/class-overview.html:55 templates/create-accounts.html:49
+#: templates/class-overview.html:55 templates/create-accounts.html:45
 #, fuzzy
 msgid "create_accounts"
 msgstr "Create multiple accounts"
@@ -848,6 +865,10 @@ msgstr "Are you sure you want to remove this class invitation?"
 msgid "class_already_joined"
 msgstr "Kamu sudah terdaftar sebelumnya di kelas ini"
 
+#: templates/class-prejoin.html:9 templates/error-page.html:6
+msgid "error_logo_alt"
+msgstr ""
+
 #: templates/class-prejoin.html:11
 msgid "goto_profile"
 msgstr "Ke profil saya"
@@ -866,7 +887,8 @@ msgstr ""
 msgid "join_class"
 msgstr "Gabung kelas"
 
-#: templates/class-stats.html:22 templates/customize-class.html:166
+#: templates/class-stats.html:22 templates/create-accounts.html:41
+#: templates/customize-class.html:166
 #, fuzzy
 msgid "back_to_class"
 msgstr "Go back to class"
@@ -907,27 +929,22 @@ msgstr ""
 msgid "create_accounts_prompt"
 msgstr "Are you sure you want to create these accounts?"
 
-#: templates/create-accounts.html:19
-#, fuzzy
-msgid "select_class"
-msgstr "Select class"
-
-#: templates/create-accounts.html:30
+#: templates/create-accounts.html:25
 #, fuzzy
 msgid "download_login_credentials"
 msgstr ""
 
-#: templates/create-accounts.html:34 templates/layout.html:22
+#: templates/create-accounts.html:29 templates/layout.html:22
 #: templates/signup.html:64
 msgid "yes"
 msgstr "Ya"
 
-#: templates/create-accounts.html:38 templates/layout.html:23
+#: templates/create-accounts.html:33 templates/layout.html:23
 #: templates/signup.html:68
 msgid "no"
 msgstr "Tidak"
 
-#: templates/create-accounts.html:48 templates/programs.html:24
+#: templates/create-accounts.html:44 templates/programs.html:24
 #, fuzzy
 msgid "reset_view"
 msgstr "Reset"
@@ -1252,7 +1269,7 @@ msgstr "View"
 msgid "adventure_prompt"
 msgstr "Please enter the name of the adventure"
 
-#: templates/for-teachers.html:59 website/teacher.py:499
+#: templates/for-teachers.html:59 website/teacher.py:501
 #, fuzzy
 msgid "create_adventure"
 msgstr "Create adventure"
@@ -1320,6 +1337,10 @@ msgstr "Next exercise"
 #: templates/incl-editor-and-output.html:144
 msgid "edit_code_button"
 msgstr "Ubah kode"
+
+#: templates/incl-editor-and-output.html:146
+msgid "repair_program_logo_alt"
+msgstr ""
 
 #: templates/incl-editor-and-output.html:150
 msgid "read_code_label"
@@ -1415,25 +1436,52 @@ msgstr ""
 "Welcome to Hedy! Your are now the proud owner of a teachers account which"
 " allows you to create classes and invite students."
 
+#: templates/landing-page.html:11
+#, fuzzy
+msgid "teacher_tutorial_logo_alt"
+msgstr "You have received an invitation to join class"
+
 #: templates/landing-page.html:13
 #, fuzzy
 msgid "start_teacher_tutorial"
 msgstr "Start teacher tutorial"
+
+#: templates/landing-page.html:18
+#, fuzzy
+msgid "hedy_tutorial_logo_alt"
+msgstr "Start hedy tutorial"
 
 #: templates/landing-page.html:20
 #, fuzzy
 msgid "start_hedy_tutorial"
 msgstr "Start hedy tutorial"
 
+#: templates/landing-page.html:25
+#, fuzzy
+msgid "start_programming_logo_alt"
+msgstr "Directly start programming"
+
 #: templates/landing-page.html:27
 #, fuzzy
 msgid "start_programming"
 msgstr "Directly start programming"
 
+#: templates/landing-page.html:31
+#, fuzzy
+msgid "explore_programs_logo_alt"
+msgstr "Explore programs"
+
 #: templates/landing-page.html:39
 #, fuzzy
 msgid "your_account"
 msgstr "Belum punya akun?"
+
+#: templates/landing-page.html:43 templates/landing-page.html:45
+#: templates/profile.html:33 templates/public-page.html:7
+#: templates/public-page.html:9
+#, fuzzy
+msgid "profile_logo_alt"
+msgstr "Profil berhasil diubah."
 
 #: templates/landing-page.html:52 templates/public-page.html:16
 #, fuzzy
@@ -1811,6 +1859,10 @@ msgstr "Tulis program pertamamu!"
 #, fuzzy
 msgid "no_shared_programs"
 msgstr "has no shared programs..."
+
+#: templates/quiz.html:4
+msgid "quiz_logo_alt"
+msgstr ""
 
 #: templates/quiz.html:7
 #, fuzzy
@@ -2253,7 +2305,7 @@ msgstr "Program berhasil untuk berhenti dibagikan"
 msgid "favourite_success"
 msgstr "Your program is set as favourite."
 
-#: website/quiz.py:45 website/quiz.py:71 website/teacher.py:452
+#: website/quiz.py:45 website/quiz.py:71 website/teacher.py:454
 #, fuzzy
 msgid "level_invalid"
 msgstr "This Hedy level in invalid."
@@ -2286,6 +2338,7 @@ msgstr "Only teachers can retrieve classes"
 #: website/statistics.py:41 website/teacher.py:38 website/teacher.py:131
 #: website/teacher.py:150 website/teacher.py:212 website/teacher.py:234
 #: website/teacher.py:246 website/teacher.py:313 website/teacher.py:352
+#: website/teacher.py:364
 #, fuzzy
 msgid "no_such_class"
 msgstr "No such Hedy class"
@@ -2320,7 +2373,7 @@ msgstr "You didn't enter a class name!"
 msgid "class_name_duplicate"
 msgstr "You already have a class with this name."
 
-#: website/teacher.py:162 website/teacher.py:178 website/teacher.py:531
+#: website/teacher.py:162 website/teacher.py:178 website/teacher.py:533
 #, fuzzy
 msgid "invalid_class_link"
 msgstr "Invalid link for joining the class."
@@ -2365,78 +2418,78 @@ msgstr "This student is already in your class."
 msgid "student_already_invite"
 msgstr "This student already has a pending invitation."
 
-#: website/teacher.py:380
+#: website/teacher.py:382
 #, fuzzy
 msgid "no_accounts"
 msgstr "There are no accounts to create."
 
-#: website/teacher.py:390
+#: website/teacher.py:392
 #, fuzzy
 msgid "unique_usernames"
 msgstr "All usernames need to be unique."
 
-#: website/teacher.py:399
+#: website/teacher.py:401
 #, fuzzy
 msgid "usernames_exist"
 msgstr "One or more usernames is already in use."
 
-#: website/teacher.py:410
+#: website/teacher.py:412
 #, fuzzy
 msgid "accounts_created"
 msgstr "Accounts where successfully created."
 
-#: website/teacher.py:416 website/teacher.py:421 website/teacher.py:432
-#: website/teacher.py:461 website/teacher.py:487
+#: website/teacher.py:418 website/teacher.py:423 website/teacher.py:434
+#: website/teacher.py:463 website/teacher.py:489
 #, fuzzy
 msgid "retrieve_adventure_error"
 msgstr "You're not allowed to view this adventure!"
 
-#: website/teacher.py:426
+#: website/teacher.py:428
 #, fuzzy
 msgid "title_view-adventure"
 msgstr "Hedy - View adventure"
 
-#: website/teacher.py:437
+#: website/teacher.py:439
 #, fuzzy
 msgid "title_customize-adventure"
 msgstr "Hedy - Customize adventure"
 
-#: website/teacher.py:448
+#: website/teacher.py:450
 #, fuzzy
 msgid "adventure_id_invalid"
 msgstr "This adventure id is invalid."
 
-#: website/teacher.py:450 website/teacher.py:506
+#: website/teacher.py:452 website/teacher.py:508
 #, fuzzy
 msgid "adventure_name_invalid"
 msgstr "This adventure name is invalid."
 
-#: website/teacher.py:454
+#: website/teacher.py:456
 #, fuzzy
 msgid "content_invalid"
 msgstr "This adventure is invalid."
 
-#: website/teacher.py:456
+#: website/teacher.py:458
 #, fuzzy
 msgid "adventure_length"
 msgstr "Your adventure has to be at least 20 characters."
 
-#: website/teacher.py:458
+#: website/teacher.py:460
 #, fuzzy
 msgid "public_invalid"
 msgstr "This agreement selection is invalid"
 
-#: website/teacher.py:469 website/teacher.py:513
+#: website/teacher.py:471 website/teacher.py:515
 #, fuzzy
 msgid "adventure_duplicate"
 msgstr "You already have an adventure with this name."
 
-#: website/teacher.py:481
+#: website/teacher.py:483
 #, fuzzy
 msgid "adventure_updated"
 msgstr "The adventure has been updated!"
 
-#: website/teacher.py:508
+#: website/teacher.py:510
 #, fuzzy
 msgid "adventure_empty"
 msgstr "You didn't enter an adventure name!"
@@ -2601,4 +2654,7 @@ msgstr "You didn't enter an adventure name!"
 
 #~ msgid "go_to_first_exercise"
 #~ msgstr "Go to question 1"
+
+#~ msgid "select_class"
+#~ msgstr "Select class"
 

--- a/translations/it/LC_MESSAGES/messages.po
+++ b/translations/it/LC_MESSAGES/messages.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-21 10:36+0200\n"
+"POT-Creation-Date: 2022-06-23 14:02+0200\n"
 "PO-Revision-Date: 2022-06-18 14:19+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: it\n"
@@ -25,7 +25,7 @@ msgid "title_achievements"
 msgstr "Hedy - My achievements"
 
 #: app.py:639 app.py:743 app.py:1085 website/teacher.py:361
-#: website/teacher.py:370
+#: website/teacher.py:372
 #, fuzzy
 msgid "not_teacher"
 msgstr "Looks like you are not a teacher!"
@@ -69,8 +69,8 @@ msgstr "No such Hedy program!"
 msgid "level_not_class"
 msgstr "You're in a class where this level has not been made available yet"
 
-#: app.py:923 website/teacher.py:419 website/teacher.py:435
-#: website/teacher.py:464 website/teacher.py:490
+#: app.py:923 website/teacher.py:421 website/teacher.py:437
+#: website/teacher.py:466 website/teacher.py:492
 #, fuzzy
 msgid "no_such_adventure"
 msgstr "This adventure doesn't exist!"
@@ -367,8 +367,8 @@ msgstr ""
 #: website/auth.py:671 website/auth.py:718 website/auth.py:745
 #: website/quiz.py:43 website/quiz.py:69 website/teacher.py:88
 #: website/teacher.py:123 website/teacher.py:195 website/teacher.py:251
-#: website/teacher.py:298 website/teacher.py:339 website/teacher.py:375
-#: website/teacher.py:446 website/teacher.py:504
+#: website/teacher.py:298 website/teacher.py:339 website/teacher.py:377
+#: website/teacher.py:448 website/teacher.py:506
 msgid "ajax_error"
 msgstr "C'è stato un problema, per favore riprova."
 
@@ -707,6 +707,23 @@ msgstr "Hint?"
 msgid "hedy_achievements"
 msgstr "My achievements"
 
+#: templates/achievements.html:36 templates/achievements.html:50
+#: templates/landing-page.html:89 templates/layout.html:92
+#: templates/public-page.html:51
+#, fuzzy
+msgid "achievements_logo_alt"
+msgstr "achievements"
+
+#: templates/achievements.html:37
+#, fuzzy
+msgid "achievements_check_icon_alt"
+msgstr "You've earned an achievement!"
+
+#: templates/base_email.html:3 templates/cheatsheet.html:15
+#: templates/incl-menubar.html:4
+msgid "hedy_logo_alt"
+msgstr ""
+
 #: templates/cheatsheet.html:14
 #, fuzzy
 msgid "cheatsheet_title"
@@ -830,7 +847,7 @@ msgstr "Enter a username"
 msgid "invite_by_username"
 msgstr "All usernames need to be unique."
 
-#: templates/class-overview.html:55 templates/create-accounts.html:49
+#: templates/class-overview.html:55 templates/create-accounts.html:45
 #, fuzzy
 msgid "create_accounts"
 msgstr "Create multiple accounts"
@@ -860,6 +877,10 @@ msgstr "Are you sure you want to remove this class invitation?"
 msgid "class_already_joined"
 msgstr "You are already a student of class"
 
+#: templates/class-prejoin.html:9 templates/error-page.html:6
+msgid "error_logo_alt"
+msgstr ""
+
 #: templates/class-prejoin.html:11
 #, fuzzy
 msgid "goto_profile"
@@ -880,7 +901,8 @@ msgstr "You need to have an account to join a class. Would you like to login now
 msgid "join_class"
 msgstr "Join class"
 
-#: templates/class-stats.html:22 templates/customize-class.html:166
+#: templates/class-stats.html:22 templates/create-accounts.html:41
+#: templates/customize-class.html:166
 #, fuzzy
 msgid "back_to_class"
 msgstr "Go back to class"
@@ -921,29 +943,24 @@ msgstr ""
 msgid "create_accounts_prompt"
 msgstr "Are you sure you want to create these accounts?"
 
-#: templates/create-accounts.html:19
-#, fuzzy
-msgid "select_class"
-msgstr "Select class"
-
-#: templates/create-accounts.html:30
+#: templates/create-accounts.html:25
 #, fuzzy
 msgid "download_login_credentials"
 msgstr ""
 
-#: templates/create-accounts.html:34 templates/layout.html:22
+#: templates/create-accounts.html:29 templates/layout.html:22
 #: templates/signup.html:64
 #, fuzzy
 msgid "yes"
 msgstr "Yes"
 
-#: templates/create-accounts.html:38 templates/layout.html:23
+#: templates/create-accounts.html:33 templates/layout.html:23
 #: templates/signup.html:68
 #, fuzzy
 msgid "no"
 msgstr "No"
 
-#: templates/create-accounts.html:48 templates/programs.html:24
+#: templates/create-accounts.html:44 templates/programs.html:24
 #, fuzzy
 msgid "reset_view"
 msgstr "Reset"
@@ -1273,7 +1290,7 @@ msgstr "View"
 msgid "adventure_prompt"
 msgstr "Please enter the name of the adventure"
 
-#: templates/for-teachers.html:59 website/teacher.py:499
+#: templates/for-teachers.html:59 website/teacher.py:501
 #, fuzzy
 msgid "create_adventure"
 msgstr "Create adventure"
@@ -1342,6 +1359,10 @@ msgstr "Next exercise"
 #, fuzzy
 msgid "edit_code_button"
 msgstr "Edit code"
+
+#: templates/incl-editor-and-output.html:146
+msgid "repair_program_logo_alt"
+msgstr ""
 
 #: templates/incl-editor-and-output.html:150
 msgid "read_code_label"
@@ -1438,25 +1459,52 @@ msgstr ""
 "Welcome to Hedy! Your are now the proud owner of a teachers account which"
 " allows you to create classes and invite students."
 
+#: templates/landing-page.html:11
+#, fuzzy
+msgid "teacher_tutorial_logo_alt"
+msgstr "You have received an invitation to join class"
+
 #: templates/landing-page.html:13
 #, fuzzy
 msgid "start_teacher_tutorial"
 msgstr "Start teacher tutorial"
+
+#: templates/landing-page.html:18
+#, fuzzy
+msgid "hedy_tutorial_logo_alt"
+msgstr "Start hedy tutorial"
 
 #: templates/landing-page.html:20
 #, fuzzy
 msgid "start_hedy_tutorial"
 msgstr "Start hedy tutorial"
 
+#: templates/landing-page.html:25
+#, fuzzy
+msgid "start_programming_logo_alt"
+msgstr "Directly start programming"
+
 #: templates/landing-page.html:27
 #, fuzzy
 msgid "start_programming"
 msgstr "Directly start programming"
 
+#: templates/landing-page.html:31
+#, fuzzy
+msgid "explore_programs_logo_alt"
+msgstr "Explore programs"
+
 #: templates/landing-page.html:39
 #, fuzzy
 msgid "your_account"
 msgstr "Non hai ancora un account?"
+
+#: templates/landing-page.html:43 templates/landing-page.html:45
+#: templates/profile.html:33 templates/public-page.html:7
+#: templates/public-page.html:9
+#, fuzzy
+msgid "profile_logo_alt"
+msgstr "Profilo aggiornato."
 
 #: templates/landing-page.html:52 templates/public-page.html:16
 #, fuzzy
@@ -1850,6 +1898,10 @@ msgstr "Scrivi il tuo primo programma!"
 #, fuzzy
 msgid "no_shared_programs"
 msgstr "has no shared programs..."
+
+#: templates/quiz.html:4
+msgid "quiz_logo_alt"
+msgstr ""
 
 #: templates/quiz.html:7
 #, fuzzy
@@ -2301,7 +2353,7 @@ msgstr "Program unshared successfully."
 msgid "favourite_success"
 msgstr "Your program is set as favourite."
 
-#: website/quiz.py:45 website/quiz.py:71 website/teacher.py:452
+#: website/quiz.py:45 website/quiz.py:71 website/teacher.py:454
 #, fuzzy
 msgid "level_invalid"
 msgstr "This Hedy level in invalid."
@@ -2334,6 +2386,7 @@ msgstr "Only teachers can retrieve classes"
 #: website/statistics.py:41 website/teacher.py:38 website/teacher.py:131
 #: website/teacher.py:150 website/teacher.py:212 website/teacher.py:234
 #: website/teacher.py:246 website/teacher.py:313 website/teacher.py:352
+#: website/teacher.py:364
 #, fuzzy
 msgid "no_such_class"
 msgstr "No such Hedy class"
@@ -2368,7 +2421,7 @@ msgstr "You didn't enter a class name!"
 msgid "class_name_duplicate"
 msgstr "You already have a class with this name."
 
-#: website/teacher.py:162 website/teacher.py:178 website/teacher.py:531
+#: website/teacher.py:162 website/teacher.py:178 website/teacher.py:533
 #, fuzzy
 msgid "invalid_class_link"
 msgstr "Invalid link for joining the class."
@@ -2413,78 +2466,78 @@ msgstr "This student is already in your class."
 msgid "student_already_invite"
 msgstr "This student already has a pending invitation."
 
-#: website/teacher.py:380
+#: website/teacher.py:382
 #, fuzzy
 msgid "no_accounts"
 msgstr "There are no accounts to create."
 
-#: website/teacher.py:390
+#: website/teacher.py:392
 #, fuzzy
 msgid "unique_usernames"
 msgstr "All usernames need to be unique."
 
-#: website/teacher.py:399
+#: website/teacher.py:401
 #, fuzzy
 msgid "usernames_exist"
 msgstr "One or more usernames is already in use."
 
-#: website/teacher.py:410
+#: website/teacher.py:412
 #, fuzzy
 msgid "accounts_created"
 msgstr "Accounts where successfully created."
 
-#: website/teacher.py:416 website/teacher.py:421 website/teacher.py:432
-#: website/teacher.py:461 website/teacher.py:487
+#: website/teacher.py:418 website/teacher.py:423 website/teacher.py:434
+#: website/teacher.py:463 website/teacher.py:489
 #, fuzzy
 msgid "retrieve_adventure_error"
 msgstr "You're not allowed to view this adventure!"
 
-#: website/teacher.py:426
+#: website/teacher.py:428
 #, fuzzy
 msgid "title_view-adventure"
 msgstr "Hedy - View adventure"
 
-#: website/teacher.py:437
+#: website/teacher.py:439
 #, fuzzy
 msgid "title_customize-adventure"
 msgstr "Hedy - Customize adventure"
 
-#: website/teacher.py:448
+#: website/teacher.py:450
 #, fuzzy
 msgid "adventure_id_invalid"
 msgstr "This adventure id is invalid."
 
-#: website/teacher.py:450 website/teacher.py:506
+#: website/teacher.py:452 website/teacher.py:508
 #, fuzzy
 msgid "adventure_name_invalid"
 msgstr "This adventure name is invalid."
 
-#: website/teacher.py:454
+#: website/teacher.py:456
 #, fuzzy
 msgid "content_invalid"
 msgstr "This adventure is invalid."
 
-#: website/teacher.py:456
+#: website/teacher.py:458
 #, fuzzy
 msgid "adventure_length"
 msgstr "Your adventure has to be at least 20 characters."
 
-#: website/teacher.py:458
+#: website/teacher.py:460
 #, fuzzy
 msgid "public_invalid"
 msgstr "This agreement selection is invalid"
 
-#: website/teacher.py:469 website/teacher.py:513
+#: website/teacher.py:471 website/teacher.py:515
 #, fuzzy
 msgid "adventure_duplicate"
 msgstr "You already have an adventure with this name."
 
-#: website/teacher.py:481
+#: website/teacher.py:483
 #, fuzzy
 msgid "adventure_updated"
 msgstr "The adventure has been updated!"
 
-#: website/teacher.py:508
+#: website/teacher.py:510
 #, fuzzy
 msgid "adventure_empty"
 msgstr "You didn't enter an adventure name!"
@@ -2643,4 +2696,7 @@ msgstr "You didn't enter an adventure name!"
 
 #~ msgid "go_to_first_exercise"
 #~ msgstr "Go to question 1"
+
+#~ msgid "select_class"
+#~ msgstr "Select class"
 

--- a/translations/ja/LC_MESSAGES/messages.po
+++ b/translations/ja/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-06-21 10:36+0200\n"
+"POT-Creation-Date: 2022-06-23 14:02+0200\n"
 "PO-Revision-Date: 2022-06-18 14:19+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: ja\n"
@@ -27,7 +27,7 @@ msgid "title_achievements"
 msgstr "Hedy - 実績"
 
 #: app.py:639 app.py:743 app.py:1085 website/teacher.py:361
-#: website/teacher.py:370
+#: website/teacher.py:372
 msgid "not_teacher"
 msgstr "あなたは先生じゃないみたい！"
 
@@ -64,8 +64,8 @@ msgstr "そのプログラムはありません！"
 msgid "level_not_class"
 msgstr "まだこのレベルはあなたのクラスで使えません"
 
-#: app.py:923 website/teacher.py:419 website/teacher.py:435
-#: website/teacher.py:464 website/teacher.py:490
+#: app.py:923 website/teacher.py:421 website/teacher.py:437
+#: website/teacher.py:466 website/teacher.py:492
 msgid "no_such_adventure"
 msgstr "この冒険は存在しません！"
 
@@ -373,8 +373,8 @@ msgstr ""
 #: website/auth.py:671 website/auth.py:718 website/auth.py:745
 #: website/quiz.py:43 website/quiz.py:69 website/teacher.py:88
 #: website/teacher.py:123 website/teacher.py:195 website/teacher.py:251
-#: website/teacher.py:298 website/teacher.py:339 website/teacher.py:375
-#: website/teacher.py:446 website/teacher.py:504
+#: website/teacher.py:298 website/teacher.py:339 website/teacher.py:377
+#: website/teacher.py:448 website/teacher.py:506
 #, fuzzy
 msgid "ajax_error"
 msgstr "There was an error, please try again."
@@ -735,6 +735,23 @@ msgstr "Hidden"
 msgid "hedy_achievements"
 msgstr "Hedy achievements"
 
+#: templates/achievements.html:36 templates/achievements.html:50
+#: templates/landing-page.html:89 templates/layout.html:92
+#: templates/public-page.html:51
+#, fuzzy
+msgid "achievements_logo_alt"
+msgstr "achievements"
+
+#: templates/achievements.html:37
+#, fuzzy
+msgid "achievements_check_icon_alt"
+msgstr "You've earned an achievement!"
+
+#: templates/base_email.html:3 templates/cheatsheet.html:15
+#: templates/incl-menubar.html:4
+msgid "hedy_logo_alt"
+msgstr ""
+
 #: templates/cheatsheet.html:14
 #, fuzzy
 msgid "cheatsheet_title"
@@ -860,7 +877,7 @@ msgstr "Enter a username"
 msgid "invite_by_username"
 msgstr "All usernames need to be unique."
 
-#: templates/class-overview.html:55 templates/create-accounts.html:49
+#: templates/class-overview.html:55 templates/create-accounts.html:45
 #, fuzzy
 msgid "create_accounts"
 msgstr "Create multiple accounts"
@@ -890,6 +907,10 @@ msgstr "Are you sure you want to remove this class invitation?"
 msgid "class_already_joined"
 msgstr "You are already a student of class"
 
+#: templates/class-prejoin.html:9 templates/error-page.html:6
+msgid "error_logo_alt"
+msgstr ""
+
 #: templates/class-prejoin.html:11
 #, fuzzy
 msgid "goto_profile"
@@ -910,7 +931,8 @@ msgstr "You need to have an account to join a class. Would you like to login now
 msgid "join_class"
 msgstr "Join class"
 
-#: templates/class-stats.html:22 templates/customize-class.html:166
+#: templates/class-stats.html:22 templates/create-accounts.html:41
+#: templates/customize-class.html:166
 #, fuzzy
 msgid "back_to_class"
 msgstr "Go back to class"
@@ -952,29 +974,24 @@ msgstr ""
 msgid "create_accounts_prompt"
 msgstr "Are you sure you want to create these accounts?"
 
-#: templates/create-accounts.html:19
-#, fuzzy
-msgid "select_class"
-msgstr "Select class"
-
-#: templates/create-accounts.html:30
+#: templates/create-accounts.html:25
 #, fuzzy
 msgid "download_login_credentials"
 msgstr "Do you want to download the login credentials after the accounts creation?"
 
-#: templates/create-accounts.html:34 templates/layout.html:22
+#: templates/create-accounts.html:29 templates/layout.html:22
 #: templates/signup.html:64
 #, fuzzy
 msgid "yes"
 msgstr "Yes"
 
-#: templates/create-accounts.html:38 templates/layout.html:23
+#: templates/create-accounts.html:33 templates/layout.html:23
 #: templates/signup.html:68
 #, fuzzy
 msgid "no"
 msgstr "No"
 
-#: templates/create-accounts.html:48 templates/programs.html:24
+#: templates/create-accounts.html:44 templates/programs.html:24
 #, fuzzy
 msgid "reset_view"
 msgstr "Reset"
@@ -1319,7 +1336,7 @@ msgstr "View"
 msgid "adventure_prompt"
 msgstr "Please enter the name of the adventure"
 
-#: templates/for-teachers.html:59 website/teacher.py:499
+#: templates/for-teachers.html:59 website/teacher.py:501
 #, fuzzy
 msgid "create_adventure"
 msgstr "Create adventure"
@@ -1392,6 +1409,10 @@ msgstr "Next exercise"
 #, fuzzy
 msgid "edit_code_button"
 msgstr "Edit code"
+
+#: templates/incl-editor-and-output.html:146
+msgid "repair_program_logo_alt"
+msgstr ""
 
 #: templates/incl-editor-and-output.html:150
 #, fuzzy
@@ -1491,25 +1512,52 @@ msgstr "Welcome"
 msgid "welcome_back"
 msgstr "Welcome back"
 
+#: templates/landing-page.html:11
+#, fuzzy
+msgid "teacher_tutorial_logo_alt"
+msgstr "Click on 'next step' to get started as a Hedy teacher!"
+
 #: templates/landing-page.html:13
 #, fuzzy
 msgid "start_teacher_tutorial"
 msgstr "Start teacher tutorial"
+
+#: templates/landing-page.html:18
+#, fuzzy
+msgid "hedy_tutorial_logo_alt"
+msgstr "Start hedy tutorial"
 
 #: templates/landing-page.html:20
 #, fuzzy
 msgid "start_hedy_tutorial"
 msgstr "Start hedy tutorial"
 
+#: templates/landing-page.html:25
+#, fuzzy
+msgid "start_programming_logo_alt"
+msgstr "Start programming"
+
 #: templates/landing-page.html:27
 #, fuzzy
 msgid "start_programming"
 msgstr "Start programming"
 
+#: templates/landing-page.html:31
+#, fuzzy
+msgid "explore_programs_logo_alt"
+msgstr "Explore programs"
+
 #: templates/landing-page.html:39
 #, fuzzy
 msgid "your_account"
 msgstr "Your profile"
+
+#: templates/landing-page.html:43 templates/landing-page.html:45
+#: templates/profile.html:33 templates/public-page.html:7
+#: templates/public-page.html:9
+#, fuzzy
+msgid "profile_logo_alt"
+msgstr "Profile updated."
 
 #: templates/landing-page.html:52 templates/public-page.html:16
 #, fuzzy
@@ -1930,6 +1978,10 @@ msgstr "Write your first program!"
 #, fuzzy
 msgid "no_shared_programs"
 msgstr "has no shared programs..."
+
+#: templates/quiz.html:4
+msgid "quiz_logo_alt"
+msgstr ""
 
 #: templates/quiz.html:7
 #, fuzzy
@@ -2419,7 +2471,7 @@ msgstr "Program unshared successfully."
 msgid "favourite_success"
 msgstr "Your program is set as favourite."
 
-#: website/quiz.py:45 website/quiz.py:71 website/teacher.py:452
+#: website/quiz.py:45 website/quiz.py:71 website/teacher.py:454
 #, fuzzy
 msgid "level_invalid"
 msgstr "This Hedy level in invalid."
@@ -2450,6 +2502,7 @@ msgstr "Only teachers can retrieve classes"
 #: website/statistics.py:41 website/teacher.py:38 website/teacher.py:131
 #: website/teacher.py:150 website/teacher.py:212 website/teacher.py:234
 #: website/teacher.py:246 website/teacher.py:313 website/teacher.py:352
+#: website/teacher.py:364
 #, fuzzy
 msgid "no_such_class"
 msgstr "No such Hedy class."
@@ -2484,7 +2537,7 @@ msgstr "You didn't enter a class name!"
 msgid "class_name_duplicate"
 msgstr "You already have a class with this name."
 
-#: website/teacher.py:162 website/teacher.py:178 website/teacher.py:531
+#: website/teacher.py:162 website/teacher.py:178 website/teacher.py:533
 #, fuzzy
 msgid "invalid_class_link"
 msgstr "Invalid link for joining the class."
@@ -2529,78 +2582,78 @@ msgstr "This student is already in your class."
 msgid "student_already_invite"
 msgstr "This student already has a pending invitation."
 
-#: website/teacher.py:380
+#: website/teacher.py:382
 #, fuzzy
 msgid "no_accounts"
 msgstr "There are no accounts to create."
 
-#: website/teacher.py:390
+#: website/teacher.py:392
 #, fuzzy
 msgid "unique_usernames"
 msgstr "All usernames need to be unique."
 
-#: website/teacher.py:399
+#: website/teacher.py:401
 #, fuzzy
 msgid "usernames_exist"
 msgstr "One or more usernames is already in use."
 
-#: website/teacher.py:410
+#: website/teacher.py:412
 #, fuzzy
 msgid "accounts_created"
 msgstr "Accounts where successfully created."
 
-#: website/teacher.py:416 website/teacher.py:421 website/teacher.py:432
-#: website/teacher.py:461 website/teacher.py:487
+#: website/teacher.py:418 website/teacher.py:423 website/teacher.py:434
+#: website/teacher.py:463 website/teacher.py:489
 #, fuzzy
 msgid "retrieve_adventure_error"
 msgstr "You're not allowed to view this adventure!"
 
-#: website/teacher.py:426
+#: website/teacher.py:428
 #, fuzzy
 msgid "title_view-adventure"
 msgstr "Hedy - View adventure"
 
-#: website/teacher.py:437
+#: website/teacher.py:439
 #, fuzzy
 msgid "title_customize-adventure"
 msgstr "Hedy - Customize adventure"
 
-#: website/teacher.py:448
+#: website/teacher.py:450
 #, fuzzy
 msgid "adventure_id_invalid"
 msgstr "This adventure id is invalid."
 
-#: website/teacher.py:450 website/teacher.py:506
+#: website/teacher.py:452 website/teacher.py:508
 #, fuzzy
 msgid "adventure_name_invalid"
 msgstr "This adventure name is invalid."
 
-#: website/teacher.py:454
+#: website/teacher.py:456
 #, fuzzy
 msgid "content_invalid"
 msgstr "This adventure is invalid."
 
-#: website/teacher.py:456
+#: website/teacher.py:458
 #, fuzzy
 msgid "adventure_length"
 msgstr "Your adventure has to be at least 20 characters."
 
-#: website/teacher.py:458
+#: website/teacher.py:460
 #, fuzzy
 msgid "public_invalid"
 msgstr "This agreement selection is invalid"
 
-#: website/teacher.py:469 website/teacher.py:513
+#: website/teacher.py:471 website/teacher.py:515
 #, fuzzy
 msgid "adventure_duplicate"
 msgstr "You already have an adventure with this name."
 
-#: website/teacher.py:481
+#: website/teacher.py:483
 #, fuzzy
 msgid "adventure_updated"
 msgstr "The adventure has been updated!"
 
-#: website/teacher.py:508
+#: website/teacher.py:510
 #, fuzzy
 msgid "adventure_empty"
 msgstr "You didn't enter an adventure name!"
@@ -2616,4 +2669,7 @@ msgstr "You didn't enter an adventure name!"
 
 #~ msgid "go_to_first_exercise"
 #~ msgstr "Go to exercise 1"
+
+#~ msgid "select_class"
+#~ msgstr "Select class"
 

--- a/translations/nb_NO/LC_MESSAGES/messages.po
+++ b/translations/nb_NO/LC_MESSAGES/messages.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-21 10:36+0200\n"
+"POT-Creation-Date: 2022-06-23 14:02+0200\n"
 "PO-Revision-Date: 2022-06-18 14:19+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: nb_NO\n"
@@ -23,7 +23,7 @@ msgid "title_achievements"
 msgstr "Hedy - Mine prestasjoner"
 
 #: app.py:639 app.py:743 app.py:1085 website/teacher.py:361
-#: website/teacher.py:370
+#: website/teacher.py:372
 msgid "not_teacher"
 msgstr "Ser ut til at du ikke er en lærer!"
 
@@ -59,8 +59,8 @@ msgstr "Dette Hedy programmet fins ikke!"
 msgid "level_not_class"
 msgstr "Klassen din har ikke tilgang til dette nivået enda"
 
-#: app.py:923 website/teacher.py:419 website/teacher.py:435
-#: website/teacher.py:464 website/teacher.py:490
+#: app.py:923 website/teacher.py:421 website/teacher.py:437
+#: website/teacher.py:466 website/teacher.py:492
 msgid "no_such_adventure"
 msgstr "Dette eventyret eksisterer ikke!"
 
@@ -344,8 +344,8 @@ msgstr ""
 #: website/auth.py:671 website/auth.py:718 website/auth.py:745
 #: website/quiz.py:43 website/quiz.py:69 website/teacher.py:88
 #: website/teacher.py:123 website/teacher.py:195 website/teacher.py:251
-#: website/teacher.py:298 website/teacher.py:339 website/teacher.py:375
-#: website/teacher.py:446 website/teacher.py:504
+#: website/teacher.py:298 website/teacher.py:339 website/teacher.py:377
+#: website/teacher.py:448 website/teacher.py:506
 msgid "ajax_error"
 msgstr "Det skjedde noe feil, vennligst prøv igjen."
 
@@ -646,6 +646,23 @@ msgstr "Skjult"
 msgid "hedy_achievements"
 msgstr "Hedy Prestasjoner"
 
+#: templates/achievements.html:36 templates/achievements.html:50
+#: templates/landing-page.html:89 templates/layout.html:92
+#: templates/public-page.html:51
+#, fuzzy
+msgid "achievements_logo_alt"
+msgstr "prestasjoner"
+
+#: templates/achievements.html:37
+#, fuzzy
+msgid "achievements_check_icon_alt"
+msgstr "Du oppnådde en prestasjon!"
+
+#: templates/base_email.html:3 templates/cheatsheet.html:15
+#: templates/incl-menubar.html:4
+msgid "hedy_logo_alt"
+msgstr ""
+
 #: templates/cheatsheet.html:14
 msgid "cheatsheet_title"
 msgstr "Skjul hjelpeark"
@@ -752,7 +769,7 @@ msgstr "Oppgi et brukernavn"
 msgid "invite_by_username"
 msgstr "Alle brukernavnene må være unike."
 
-#: templates/class-overview.html:55 templates/create-accounts.html:49
+#: templates/class-overview.html:55 templates/create-accounts.html:45
 msgid "create_accounts"
 msgstr "Opprett flere kontoer"
 
@@ -776,6 +793,10 @@ msgstr "Er du sikker på at du vil fjerne denne klasseinvitasjonen?"
 msgid "class_already_joined"
 msgstr "Du er allerede elev i denne klassen"
 
+#: templates/class-prejoin.html:9 templates/error-page.html:6
+msgid "error_logo_alt"
+msgstr ""
+
 #: templates/class-prejoin.html:11
 msgid "goto_profile"
 msgstr "Gå til min profil"
@@ -792,7 +813,8 @@ msgstr "Du trenger en konto for å bli med i klassen. Vil du logge inn nå?"
 msgid "join_class"
 msgstr "Bli med i klassen"
 
-#: templates/class-stats.html:22 templates/customize-class.html:166
+#: templates/class-stats.html:22 templates/create-accounts.html:41
+#: templates/customize-class.html:166
 msgid "back_to_class"
 msgstr "Gå tilbake til klassen"
 
@@ -829,26 +851,22 @@ msgstr ""
 msgid "create_accounts_prompt"
 msgstr "Er du sikker på at du vil opprette disse kontoene?"
 
-#: templates/create-accounts.html:19
-msgid "select_class"
-msgstr "Velg klasse"
-
-#: templates/create-accounts.html:30
+#: templates/create-accounts.html:25
 #, fuzzy
 msgid "download_login_credentials"
 msgstr ""
 
-#: templates/create-accounts.html:34 templates/layout.html:22
+#: templates/create-accounts.html:29 templates/layout.html:22
 #: templates/signup.html:64
 msgid "yes"
 msgstr "Ja"
 
-#: templates/create-accounts.html:38 templates/layout.html:23
+#: templates/create-accounts.html:33 templates/layout.html:23
 #: templates/signup.html:68
 msgid "no"
 msgstr "Nei"
 
-#: templates/create-accounts.html:48 templates/programs.html:24
+#: templates/create-accounts.html:44 templates/programs.html:24
 msgid "reset_view"
 msgstr "Tilbakestill"
 
@@ -1148,7 +1166,7 @@ msgstr "Se"
 msgid "adventure_prompt"
 msgstr "Vennligst skriv inn navnet på eventyret"
 
-#: templates/for-teachers.html:59 website/teacher.py:499
+#: templates/for-teachers.html:59 website/teacher.py:501
 msgid "create_adventure"
 msgstr "Opprett eventyr"
 
@@ -1212,6 +1230,10 @@ msgstr "Next exercise"
 #: templates/incl-editor-and-output.html:144
 msgid "edit_code_button"
 msgstr "Endre kode"
+
+#: templates/incl-editor-and-output.html:146
+msgid "repair_program_logo_alt"
+msgstr ""
 
 #: templates/incl-editor-and-output.html:150
 msgid "read_code_label"
@@ -1300,25 +1322,52 @@ msgstr ""
 "Velkommen til Hedy! Du er nå den stolte eier av en lærerkonto som gir deg"
 " muligheten til å lage klasser og invitere elever."
 
+#: templates/landing-page.html:11
+#, fuzzy
+msgid "teacher_tutorial_logo_alt"
+msgstr "Du har mottatt en invitasjon til å bli med i en klasse"
+
 #: templates/landing-page.html:13
 #, fuzzy
 msgid "start_teacher_tutorial"
 msgstr "Start teacher tutorial"
+
+#: templates/landing-page.html:18
+#, fuzzy
+msgid "hedy_tutorial_logo_alt"
+msgstr "Start hedy tutorial"
 
 #: templates/landing-page.html:20
 #, fuzzy
 msgid "start_hedy_tutorial"
 msgstr "Start hedy tutorial"
 
+#: templates/landing-page.html:25
+#, fuzzy
+msgid "start_programming_logo_alt"
+msgstr "Directly start programming"
+
 #: templates/landing-page.html:27
 #, fuzzy
 msgid "start_programming"
 msgstr "Directly start programming"
 
+#: templates/landing-page.html:31
+#, fuzzy
+msgid "explore_programs_logo_alt"
+msgstr "Utforsk programmer"
+
 #: templates/landing-page.html:39
 #, fuzzy
 msgid "your_account"
 msgstr "Ingen konto?"
+
+#: templates/landing-page.html:43 templates/landing-page.html:45
+#: templates/profile.html:33 templates/public-page.html:7
+#: templates/public-page.html:9
+#, fuzzy
+msgid "profile_logo_alt"
+msgstr "Profil oppdatert."
 
 #: templates/landing-page.html:52 templates/public-page.html:16
 msgid "achievements"
@@ -1661,6 +1710,10 @@ msgstr "Lag ditt første program!"
 #: templates/public-page.html:85
 msgid "no_shared_programs"
 msgstr "har ingen delte programmer..."
+
+#: templates/quiz.html:4
+msgid "quiz_logo_alt"
+msgstr ""
 
 #: templates/quiz.html:7
 #, fuzzy
@@ -2066,7 +2119,7 @@ msgstr "Programmet er ikke lengre delt."
 msgid "favourite_success"
 msgstr "Programmet er nå ditt favorittprogram."
 
-#: website/quiz.py:45 website/quiz.py:71 website/teacher.py:452
+#: website/quiz.py:45 website/quiz.py:71 website/teacher.py:454
 msgid "level_invalid"
 msgstr "Dette Hedynivået er ugyldig."
 
@@ -2097,6 +2150,7 @@ msgstr "Kun lærere kan hente info om klasser"
 #: website/statistics.py:41 website/teacher.py:38 website/teacher.py:131
 #: website/teacher.py:150 website/teacher.py:212 website/teacher.py:234
 #: website/teacher.py:246 website/teacher.py:313 website/teacher.py:352
+#: website/teacher.py:364
 msgid "no_such_class"
 msgstr "Denne Hedy-klassen fins ikke"
 
@@ -2124,7 +2178,7 @@ msgstr "Du skrev ikke inn et klassenavn!"
 msgid "class_name_duplicate"
 msgstr "Du har allerede en klasse med dette navnet."
 
-#: website/teacher.py:162 website/teacher.py:178 website/teacher.py:531
+#: website/teacher.py:162 website/teacher.py:178 website/teacher.py:533
 msgid "invalid_class_link"
 msgstr "Ugyldig lenke for å bli med i klassen."
 
@@ -2160,64 +2214,64 @@ msgstr "Denne eleven er allerede del av klassen din."
 msgid "student_already_invite"
 msgstr "Denne eleven har allerede fått en invitasjon. Har de glemt å svare?"
 
-#: website/teacher.py:380
+#: website/teacher.py:382
 msgid "no_accounts"
 msgstr "Det er ingen oppgitte kontoer å opprette."
 
-#: website/teacher.py:390
+#: website/teacher.py:392
 msgid "unique_usernames"
 msgstr "Alle brukernavnene må være unike."
 
-#: website/teacher.py:399
+#: website/teacher.py:401
 msgid "usernames_exist"
 msgstr "Et eller flere brukernavn er allerede i bruk."
 
-#: website/teacher.py:410
+#: website/teacher.py:412
 msgid "accounts_created"
 msgstr "Kontoene ble opprettet."
 
-#: website/teacher.py:416 website/teacher.py:421 website/teacher.py:432
-#: website/teacher.py:461 website/teacher.py:487
+#: website/teacher.py:418 website/teacher.py:423 website/teacher.py:434
+#: website/teacher.py:463 website/teacher.py:489
 msgid "retrieve_adventure_error"
 msgstr "Du har ikke lov til å se dette eventyret!"
 
-#: website/teacher.py:426
+#: website/teacher.py:428
 msgid "title_view-adventure"
 msgstr "Hedy - Se eventyr"
 
-#: website/teacher.py:437
+#: website/teacher.py:439
 msgid "title_customize-adventure"
 msgstr "Hedy - Tilpass eventyr"
 
-#: website/teacher.py:448
+#: website/teacher.py:450
 msgid "adventure_id_invalid"
 msgstr "Eventyr IDen er ugyldig."
 
-#: website/teacher.py:450 website/teacher.py:506
+#: website/teacher.py:452 website/teacher.py:508
 msgid "adventure_name_invalid"
 msgstr "Eventyrnavnet er ugyldig."
 
-#: website/teacher.py:454
+#: website/teacher.py:456
 msgid "content_invalid"
 msgstr "Eventyret er ugyldig."
 
-#: website/teacher.py:456
+#: website/teacher.py:458
 msgid "adventure_length"
 msgstr "Eventyret ditt må være minst 20 tegn."
 
-#: website/teacher.py:458
+#: website/teacher.py:460
 msgid "public_invalid"
 msgstr "Dette avtale valget er ugyldig"
 
-#: website/teacher.py:469 website/teacher.py:513
+#: website/teacher.py:471 website/teacher.py:515
 msgid "adventure_duplicate"
 msgstr "Du har allerede et eventyr med dette navnet."
 
-#: website/teacher.py:481
+#: website/teacher.py:483
 msgid "adventure_updated"
 msgstr "Eventyret har blitt oppdatert!"
 
-#: website/teacher.py:508
+#: website/teacher.py:510
 msgid "adventure_empty"
 msgstr "Du skrev ikke noe navn på eventyret!"
 
@@ -2375,4 +2429,7 @@ msgstr "Du skrev ikke noe navn på eventyret!"
 
 #~ msgid "go_to_first_exercise"
 #~ msgstr "Gå til spørsmål 1"
+
+#~ msgid "select_class"
+#~ msgstr "Velg klasse"
 

--- a/translations/nl/LC_MESSAGES/messages.po
+++ b/translations/nl/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-06-21 10:36+0200\n"
+"POT-Creation-Date: 2022-06-23 14:02+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: nl\n"
@@ -28,7 +28,7 @@ msgid "title_achievements"
 msgstr "Hedy - Mijn badges"
 
 #: app.py:639 app.py:743 app.py:1085 website/teacher.py:361
-#: website/teacher.py:370
+#: website/teacher.py:372
 msgid "not_teacher"
 msgstr "Jij bent geen leraar!"
 
@@ -64,8 +64,8 @@ msgstr "Dit programma bestaat niet!"
 msgid "level_not_class"
 msgstr "Je zit in een klas waar dit level nog niet beschikbaar is gemaakt"
 
-#: app.py:923 website/teacher.py:419 website/teacher.py:435
-#: website/teacher.py:464 website/teacher.py:490
+#: app.py:923 website/teacher.py:421 website/teacher.py:437
+#: website/teacher.py:466 website/teacher.py:492
 msgid "no_such_adventure"
 msgstr "Dit avontuur bestaat niet!"
 
@@ -341,8 +341,8 @@ msgstr "Dit is geen geldige tutorial stap, probeer het opnieuw."
 #: website/auth.py:671 website/auth.py:718 website/auth.py:745
 #: website/quiz.py:43 website/quiz.py:69 website/teacher.py:88
 #: website/teacher.py:123 website/teacher.py:195 website/teacher.py:251
-#: website/teacher.py:298 website/teacher.py:339 website/teacher.py:375
-#: website/teacher.py:446 website/teacher.py:504
+#: website/teacher.py:298 website/teacher.py:339 website/teacher.py:377
+#: website/teacher.py:448 website/teacher.py:506
 msgid "ajax_error"
 msgstr "Er is een fout opgetreden, probeer het nog eens."
 
@@ -646,6 +646,23 @@ msgstr "Verborgen badges"
 msgid "hedy_achievements"
 msgstr "Mijn badges"
 
+#: templates/achievements.html:36 templates/achievements.html:50
+#: templates/landing-page.html:89 templates/layout.html:92
+#: templates/public-page.html:51
+#, fuzzy
+msgid "achievements_logo_alt"
+msgstr "badges"
+
+#: templates/achievements.html:37
+#, fuzzy
+msgid "achievements_check_icon_alt"
+msgstr "Je hebt een badge verdiend!"
+
+#: templates/base_email.html:3 templates/cheatsheet.html:15
+#: templates/incl-menubar.html:4
+msgid "hedy_logo_alt"
+msgstr ""
+
 #: templates/cheatsheet.html:14
 msgid "cheatsheet_title"
 msgstr "Spiekbriefje"
@@ -748,7 +765,7 @@ msgstr "Vul een gebruikersnaam in"
 msgid "invite_by_username"
 msgstr "Uitnodigen bij gebruikersnaam"
 
-#: templates/class-overview.html:55 templates/create-accounts.html:49
+#: templates/class-overview.html:55 templates/create-accounts.html:45
 msgid "create_accounts"
 msgstr "Accounts aanmaken"
 
@@ -772,6 +789,10 @@ msgstr "Weet je zeker dat je deze uitnodiging wilt verwijderen?"
 msgid "class_already_joined"
 msgstr "Je zit al in deze klas"
 
+#: templates/class-prejoin.html:9 templates/error-page.html:6
+msgid "error_logo_alt"
+msgstr ""
+
 #: templates/class-prejoin.html:11
 msgid "goto_profile"
 msgstr "Ga naar mijn profiel"
@@ -790,7 +811,8 @@ msgstr ""
 msgid "join_class"
 msgstr "Inschrijven voor klas"
 
-#: templates/class-stats.html:22 templates/customize-class.html:166
+#: templates/class-stats.html:22 templates/create-accounts.html:41
+#: templates/customize-class.html:166
 msgid "back_to_class"
 msgstr "Ga terug naar klas"
 
@@ -815,36 +837,32 @@ msgstr "Meerdere accounts aanmaken"
 msgid "accounts_intro"
 msgstr ""
 "Op deze pagina kun je accounts aan maken voor meerdere studenten "
-"tegelijkertijd. Ze worden automatisch toegevoegd aan de huidige klas, controleer of dit klopt!"
-" Door op het groene kruisje rechtsonderin te klikken kun je meer rijen "
-"toevoegen. Met het rode kruisje kun je een rij weer verwijderen. Zorg "
-"ervoor dat alle rijen gevuld zijn voordat je klikt op \"Accounts "
-"aanmaken\". Denk eraan dat elke gebruikersnaam uniek moet zijn. Ook moet "
-"het wachtwoord <b>minimaal</b> 6 tekens zijn."
+"tegelijkertijd. Ze worden automatisch toegevoegd aan de huidige klas, "
+"controleer of dit klopt! Door op het groene kruisje rechtsonderin te "
+"klikken kun je meer rijen toevoegen. Met het rode kruisje kun je een rij "
+"weer verwijderen. Zorg ervoor dat alle rijen gevuld zijn voordat je klikt"
+" op \"Accounts aanmaken\". Denk eraan dat elke gebruikersnaam uniek moet "
+"zijn. Ook moet het wachtwoord <b>minimaal</b> 6 tekens zijn."
 
 #: templates/create-accounts.html:10
 msgid "create_accounts_prompt"
 msgstr "Weet je zeker dat je deze accounts wilt aanmaken?"
 
-#: templates/create-accounts.html:19
-msgid "select_class"
-msgstr "Kies klas"
-
-#: templates/create-accounts.html:30
+#: templates/create-accounts.html:25
 msgid "download_login_credentials"
 msgstr "Wil je de login gegevens downloaden na het aanmaken van de accounts?"
 
-#: templates/create-accounts.html:34 templates/layout.html:22
+#: templates/create-accounts.html:29 templates/layout.html:22
 #: templates/signup.html:64
 msgid "yes"
 msgstr "Ja"
 
-#: templates/create-accounts.html:38 templates/layout.html:23
+#: templates/create-accounts.html:33 templates/layout.html:23
 #: templates/signup.html:68
 msgid "no"
 msgstr "Nee"
 
-#: templates/create-accounts.html:48 templates/programs.html:24
+#: templates/create-accounts.html:44 templates/programs.html:24
 msgid "reset_view"
 msgstr "Reset"
 
@@ -1136,7 +1154,7 @@ msgstr "Bekijk"
 msgid "adventure_prompt"
 msgstr "Geef je nieuwe avontuur een naam"
 
-#: templates/for-teachers.html:59 website/teacher.py:499
+#: templates/for-teachers.html:59 website/teacher.py:501
 msgid "create_adventure"
 msgstr "Maak nieuw avontuur"
 
@@ -1195,6 +1213,10 @@ msgstr "Volgende opdracht"
 #: templates/incl-editor-and-output.html:144
 msgid "edit_code_button"
 msgstr "Pas de code aan"
+
+#: templates/incl-editor-and-output.html:146
+msgid "repair_program_logo_alt"
+msgstr ""
 
 #: templates/incl-editor-and-output.html:150
 msgid "read_code_label"
@@ -1275,21 +1297,48 @@ msgstr "Welkom"
 msgid "welcome_back"
 msgstr "Welkom terug"
 
+#: templates/landing-page.html:11
+#, fuzzy
+msgid "teacher_tutorial_logo_alt"
+msgstr "Klik op 'volgende stap' om als leraar aan de slag te gaan met Hedy!"
+
 #: templates/landing-page.html:13
 msgid "start_teacher_tutorial"
 msgstr "Begin leraren tutorial"
+
+#: templates/landing-page.html:18
+#, fuzzy
+msgid "hedy_tutorial_logo_alt"
+msgstr "Begin Hedy tutorial"
 
 #: templates/landing-page.html:20
 msgid "start_hedy_tutorial"
 msgstr "Begin Hedy tutorial"
 
+#: templates/landing-page.html:25
+#, fuzzy
+msgid "start_programming_logo_alt"
+msgstr "Begin met programmeren"
+
 #: templates/landing-page.html:27
 msgid "start_programming"
 msgstr "Begin met programmeren"
 
+#: templates/landing-page.html:31
+#, fuzzy
+msgid "explore_programs_logo_alt"
+msgstr "Programma's ontdekken"
+
 #: templates/landing-page.html:39
 msgid "your_account"
 msgstr "Jouw profiel"
+
+#: templates/landing-page.html:43 templates/landing-page.html:45
+#: templates/profile.html:33 templates/public-page.html:7
+#: templates/public-page.html:9
+#, fuzzy
+msgid "profile_logo_alt"
+msgstr "Je profiel is aangepast."
 
 #: templates/landing-page.html:52 templates/public-page.html:16
 msgid "achievements"
@@ -1628,6 +1677,10 @@ msgstr "Schrijf je eerste programma!"
 #: templates/public-page.html:85
 msgid "no_shared_programs"
 msgstr "heeft geen gedeelde programma's..."
+
+#: templates/quiz.html:4
+msgid "quiz_logo_alt"
+msgstr ""
 
 #: templates/quiz.html:7
 msgid "start_quiz"
@@ -2029,7 +2082,7 @@ msgstr "Programma wordt niet meer gedeeld."
 msgid "favourite_success"
 msgstr "Je programma is ingesteld als favoriet."
 
-#: website/quiz.py:45 website/quiz.py:71 website/teacher.py:452
+#: website/quiz.py:45 website/quiz.py:71 website/teacher.py:454
 msgid "level_invalid"
 msgstr "Dit Hedy level is ongeldig."
 
@@ -2060,6 +2113,7 @@ msgstr "Alleen leerkrachten mogen klassen openen"
 #: website/statistics.py:41 website/teacher.py:38 website/teacher.py:131
 #: website/teacher.py:150 website/teacher.py:212 website/teacher.py:234
 #: website/teacher.py:246 website/teacher.py:313 website/teacher.py:352
+#: website/teacher.py:364
 msgid "no_such_class"
 msgstr "Deze klas bestaat niet."
 
@@ -2087,7 +2141,7 @@ msgstr "Je hebt geen klasnaam ingevuld!"
 msgid "class_name_duplicate"
 msgstr "Je hebt al een klas met deze naam."
 
-#: website/teacher.py:162 website/teacher.py:178 website/teacher.py:531
+#: website/teacher.py:162 website/teacher.py:178 website/teacher.py:533
 msgid "invalid_class_link"
 msgstr "Ongeldige klassenlink."
 
@@ -2123,64 +2177,64 @@ msgstr "Deze leerling zit al in jouw klas."
 msgid "student_already_invite"
 msgstr "Deze leerling heeft al een openstaande uitnodiging."
 
-#: website/teacher.py:380
+#: website/teacher.py:382
 msgid "no_accounts"
 msgstr "Er zijn geen accounts om aan te maken."
 
-#: website/teacher.py:390
+#: website/teacher.py:392
 msgid "unique_usernames"
 msgstr "Alle gebruikersnamen moeten uniek zijn."
 
-#: website/teacher.py:399
+#: website/teacher.py:401
 msgid "usernames_exist"
 msgstr "Een of meerdere gebruikersnamen is al in gebruik."
 
-#: website/teacher.py:410
+#: website/teacher.py:412
 msgid "accounts_created"
 msgstr "Account succesvol aangemaakt."
 
-#: website/teacher.py:416 website/teacher.py:421 website/teacher.py:432
-#: website/teacher.py:461 website/teacher.py:487
+#: website/teacher.py:418 website/teacher.py:423 website/teacher.py:434
+#: website/teacher.py:463 website/teacher.py:489
 msgid "retrieve_adventure_error"
 msgstr "Jij mag dit avontuur niet bekijken!"
 
-#: website/teacher.py:426
+#: website/teacher.py:428
 msgid "title_view-adventure"
 msgstr "Hedy - Avontuur bekijken"
 
-#: website/teacher.py:437
+#: website/teacher.py:439
 msgid "title_customize-adventure"
 msgstr "Hedy - Avontuur personaliseren"
 
-#: website/teacher.py:448
+#: website/teacher.py:450
 msgid "adventure_id_invalid"
 msgstr "Dit avontuur id is ongeldig."
 
-#: website/teacher.py:450 website/teacher.py:506
+#: website/teacher.py:452 website/teacher.py:508
 msgid "adventure_name_invalid"
 msgstr "Deze avontuur naam is ongeldig."
 
-#: website/teacher.py:454
+#: website/teacher.py:456
 msgid "content_invalid"
 msgstr "Dit avontuur is ongeldig."
 
-#: website/teacher.py:456
+#: website/teacher.py:458
 msgid "adventure_length"
 msgstr "Jouw avontuur moet minimaal 20 karakters zijn."
 
-#: website/teacher.py:458
+#: website/teacher.py:460
 msgid "public_invalid"
 msgstr "Deze waarde voor het beschikbaar maken van je avontuur is ongeldig"
 
-#: website/teacher.py:469 website/teacher.py:513
+#: website/teacher.py:471 website/teacher.py:515
 msgid "adventure_duplicate"
 msgstr "Je hebt al een avontuur met deze naam."
 
-#: website/teacher.py:481
+#: website/teacher.py:483
 msgid "adventure_updated"
 msgstr "Jouw avontuur is bijgewerkt!"
 
-#: website/teacher.py:508
+#: website/teacher.py:510
 msgid "adventure_empty"
 msgstr "Je hebt geen avonturen naam ingevuld!"
 
@@ -2254,4 +2308,7 @@ msgstr "Je hebt geen avonturen naam ingevuld!"
 
 #~ msgid "go_to_first_exercise"
 #~ msgstr "Ga naar opdracht 1"
+
+#~ msgid "select_class"
+#~ msgstr "Kies klas"
 

--- a/translations/nl/LC_MESSAGES/messages.po
+++ b/translations/nl/LC_MESSAGES/messages.po
@@ -649,19 +649,16 @@ msgstr "Mijn badges"
 #: templates/achievements.html:36 templates/achievements.html:50
 #: templates/landing-page.html:89 templates/layout.html:92
 #: templates/public-page.html:51
-#, fuzzy
 msgid "achievements_logo_alt"
-msgstr "badges"
+msgstr "Badges logo"
 
 #: templates/achievements.html:37
-#, fuzzy
 msgid "achievements_check_icon_alt"
-msgstr "Je hebt een badge verdiend!"
+msgstr "Badges check icon"
 
 #: templates/base_email.html:3 templates/cheatsheet.html:15
-#: templates/incl-menubar.html:4
 msgid "hedy_logo_alt"
-msgstr ""
+msgstr "Hedy logo"
 
 #: templates/cheatsheet.html:14
 msgid "cheatsheet_title"
@@ -791,7 +788,7 @@ msgstr "Je zit al in deze klas"
 
 #: templates/class-prejoin.html:9 templates/error-page.html:6
 msgid "error_logo_alt"
-msgstr ""
+msgstr "Error logo"
 
 #: templates/class-prejoin.html:11
 msgid "goto_profile"
@@ -1216,7 +1213,7 @@ msgstr "Pas de code aan"
 
 #: templates/incl-editor-and-output.html:146
 msgid "repair_program_logo_alt"
-msgstr ""
+msgstr "Repareer programma icon"
 
 #: templates/incl-editor-and-output.html:150
 msgid "read_code_label"
@@ -1298,36 +1295,32 @@ msgid "welcome_back"
 msgstr "Welkom terug"
 
 #: templates/landing-page.html:11
-#, fuzzy
 msgid "teacher_tutorial_logo_alt"
-msgstr "Klik op 'volgende stap' om als leraar aan de slag te gaan met Hedy!"
+msgstr "Leraren tutorial icon"
 
 #: templates/landing-page.html:13
 msgid "start_teacher_tutorial"
 msgstr "Begin leraren tutorial"
 
 #: templates/landing-page.html:18
-#, fuzzy
 msgid "hedy_tutorial_logo_alt"
-msgstr "Begin Hedy tutorial"
+msgstr "Hedy tutorial icon"
 
 #: templates/landing-page.html:20
 msgid "start_hedy_tutorial"
 msgstr "Begin Hedy tutorial"
 
 #: templates/landing-page.html:25
-#, fuzzy
 msgid "start_programming_logo_alt"
-msgstr "Begin met programmeren"
+msgstr "Begin met programmeren icon"
 
 #: templates/landing-page.html:27
 msgid "start_programming"
 msgstr "Begin met programmeren"
 
 #: templates/landing-page.html:31
-#, fuzzy
 msgid "explore_programs_logo_alt"
-msgstr "Programma's ontdekken"
+msgstr "Programma's ontdekken icon"
 
 #: templates/landing-page.html:39
 msgid "your_account"
@@ -1336,9 +1329,8 @@ msgstr "Jouw profiel"
 #: templates/landing-page.html:43 templates/landing-page.html:45
 #: templates/profile.html:33 templates/public-page.html:7
 #: templates/public-page.html:9
-#, fuzzy
 msgid "profile_logo_alt"
-msgstr "Je profiel is aangepast."
+msgstr "Profiel icon"
 
 #: templates/landing-page.html:52 templates/public-page.html:16
 msgid "achievements"
@@ -1680,7 +1672,7 @@ msgstr "heeft geen gedeelde programma's..."
 
 #: templates/quiz.html:4
 msgid "quiz_logo_alt"
-msgstr ""
+msgstr "Quiz logo"
 
 #: templates/quiz.html:7
 msgid "start_quiz"

--- a/translations/pl/LC_MESSAGES/messages.po
+++ b/translations/pl/LC_MESSAGES/messages.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-21 10:36+0200\n"
+"POT-Creation-Date: 2022-06-23 14:02+0200\n"
 "PO-Revision-Date: 2022-06-18 14:19+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: pl\n"
@@ -25,7 +25,7 @@ msgid "title_achievements"
 msgstr "Hedy - Moje osiągnięcia"
 
 #: app.py:639 app.py:743 app.py:1085 website/teacher.py:361
-#: website/teacher.py:370
+#: website/teacher.py:372
 msgid "not_teacher"
 msgstr "Wygląda na to, że nie jesteś nauczycielem!"
 
@@ -62,8 +62,8 @@ msgstr "Nie ma takiego programu!"
 msgid "level_not_class"
 msgstr "Ten poziom nie jest jeszcze dostępny w twojej klasie"
 
-#: app.py:923 website/teacher.py:419 website/teacher.py:435
-#: website/teacher.py:464 website/teacher.py:490
+#: app.py:923 website/teacher.py:421 website/teacher.py:437
+#: website/teacher.py:466 website/teacher.py:492
 msgid "no_such_adventure"
 msgstr "Ta przygoda nie istnieje!"
 
@@ -355,8 +355,8 @@ msgstr ""
 #: website/auth.py:671 website/auth.py:718 website/auth.py:745
 #: website/quiz.py:43 website/quiz.py:69 website/teacher.py:88
 #: website/teacher.py:123 website/teacher.py:195 website/teacher.py:251
-#: website/teacher.py:298 website/teacher.py:339 website/teacher.py:375
-#: website/teacher.py:446 website/teacher.py:504
+#: website/teacher.py:298 website/teacher.py:339 website/teacher.py:377
+#: website/teacher.py:448 website/teacher.py:506
 msgid "ajax_error"
 msgstr "Wystąpił błąd, proszę spróbować ponownie."
 
@@ -699,6 +699,23 @@ msgstr "Podpowiedź?"
 msgid "hedy_achievements"
 msgstr "Moje osiągnięcia"
 
+#: templates/achievements.html:36 templates/achievements.html:50
+#: templates/landing-page.html:89 templates/layout.html:92
+#: templates/public-page.html:51
+#, fuzzy
+msgid "achievements_logo_alt"
+msgstr "osiągnięcia"
+
+#: templates/achievements.html:37
+#, fuzzy
+msgid "achievements_check_icon_alt"
+msgstr "You've earned an achievement!"
+
+#: templates/base_email.html:3 templates/cheatsheet.html:15
+#: templates/incl-menubar.html:4
+msgid "hedy_logo_alt"
+msgstr ""
+
 #: templates/cheatsheet.html:14
 #, fuzzy
 msgid "cheatsheet_title"
@@ -815,7 +832,7 @@ msgstr "Wprowadź nazwę użytkownika"
 msgid "invite_by_username"
 msgstr "Wszystkie nazwy użytkowników muszą być unikalne."
 
-#: templates/class-overview.html:55 templates/create-accounts.html:49
+#: templates/class-overview.html:55 templates/create-accounts.html:45
 msgid "create_accounts"
 msgstr "Utwórz wiele kont"
 
@@ -841,6 +858,10 @@ msgstr "Are you sure you want to remove this class invitation?"
 msgid "class_already_joined"
 msgstr "You are already a student of class"
 
+#: templates/class-prejoin.html:9 templates/error-page.html:6
+msgid "error_logo_alt"
+msgstr ""
+
 #: templates/class-prejoin.html:11
 #, fuzzy
 msgid "goto_profile"
@@ -859,7 +880,8 @@ msgstr "You need to have an account to join a class. Would you like to login now
 msgid "join_class"
 msgstr "Dołącz do klasy"
 
-#: templates/class-stats.html:22 templates/customize-class.html:166
+#: templates/class-stats.html:22 templates/create-accounts.html:41
+#: templates/customize-class.html:166
 msgid "back_to_class"
 msgstr "Powróć do klasy"
 
@@ -898,26 +920,22 @@ msgstr ""
 msgid "create_accounts_prompt"
 msgstr "Are you sure you want to create these accounts?"
 
-#: templates/create-accounts.html:19
-msgid "select_class"
-msgstr "Wybierz klasę"
-
-#: templates/create-accounts.html:30
+#: templates/create-accounts.html:25
 #, fuzzy
 msgid "download_login_credentials"
 msgstr ""
 
-#: templates/create-accounts.html:34 templates/layout.html:22
+#: templates/create-accounts.html:29 templates/layout.html:22
 #: templates/signup.html:64
 msgid "yes"
 msgstr "Tak"
 
-#: templates/create-accounts.html:38 templates/layout.html:23
+#: templates/create-accounts.html:33 templates/layout.html:23
 #: templates/signup.html:68
 msgid "no"
 msgstr "Nie"
 
-#: templates/create-accounts.html:48 templates/programs.html:24
+#: templates/create-accounts.html:44 templates/programs.html:24
 #, fuzzy
 msgid "reset_view"
 msgstr "Reset"
@@ -1231,7 +1249,7 @@ msgstr "Wyświetl"
 msgid "adventure_prompt"
 msgstr "Please enter the name of the adventure"
 
-#: templates/for-teachers.html:59 website/teacher.py:499
+#: templates/for-teachers.html:59 website/teacher.py:501
 msgid "create_adventure"
 msgstr "Utwórz przygodę"
 
@@ -1299,6 +1317,10 @@ msgstr "Next exercise"
 #: templates/incl-editor-and-output.html:144
 msgid "edit_code_button"
 msgstr "Edytuj kod"
+
+#: templates/incl-editor-and-output.html:146
+msgid "repair_program_logo_alt"
+msgstr ""
 
 #: templates/incl-editor-and-output.html:150
 msgid "read_code_label"
@@ -1389,25 +1411,52 @@ msgstr ""
 "Welcome to Hedy! Your are now the proud owner of a teachers account which"
 " allows you to create classes and invite students."
 
+#: templates/landing-page.html:11
+#, fuzzy
+msgid "teacher_tutorial_logo_alt"
+msgstr "You have received an invitation to join class"
+
 #: templates/landing-page.html:13
 #, fuzzy
 msgid "start_teacher_tutorial"
 msgstr "Start teacher tutorial"
+
+#: templates/landing-page.html:18
+#, fuzzy
+msgid "hedy_tutorial_logo_alt"
+msgstr "Start hedy tutorial"
 
 #: templates/landing-page.html:20
 #, fuzzy
 msgid "start_hedy_tutorial"
 msgstr "Start hedy tutorial"
 
+#: templates/landing-page.html:25
+#, fuzzy
+msgid "start_programming_logo_alt"
+msgstr "Directly start programming"
+
 #: templates/landing-page.html:27
 #, fuzzy
 msgid "start_programming"
 msgstr "Directly start programming"
 
+#: templates/landing-page.html:31
+#, fuzzy
+msgid "explore_programs_logo_alt"
+msgstr "Explore programs"
+
 #: templates/landing-page.html:39
 #, fuzzy
 msgid "your_account"
 msgstr "Nie masz konta?"
+
+#: templates/landing-page.html:43 templates/landing-page.html:45
+#: templates/profile.html:33 templates/public-page.html:7
+#: templates/public-page.html:9
+#, fuzzy
+msgid "profile_logo_alt"
+msgstr "Profil został zaktualizowany."
 
 #: templates/landing-page.html:52 templates/public-page.html:16
 msgid "achievements"
@@ -1775,6 +1824,10 @@ msgstr "Napisz swój pierwszy program!"
 #, fuzzy
 msgid "no_shared_programs"
 msgstr "has no shared programs..."
+
+#: templates/quiz.html:4
+msgid "quiz_logo_alt"
+msgstr ""
 
 #: templates/quiz.html:7
 #, fuzzy
@@ -2226,7 +2279,7 @@ msgstr "Program unshared successfully."
 msgid "favourite_success"
 msgstr "Your program is set as favourite."
 
-#: website/quiz.py:45 website/quiz.py:71 website/teacher.py:452
+#: website/quiz.py:45 website/quiz.py:71 website/teacher.py:454
 msgid "level_invalid"
 msgstr "Ten poziom Hedy jest nieprawidłowy."
 
@@ -2258,6 +2311,7 @@ msgstr "Only teachers can retrieve classes"
 #: website/statistics.py:41 website/teacher.py:38 website/teacher.py:131
 #: website/teacher.py:150 website/teacher.py:212 website/teacher.py:234
 #: website/teacher.py:246 website/teacher.py:313 website/teacher.py:352
+#: website/teacher.py:364
 #, fuzzy
 msgid "no_such_class"
 msgstr "No such Hedy class"
@@ -2289,7 +2343,7 @@ msgstr "You didn't enter a class name!"
 msgid "class_name_duplicate"
 msgstr "You already have a class with this name."
 
-#: website/teacher.py:162 website/teacher.py:178 website/teacher.py:531
+#: website/teacher.py:162 website/teacher.py:178 website/teacher.py:533
 #, fuzzy
 msgid "invalid_class_link"
 msgstr "Invalid link for joining the class."
@@ -2333,71 +2387,71 @@ msgstr "This student is already in your class."
 msgid "student_already_invite"
 msgstr "This student already has a pending invitation."
 
-#: website/teacher.py:380
+#: website/teacher.py:382
 #, fuzzy
 msgid "no_accounts"
 msgstr "There are no accounts to create."
 
-#: website/teacher.py:390
+#: website/teacher.py:392
 msgid "unique_usernames"
 msgstr "Wszystkie nazwy użytkowników muszą być unikalne."
 
-#: website/teacher.py:399
+#: website/teacher.py:401
 #, fuzzy
 msgid "usernames_exist"
 msgstr "One or more usernames is already in use."
 
-#: website/teacher.py:410
+#: website/teacher.py:412
 #, fuzzy
 msgid "accounts_created"
 msgstr "Accounts where successfully created."
 
-#: website/teacher.py:416 website/teacher.py:421 website/teacher.py:432
-#: website/teacher.py:461 website/teacher.py:487
+#: website/teacher.py:418 website/teacher.py:423 website/teacher.py:434
+#: website/teacher.py:463 website/teacher.py:489
 #, fuzzy
 msgid "retrieve_adventure_error"
 msgstr "You're not allowed to view this adventure!"
 
-#: website/teacher.py:426
+#: website/teacher.py:428
 msgid "title_view-adventure"
 msgstr "Hedy - Wyświetl przygodę"
 
-#: website/teacher.py:437
+#: website/teacher.py:439
 #, fuzzy
 msgid "title_customize-adventure"
 msgstr "Hedy - Customize adventure"
 
-#: website/teacher.py:448
+#: website/teacher.py:450
 msgid "adventure_id_invalid"
 msgstr "Ten identyfikator przygody jest nieprawidłowy."
 
-#: website/teacher.py:450 website/teacher.py:506
+#: website/teacher.py:452 website/teacher.py:508
 msgid "adventure_name_invalid"
 msgstr "Ta nazwa przygody jest nieprawidłowa."
 
-#: website/teacher.py:454
+#: website/teacher.py:456
 msgid "content_invalid"
 msgstr "Ta przygoda jest nieprawidłowa."
 
-#: website/teacher.py:456
+#: website/teacher.py:458
 #, fuzzy
 msgid "adventure_length"
 msgstr "Your adventure has to be at least 20 characters."
 
-#: website/teacher.py:458
+#: website/teacher.py:460
 #, fuzzy
 msgid "public_invalid"
 msgstr "This agreement selection is invalid"
 
-#: website/teacher.py:469 website/teacher.py:513
+#: website/teacher.py:471 website/teacher.py:515
 msgid "adventure_duplicate"
 msgstr "Posiadasz już przygodę o tej nazwie."
 
-#: website/teacher.py:481
+#: website/teacher.py:483
 msgid "adventure_updated"
 msgstr "Przygoda została zaktualizowana!"
 
-#: website/teacher.py:508
+#: website/teacher.py:510
 #, fuzzy
 msgid "adventure_empty"
 msgstr "You didn't enter an adventure name!"
@@ -2559,4 +2613,7 @@ msgstr "You didn't enter an adventure name!"
 
 #~ msgid "go_to_first_exercise"
 #~ msgstr "Przejdź do pytania 1"
+
+#~ msgid "select_class"
+#~ msgstr "Wybierz klasę"
 

--- a/translations/pt_BR/LC_MESSAGES/messages.po
+++ b/translations/pt_BR/LC_MESSAGES/messages.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-21 10:36+0200\n"
+"POT-Creation-Date: 2022-06-23 14:02+0200\n"
 "PO-Revision-Date: 2022-06-18 14:19+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: pt_BR\n"
@@ -25,7 +25,7 @@ msgid "title_achievements"
 msgstr "Hedy - My achievements"
 
 #: app.py:639 app.py:743 app.py:1085 website/teacher.py:361
-#: website/teacher.py:370
+#: website/teacher.py:372
 #, fuzzy
 msgid "not_teacher"
 msgstr "Looks like you are not a teacher!"
@@ -69,8 +69,8 @@ msgstr "No such Hedy program!"
 msgid "level_not_class"
 msgstr "You're in a class where this level has not been made available yet"
 
-#: app.py:923 website/teacher.py:419 website/teacher.py:435
-#: website/teacher.py:464 website/teacher.py:490
+#: app.py:923 website/teacher.py:421 website/teacher.py:437
+#: website/teacher.py:466 website/teacher.py:492
 #, fuzzy
 msgid "no_such_adventure"
 msgstr "This adventure doesn't exist!"
@@ -367,8 +367,8 @@ msgstr ""
 #: website/auth.py:671 website/auth.py:718 website/auth.py:745
 #: website/quiz.py:43 website/quiz.py:69 website/teacher.py:88
 #: website/teacher.py:123 website/teacher.py:195 website/teacher.py:251
-#: website/teacher.py:298 website/teacher.py:339 website/teacher.py:375
-#: website/teacher.py:446 website/teacher.py:504
+#: website/teacher.py:298 website/teacher.py:339 website/teacher.py:377
+#: website/teacher.py:448 website/teacher.py:506
 msgid "ajax_error"
 msgstr "Ocorreu um erro, por favor, tente novamente."
 
@@ -706,6 +706,23 @@ msgstr "Hint?"
 msgid "hedy_achievements"
 msgstr "My achievements"
 
+#: templates/achievements.html:36 templates/achievements.html:50
+#: templates/landing-page.html:89 templates/layout.html:92
+#: templates/public-page.html:51
+#, fuzzy
+msgid "achievements_logo_alt"
+msgstr "achievements"
+
+#: templates/achievements.html:37
+#, fuzzy
+msgid "achievements_check_icon_alt"
+msgstr "You've earned an achievement!"
+
+#: templates/base_email.html:3 templates/cheatsheet.html:15
+#: templates/incl-menubar.html:4
+msgid "hedy_logo_alt"
+msgstr ""
+
 #: templates/cheatsheet.html:14
 #, fuzzy
 msgid "cheatsheet_title"
@@ -822,7 +839,7 @@ msgstr "Enter a username"
 msgid "invite_by_username"
 msgstr "All usernames need to be unique."
 
-#: templates/class-overview.html:55 templates/create-accounts.html:49
+#: templates/class-overview.html:55 templates/create-accounts.html:45
 #, fuzzy
 msgid "create_accounts"
 msgstr "Create multiple accounts"
@@ -851,6 +868,10 @@ msgstr "Are you sure you want to remove this class invitation?"
 msgid "class_already_joined"
 msgstr "Você ja faz parte da turma"
 
+#: templates/class-prejoin.html:9 templates/error-page.html:6
+msgid "error_logo_alt"
+msgstr ""
+
 #: templates/class-prejoin.html:11
 msgid "goto_profile"
 msgstr "Ir para meu perfil"
@@ -869,7 +890,8 @@ msgstr ""
 msgid "join_class"
 msgstr "Entrar na turma"
 
-#: templates/class-stats.html:22 templates/customize-class.html:166
+#: templates/class-stats.html:22 templates/create-accounts.html:41
+#: templates/customize-class.html:166
 #, fuzzy
 msgid "back_to_class"
 msgstr "Go back to class"
@@ -910,27 +932,22 @@ msgstr ""
 msgid "create_accounts_prompt"
 msgstr "Are you sure you want to create these accounts?"
 
-#: templates/create-accounts.html:19
-#, fuzzy
-msgid "select_class"
-msgstr "Select class"
-
-#: templates/create-accounts.html:30
+#: templates/create-accounts.html:25
 #, fuzzy
 msgid "download_login_credentials"
 msgstr ""
 
-#: templates/create-accounts.html:34 templates/layout.html:22
+#: templates/create-accounts.html:29 templates/layout.html:22
 #: templates/signup.html:64
 msgid "yes"
 msgstr "Sim"
 
-#: templates/create-accounts.html:38 templates/layout.html:23
+#: templates/create-accounts.html:33 templates/layout.html:23
 #: templates/signup.html:68
 msgid "no"
 msgstr "Não"
 
-#: templates/create-accounts.html:48 templates/programs.html:24
+#: templates/create-accounts.html:44 templates/programs.html:24
 #, fuzzy
 msgid "reset_view"
 msgstr "Reset"
@@ -1256,7 +1273,7 @@ msgstr "View"
 msgid "adventure_prompt"
 msgstr "Please enter the name of the adventure"
 
-#: templates/for-teachers.html:59 website/teacher.py:499
+#: templates/for-teachers.html:59 website/teacher.py:501
 #, fuzzy
 msgid "create_adventure"
 msgstr "Create adventure"
@@ -1324,6 +1341,10 @@ msgstr "Next exercise"
 #: templates/incl-editor-and-output.html:144
 msgid "edit_code_button"
 msgstr "Editar código"
+
+#: templates/incl-editor-and-output.html:146
+msgid "repair_program_logo_alt"
+msgstr ""
 
 #: templates/incl-editor-and-output.html:150
 msgid "read_code_label"
@@ -1415,25 +1436,52 @@ msgstr ""
 "Welcome to Hedy! Your are now the proud owner of a teachers account which"
 " allows you to create classes and invite students."
 
+#: templates/landing-page.html:11
+#, fuzzy
+msgid "teacher_tutorial_logo_alt"
+msgstr "You have received an invitation to join class"
+
 #: templates/landing-page.html:13
 #, fuzzy
 msgid "start_teacher_tutorial"
 msgstr "Start teacher tutorial"
+
+#: templates/landing-page.html:18
+#, fuzzy
+msgid "hedy_tutorial_logo_alt"
+msgstr "Start hedy tutorial"
 
 #: templates/landing-page.html:20
 #, fuzzy
 msgid "start_hedy_tutorial"
 msgstr "Start hedy tutorial"
 
+#: templates/landing-page.html:25
+#, fuzzy
+msgid "start_programming_logo_alt"
+msgstr "Directly start programming"
+
 #: templates/landing-page.html:27
 #, fuzzy
 msgid "start_programming"
 msgstr "Directly start programming"
 
+#: templates/landing-page.html:31
+#, fuzzy
+msgid "explore_programs_logo_alt"
+msgstr "Explore programs"
+
 #: templates/landing-page.html:39
 #, fuzzy
 msgid "your_account"
 msgstr "Ainda não tem uma conta?"
+
+#: templates/landing-page.html:43 templates/landing-page.html:45
+#: templates/profile.html:33 templates/public-page.html:7
+#: templates/public-page.html:9
+#, fuzzy
+msgid "profile_logo_alt"
+msgstr "Perfil atualizada."
 
 #: templates/landing-page.html:52 templates/public-page.html:16
 #, fuzzy
@@ -1815,6 +1863,10 @@ msgstr "Escreva seu primeiro programa!"
 #, fuzzy
 msgid "no_shared_programs"
 msgstr "has no shared programs..."
+
+#: templates/quiz.html:4
+msgid "quiz_logo_alt"
+msgstr ""
 
 #: templates/quiz.html:7
 #, fuzzy
@@ -2257,7 +2309,7 @@ msgstr "Compartilhamento do programa cancelado com sucesso"
 msgid "favourite_success"
 msgstr "Your program is set as favourite."
 
-#: website/quiz.py:45 website/quiz.py:71 website/teacher.py:452
+#: website/quiz.py:45 website/quiz.py:71 website/teacher.py:454
 #, fuzzy
 msgid "level_invalid"
 msgstr "This Hedy level in invalid."
@@ -2290,6 +2342,7 @@ msgstr "Only teachers can retrieve classes"
 #: website/statistics.py:41 website/teacher.py:38 website/teacher.py:131
 #: website/teacher.py:150 website/teacher.py:212 website/teacher.py:234
 #: website/teacher.py:246 website/teacher.py:313 website/teacher.py:352
+#: website/teacher.py:364
 #, fuzzy
 msgid "no_such_class"
 msgstr "No such Hedy class"
@@ -2324,7 +2377,7 @@ msgstr "You didn't enter a class name!"
 msgid "class_name_duplicate"
 msgstr "You already have a class with this name."
 
-#: website/teacher.py:162 website/teacher.py:178 website/teacher.py:531
+#: website/teacher.py:162 website/teacher.py:178 website/teacher.py:533
 #, fuzzy
 msgid "invalid_class_link"
 msgstr "Invalid link for joining the class."
@@ -2369,78 +2422,78 @@ msgstr "This student is already in your class."
 msgid "student_already_invite"
 msgstr "This student already has a pending invitation."
 
-#: website/teacher.py:380
+#: website/teacher.py:382
 #, fuzzy
 msgid "no_accounts"
 msgstr "There are no accounts to create."
 
-#: website/teacher.py:390
+#: website/teacher.py:392
 #, fuzzy
 msgid "unique_usernames"
 msgstr "All usernames need to be unique."
 
-#: website/teacher.py:399
+#: website/teacher.py:401
 #, fuzzy
 msgid "usernames_exist"
 msgstr "One or more usernames is already in use."
 
-#: website/teacher.py:410
+#: website/teacher.py:412
 #, fuzzy
 msgid "accounts_created"
 msgstr "Accounts where successfully created."
 
-#: website/teacher.py:416 website/teacher.py:421 website/teacher.py:432
-#: website/teacher.py:461 website/teacher.py:487
+#: website/teacher.py:418 website/teacher.py:423 website/teacher.py:434
+#: website/teacher.py:463 website/teacher.py:489
 #, fuzzy
 msgid "retrieve_adventure_error"
 msgstr "You're not allowed to view this adventure!"
 
-#: website/teacher.py:426
+#: website/teacher.py:428
 #, fuzzy
 msgid "title_view-adventure"
 msgstr "Hedy - View adventure"
 
-#: website/teacher.py:437
+#: website/teacher.py:439
 #, fuzzy
 msgid "title_customize-adventure"
 msgstr "Hedy - Customize adventure"
 
-#: website/teacher.py:448
+#: website/teacher.py:450
 #, fuzzy
 msgid "adventure_id_invalid"
 msgstr "This adventure id is invalid."
 
-#: website/teacher.py:450 website/teacher.py:506
+#: website/teacher.py:452 website/teacher.py:508
 #, fuzzy
 msgid "adventure_name_invalid"
 msgstr "This adventure name is invalid."
 
-#: website/teacher.py:454
+#: website/teacher.py:456
 #, fuzzy
 msgid "content_invalid"
 msgstr "This adventure is invalid."
 
-#: website/teacher.py:456
+#: website/teacher.py:458
 #, fuzzy
 msgid "adventure_length"
 msgstr "Your adventure has to be at least 20 characters."
 
-#: website/teacher.py:458
+#: website/teacher.py:460
 #, fuzzy
 msgid "public_invalid"
 msgstr "This agreement selection is invalid"
 
-#: website/teacher.py:469 website/teacher.py:513
+#: website/teacher.py:471 website/teacher.py:515
 #, fuzzy
 msgid "adventure_duplicate"
 msgstr "You already have an adventure with this name."
 
-#: website/teacher.py:481
+#: website/teacher.py:483
 #, fuzzy
 msgid "adventure_updated"
 msgstr "The adventure has been updated!"
 
-#: website/teacher.py:508
+#: website/teacher.py:510
 #, fuzzy
 msgid "adventure_empty"
 msgstr "You didn't enter an adventure name!"
@@ -2599,4 +2652,7 @@ msgstr "You didn't enter an adventure name!"
 
 #~ msgid "go_to_first_exercise"
 #~ msgstr "Go to question 1"
+
+#~ msgid "select_class"
+#~ msgstr "Select class"
 

--- a/translations/pt_PT/LC_MESSAGES/messages.po
+++ b/translations/pt_PT/LC_MESSAGES/messages.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-21 10:36+0200\n"
+"POT-Creation-Date: 2022-06-23 14:02+0200\n"
 "PO-Revision-Date: 2022-06-18 14:19+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: pt_PT\n"
@@ -25,7 +25,7 @@ msgid "title_achievements"
 msgstr "Hedy - My achievements"
 
 #: app.py:639 app.py:743 app.py:1085 website/teacher.py:361
-#: website/teacher.py:370
+#: website/teacher.py:372
 #, fuzzy
 msgid "not_teacher"
 msgstr "Looks like you are not a teacher!"
@@ -69,8 +69,8 @@ msgstr "No such Hedy program!"
 msgid "level_not_class"
 msgstr "You're in a class where this level has not been made available yet"
 
-#: app.py:923 website/teacher.py:419 website/teacher.py:435
-#: website/teacher.py:464 website/teacher.py:490
+#: app.py:923 website/teacher.py:421 website/teacher.py:437
+#: website/teacher.py:466 website/teacher.py:492
 #, fuzzy
 msgid "no_such_adventure"
 msgstr "This adventure doesn't exist!"
@@ -367,8 +367,8 @@ msgstr ""
 #: website/auth.py:671 website/auth.py:718 website/auth.py:745
 #: website/quiz.py:43 website/quiz.py:69 website/teacher.py:88
 #: website/teacher.py:123 website/teacher.py:195 website/teacher.py:251
-#: website/teacher.py:298 website/teacher.py:339 website/teacher.py:375
-#: website/teacher.py:446 website/teacher.py:504
+#: website/teacher.py:298 website/teacher.py:339 website/teacher.py:377
+#: website/teacher.py:448 website/teacher.py:506
 msgid "ajax_error"
 msgstr "Ocorreu um erro, por favor tenta novamente."
 
@@ -707,6 +707,23 @@ msgstr "Hint?"
 msgid "hedy_achievements"
 msgstr "My achievements"
 
+#: templates/achievements.html:36 templates/achievements.html:50
+#: templates/landing-page.html:89 templates/layout.html:92
+#: templates/public-page.html:51
+#, fuzzy
+msgid "achievements_logo_alt"
+msgstr "achievements"
+
+#: templates/achievements.html:37
+#, fuzzy
+msgid "achievements_check_icon_alt"
+msgstr "You've earned an achievement!"
+
+#: templates/base_email.html:3 templates/cheatsheet.html:15
+#: templates/incl-menubar.html:4
+msgid "hedy_logo_alt"
+msgstr ""
+
 #: templates/cheatsheet.html:14
 #, fuzzy
 msgid "cheatsheet_title"
@@ -830,7 +847,7 @@ msgstr "Enter a username"
 msgid "invite_by_username"
 msgstr "All usernames need to be unique."
 
-#: templates/class-overview.html:55 templates/create-accounts.html:49
+#: templates/class-overview.html:55 templates/create-accounts.html:45
 #, fuzzy
 msgid "create_accounts"
 msgstr "Create multiple accounts"
@@ -860,6 +877,10 @@ msgstr "Are you sure you want to remove this class invitation?"
 msgid "class_already_joined"
 msgstr "You are already a student of class"
 
+#: templates/class-prejoin.html:9 templates/error-page.html:6
+msgid "error_logo_alt"
+msgstr ""
+
 #: templates/class-prejoin.html:11
 #, fuzzy
 msgid "goto_profile"
@@ -880,7 +901,8 @@ msgstr "You need to have an account to join a class. Would you like to login now
 msgid "join_class"
 msgstr "Join class"
 
-#: templates/class-stats.html:22 templates/customize-class.html:166
+#: templates/class-stats.html:22 templates/create-accounts.html:41
+#: templates/customize-class.html:166
 #, fuzzy
 msgid "back_to_class"
 msgstr "Go back to class"
@@ -921,27 +943,22 @@ msgstr ""
 msgid "create_accounts_prompt"
 msgstr "Are you sure you want to create these accounts?"
 
-#: templates/create-accounts.html:19
-#, fuzzy
-msgid "select_class"
-msgstr "Select class"
-
-#: templates/create-accounts.html:30
+#: templates/create-accounts.html:25
 #, fuzzy
 msgid "download_login_credentials"
 msgstr ""
 
-#: templates/create-accounts.html:34 templates/layout.html:22
+#: templates/create-accounts.html:29 templates/layout.html:22
 #: templates/signup.html:64
 msgid "yes"
 msgstr "Sim"
 
-#: templates/create-accounts.html:38 templates/layout.html:23
+#: templates/create-accounts.html:33 templates/layout.html:23
 #: templates/signup.html:68
 msgid "no"
 msgstr "Não"
 
-#: templates/create-accounts.html:48 templates/programs.html:24
+#: templates/create-accounts.html:44 templates/programs.html:24
 #, fuzzy
 msgid "reset_view"
 msgstr "Reset"
@@ -1270,7 +1287,7 @@ msgstr "View"
 msgid "adventure_prompt"
 msgstr "Please enter the name of the adventure"
 
-#: templates/for-teachers.html:59 website/teacher.py:499
+#: templates/for-teachers.html:59 website/teacher.py:501
 #, fuzzy
 msgid "create_adventure"
 msgstr "Create adventure"
@@ -1339,6 +1356,10 @@ msgstr "Next exercise"
 #: templates/incl-editor-and-output.html:144
 msgid "edit_code_button"
 msgstr "Edita o código"
+
+#: templates/incl-editor-and-output.html:146
+msgid "repair_program_logo_alt"
+msgstr ""
 
 #: templates/incl-editor-and-output.html:150
 msgid "read_code_label"
@@ -1435,25 +1456,52 @@ msgstr ""
 "Welcome to Hedy! Your are now the proud owner of a teachers account which"
 " allows you to create classes and invite students."
 
+#: templates/landing-page.html:11
+#, fuzzy
+msgid "teacher_tutorial_logo_alt"
+msgstr "You have received an invitation to join class"
+
 #: templates/landing-page.html:13
 #, fuzzy
 msgid "start_teacher_tutorial"
 msgstr "Start teacher tutorial"
+
+#: templates/landing-page.html:18
+#, fuzzy
+msgid "hedy_tutorial_logo_alt"
+msgstr "Start hedy tutorial"
 
 #: templates/landing-page.html:20
 #, fuzzy
 msgid "start_hedy_tutorial"
 msgstr "Start hedy tutorial"
 
+#: templates/landing-page.html:25
+#, fuzzy
+msgid "start_programming_logo_alt"
+msgstr "Directly start programming"
+
 #: templates/landing-page.html:27
 #, fuzzy
 msgid "start_programming"
 msgstr "Directly start programming"
 
+#: templates/landing-page.html:31
+#, fuzzy
+msgid "explore_programs_logo_alt"
+msgstr "Explore programs"
+
 #: templates/landing-page.html:39
 #, fuzzy
 msgid "your_account"
 msgstr "Ainda não tens conta?"
+
+#: templates/landing-page.html:43 templates/landing-page.html:45
+#: templates/profile.html:33 templates/public-page.html:7
+#: templates/public-page.html:9
+#, fuzzy
+msgid "profile_logo_alt"
+msgstr "Perfil atualizado."
 
 #: templates/landing-page.html:52 templates/public-page.html:16
 #, fuzzy
@@ -1839,6 +1887,10 @@ msgstr "Escreve o teu primeiro programa!"
 #, fuzzy
 msgid "no_shared_programs"
 msgstr "has no shared programs..."
+
+#: templates/quiz.html:4
+msgid "quiz_logo_alt"
+msgstr ""
 
 #: templates/quiz.html:7
 #, fuzzy
@@ -2281,7 +2333,7 @@ msgstr "Programa removido da partilha com sucesso"
 msgid "favourite_success"
 msgstr "Your program is set as favourite."
 
-#: website/quiz.py:45 website/quiz.py:71 website/teacher.py:452
+#: website/quiz.py:45 website/quiz.py:71 website/teacher.py:454
 #, fuzzy
 msgid "level_invalid"
 msgstr "This Hedy level in invalid."
@@ -2314,6 +2366,7 @@ msgstr "Only teachers can retrieve classes"
 #: website/statistics.py:41 website/teacher.py:38 website/teacher.py:131
 #: website/teacher.py:150 website/teacher.py:212 website/teacher.py:234
 #: website/teacher.py:246 website/teacher.py:313 website/teacher.py:352
+#: website/teacher.py:364
 #, fuzzy
 msgid "no_such_class"
 msgstr "No such Hedy class"
@@ -2348,7 +2401,7 @@ msgstr "You didn't enter a class name!"
 msgid "class_name_duplicate"
 msgstr "You already have a class with this name."
 
-#: website/teacher.py:162 website/teacher.py:178 website/teacher.py:531
+#: website/teacher.py:162 website/teacher.py:178 website/teacher.py:533
 #, fuzzy
 msgid "invalid_class_link"
 msgstr "Invalid link for joining the class."
@@ -2393,78 +2446,78 @@ msgstr "This student is already in your class."
 msgid "student_already_invite"
 msgstr "This student already has a pending invitation."
 
-#: website/teacher.py:380
+#: website/teacher.py:382
 #, fuzzy
 msgid "no_accounts"
 msgstr "There are no accounts to create."
 
-#: website/teacher.py:390
+#: website/teacher.py:392
 #, fuzzy
 msgid "unique_usernames"
 msgstr "All usernames need to be unique."
 
-#: website/teacher.py:399
+#: website/teacher.py:401
 #, fuzzy
 msgid "usernames_exist"
 msgstr "One or more usernames is already in use."
 
-#: website/teacher.py:410
+#: website/teacher.py:412
 #, fuzzy
 msgid "accounts_created"
 msgstr "Accounts where successfully created."
 
-#: website/teacher.py:416 website/teacher.py:421 website/teacher.py:432
-#: website/teacher.py:461 website/teacher.py:487
+#: website/teacher.py:418 website/teacher.py:423 website/teacher.py:434
+#: website/teacher.py:463 website/teacher.py:489
 #, fuzzy
 msgid "retrieve_adventure_error"
 msgstr "You're not allowed to view this adventure!"
 
-#: website/teacher.py:426
+#: website/teacher.py:428
 #, fuzzy
 msgid "title_view-adventure"
 msgstr "Hedy - View adventure"
 
-#: website/teacher.py:437
+#: website/teacher.py:439
 #, fuzzy
 msgid "title_customize-adventure"
 msgstr "Hedy - Customize adventure"
 
-#: website/teacher.py:448
+#: website/teacher.py:450
 #, fuzzy
 msgid "adventure_id_invalid"
 msgstr "This adventure id is invalid."
 
-#: website/teacher.py:450 website/teacher.py:506
+#: website/teacher.py:452 website/teacher.py:508
 #, fuzzy
 msgid "adventure_name_invalid"
 msgstr "This adventure name is invalid."
 
-#: website/teacher.py:454
+#: website/teacher.py:456
 #, fuzzy
 msgid "content_invalid"
 msgstr "This adventure is invalid."
 
-#: website/teacher.py:456
+#: website/teacher.py:458
 #, fuzzy
 msgid "adventure_length"
 msgstr "Your adventure has to be at least 20 characters."
 
-#: website/teacher.py:458
+#: website/teacher.py:460
 #, fuzzy
 msgid "public_invalid"
 msgstr "This agreement selection is invalid"
 
-#: website/teacher.py:469 website/teacher.py:513
+#: website/teacher.py:471 website/teacher.py:515
 #, fuzzy
 msgid "adventure_duplicate"
 msgstr "You already have an adventure with this name."
 
-#: website/teacher.py:481
+#: website/teacher.py:483
 #, fuzzy
 msgid "adventure_updated"
 msgstr "The adventure has been updated!"
 
-#: website/teacher.py:508
+#: website/teacher.py:510
 #, fuzzy
 msgid "adventure_empty"
 msgstr "You didn't enter an adventure name!"
@@ -2623,4 +2676,7 @@ msgstr "You didn't enter an adventure name!"
 
 #~ msgid "go_to_first_exercise"
 #~ msgstr "Go to question 1"
+
+#~ msgid "select_class"
+#~ msgstr "Select class"
 

--- a/translations/ru/LC_MESSAGES/messages.po
+++ b/translations/ru/LC_MESSAGES/messages.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-21 10:36+0200\n"
+"POT-Creation-Date: 2022-06-23 14:02+0200\n"
 "PO-Revision-Date: 2022-06-18 14:19+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: ru\n"
@@ -26,7 +26,7 @@ msgid "title_achievements"
 msgstr "Hedy - My achievements"
 
 #: app.py:639 app.py:743 app.py:1085 website/teacher.py:361
-#: website/teacher.py:370
+#: website/teacher.py:372
 #, fuzzy
 msgid "not_teacher"
 msgstr "Looks like you are not a teacher!"
@@ -70,8 +70,8 @@ msgstr "No such Hedy program!"
 msgid "level_not_class"
 msgstr "You're in a class where this level has not been made available yet"
 
-#: app.py:923 website/teacher.py:419 website/teacher.py:435
-#: website/teacher.py:464 website/teacher.py:490
+#: app.py:923 website/teacher.py:421 website/teacher.py:437
+#: website/teacher.py:466 website/teacher.py:492
 #, fuzzy
 msgid "no_such_adventure"
 msgstr "This adventure doesn't exist!"
@@ -368,8 +368,8 @@ msgstr ""
 #: website/auth.py:671 website/auth.py:718 website/auth.py:745
 #: website/quiz.py:43 website/quiz.py:69 website/teacher.py:88
 #: website/teacher.py:123 website/teacher.py:195 website/teacher.py:251
-#: website/teacher.py:298 website/teacher.py:339 website/teacher.py:375
-#: website/teacher.py:446 website/teacher.py:504
+#: website/teacher.py:298 website/teacher.py:339 website/teacher.py:377
+#: website/teacher.py:448 website/teacher.py:506
 #, fuzzy
 msgid "ajax_error"
 msgstr "There was an error, please try again."
@@ -730,6 +730,23 @@ msgstr "Hint?"
 msgid "hedy_achievements"
 msgstr "My achievements"
 
+#: templates/achievements.html:36 templates/achievements.html:50
+#: templates/landing-page.html:89 templates/layout.html:92
+#: templates/public-page.html:51
+#, fuzzy
+msgid "achievements_logo_alt"
+msgstr "achievements"
+
+#: templates/achievements.html:37
+#, fuzzy
+msgid "achievements_check_icon_alt"
+msgstr "You've earned an achievement!"
+
+#: templates/base_email.html:3 templates/cheatsheet.html:15
+#: templates/incl-menubar.html:4
+msgid "hedy_logo_alt"
+msgstr ""
+
 #: templates/cheatsheet.html:14
 #, fuzzy
 msgid "cheatsheet_title"
@@ -855,7 +872,7 @@ msgstr "Enter a username"
 msgid "invite_by_username"
 msgstr "All usernames need to be unique."
 
-#: templates/class-overview.html:55 templates/create-accounts.html:49
+#: templates/class-overview.html:55 templates/create-accounts.html:45
 #, fuzzy
 msgid "create_accounts"
 msgstr "Create multiple accounts"
@@ -885,6 +902,10 @@ msgstr "Are you sure you want to remove this class invitation?"
 msgid "class_already_joined"
 msgstr "You are already a student of class"
 
+#: templates/class-prejoin.html:9 templates/error-page.html:6
+msgid "error_logo_alt"
+msgstr ""
+
 #: templates/class-prejoin.html:11
 #, fuzzy
 msgid "goto_profile"
@@ -905,7 +926,8 @@ msgstr "You need to have an account to join a class. Would you like to login now
 msgid "join_class"
 msgstr "Join class"
 
-#: templates/class-stats.html:22 templates/customize-class.html:166
+#: templates/class-stats.html:22 templates/create-accounts.html:41
+#: templates/customize-class.html:166
 #, fuzzy
 msgid "back_to_class"
 msgstr "Go back to class"
@@ -947,29 +969,24 @@ msgstr ""
 msgid "create_accounts_prompt"
 msgstr "Are you sure you want to create these accounts?"
 
-#: templates/create-accounts.html:19
-#, fuzzy
-msgid "select_class"
-msgstr "Select class"
-
-#: templates/create-accounts.html:30
+#: templates/create-accounts.html:25
 #, fuzzy
 msgid "download_login_credentials"
 msgstr ""
 
-#: templates/create-accounts.html:34 templates/layout.html:22
+#: templates/create-accounts.html:29 templates/layout.html:22
 #: templates/signup.html:64
 #, fuzzy
 msgid "yes"
 msgstr "Yes"
 
-#: templates/create-accounts.html:38 templates/layout.html:23
+#: templates/create-accounts.html:33 templates/layout.html:23
 #: templates/signup.html:68
 #, fuzzy
 msgid "no"
 msgstr "No"
 
-#: templates/create-accounts.html:48 templates/programs.html:24
+#: templates/create-accounts.html:44 templates/programs.html:24
 #, fuzzy
 msgid "reset_view"
 msgstr "Reset"
@@ -1313,7 +1330,7 @@ msgstr "View"
 msgid "adventure_prompt"
 msgstr "Please enter the name of the adventure"
 
-#: templates/for-teachers.html:59 website/teacher.py:499
+#: templates/for-teachers.html:59 website/teacher.py:501
 #, fuzzy
 msgid "create_adventure"
 msgstr "Create adventure"
@@ -1385,6 +1402,10 @@ msgstr "Next exercise"
 #, fuzzy
 msgid "edit_code_button"
 msgstr "Edit code"
+
+#: templates/incl-editor-and-output.html:146
+msgid "repair_program_logo_alt"
+msgstr ""
 
 #: templates/incl-editor-and-output.html:150
 #, fuzzy
@@ -1488,25 +1509,52 @@ msgstr ""
 "Welcome to Hedy! Your are now the proud owner of a teachers account which"
 " allows you to create classes and invite students."
 
+#: templates/landing-page.html:11
+#, fuzzy
+msgid "teacher_tutorial_logo_alt"
+msgstr "You have received an invitation to join class"
+
 #: templates/landing-page.html:13
 #, fuzzy
 msgid "start_teacher_tutorial"
 msgstr "Start teacher tutorial"
+
+#: templates/landing-page.html:18
+#, fuzzy
+msgid "hedy_tutorial_logo_alt"
+msgstr "Start hedy tutorial"
 
 #: templates/landing-page.html:20
 #, fuzzy
 msgid "start_hedy_tutorial"
 msgstr "Start hedy tutorial"
 
+#: templates/landing-page.html:25
+#, fuzzy
+msgid "start_programming_logo_alt"
+msgstr "Directly start programming"
+
 #: templates/landing-page.html:27
 #, fuzzy
 msgid "start_programming"
 msgstr "Directly start programming"
 
+#: templates/landing-page.html:31
+#, fuzzy
+msgid "explore_programs_logo_alt"
+msgstr "Explore programs"
+
 #: templates/landing-page.html:39
 #, fuzzy
 msgid "your_account"
 msgstr "No account?"
+
+#: templates/landing-page.html:43 templates/landing-page.html:45
+#: templates/profile.html:33 templates/public-page.html:7
+#: templates/public-page.html:9
+#, fuzzy
+msgid "profile_logo_alt"
+msgstr "Profile updated."
 
 #: templates/landing-page.html:52 templates/public-page.html:16
 #, fuzzy
@@ -1927,6 +1975,10 @@ msgstr "Write your first program!"
 #, fuzzy
 msgid "no_shared_programs"
 msgstr "has no shared programs..."
+
+#: templates/quiz.html:4
+msgid "quiz_logo_alt"
+msgstr ""
 
 #: templates/quiz.html:7
 #, fuzzy
@@ -2402,7 +2454,7 @@ msgstr "Program unshared successfully."
 msgid "favourite_success"
 msgstr "Your program is set as favourite."
 
-#: website/quiz.py:45 website/quiz.py:71 website/teacher.py:452
+#: website/quiz.py:45 website/quiz.py:71 website/teacher.py:454
 #, fuzzy
 msgid "level_invalid"
 msgstr "This Hedy level in invalid."
@@ -2435,6 +2487,7 @@ msgstr "Only teachers can retrieve classes"
 #: website/statistics.py:41 website/teacher.py:38 website/teacher.py:131
 #: website/teacher.py:150 website/teacher.py:212 website/teacher.py:234
 #: website/teacher.py:246 website/teacher.py:313 website/teacher.py:352
+#: website/teacher.py:364
 #, fuzzy
 msgid "no_such_class"
 msgstr "No such Hedy class"
@@ -2469,7 +2522,7 @@ msgstr "You didn't enter a class name!"
 msgid "class_name_duplicate"
 msgstr "You already have a class with this name."
 
-#: website/teacher.py:162 website/teacher.py:178 website/teacher.py:531
+#: website/teacher.py:162 website/teacher.py:178 website/teacher.py:533
 #, fuzzy
 msgid "invalid_class_link"
 msgstr "Invalid link for joining the class."
@@ -2514,78 +2567,78 @@ msgstr "This student is already in your class."
 msgid "student_already_invite"
 msgstr "This student already has a pending invitation."
 
-#: website/teacher.py:380
+#: website/teacher.py:382
 #, fuzzy
 msgid "no_accounts"
 msgstr "There are no accounts to create."
 
-#: website/teacher.py:390
+#: website/teacher.py:392
 #, fuzzy
 msgid "unique_usernames"
 msgstr "All usernames need to be unique."
 
-#: website/teacher.py:399
+#: website/teacher.py:401
 #, fuzzy
 msgid "usernames_exist"
 msgstr "One or more usernames is already in use."
 
-#: website/teacher.py:410
+#: website/teacher.py:412
 #, fuzzy
 msgid "accounts_created"
 msgstr "Accounts where successfully created."
 
-#: website/teacher.py:416 website/teacher.py:421 website/teacher.py:432
-#: website/teacher.py:461 website/teacher.py:487
+#: website/teacher.py:418 website/teacher.py:423 website/teacher.py:434
+#: website/teacher.py:463 website/teacher.py:489
 #, fuzzy
 msgid "retrieve_adventure_error"
 msgstr "You're not allowed to view this adventure!"
 
-#: website/teacher.py:426
+#: website/teacher.py:428
 #, fuzzy
 msgid "title_view-adventure"
 msgstr "Hedy - View adventure"
 
-#: website/teacher.py:437
+#: website/teacher.py:439
 #, fuzzy
 msgid "title_customize-adventure"
 msgstr "Hedy - Customize adventure"
 
-#: website/teacher.py:448
+#: website/teacher.py:450
 #, fuzzy
 msgid "adventure_id_invalid"
 msgstr "This adventure id is invalid."
 
-#: website/teacher.py:450 website/teacher.py:506
+#: website/teacher.py:452 website/teacher.py:508
 #, fuzzy
 msgid "adventure_name_invalid"
 msgstr "This adventure name is invalid."
 
-#: website/teacher.py:454
+#: website/teacher.py:456
 #, fuzzy
 msgid "content_invalid"
 msgstr "This adventure is invalid."
 
-#: website/teacher.py:456
+#: website/teacher.py:458
 #, fuzzy
 msgid "adventure_length"
 msgstr "Your adventure has to be at least 20 characters."
 
-#: website/teacher.py:458
+#: website/teacher.py:460
 #, fuzzy
 msgid "public_invalid"
 msgstr "This agreement selection is invalid"
 
-#: website/teacher.py:469 website/teacher.py:513
+#: website/teacher.py:471 website/teacher.py:515
 #, fuzzy
 msgid "adventure_duplicate"
 msgstr "You already have an adventure with this name."
 
-#: website/teacher.py:481
+#: website/teacher.py:483
 #, fuzzy
 msgid "adventure_updated"
 msgstr "The adventure has been updated!"
 
-#: website/teacher.py:508
+#: website/teacher.py:510
 #, fuzzy
 msgid "adventure_empty"
 msgstr "You didn't enter an adventure name!"
@@ -2744,4 +2797,7 @@ msgstr "You didn't enter an adventure name!"
 
 #~ msgid "go_to_first_exercise"
 #~ msgstr "Go to question 1"
+
+#~ msgid "select_class"
+#~ msgstr "Select class"
 

--- a/translations/sw/LC_MESSAGES/messages.po
+++ b/translations/sw/LC_MESSAGES/messages.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-21 10:36+0200\n"
+"POT-Creation-Date: 2022-06-23 14:02+0200\n"
 "PO-Revision-Date: 2022-06-18 14:19+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: sw\n"
@@ -25,7 +25,7 @@ msgid "title_achievements"
 msgstr "Hedy - My achievements"
 
 #: app.py:639 app.py:743 app.py:1085 website/teacher.py:361
-#: website/teacher.py:370
+#: website/teacher.py:372
 #, fuzzy
 msgid "not_teacher"
 msgstr "Looks like you are not a teacher!"
@@ -69,8 +69,8 @@ msgstr "No such Hedy program!"
 msgid "level_not_class"
 msgstr "You're in a class where this level has not been made available yet"
 
-#: app.py:923 website/teacher.py:419 website/teacher.py:435
-#: website/teacher.py:464 website/teacher.py:490
+#: app.py:923 website/teacher.py:421 website/teacher.py:437
+#: website/teacher.py:466 website/teacher.py:492
 #, fuzzy
 msgid "no_such_adventure"
 msgstr "This adventure doesn't exist!"
@@ -367,8 +367,8 @@ msgstr ""
 #: website/auth.py:671 website/auth.py:718 website/auth.py:745
 #: website/quiz.py:43 website/quiz.py:69 website/teacher.py:88
 #: website/teacher.py:123 website/teacher.py:195 website/teacher.py:251
-#: website/teacher.py:298 website/teacher.py:339 website/teacher.py:375
-#: website/teacher.py:446 website/teacher.py:504
+#: website/teacher.py:298 website/teacher.py:339 website/teacher.py:377
+#: website/teacher.py:448 website/teacher.py:506
 msgid "ajax_error"
 msgstr "Kulikuwa na hitilafu, tafadhali jaribu tena."
 
@@ -710,6 +710,23 @@ msgstr "Hint?"
 msgid "hedy_achievements"
 msgstr "My achievements"
 
+#: templates/achievements.html:36 templates/achievements.html:50
+#: templates/landing-page.html:89 templates/layout.html:92
+#: templates/public-page.html:51
+#, fuzzy
+msgid "achievements_logo_alt"
+msgstr "achievements"
+
+#: templates/achievements.html:37
+#, fuzzy
+msgid "achievements_check_icon_alt"
+msgstr "You've earned an achievement!"
+
+#: templates/base_email.html:3 templates/cheatsheet.html:15
+#: templates/incl-menubar.html:4
+msgid "hedy_logo_alt"
+msgstr ""
+
 #: templates/cheatsheet.html:14
 #, fuzzy
 msgid "cheatsheet_title"
@@ -833,7 +850,7 @@ msgstr "Enter a username"
 msgid "invite_by_username"
 msgstr "All usernames need to be unique."
 
-#: templates/class-overview.html:55 templates/create-accounts.html:49
+#: templates/class-overview.html:55 templates/create-accounts.html:45
 #, fuzzy
 msgid "create_accounts"
 msgstr "Create multiple accounts"
@@ -863,6 +880,10 @@ msgstr "Are you sure you want to remove this class invitation?"
 msgid "class_already_joined"
 msgstr "You are already a student of class"
 
+#: templates/class-prejoin.html:9 templates/error-page.html:6
+msgid "error_logo_alt"
+msgstr ""
+
 #: templates/class-prejoin.html:11
 #, fuzzy
 msgid "goto_profile"
@@ -883,7 +904,8 @@ msgstr "You need to have an account to join a class. Would you like to login now
 msgid "join_class"
 msgstr "Join class"
 
-#: templates/class-stats.html:22 templates/customize-class.html:166
+#: templates/class-stats.html:22 templates/create-accounts.html:41
+#: templates/customize-class.html:166
 #, fuzzy
 msgid "back_to_class"
 msgstr "Go back to class"
@@ -924,29 +946,24 @@ msgstr ""
 msgid "create_accounts_prompt"
 msgstr "Are you sure you want to create these accounts?"
 
-#: templates/create-accounts.html:19
-#, fuzzy
-msgid "select_class"
-msgstr "Select class"
-
-#: templates/create-accounts.html:30
+#: templates/create-accounts.html:25
 #, fuzzy
 msgid "download_login_credentials"
 msgstr ""
 
-#: templates/create-accounts.html:34 templates/layout.html:22
+#: templates/create-accounts.html:29 templates/layout.html:22
 #: templates/signup.html:64
 #, fuzzy
 msgid "yes"
 msgstr "Yes"
 
-#: templates/create-accounts.html:38 templates/layout.html:23
+#: templates/create-accounts.html:33 templates/layout.html:23
 #: templates/signup.html:68
 #, fuzzy
 msgid "no"
 msgstr "No"
 
-#: templates/create-accounts.html:48 templates/programs.html:24
+#: templates/create-accounts.html:44 templates/programs.html:24
 #, fuzzy
 msgid "reset_view"
 msgstr "Reset"
@@ -1276,7 +1293,7 @@ msgstr "View"
 msgid "adventure_prompt"
 msgstr "Please enter the name of the adventure"
 
-#: templates/for-teachers.html:59 website/teacher.py:499
+#: templates/for-teachers.html:59 website/teacher.py:501
 #, fuzzy
 msgid "create_adventure"
 msgstr "Create adventure"
@@ -1346,6 +1363,10 @@ msgstr "Next exercise"
 #, fuzzy
 msgid "edit_code_button"
 msgstr "Edit code"
+
+#: templates/incl-editor-and-output.html:146
+msgid "repair_program_logo_alt"
+msgstr ""
 
 #: templates/incl-editor-and-output.html:150
 msgid "read_code_label"
@@ -1439,25 +1460,52 @@ msgstr ""
 "Welcome to Hedy! Your are now the proud owner of a teachers account which"
 " allows you to create classes and invite students."
 
+#: templates/landing-page.html:11
+#, fuzzy
+msgid "teacher_tutorial_logo_alt"
+msgstr "You have received an invitation to join class"
+
 #: templates/landing-page.html:13
 #, fuzzy
 msgid "start_teacher_tutorial"
 msgstr "Start teacher tutorial"
+
+#: templates/landing-page.html:18
+#, fuzzy
+msgid "hedy_tutorial_logo_alt"
+msgstr "Start hedy tutorial"
 
 #: templates/landing-page.html:20
 #, fuzzy
 msgid "start_hedy_tutorial"
 msgstr "Start hedy tutorial"
 
+#: templates/landing-page.html:25
+#, fuzzy
+msgid "start_programming_logo_alt"
+msgstr "Directly start programming"
+
 #: templates/landing-page.html:27
 #, fuzzy
 msgid "start_programming"
 msgstr "Directly start programming"
 
+#: templates/landing-page.html:31
+#, fuzzy
+msgid "explore_programs_logo_alt"
+msgstr "Explore programs"
+
 #: templates/landing-page.html:39
 #, fuzzy
 msgid "your_account"
 msgstr "Hakuna akaunti bado?"
+
+#: templates/landing-page.html:43 templates/landing-page.html:45
+#: templates/profile.html:33 templates/public-page.html:7
+#: templates/public-page.html:9
+#, fuzzy
+msgid "profile_logo_alt"
+msgstr "Wasifu umesasishwa."
 
 #: templates/landing-page.html:52 templates/public-page.html:16
 #, fuzzy
@@ -1849,6 +1897,10 @@ msgstr "Andika programu yako ya kwanza."
 #, fuzzy
 msgid "no_shared_programs"
 msgstr "has no shared programs..."
+
+#: templates/quiz.html:4
+msgid "quiz_logo_alt"
+msgstr ""
 
 #: templates/quiz.html:7
 #, fuzzy
@@ -2294,7 +2346,7 @@ msgstr "Program unshared successfully."
 msgid "favourite_success"
 msgstr "Your program is set as favourite."
 
-#: website/quiz.py:45 website/quiz.py:71 website/teacher.py:452
+#: website/quiz.py:45 website/quiz.py:71 website/teacher.py:454
 #, fuzzy
 msgid "level_invalid"
 msgstr "This Hedy level in invalid."
@@ -2327,6 +2379,7 @@ msgstr "Only teachers can retrieve classes"
 #: website/statistics.py:41 website/teacher.py:38 website/teacher.py:131
 #: website/teacher.py:150 website/teacher.py:212 website/teacher.py:234
 #: website/teacher.py:246 website/teacher.py:313 website/teacher.py:352
+#: website/teacher.py:364
 #, fuzzy
 msgid "no_such_class"
 msgstr "No such Hedy class"
@@ -2361,7 +2414,7 @@ msgstr "You didn't enter a class name!"
 msgid "class_name_duplicate"
 msgstr "You already have a class with this name."
 
-#: website/teacher.py:162 website/teacher.py:178 website/teacher.py:531
+#: website/teacher.py:162 website/teacher.py:178 website/teacher.py:533
 #, fuzzy
 msgid "invalid_class_link"
 msgstr "Invalid link for joining the class."
@@ -2406,78 +2459,78 @@ msgstr "This student is already in your class."
 msgid "student_already_invite"
 msgstr "This student already has a pending invitation."
 
-#: website/teacher.py:380
+#: website/teacher.py:382
 #, fuzzy
 msgid "no_accounts"
 msgstr "There are no accounts to create."
 
-#: website/teacher.py:390
+#: website/teacher.py:392
 #, fuzzy
 msgid "unique_usernames"
 msgstr "All usernames need to be unique."
 
-#: website/teacher.py:399
+#: website/teacher.py:401
 #, fuzzy
 msgid "usernames_exist"
 msgstr "One or more usernames is already in use."
 
-#: website/teacher.py:410
+#: website/teacher.py:412
 #, fuzzy
 msgid "accounts_created"
 msgstr "Accounts where successfully created."
 
-#: website/teacher.py:416 website/teacher.py:421 website/teacher.py:432
-#: website/teacher.py:461 website/teacher.py:487
+#: website/teacher.py:418 website/teacher.py:423 website/teacher.py:434
+#: website/teacher.py:463 website/teacher.py:489
 #, fuzzy
 msgid "retrieve_adventure_error"
 msgstr "You're not allowed to view this adventure!"
 
-#: website/teacher.py:426
+#: website/teacher.py:428
 #, fuzzy
 msgid "title_view-adventure"
 msgstr "Hedy - View adventure"
 
-#: website/teacher.py:437
+#: website/teacher.py:439
 #, fuzzy
 msgid "title_customize-adventure"
 msgstr "Hedy - Customize adventure"
 
-#: website/teacher.py:448
+#: website/teacher.py:450
 #, fuzzy
 msgid "adventure_id_invalid"
 msgstr "This adventure id is invalid."
 
-#: website/teacher.py:450 website/teacher.py:506
+#: website/teacher.py:452 website/teacher.py:508
 #, fuzzy
 msgid "adventure_name_invalid"
 msgstr "This adventure name is invalid."
 
-#: website/teacher.py:454
+#: website/teacher.py:456
 #, fuzzy
 msgid "content_invalid"
 msgstr "This adventure is invalid."
 
-#: website/teacher.py:456
+#: website/teacher.py:458
 #, fuzzy
 msgid "adventure_length"
 msgstr "Your adventure has to be at least 20 characters."
 
-#: website/teacher.py:458
+#: website/teacher.py:460
 #, fuzzy
 msgid "public_invalid"
 msgstr "This agreement selection is invalid"
 
-#: website/teacher.py:469 website/teacher.py:513
+#: website/teacher.py:471 website/teacher.py:515
 #, fuzzy
 msgid "adventure_duplicate"
 msgstr "You already have an adventure with this name."
 
-#: website/teacher.py:481
+#: website/teacher.py:483
 #, fuzzy
 msgid "adventure_updated"
 msgstr "The adventure has been updated!"
 
-#: website/teacher.py:508
+#: website/teacher.py:510
 #, fuzzy
 msgid "adventure_empty"
 msgstr "You didn't enter an adventure name!"
@@ -2636,4 +2689,7 @@ msgstr "You didn't enter an adventure name!"
 
 #~ msgid "go_to_first_exercise"
 #~ msgstr "Go to question 1"
+
+#~ msgid "select_class"
+#~ msgstr "Select class"
 

--- a/translations/tr/LC_MESSAGES/messages.po
+++ b/translations/tr/LC_MESSAGES/messages.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-21 10:36+0200\n"
+"POT-Creation-Date: 2022-06-23 14:02+0200\n"
 "PO-Revision-Date: 2022-06-18 14:19+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: tr\n"
@@ -25,7 +25,7 @@ msgid "title_achievements"
 msgstr "Hedy - My achievements"
 
 #: app.py:639 app.py:743 app.py:1085 website/teacher.py:361
-#: website/teacher.py:370
+#: website/teacher.py:372
 #, fuzzy
 msgid "not_teacher"
 msgstr "Looks like you are not a teacher!"
@@ -69,8 +69,8 @@ msgstr "No such Hedy program!"
 msgid "level_not_class"
 msgstr "You're in a class where this level has not been made available yet"
 
-#: app.py:923 website/teacher.py:419 website/teacher.py:435
-#: website/teacher.py:464 website/teacher.py:490
+#: app.py:923 website/teacher.py:421 website/teacher.py:437
+#: website/teacher.py:466 website/teacher.py:492
 #, fuzzy
 msgid "no_such_adventure"
 msgstr "This adventure doesn't exist!"
@@ -367,8 +367,8 @@ msgstr ""
 #: website/auth.py:671 website/auth.py:718 website/auth.py:745
 #: website/quiz.py:43 website/quiz.py:69 website/teacher.py:88
 #: website/teacher.py:123 website/teacher.py:195 website/teacher.py:251
-#: website/teacher.py:298 website/teacher.py:339 website/teacher.py:375
-#: website/teacher.py:446 website/teacher.py:504
+#: website/teacher.py:298 website/teacher.py:339 website/teacher.py:377
+#: website/teacher.py:448 website/teacher.py:506
 #, fuzzy
 msgid "ajax_error"
 msgstr "There was an error, please try again."
@@ -728,6 +728,23 @@ msgstr "Hint?"
 msgid "hedy_achievements"
 msgstr "My achievements"
 
+#: templates/achievements.html:36 templates/achievements.html:50
+#: templates/landing-page.html:89 templates/layout.html:92
+#: templates/public-page.html:51
+#, fuzzy
+msgid "achievements_logo_alt"
+msgstr "achievements"
+
+#: templates/achievements.html:37
+#, fuzzy
+msgid "achievements_check_icon_alt"
+msgstr "You've earned an achievement!"
+
+#: templates/base_email.html:3 templates/cheatsheet.html:15
+#: templates/incl-menubar.html:4
+msgid "hedy_logo_alt"
+msgstr ""
+
 #: templates/cheatsheet.html:14
 #, fuzzy
 msgid "cheatsheet_title"
@@ -851,7 +868,7 @@ msgstr "Enter a username"
 msgid "invite_by_username"
 msgstr "All usernames need to be unique."
 
-#: templates/class-overview.html:55 templates/create-accounts.html:49
+#: templates/class-overview.html:55 templates/create-accounts.html:45
 #, fuzzy
 msgid "create_accounts"
 msgstr "Create multiple accounts"
@@ -881,6 +898,10 @@ msgstr "Are you sure you want to remove this class invitation?"
 msgid "class_already_joined"
 msgstr "You are already a student of class"
 
+#: templates/class-prejoin.html:9 templates/error-page.html:6
+msgid "error_logo_alt"
+msgstr ""
+
 #: templates/class-prejoin.html:11
 #, fuzzy
 msgid "goto_profile"
@@ -901,7 +922,8 @@ msgstr "You need to have an account to join a class. Would you like to login now
 msgid "join_class"
 msgstr "Join class"
 
-#: templates/class-stats.html:22 templates/customize-class.html:166
+#: templates/class-stats.html:22 templates/create-accounts.html:41
+#: templates/customize-class.html:166
 #, fuzzy
 msgid "back_to_class"
 msgstr "Go back to class"
@@ -943,29 +965,24 @@ msgstr ""
 msgid "create_accounts_prompt"
 msgstr "Are you sure you want to create these accounts?"
 
-#: templates/create-accounts.html:19
-#, fuzzy
-msgid "select_class"
-msgstr "Select class"
-
-#: templates/create-accounts.html:30
+#: templates/create-accounts.html:25
 #, fuzzy
 msgid "download_login_credentials"
 msgstr ""
 
-#: templates/create-accounts.html:34 templates/layout.html:22
+#: templates/create-accounts.html:29 templates/layout.html:22
 #: templates/signup.html:64
 #, fuzzy
 msgid "yes"
 msgstr "Yes"
 
-#: templates/create-accounts.html:38 templates/layout.html:23
+#: templates/create-accounts.html:33 templates/layout.html:23
 #: templates/signup.html:68
 #, fuzzy
 msgid "no"
 msgstr "No"
 
-#: templates/create-accounts.html:48 templates/programs.html:24
+#: templates/create-accounts.html:44 templates/programs.html:24
 #, fuzzy
 msgid "reset_view"
 msgstr "Reset"
@@ -1297,7 +1314,7 @@ msgstr "View"
 msgid "adventure_prompt"
 msgstr "Please enter the name of the adventure"
 
-#: templates/for-teachers.html:59 website/teacher.py:499
+#: templates/for-teachers.html:59 website/teacher.py:501
 #, fuzzy
 msgid "create_adventure"
 msgstr "Create adventure"
@@ -1369,6 +1386,10 @@ msgstr "Next exercise"
 #, fuzzy
 msgid "edit_code_button"
 msgstr "Edit code"
+
+#: templates/incl-editor-and-output.html:146
+msgid "repair_program_logo_alt"
+msgstr ""
 
 #: templates/incl-editor-and-output.html:150
 #, fuzzy
@@ -1471,25 +1492,52 @@ msgstr ""
 "Welcome to Hedy! Your are now the proud owner of a teachers account which"
 " allows you to create classes and invite students."
 
+#: templates/landing-page.html:11
+#, fuzzy
+msgid "teacher_tutorial_logo_alt"
+msgstr "You have received an invitation to join class"
+
 #: templates/landing-page.html:13
 #, fuzzy
 msgid "start_teacher_tutorial"
 msgstr "Start teacher tutorial"
+
+#: templates/landing-page.html:18
+#, fuzzy
+msgid "hedy_tutorial_logo_alt"
+msgstr "Start hedy tutorial"
 
 #: templates/landing-page.html:20
 #, fuzzy
 msgid "start_hedy_tutorial"
 msgstr "Start hedy tutorial"
 
+#: templates/landing-page.html:25
+#, fuzzy
+msgid "start_programming_logo_alt"
+msgstr "Directly start programming"
+
 #: templates/landing-page.html:27
 #, fuzzy
 msgid "start_programming"
 msgstr "Directly start programming"
 
+#: templates/landing-page.html:31
+#, fuzzy
+msgid "explore_programs_logo_alt"
+msgstr "Explore programs"
+
 #: templates/landing-page.html:39
 #, fuzzy
 msgid "your_account"
 msgstr "Henüz hesabınız yok mu?"
+
+#: templates/landing-page.html:43 templates/landing-page.html:45
+#: templates/profile.html:33 templates/public-page.html:7
+#: templates/public-page.html:9
+#, fuzzy
+msgid "profile_logo_alt"
+msgstr "Profile updated."
 
 #: templates/landing-page.html:52 templates/public-page.html:16
 #, fuzzy
@@ -1906,6 +1954,10 @@ msgstr "Write your first program!"
 #, fuzzy
 msgid "no_shared_programs"
 msgstr "has no shared programs..."
+
+#: templates/quiz.html:4
+msgid "quiz_logo_alt"
+msgstr ""
 
 #: templates/quiz.html:7
 #, fuzzy
@@ -2381,7 +2433,7 @@ msgstr "Program unshared successfully."
 msgid "favourite_success"
 msgstr "Your program is set as favourite."
 
-#: website/quiz.py:45 website/quiz.py:71 website/teacher.py:452
+#: website/quiz.py:45 website/quiz.py:71 website/teacher.py:454
 #, fuzzy
 msgid "level_invalid"
 msgstr "This Hedy level in invalid."
@@ -2414,6 +2466,7 @@ msgstr "Only teachers can retrieve classes"
 #: website/statistics.py:41 website/teacher.py:38 website/teacher.py:131
 #: website/teacher.py:150 website/teacher.py:212 website/teacher.py:234
 #: website/teacher.py:246 website/teacher.py:313 website/teacher.py:352
+#: website/teacher.py:364
 #, fuzzy
 msgid "no_such_class"
 msgstr "No such Hedy class"
@@ -2448,7 +2501,7 @@ msgstr "You didn't enter a class name!"
 msgid "class_name_duplicate"
 msgstr "You already have a class with this name."
 
-#: website/teacher.py:162 website/teacher.py:178 website/teacher.py:531
+#: website/teacher.py:162 website/teacher.py:178 website/teacher.py:533
 #, fuzzy
 msgid "invalid_class_link"
 msgstr "Invalid link for joining the class."
@@ -2493,78 +2546,78 @@ msgstr "This student is already in your class."
 msgid "student_already_invite"
 msgstr "This student already has a pending invitation."
 
-#: website/teacher.py:380
+#: website/teacher.py:382
 #, fuzzy
 msgid "no_accounts"
 msgstr "There are no accounts to create."
 
-#: website/teacher.py:390
+#: website/teacher.py:392
 #, fuzzy
 msgid "unique_usernames"
 msgstr "All usernames need to be unique."
 
-#: website/teacher.py:399
+#: website/teacher.py:401
 #, fuzzy
 msgid "usernames_exist"
 msgstr "One or more usernames is already in use."
 
-#: website/teacher.py:410
+#: website/teacher.py:412
 #, fuzzy
 msgid "accounts_created"
 msgstr "Accounts where successfully created."
 
-#: website/teacher.py:416 website/teacher.py:421 website/teacher.py:432
-#: website/teacher.py:461 website/teacher.py:487
+#: website/teacher.py:418 website/teacher.py:423 website/teacher.py:434
+#: website/teacher.py:463 website/teacher.py:489
 #, fuzzy
 msgid "retrieve_adventure_error"
 msgstr "You're not allowed to view this adventure!"
 
-#: website/teacher.py:426
+#: website/teacher.py:428
 #, fuzzy
 msgid "title_view-adventure"
 msgstr "Hedy - View adventure"
 
-#: website/teacher.py:437
+#: website/teacher.py:439
 #, fuzzy
 msgid "title_customize-adventure"
 msgstr "Hedy - Customize adventure"
 
-#: website/teacher.py:448
+#: website/teacher.py:450
 #, fuzzy
 msgid "adventure_id_invalid"
 msgstr "This adventure id is invalid."
 
-#: website/teacher.py:450 website/teacher.py:506
+#: website/teacher.py:452 website/teacher.py:508
 #, fuzzy
 msgid "adventure_name_invalid"
 msgstr "This adventure name is invalid."
 
-#: website/teacher.py:454
+#: website/teacher.py:456
 #, fuzzy
 msgid "content_invalid"
 msgstr "This adventure is invalid."
 
-#: website/teacher.py:456
+#: website/teacher.py:458
 #, fuzzy
 msgid "adventure_length"
 msgstr "Your adventure has to be at least 20 characters."
 
-#: website/teacher.py:458
+#: website/teacher.py:460
 #, fuzzy
 msgid "public_invalid"
 msgstr "This agreement selection is invalid"
 
-#: website/teacher.py:469 website/teacher.py:513
+#: website/teacher.py:471 website/teacher.py:515
 #, fuzzy
 msgid "adventure_duplicate"
 msgstr "You already have an adventure with this name."
 
-#: website/teacher.py:481
+#: website/teacher.py:483
 #, fuzzy
 msgid "adventure_updated"
 msgstr "The adventure has been updated!"
 
-#: website/teacher.py:508
+#: website/teacher.py:510
 #, fuzzy
 msgid "adventure_empty"
 msgstr "You didn't enter an adventure name!"
@@ -2723,4 +2776,7 @@ msgstr "You didn't enter an adventure name!"
 
 #~ msgid "go_to_first_exercise"
 #~ msgstr "Go to question 1"
+
+#~ msgid "select_class"
+#~ msgstr "Select class"
 

--- a/translations/zh_Hans/LC_MESSAGES/messages.po
+++ b/translations/zh_Hans/LC_MESSAGES/messages.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-21 10:36+0200\n"
+"POT-Creation-Date: 2022-06-23 14:02+0200\n"
 "PO-Revision-Date: 2022-06-18 14:19+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: zh_Hans\n"
@@ -23,7 +23,7 @@ msgid "title_achievements"
 msgstr "海迪 - 我的成绩"
 
 #: app.py:639 app.py:743 app.py:1085 website/teacher.py:361
-#: website/teacher.py:370
+#: website/teacher.py:372
 msgid "not_teacher"
 msgstr "看来你不是一个老师!"
 
@@ -63,8 +63,8 @@ msgstr "没有这样的海迪程序！"
 msgid "level_not_class"
 msgstr "此级别还没有提供给你所在的班级"
 
-#: app.py:923 website/teacher.py:419 website/teacher.py:435
-#: website/teacher.py:464 website/teacher.py:490
+#: app.py:923 website/teacher.py:421 website/teacher.py:437
+#: website/teacher.py:466 website/teacher.py:492
 #, fuzzy
 msgid "no_such_adventure"
 msgstr "这个探险活动不存在！"
@@ -348,8 +348,8 @@ msgstr ""
 #: website/auth.py:671 website/auth.py:718 website/auth.py:745
 #: website/quiz.py:43 website/quiz.py:69 website/teacher.py:88
 #: website/teacher.py:123 website/teacher.py:195 website/teacher.py:251
-#: website/teacher.py:298 website/teacher.py:339 website/teacher.py:375
-#: website/teacher.py:446 website/teacher.py:504
+#: website/teacher.py:298 website/teacher.py:339 website/teacher.py:377
+#: website/teacher.py:448 website/teacher.py:506
 #, fuzzy
 msgid "ajax_error"
 msgstr "出现了一个错误，请再试一次。"
@@ -692,6 +692,23 @@ msgstr "隐藏"
 msgid "hedy_achievements"
 msgstr "海迪成绩"
 
+#: templates/achievements.html:36 templates/achievements.html:50
+#: templates/landing-page.html:89 templates/layout.html:92
+#: templates/public-page.html:51
+#, fuzzy
+msgid "achievements_logo_alt"
+msgstr "achievements"
+
+#: templates/achievements.html:37
+#, fuzzy
+msgid "achievements_check_icon_alt"
+msgstr "You've earned an achievement!"
+
+#: templates/base_email.html:3 templates/cheatsheet.html:15
+#: templates/incl-menubar.html:4
+msgid "hedy_logo_alt"
+msgstr ""
+
 #: templates/cheatsheet.html:14
 #, fuzzy
 msgid "cheatsheet_title"
@@ -816,7 +833,7 @@ msgstr "Enter a username"
 msgid "invite_by_username"
 msgstr "所有用户名都必须是唯一的。"
 
-#: templates/class-overview.html:55 templates/create-accounts.html:49
+#: templates/class-overview.html:55 templates/create-accounts.html:45
 msgid "create_accounts"
 msgstr "创建多个账户"
 
@@ -845,6 +862,10 @@ msgstr "Are you sure you want to remove this class invitation?"
 msgid "class_already_joined"
 msgstr "You are already a student of class"
 
+#: templates/class-prejoin.html:9 templates/error-page.html:6
+msgid "error_logo_alt"
+msgstr ""
+
 #: templates/class-prejoin.html:11
 #, fuzzy
 msgid "goto_profile"
@@ -865,7 +886,8 @@ msgstr "You need to have an account to join a class. Would you like to login now
 msgid "join_class"
 msgstr "Join class"
 
-#: templates/class-stats.html:22 templates/customize-class.html:166
+#: templates/class-stats.html:22 templates/create-accounts.html:41
+#: templates/customize-class.html:166
 #, fuzzy
 msgid "back_to_class"
 msgstr "Go back to class"
@@ -907,28 +929,24 @@ msgstr ""
 msgid "create_accounts_prompt"
 msgstr "Are you sure you want to create these accounts?"
 
-#: templates/create-accounts.html:19
-msgid "select_class"
-msgstr "选择班级"
-
-#: templates/create-accounts.html:30
+#: templates/create-accounts.html:25
 #, fuzzy
 msgid "download_login_credentials"
 msgstr ""
 
-#: templates/create-accounts.html:34 templates/layout.html:22
+#: templates/create-accounts.html:29 templates/layout.html:22
 #: templates/signup.html:64
 #, fuzzy
 msgid "yes"
 msgstr "Yes"
 
-#: templates/create-accounts.html:38 templates/layout.html:23
+#: templates/create-accounts.html:33 templates/layout.html:23
 #: templates/signup.html:68
 #, fuzzy
 msgid "no"
 msgstr "No"
 
-#: templates/create-accounts.html:48 templates/programs.html:24
+#: templates/create-accounts.html:44 templates/programs.html:24
 msgid "reset_view"
 msgstr "重置"
 
@@ -1267,7 +1285,7 @@ msgstr "View"
 msgid "adventure_prompt"
 msgstr "Please enter the name of the adventure"
 
-#: templates/for-teachers.html:59 website/teacher.py:499
+#: templates/for-teachers.html:59 website/teacher.py:501
 #, fuzzy
 msgid "create_adventure"
 msgstr "Create adventure"
@@ -1339,6 +1357,10 @@ msgstr "Next exercise"
 #, fuzzy
 msgid "edit_code_button"
 msgstr "Edit code"
+
+#: templates/incl-editor-and-output.html:146
+msgid "repair_program_logo_alt"
+msgstr ""
 
 #: templates/incl-editor-and-output.html:150
 #, fuzzy
@@ -1442,25 +1464,52 @@ msgstr ""
 "Welcome to Hedy! Your are now the proud owner of a teachers account which"
 " allows you to create classes and invite students."
 
+#: templates/landing-page.html:11
+#, fuzzy
+msgid "teacher_tutorial_logo_alt"
+msgstr "You have received an invitation to join class"
+
 #: templates/landing-page.html:13
 #, fuzzy
 msgid "start_teacher_tutorial"
 msgstr "Start teacher tutorial"
+
+#: templates/landing-page.html:18
+#, fuzzy
+msgid "hedy_tutorial_logo_alt"
+msgstr "Start hedy tutorial"
 
 #: templates/landing-page.html:20
 #, fuzzy
 msgid "start_hedy_tutorial"
 msgstr "Start hedy tutorial"
 
+#: templates/landing-page.html:25
+#, fuzzy
+msgid "start_programming_logo_alt"
+msgstr "Directly start programming"
+
 #: templates/landing-page.html:27
 #, fuzzy
 msgid "start_programming"
 msgstr "Directly start programming"
 
+#: templates/landing-page.html:31
+#, fuzzy
+msgid "explore_programs_logo_alt"
+msgstr "Explore programs"
+
 #: templates/landing-page.html:39
 #, fuzzy
 msgid "your_account"
 msgstr "No account?"
+
+#: templates/landing-page.html:43 templates/landing-page.html:45
+#: templates/profile.html:33 templates/public-page.html:7
+#: templates/public-page.html:9
+#, fuzzy
+msgid "profile_logo_alt"
+msgstr "Profile updated."
 
 #: templates/landing-page.html:52 templates/public-page.html:16
 #, fuzzy
@@ -1881,6 +1930,10 @@ msgstr "Write your first program!"
 #, fuzzy
 msgid "no_shared_programs"
 msgstr "has no shared programs..."
+
+#: templates/quiz.html:4
+msgid "quiz_logo_alt"
+msgstr ""
 
 #: templates/quiz.html:7
 #, fuzzy
@@ -2354,7 +2407,7 @@ msgstr "程序已成功取消分享。"
 msgid "favourite_success"
 msgstr "你的程序被设定为最喜欢的程序。"
 
-#: website/quiz.py:45 website/quiz.py:71 website/teacher.py:452
+#: website/quiz.py:45 website/quiz.py:71 website/teacher.py:454
 msgid "level_invalid"
 msgstr "此海迪级别无效。"
 
@@ -2385,6 +2438,7 @@ msgstr "只有教师可以获得有关班级的信息"
 #: website/statistics.py:41 website/teacher.py:38 website/teacher.py:131
 #: website/teacher.py:150 website/teacher.py:212 website/teacher.py:234
 #: website/teacher.py:246 website/teacher.py:313 website/teacher.py:352
+#: website/teacher.py:364
 msgid "no_such_class"
 msgstr "这个班级不存在。"
 
@@ -2412,7 +2466,7 @@ msgstr "你没有输入班级名称!"
 msgid "class_name_duplicate"
 msgstr "您已经有一个同名的班级了。"
 
-#: website/teacher.py:162 website/teacher.py:178 website/teacher.py:531
+#: website/teacher.py:162 website/teacher.py:178 website/teacher.py:533
 msgid "invalid_class_link"
 msgstr "用于加入班级的链接无效。"
 
@@ -2449,70 +2503,70 @@ msgstr "该学生已在你的班级中。"
 msgid "student_already_invite"
 msgstr "该学生已有待处理的邀请。"
 
-#: website/teacher.py:380
+#: website/teacher.py:382
 #, fuzzy
 msgid "no_accounts"
 msgstr "没有账户需要创建。"
 
-#: website/teacher.py:390
+#: website/teacher.py:392
 msgid "unique_usernames"
 msgstr "所有用户名都必须是唯一的。"
 
-#: website/teacher.py:399
+#: website/teacher.py:401
 msgid "usernames_exist"
 msgstr "一个或多个用户名已在使用中。"
 
-#: website/teacher.py:410
+#: website/teacher.py:412
 msgid "accounts_created"
 msgstr "账户已成功创建。"
 
-#: website/teacher.py:416 website/teacher.py:421 website/teacher.py:432
-#: website/teacher.py:461 website/teacher.py:487
+#: website/teacher.py:418 website/teacher.py:423 website/teacher.py:434
+#: website/teacher.py:463 website/teacher.py:489
 msgid "retrieve_adventure_error"
 msgstr "您无权查看这个探险活动！"
 
-#: website/teacher.py:426
+#: website/teacher.py:428
 #, fuzzy
 msgid "title_view-adventure"
 msgstr "海迪-查看探险活动"
 
-#: website/teacher.py:437
+#: website/teacher.py:439
 #, fuzzy
 msgid "title_customize-adventure"
 msgstr "海迪-定制自己的探险活动"
 
-#: website/teacher.py:448
+#: website/teacher.py:450
 #, fuzzy
 msgid "adventure_id_invalid"
 msgstr "这个探险活动的账号是无效的。"
 
-#: website/teacher.py:450 website/teacher.py:506
+#: website/teacher.py:452 website/teacher.py:508
 #, fuzzy
 msgid "adventure_name_invalid"
 msgstr "这个探险活动的用户名是无效的。"
 
-#: website/teacher.py:454
+#: website/teacher.py:456
 msgid "content_invalid"
 msgstr "这个探险活动无效。"
 
-#: website/teacher.py:456
+#: website/teacher.py:458
 msgid "adventure_length"
 msgstr "你的探险活动必须至少有20个字符。"
 
-#: website/teacher.py:458
+#: website/teacher.py:460
 #, fuzzy
 msgid "public_invalid"
 msgstr "此协议选择无效"
 
-#: website/teacher.py:469 website/teacher.py:513
+#: website/teacher.py:471 website/teacher.py:515
 msgid "adventure_duplicate"
 msgstr "您已经使用此名称进行了一次探险活动。"
 
-#: website/teacher.py:481
+#: website/teacher.py:483
 msgid "adventure_updated"
 msgstr "这个探险活动已被更新！"
 
-#: website/teacher.py:508
+#: website/teacher.py:510
 #, fuzzy
 msgid "adventure_empty"
 msgstr "你没有输入一个探险活动的名字！"
@@ -2653,4 +2707,7 @@ msgstr "你没有输入一个探险活动的名字！"
 
 #~ msgid "go_to_first_exercise"
 #~ msgstr "Go to question 1"
+
+#~ msgid "select_class"
+#~ msgstr "选择班级"
 


### PR DESCRIPTION
**Description**
In this PR we change the hard-coded `alt` attributes on the images with Babel placeholders. Enabling contributors to translate them in their language of choice. We also add translations for English and Dutch right away.

**Fixes**
This PR fixes #2945.

**How to test**
Nothing to test as it's a back-end task. However, you could verify that when on either English or Dutch; the alt attributes on images are shown correctly in the browser.
