### PR TITLE
[FEATURE] Always shows user in highscores, also when not ranked

### DIFF
--- a/app.py
+++ b/app.py
@@ -1213,21 +1213,20 @@ def get_highscores_page(user, filter):
     country = user_data.get('country')
 
     if filter == "global":
-        highscores = DATABASE.get_highscores(filter)
+        highscores = DATABASE.get_highscores(user['username'], filter)
     elif filter == "country":
         # Can't get a country highscore if you're not in a country!
         if not country:
             return utils.error_page(error=403, ui_message=gettext('no_such_highscore'))
-        highscores = DATABASE.get_highscores(filter, country)
+        highscores = DATABASE.get_highscores(user['username'], filter, country)
     elif filter == "class":
         # Can't get a class highscore if you're not in a class!
         if not classes:
             return utils.error_page(error=403, ui_message=gettext('no_such_highscore'))
-        highscores = DATABASE.get_highscores(filter, classes[0])
+        highscores = DATABASE.get_highscores(user['username'], filter, classes[0])
 
-    # We have to make the data a bit nicer if possible
-    highscores = copy.deepcopy(highscores)
     for highscore in highscores:
+        print(highscore)
         highscore['country'] = "-" if not highscore.get('country') else highscore.get('country')
         highscore['last_achievement'] = utils.delta_timestamp(highscore.get('last_achievement'))
     return render_template('highscores.html', highscores=highscores, has_country=True if country else False,

--- a/templates/highscores.html
+++ b/templates/highscores.html
@@ -27,7 +27,7 @@
             </thead>
             {% for highscore in highscores %}
                 <tr>
-                    <td class="font-bold border-r border-gray-500 text-center">{{ loop.index }}.</td>
+                    <td class="font-bold border-r border-gray-500 text-center">{{ highscore.ranking }}.</td>
                     <td class="px-2"><a href="/user/{{highscore.username}}">{{highscore.username}}</a></td>
                     <td class="px-2">{{highscore.achievements}}</td>
                     <td class="px-2">{{highscore.country}}</td>

--- a/website/database.py
+++ b/website/database.py
@@ -222,7 +222,7 @@ class Database:
     def get_all_public_programs(self):
         return PROGRAMS.get_many({'public': 1}, sort_key='date', reverse=True)
 
-    def get_highscores(self, filter, filter_value=None):
+    def get_highscores(self, username, filter, filter_value=None):
         profiles = []
 
         if filter == "global" or filter == "country":
@@ -250,6 +250,16 @@ class Database:
         # First sort by amount of achievements, then by time of getting them -> high/low then low/high
         profiles = sorted(profiles, key=lambda d: d.get('achievements'), reverse=True)
         profiles = sorted(profiles, key=lambda d: d.get('last_achievement'))
+
+        # Add ranking for each profile
+        ranking = 1
+        for profile in profiles:
+            profile['ranking'] = ranking
+            ranking += 1
+
+        # If the user is not in the current top 50: still append to the results
+        if not any(d['username'] == username for d in profiles[:50]):
+            return profiles[:50] + [i for i in profiles if i['username'] == username]
         return profiles[:50]
 
 


### PR DESCRIPTION
**Description**
In this PR we make a nice QoL fix where we always show the current user in the highscore, even if not ranked top 50. This is nice when deploying to production as we have 50+ users with a public profile. When not in the top 50 the user is still shown in the list with their own ranking. So for example:
```
1. user1 
2. user2
...
49. user49
50. user50
124. <current_user>
```

**Fixes**
This PR fixes #2969.

**How to test**
Can't be tested. Validate that the code seems logical and deploy to production, there we can validate that it works.
