### PR TITLE
[BUG FIX] Highscores country filtering no longer crashes

### DIFF
--- a/messages.pot
+++ b/messages.pot
@@ -8,14 +8,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-06-28 18:38+0300\n"
+"POT-Creation-Date: 2022-06-29 14:20+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.9.1\n"
+"Generated-By: Babel 2.10.1\n"
 
 #: app.py:417
 msgid "program_contains_error"
@@ -25,7 +25,7 @@ msgstr ""
 msgid "title_achievements"
 msgstr ""
 
-#: app.py:644 app.py:748 app.py:1090 website/teacher.py:361
+#: app.py:644 app.py:746 app.py:1088 website/teacher.py:361
 #: website/teacher.py:372
 msgid "not_teacher"
 msgstr ""
@@ -34,11 +34,11 @@ msgstr ""
 msgid "not_enrolled"
 msgstr ""
 
-#: app.py:686
+#: app.py:684
 msgid "title_programs"
 msgstr ""
 
-#: app.py:696 app.py:706 app.py:710 app.py:725 app.py:1005 app.py:1550
+#: app.py:694 app.py:704 app.py:708 app.py:723 app.py:1003 app.py:1548
 #: website/admin.py:17 website/admin.py:24 website/admin.py:92
 #: website/admin.py:111 website/admin.py:129 website/admin.py:136
 #: website/admin.py:144 website/auth.py:716 website/auth.py:743
@@ -46,256 +46,256 @@ msgstr ""
 msgid "unauthorized"
 msgstr ""
 
-#: app.py:762 app.py:1107
+#: app.py:760 app.py:1105
 msgid "title_for-teacher"
 msgstr ""
 
-#: app.py:779 app.py:781 app.py:923 app.py:945 app.py:947
+#: app.py:777 app.py:779 app.py:921 app.py:943 app.py:945
 msgid "no_such_level"
 msgstr ""
 
-#: app.py:789 app.py:796 app.py:877 app.py:883
+#: app.py:787 app.py:794 app.py:875 app.py:881
 msgid "no_such_program"
 msgstr ""
 
-#: app.py:819
+#: app.py:817
 msgid "level_not_class"
 msgstr ""
 
-#: app.py:928 website/teacher.py:421 website/teacher.py:437
+#: app.py:926 website/teacher.py:421 website/teacher.py:437
 #: website/teacher.py:466 website/teacher.py:492
 msgid "no_such_adventure"
 msgstr ""
 
-#: app.py:956 app.py:1209
+#: app.py:954 app.py:1207
 msgid "page_not_found"
 msgstr ""
 
-#: app.py:976
+#: app.py:974
 msgid "title_signup"
 msgstr ""
 
-#: app.py:983
+#: app.py:981
 msgid "title_login"
 msgstr ""
 
-#: app.py:990
+#: app.py:988
 msgid "title_recover"
 msgstr ""
 
-#: app.py:1006
+#: app.py:1004
 msgid "title_reset"
 msgstr ""
 
-#: app.py:1032
+#: app.py:1030
 msgid "title_my-profile"
 msgstr ""
 
-#: app.py:1048
+#: app.py:1046
 msgid "title_learn-more"
 msgstr ""
 
-#: app.py:1054
+#: app.py:1052
 msgid "title_privacy"
 msgstr ""
 
-#: app.py:1064
+#: app.py:1062
 msgid "title_start"
 msgstr ""
 
-#: app.py:1082
+#: app.py:1080
 msgid "title_landing-page"
 msgstr ""
 
-#: app.py:1200
+#: app.py:1198
 msgid "title_explore"
 msgstr ""
 
-#: app.py:1221 app.py:1226
+#: app.py:1219 app.py:1224
 msgid "no_such_highscore"
 msgstr ""
 
-#: app.py:1255 app.py:1257
+#: app.py:1253 app.py:1255
 msgid "translate_error"
 msgstr ""
 
-#: app.py:1262 app.py:1296
+#: app.py:1260 app.py:1294
 msgid "tutorial_start_title"
 msgstr ""
 
-#: app.py:1262
+#: app.py:1260
 msgid "tutorial_start_message"
 msgstr ""
 
-#: app.py:1264
+#: app.py:1262
 msgid "tutorial_editor_title"
 msgstr ""
 
-#: app.py:1264
+#: app.py:1262
 msgid "tutorial_editor_message"
 msgstr ""
 
-#: app.py:1266
+#: app.py:1264
 msgid "tutorial_output_title"
 msgstr ""
 
-#: app.py:1266
+#: app.py:1264
 msgid "tutorial_output_message"
 msgstr ""
 
-#: app.py:1268
+#: app.py:1266
 msgid "tutorial_run_title"
 msgstr ""
 
-#: app.py:1268
+#: app.py:1266
 msgid "tutorial_run_message"
 msgstr ""
 
-#: app.py:1270
+#: app.py:1268
 msgid "tutorial_tryit_title"
 msgstr ""
 
-#: app.py:1270
+#: app.py:1268
 msgid "tutorial_tryit_message"
 msgstr ""
 
-#: app.py:1272
+#: app.py:1270
 msgid "tutorial_speakaloud_title"
 msgstr ""
 
-#: app.py:1272
+#: app.py:1270
 msgid "tutorial_speakaloud_message"
 msgstr ""
 
-#: app.py:1274
+#: app.py:1272
 msgid "tutorial_speakaloud_run_title"
 msgstr ""
 
-#: app.py:1274
+#: app.py:1272
 msgid "tutorial_speakaloud_run_message"
 msgstr ""
 
-#: app.py:1276
+#: app.py:1274
 msgid "tutorial_nextlevel_title"
 msgstr ""
 
-#: app.py:1276
+#: app.py:1274
 msgid "tutorial_nextlevel_message"
 msgstr ""
 
-#: app.py:1278
+#: app.py:1276
 msgid "tutorial_leveldefault_title"
 msgstr ""
 
-#: app.py:1278
+#: app.py:1276
 msgid "tutorial_leveldefault_message"
 msgstr ""
 
-#: app.py:1280
+#: app.py:1278
 msgid "tutorial_adventures_title"
 msgstr ""
 
-#: app.py:1280
+#: app.py:1278
 msgid "tutorial_adventures_message"
 msgstr ""
 
-#: app.py:1282
+#: app.py:1280
 msgid "tutorial_quiz_title"
 msgstr ""
 
-#: app.py:1282
+#: app.py:1280
 msgid "tutorial_quiz_message"
 msgstr ""
 
-#: app.py:1284
+#: app.py:1282
 msgid "tutorial_saveshare_title"
 msgstr ""
 
-#: app.py:1284
+#: app.py:1282
 msgid "tutorial_saveshare_message"
 msgstr ""
 
-#: app.py:1286
+#: app.py:1284
 msgid "tutorial_cheatsheet_title"
 msgstr ""
 
-#: app.py:1286
+#: app.py:1284
 msgid "tutorial_cheatsheet_message"
 msgstr ""
 
-#: app.py:1288 app.py:1308
+#: app.py:1286 app.py:1306
 msgid "tutorial_end_title"
 msgstr ""
 
-#: app.py:1288
+#: app.py:1286
 msgid "tutorial_end_message"
 msgstr ""
 
-#: app.py:1290 app.py:1310
+#: app.py:1288 app.py:1308
 msgid "tutorial_title_not_found"
 msgstr ""
 
-#: app.py:1290 app.py:1310
+#: app.py:1288 app.py:1308
 msgid "tutorial_message_not_found"
 msgstr ""
 
-#: app.py:1296
+#: app.py:1294
 msgid "teacher_tutorial_start_message"
 msgstr ""
 
-#: app.py:1298
+#: app.py:1296
 msgid "tutorial_class_title"
 msgstr ""
 
-#: app.py:1298
+#: app.py:1296
 msgid "tutorial_class_message"
 msgstr ""
 
-#: app.py:1300
+#: app.py:1298
 msgid "tutorial_customize_class_title"
 msgstr ""
 
-#: app.py:1300
+#: app.py:1298
 msgid "tutorial_customize_class_message"
 msgstr ""
 
-#: app.py:1302
+#: app.py:1300
 msgid "tutorial_own_adventures_title"
 msgstr ""
 
-#: app.py:1302
+#: app.py:1300
 msgid "tutorial_own_adventures_message"
 msgstr ""
 
-#: app.py:1304
+#: app.py:1302
 msgid "tutorial_accounts_title"
 msgstr ""
 
-#: app.py:1304
+#: app.py:1302
 msgid "tutorial_accounts_message"
 msgstr ""
 
-#: app.py:1306
+#: app.py:1304
 msgid "tutorial_documentation_title"
 msgstr ""
 
-#: app.py:1306
+#: app.py:1304
 msgid "tutorial_documentation_message"
 msgstr ""
 
-#: app.py:1308
+#: app.py:1306
 msgid "teacher_tutorial_end_message"
 msgstr ""
 
-#: app.py:1318
+#: app.py:1316
 msgid "tutorial_code_snippet"
 msgstr ""
 
-#: app.py:1322 app.py:1332
+#: app.py:1320 app.py:1330
 msgid "invalid_tutorial_step"
 msgstr ""
 
-#: app.py:1489 website/auth.py:278 website/auth.py:333 website/auth.py:469
+#: app.py:1487 website/auth.py:278 website/auth.py:333 website/auth.py:469
 #: website/auth.py:494 website/auth.py:524 website/auth.py:637
 #: website/auth.py:675 website/auth.py:722 website/auth.py:749
 #: website/quiz.py:43 website/quiz.py:69 website/teacher.py:88
@@ -305,27 +305,27 @@ msgstr ""
 msgid "ajax_error"
 msgstr ""
 
-#: app.py:1492
+#: app.py:1490
 msgid "image_invalid"
 msgstr ""
 
-#: app.py:1494
+#: app.py:1492
 msgid "personal_text_invalid"
 msgstr ""
 
-#: app.py:1496 app.py:1502
+#: app.py:1494 app.py:1500
 msgid "favourite_program_invalid"
 msgstr ""
 
-#: app.py:1516 app.py:1517
+#: app.py:1514 app.py:1515
 msgid "public_profile_updated"
 msgstr ""
 
-#: app.py:1554 app.py:1579
+#: app.py:1552 app.py:1577
 msgid "user_not_private"
 msgstr ""
 
-#: app.py:1587
+#: app.py:1585
 msgid "invalid_teacher_invitation_code"
 msgstr ""
 
@@ -569,125 +569,125 @@ msgstr ""
 msgid "back_to_class"
 msgstr ""
 
-#: templates/class-overview.html:13 templates/for-teachers.html:35
+#: templates/class-overview.html:14 templates/for-teachers.html:35
 msgid "class_name_prompt"
 msgstr ""
 
-#: templates/class-overview.html:19 templates/class-overview.html:66
+#: templates/class-overview.html:20 templates/class-overview.html:71
 #: templates/create-accounts.html:16 templates/highscores.html:25
 #: templates/login.html:12 templates/profile.html:89 templates/recover.html:8
 #: templates/signup.html:10
 msgid "username"
 msgstr ""
 
-#: templates/class-overview.html:20
+#: templates/class-overview.html:21
 msgid "last_login"
 msgstr ""
 
-#: templates/class-overview.html:21
+#: templates/class-overview.html:22
 msgid "highest_level_reached"
 msgstr ""
 
-#: templates/class-overview.html:22
+#: templates/class-overview.html:23
 msgid "number_programs"
 msgstr ""
 
-#: templates/class-overview.html:23
+#: templates/class-overview.html:24
 msgid "programs"
 msgstr ""
 
-#: templates/class-overview.html:24 templates/create-accounts.html:17
+#: templates/class-overview.html:25 templates/create-accounts.html:17
 #: templates/login.html:15 templates/reset.html:8 templates/signup.html:19
 msgid "password"
 msgstr ""
 
-#: templates/class-overview.html:25 templates/class-overview.html:69
+#: templates/class-overview.html:26 templates/class-overview.html:74
 #: templates/customize-adventure.html:52 templates/for-teachers.html:46
 #: templates/for-teachers.html:56
 msgid "remove"
 msgstr ""
 
-#: templates/class-overview.html:35
+#: templates/class-overview.html:36
 msgid "page"
 msgstr ""
 
-#: templates/class-overview.html:36
+#: templates/class-overview.html:37
 msgid "enter_password"
 msgstr ""
 
-#: templates/class-overview.html:36
+#: templates/class-overview.html:37
 msgid "password_change_prompt"
 msgstr ""
 
-#: templates/class-overview.html:37
+#: templates/class-overview.html:38
 msgid "remove_student_prompt"
 msgstr ""
 
-#: templates/class-overview.html:44
+#: templates/class-overview.html:46
 msgid "add_students"
 msgstr ""
 
-#: templates/class-overview.html:45 templates/customize-class.html:5
+#: templates/class-overview.html:47 templates/customize-class.html:5
 msgid "customize_class"
 msgstr ""
 
-#: templates/class-overview.html:46
+#: templates/class-overview.html:48
 msgid "class_stats"
 msgstr ""
 
-#: templates/class-overview.html:47
+#: templates/class-overview.html:49
 msgid "class_logs"
 msgstr ""
 
-#: templates/class-overview.html:48 templates/customize-adventure.html:59
+#: templates/class-overview.html:52 templates/customize-adventure.html:59
 msgid "back_to_teachers_page"
 msgstr ""
 
-#: templates/class-overview.html:49
+#: templates/class-overview.html:53
 msgid "delete_class_prompt"
 msgstr ""
 
-#: templates/class-overview.html:49
+#: templates/class-overview.html:53
 msgid "delete_class"
 msgstr ""
 
-#: templates/class-overview.html:52
+#: templates/class-overview.html:57
 msgid "add_students_options"
 msgstr ""
 
-#: templates/class-overview.html:54
+#: templates/class-overview.html:59
 msgid "copy_link_success"
 msgstr ""
 
-#: templates/class-overview.html:54
+#: templates/class-overview.html:59
 msgid "copy_join_link"
 msgstr ""
 
-#: templates/class-overview.html:55
+#: templates/class-overview.html:60
 msgid "invite_prompt"
 msgstr ""
 
-#: templates/class-overview.html:55
+#: templates/class-overview.html:60
 msgid "invite_by_username"
 msgstr ""
 
-#: templates/class-overview.html:56 templates/create-accounts.html:45
+#: templates/class-overview.html:61 templates/create-accounts.html:45
 msgid "create_accounts"
 msgstr ""
 
-#: templates/class-overview.html:61
+#: templates/class-overview.html:66
 msgid "pending_invites"
 msgstr ""
 
-#: templates/class-overview.html:67
+#: templates/class-overview.html:72
 msgid "invite_date"
 msgstr ""
 
-#: templates/class-overview.html:68
+#: templates/class-overview.html:73
 msgid "expiration_date"
 msgstr ""
 
-#: templates/class-overview.html:78 templates/profile.html:16
+#: templates/class-overview.html:83 templates/profile.html:16
 msgid "delete_invite_prompt"
 msgstr ""
 
@@ -1027,9 +1027,8 @@ msgstr ""
 msgid "achievements"
 msgstr ""
 
-#: templates/highscores.html:27 templates/learn-more.html:22
-#: templates/profile.html:131 templates/signup.html:52
-msgid "country"
+#: templates/highscores.html:27
+msgid "country_title"
 msgstr ""
 
 #: templates/highscores.html:28 templates/landing-page.html:88
@@ -1269,6 +1268,11 @@ msgstr ""
 
 #: templates/learn-more.html:18
 msgid "lastname"
+msgstr ""
+
+#: templates/learn-more.html:22 templates/profile.html:131
+#: templates/signup.html:52
+msgid "country"
 msgstr ""
 
 #: templates/learn-more.html:31

--- a/templates/highscores.html
+++ b/templates/highscores.html
@@ -24,7 +24,7 @@
                   <td class="w-10 text-center"></td>
                   <td class="w-64 px-2">{{_('username')}}</td>
                   <td class="w-40 px-2">{{_('achievements')[0]|upper}}{{_('achievements')[1:]}}</td>
-                  <td class="w-64 px-2">{{_('country')}}</td>
+                  <td class="w-64 px-2">{{_('country_title')}}</td>
                   <td class="w-64 px-2">{{_('last_achievement')}}</td>
               </tr>
             </thead>

--- a/translations/ar/LC_MESSAGES/messages.po
+++ b/translations/ar/LC_MESSAGES/messages.po
@@ -3,17 +3,17 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-28 18:38+0300\n"
+"POT-Creation-Date: 2022-06-29 14:20+0200\n"
 "PO-Revision-Date: 2022-06-28 13:25+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: ar\n"
 "Language-Team: ar <LL@li.org>\n"
 "Plural-Forms: nplurals=6; plural=n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : "
-"n%100>=3 && n%100<=10 ? 3 : n%100>=11 ? 4 : 5\n"
+"n%100>=3 && n%100<=10 ? 3 : n%100>=11 ? 4 : 5;\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.9.1\n"
+"Generated-By: Babel 2.10.1\n"
 
 #: app.py:417
 msgid "program_contains_error"
@@ -23,7 +23,7 @@ msgstr "هذا البرنامج يحتوي على خطأ، هل أنت متأك�
 msgid "title_achievements"
 msgstr "هيدي - انجازاتي"
 
-#: app.py:644 app.py:748 app.py:1090 website/teacher.py:361
+#: app.py:644 app.py:746 app.py:1088 website/teacher.py:361
 #: website/teacher.py:372
 msgid "not_teacher"
 msgstr "يبدو أنك لست معلم أو معلمة!"
@@ -32,11 +32,11 @@ msgstr "يبدو أنك لست معلم أو معلمة!"
 msgid "not_enrolled"
 msgstr "يبدو أنك لست في هذا الصف!"
 
-#: app.py:686
+#: app.py:684
 msgid "title_programs"
 msgstr "هيدي -برامجي"
 
-#: app.py:696 app.py:706 app.py:710 app.py:725 app.py:1005 app.py:1550
+#: app.py:694 app.py:704 app.py:708 app.py:723 app.py:1003 app.py:1548
 #: website/admin.py:17 website/admin.py:24 website/admin.py:92
 #: website/admin.py:111 website/admin.py:129 website/admin.py:136
 #: website/admin.py:144 website/auth.py:716 website/auth.py:743
@@ -44,295 +44,295 @@ msgstr "هيدي -برامجي"
 msgid "unauthorized"
 msgstr "ليس لديك الصلاحيات اللازمة للوصول إلى هذه الصفحة"
 
-#: app.py:762 app.py:1107
+#: app.py:760 app.py:1105
 msgid "title_for-teacher"
 msgstr "هيدي - للمعلمين"
 
-#: app.py:779 app.py:781 app.py:923 app.py:945 app.py:947
+#: app.py:777 app.py:779 app.py:921 app.py:943 app.py:945
 msgid "no_such_level"
 msgstr "لا يوجد هذا المستوى في هيدي!"
 
-#: app.py:789 app.py:796 app.py:877 app.py:883
+#: app.py:787 app.py:794 app.py:875 app.py:881
 msgid "no_such_program"
 msgstr "لا يوجد هذا البرنامج في هيدي!"
 
-#: app.py:819
+#: app.py:817
 msgid "level_not_class"
 msgstr "هذا المستوى ليس متاحا لصفك الدراسي بعد"
 
-#: app.py:928 website/teacher.py:421 website/teacher.py:437
+#: app.py:926 website/teacher.py:421 website/teacher.py:437
 #: website/teacher.py:466 website/teacher.py:492
 msgid "no_such_adventure"
 msgstr "هذه المغامرة غير موجودة!"
 
-#: app.py:956 app.py:1209
+#: app.py:954 app.py:1207
 msgid "page_not_found"
 msgstr "لم نستطع ايجاد تلك الصفحة!"
 
-#: app.py:976
+#: app.py:974
 msgid "title_signup"
 msgstr "هيدي - انشاء حساب"
 
-#: app.py:983
+#: app.py:981
 msgid "title_login"
 msgstr "هيدي - تسجيل الدخول"
 
-#: app.py:990
+#: app.py:988
 msgid "title_recover"
 msgstr "هيدي - استرجاع الحساب"
 
-#: app.py:1006
+#: app.py:1004
 msgid "title_reset"
 msgstr "هيدي - اعادة ضبط كلمة المرور"
 
-#: app.py:1032
+#: app.py:1030
 msgid "title_my-profile"
 msgstr "هيدي - حسابي"
 
-#: app.py:1048
+#: app.py:1046
 msgid "title_learn-more"
 msgstr "هيدي - اعرف أكثر"
 
-#: app.py:1054
+#: app.py:1052
 msgid "title_privacy"
 msgstr "هيدي - شروط الخصوصية"
 
-#: app.py:1064
+#: app.py:1062
 msgid "title_start"
 msgstr "هيدي - لغة برمجة متدرجة"
 
-#: app.py:1082
+#: app.py:1080
 msgid "title_landing-page"
 msgstr "مرحباً في هيدي!"
 
-#: app.py:1200
+#: app.py:1198
 msgid "title_explore"
 msgstr "هيدي - استكشف"
 
-#: app.py:1221 app.py:1226
+#: app.py:1219 app.py:1224
 #, fuzzy
 msgid "no_such_highscore"
 msgstr "لا يوجد هذا المستوى في هيدي!"
 
-#: app.py:1255 app.py:1257
+#: app.py:1253 app.py:1255
 msgid "translate_error"
 msgstr ""
 "حدث خطأ ما خلال ترجمة البرنامج. حاول تنفيذ البرنامج وافحص وجود خطأ فيه. "
 "البرنامج الذي يحتوي على خطأ لا يمكن أن تتم ترجمته."
 
-#: app.py:1262 app.py:1296
+#: app.py:1260 app.py:1294
 msgid "tutorial_start_title"
 msgstr "مرحباً في هيدي!"
 
-#: app.py:1262
+#: app.py:1260
 msgid "tutorial_start_message"
 msgstr "في هذا الدليل التوجيهي نشرح كل مزايا هيدي خطوة بخطوة."
 
-#: app.py:1264
+#: app.py:1262
 msgid "tutorial_editor_title"
 msgstr "محرر الكود"
 
-#: app.py:1264
+#: app.py:1262
 msgid "tutorial_editor_message"
 msgstr ""
 "في هذه النافذة يتم كتابة البرنامج/الكود. حاول كتابة شيء ما في مكان "
 "الفراغات!"
 
-#: app.py:1266
+#: app.py:1264
 msgid "tutorial_output_title"
 msgstr "نافذة النتائج"
 
-#: app.py:1266
+#: app.py:1264
 msgid "tutorial_output_message"
 msgstr "تظهر هنا نتيجة البرنامج الذي تقوم بتنفيذه، لقد صنعت هذا بنفسك!"
 
-#: app.py:1268
+#: app.py:1266
 msgid "tutorial_run_title"
 msgstr "زر التشغيل"
 
-#: app.py:1268
+#: app.py:1266
 msgid "tutorial_run_message"
 msgstr ""
 "عند الضغط على هذا الزر يتم تشغيل البرنامج! هلّا نجرب القيام بذلك في "
 "الخطوة التالية؟"
 
-#: app.py:1270
+#: app.py:1268
 msgid "tutorial_tryit_title"
 msgstr "فلنجرب ذلك!"
 
-#: app.py:1270
+#: app.py:1268
 msgid "tutorial_tryit_message"
 msgstr "شغل البرنامج، واضغط على \"الخطوة التالية\" بعد الانتهاء."
 
-#: app.py:1272
+#: app.py:1270
 #, fuzzy
 msgid "tutorial_speakaloud_title"
 msgstr "النهاية!"
 
-#: app.py:1272
+#: app.py:1270
 #, fuzzy
 msgid "tutorial_speakaloud_message"
 msgstr "اضغط على \"الخطوة التالية\" لتبدأ فعلياً البرمجة مع هيدي!"
 
-#: app.py:1274
+#: app.py:1272
 #, fuzzy
 msgid "tutorial_speakaloud_run_title"
 msgstr "النهاية!"
 
-#: app.py:1274
+#: app.py:1272
 #, fuzzy
 msgid "tutorial_speakaloud_run_message"
 msgstr "اضغط على \"الخطوة التالية\" لتبدأ فعلياً البرمجة مع هيدي!"
 
-#: app.py:1276
+#: app.py:1274
 msgid "tutorial_nextlevel_title"
 msgstr "إلى المستوى التالي"
 
-#: app.py:1276
+#: app.py:1274
 msgid "tutorial_nextlevel_message"
 msgstr ""
 "عندما تعتقد أنك استوعبت كل شيء وتمرنت بما فيه الكفاية يمكنك الإنتقال إلى "
 "المستوى التالي. اذا وُجدَ مستوى سابق أيضا ستجد أيضاً زراً آخر لترجع إلى "
 "المستوى السابق."
 
-#: app.py:1278
+#: app.py:1276
 msgid "tutorial_leveldefault_title"
 msgstr "شرح المستوى"
 
-#: app.py:1278
+#: app.py:1276
 msgid "tutorial_leveldefault_message"
 msgstr ""
 "علامة التبويب الأولى تحتوي دائماً على شرح المستوى. في كل مستوى سيتم شرح "
 "الأوامر الجديدة هنا."
 
-#: app.py:1280
+#: app.py:1278
 msgid "tutorial_adventures_title"
 msgstr "المغامرات"
 
-#: app.py:1280
+#: app.py:1278
 msgid "tutorial_adventures_message"
 msgstr ""
 "علامات التبويب الأخرى تحتوي على مغامرات تستطيع أن تبرمجها في كل مستوى. "
 "المغامرات تنتقل من السهل الى الصعب."
 
-#: app.py:1282
+#: app.py:1280
 msgid "tutorial_quiz_title"
 msgstr "الفحص السريع"
 
-#: app.py:1282
+#: app.py:1280
 msgid "tutorial_quiz_message"
 msgstr ""
 "في نهاية كل مستوى يمكنك القيام بالفحص السريع. بهذه الطريقة يمكنك أن تتحقق"
 " اذا ما كنت ملمّاً بكل المفاهيم."
 
-#: app.py:1284
+#: app.py:1282
 msgid "tutorial_saveshare_title"
 msgstr "الحفظ والمشاركة"
 
-#: app.py:1284
+#: app.py:1282
 msgid "tutorial_saveshare_message"
 msgstr "يمكنك حفظ كل البرامج التي تنشأها ومشاركتها مع المستخدمين الآخرين ل هيدي."
 
-#: app.py:1286
+#: app.py:1284
 msgid "tutorial_cheatsheet_title"
 msgstr "ورقة الغش"
 
-#: app.py:1286
+#: app.py:1284
 msgid "tutorial_cheatsheet_message"
 msgstr ""
 "اذا نسيت أمراً برمجياً يمكنك دوماً استعمال ورقة الغش. هناك ستجد قائمة بكل"
 " الأوامر البرمجية التي يمكن استعمالها في المستوى الحالي."
 
-#: app.py:1288 app.py:1308
+#: app.py:1286 app.py:1306
 msgid "tutorial_end_title"
 msgstr "النهاية!"
 
-#: app.py:1288
+#: app.py:1286
 msgid "tutorial_end_message"
 msgstr "اضغط على \"الخطوة التالية\" لتبدأ فعلياً البرمجة مع هيدي!"
 
-#: app.py:1290 app.py:1310
+#: app.py:1288 app.py:1308
 #, fuzzy
 msgid "tutorial_title_not_found"
 msgstr "We could not find that page!"
 
-#: app.py:1290 app.py:1310
+#: app.py:1288 app.py:1308
 #, fuzzy
 msgid "tutorial_message_not_found"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1296
+#: app.py:1294
 #, fuzzy
 msgid "teacher_tutorial_start_message"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1298
+#: app.py:1296
 #, fuzzy
 msgid "tutorial_class_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1298
+#: app.py:1296
 msgid "tutorial_class_message"
 msgstr ""
 "كمعلم أو معلمة يمكنك انشاء صفوف ودعوة التلاميذ أو جعلهم ينضمون الى الصف "
 "من خلال رابط. يمكنك معاينة البرامج التي ينشأها التلاميذ بالاضافة الى "
 "احصائيات عن نشاط كل تلاميذك."
 
-#: app.py:1300
+#: app.py:1298
 msgid "tutorial_customize_class_title"
 msgstr "تخصيص الصفوف"
 
-#: app.py:1300
+#: app.py:1298
 msgid "tutorial_customize_class_message"
 msgstr ""
 "يمكنك القيام بتخصيصات معينة للصفوف من خلال اخفاء مستويات و/أو مغامرات "
 "معينة بالاضافة إلى تفعيلهم في تاريخ محدد تلقائياً."
 
-#: app.py:1302
+#: app.py:1300
 msgid "tutorial_own_adventures_title"
 msgstr "انشاء مغامرات"
 
-#: app.py:1302
+#: app.py:1300
 msgid "tutorial_own_adventures_message"
 msgstr ""
 "يمكنك انشاء مغامراتك الخاصة بك واستخدامها كمهمات لتلاميذك. يمكنك انشاؤهم "
 "هنا وتخصيصهم لصفوف معينة من خلال خاصية تخصيص الصفوف."
 
-#: app.py:1304
+#: app.py:1302
 msgid "tutorial_accounts_title"
 msgstr "انشاء حسابات"
 
-#: app.py:1304
+#: app.py:1302
 msgid "tutorial_accounts_message"
 msgstr ""
 "يمكنك انشاء عدة حسابات في المرة الواحدة، عليك فقط تزويد اسم المستخدم "
 "وكلمة المرور. يمكنك أيضاً أن تضيف هذا الحسابات إلى واحد من صفوفك بشكل "
 "مباشر."
 
-#: app.py:1306
+#: app.py:1304
 msgid "tutorial_documentation_title"
 msgstr "توثيق هيدي"
 
-#: app.py:1306
+#: app.py:1304
 #, fuzzy
 msgid "tutorial_documentation_message"
 msgstr "Customize adventure"
 
-#: app.py:1308
+#: app.py:1306
 msgid "teacher_tutorial_end_message"
 msgstr "اضغط على \"الخطوة التالية\" لتبدأ كمعلم أو معلمة في هيدي!"
 
-#: app.py:1318
+#: app.py:1316
 msgid "tutorial_code_snippet"
 msgstr ""
 "{print} مرحباً أيها العالم!\n"
 "{print} أنا أتعلم هيدي من خلال الدليل التوجيهي!"
 
-#: app.py:1322 app.py:1332
+#: app.py:1320 app.py:1330
 msgid "invalid_tutorial_step"
 msgstr ""
 
-#: app.py:1489 website/auth.py:278 website/auth.py:333 website/auth.py:469
+#: app.py:1487 website/auth.py:278 website/auth.py:333 website/auth.py:469
 #: website/auth.py:494 website/auth.py:524 website/auth.py:637
 #: website/auth.py:675 website/auth.py:722 website/auth.py:749
 #: website/quiz.py:43 website/quiz.py:69 website/teacher.py:88
@@ -342,27 +342,27 @@ msgstr ""
 msgid "ajax_error"
 msgstr "لقد حدث خطأ ما، يرجى المحاولة مرة أخرى."
 
-#: app.py:1492
+#: app.py:1490
 msgid "image_invalid"
 msgstr "الصورة التي اخترتها غير صالحة."
 
-#: app.py:1494
+#: app.py:1492
 msgid "personal_text_invalid"
 msgstr "النص الشخصي غير صالح."
 
-#: app.py:1496 app.py:1502
+#: app.py:1494 app.py:1500
 msgid "favourite_program_invalid"
 msgstr "البرنامج المفضل الذي اخترته غير صالح."
 
-#: app.py:1516 app.py:1517
+#: app.py:1514 app.py:1515
 msgid "public_profile_updated"
 msgstr "تم تحديث الملف الشخصي العام."
 
-#: app.py:1554 app.py:1579
+#: app.py:1552 app.py:1577
 msgid "user_not_private"
 msgstr "هذا الحساب إما غير موجود أو لا يوجد لديه ملف شخصي عام"
 
-#: app.py:1587
+#: app.py:1585
 msgid "invalid_teacher_invitation_code"
 msgstr ""
 "رمز الدعوة للمعلم غير صالح. لتصبح معلماً أو معلمةً تواصل معنا على "
@@ -666,131 +666,131 @@ msgstr "ورقة غش"
 msgid "back_to_class"
 msgstr "الرجوع الى صف"
 
-#: templates/class-overview.html:13 templates/for-teachers.html:35
+#: templates/class-overview.html:14 templates/for-teachers.html:35
 msgid "class_name_prompt"
 msgstr "أدخل اسم الصف رجاء"
 
-#: templates/class-overview.html:19 templates/class-overview.html:66
+#: templates/class-overview.html:20 templates/class-overview.html:71
 #: templates/create-accounts.html:16 templates/highscores.html:25
 #: templates/login.html:12 templates/profile.html:89 templates/recover.html:8
 #: templates/signup.html:10
 msgid "username"
 msgstr "اسم المستخدم"
 
-#: templates/class-overview.html:20
+#: templates/class-overview.html:21
 msgid "last_login"
 msgstr "اخر تسجيل دخول"
 
-#: templates/class-overview.html:21
+#: templates/class-overview.html:22
 msgid "highest_level_reached"
 msgstr "أعلى مستوى تم الوصول له"
 
-#: templates/class-overview.html:22
+#: templates/class-overview.html:23
 msgid "number_programs"
 msgstr "عدد البرامج"
 
-#: templates/class-overview.html:23
+#: templates/class-overview.html:24
 msgid "programs"
 msgstr "البرامج"
 
-#: templates/class-overview.html:24 templates/create-accounts.html:17
+#: templates/class-overview.html:25 templates/create-accounts.html:17
 #: templates/login.html:15 templates/reset.html:8 templates/signup.html:19
 msgid "password"
 msgstr "كلمة المرور"
 
-#: templates/class-overview.html:25 templates/class-overview.html:69
+#: templates/class-overview.html:26 templates/class-overview.html:74
 #: templates/customize-adventure.html:52 templates/for-teachers.html:46
 #: templates/for-teachers.html:56
 msgid "remove"
 msgstr "ازالة"
 
-#: templates/class-overview.html:35
+#: templates/class-overview.html:36
 msgid "page"
 msgstr "صفحة"
 
-#: templates/class-overview.html:36
+#: templates/class-overview.html:37
 msgid "enter_password"
 msgstr "أدخل كلمة سر جديدة ل"
 
-#: templates/class-overview.html:36
+#: templates/class-overview.html:37
 msgid "password_change_prompt"
 msgstr "هل أنت متأكد أنك تريد تغيير كلمة المرور هذه؟"
 
-#: templates/class-overview.html:37
+#: templates/class-overview.html:38
 msgid "remove_student_prompt"
 msgstr "هل أنت متأكد أنك تريد ازالة التلميذ من الصف؟"
 
-#: templates/class-overview.html:44
+#: templates/class-overview.html:46
 #, fuzzy
 msgid "add_students"
 msgstr "تلاميذ"
 
-#: templates/class-overview.html:45 templates/customize-class.html:5
+#: templates/class-overview.html:47 templates/customize-class.html:5
 msgid "customize_class"
 msgstr "تخصيص الصف"
 
-#: templates/class-overview.html:46
+#: templates/class-overview.html:48
 msgid "class_stats"
 msgstr "احصائيات الصف"
 
-#: templates/class-overview.html:47
+#: templates/class-overview.html:49
 #, fuzzy
 msgid "class_logs"
 msgstr "اخر تسجيل دخول"
 
-#: templates/class-overview.html:48 templates/customize-adventure.html:59
+#: templates/class-overview.html:52 templates/customize-adventure.html:59
 msgid "back_to_teachers_page"
 msgstr "الرجوع الى صفحة المعلم"
 
-#: templates/class-overview.html:49
+#: templates/class-overview.html:53
 msgid "delete_class_prompt"
 msgstr "هل أنت متأكد أنك تريدحذف الصف؟"
 
-#: templates/class-overview.html:49
+#: templates/class-overview.html:53
 msgid "delete_class"
 msgstr "حذف الصف بشكل نهائي"
 
-#: templates/class-overview.html:52
+#: templates/class-overview.html:57
 #, fuzzy
 msgid "add_students_options"
 msgstr "انشاء حسابات للتلاميذ"
 
-#: templates/class-overview.html:54
+#: templates/class-overview.html:59
 #, fuzzy
 msgid "copy_link_success"
 msgstr "انسخ الرابط لمشاركته"
 
-#: templates/class-overview.html:54
+#: templates/class-overview.html:59
 #, fuzzy
 msgid "copy_join_link"
 msgstr "الرجاء نسخ هذا الرابط ولصقه في تبويبة جديدة:"
 
-#: templates/class-overview.html:55
+#: templates/class-overview.html:60
 msgid "invite_prompt"
 msgstr "أدخل اسم مستخدم"
 
-#: templates/class-overview.html:55
+#: templates/class-overview.html:60
 #, fuzzy
 msgid "invite_by_username"
 msgstr "يجب أن تكون جميع أسماء المستخدمين لا نظير لها."
 
-#: templates/class-overview.html:56 templates/create-accounts.html:45
+#: templates/class-overview.html:61 templates/create-accounts.html:45
 msgid "create_accounts"
 msgstr "انشاء عدة حسابات"
 
-#: templates/class-overview.html:61
+#: templates/class-overview.html:66
 msgid "pending_invites"
 msgstr "الدعوات قيد الإنتظار"
 
-#: templates/class-overview.html:67
+#: templates/class-overview.html:72
 msgid "invite_date"
 msgstr "تاريخ الدعوة"
 
-#: templates/class-overview.html:68
+#: templates/class-overview.html:73
 msgid "expiration_date"
 msgstr "تاريخ انتهاء الصلاحية"
 
-#: templates/class-overview.html:78 templates/profile.html:16
+#: templates/class-overview.html:83 templates/profile.html:16
 msgid "delete_invite_prompt"
 msgstr "هل أنت متأكد أنك تريد حذف الدعوة الى هذا الصف؟"
 
@@ -1186,10 +1186,10 @@ msgstr "صفوفي"
 msgid "achievements"
 msgstr "انجازات"
 
-#: templates/highscores.html:27 templates/learn-more.html:22
-#: templates/profile.html:131 templates/signup.html:52
-msgid "country"
-msgstr "البلد"
+#: templates/highscores.html:27
+#, fuzzy
+msgid "country_title"
+msgstr "الرجاء اختيار بلد صحيح."
 
 #: templates/highscores.html:28 templates/landing-page.html:88
 #: templates/public-page.html:50
@@ -1439,6 +1439,11 @@ msgstr "الاسم الأول"
 #: templates/learn-more.html:18
 msgid "lastname"
 msgstr "اسم العائلة"
+
+#: templates/learn-more.html:22 templates/profile.html:131
+#: templates/signup.html:52
+msgid "country"
+msgstr "البلد"
 
 #: templates/learn-more.html:31
 msgid "subscribe"

--- a/translations/bg/LC_MESSAGES/messages.po
+++ b/translations/bg/LC_MESSAGES/messages.po
@@ -3,16 +3,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-28 18:38+0300\n"
+"POT-Creation-Date: 2022-06-29 14:20+0200\n"
 "PO-Revision-Date: 2022-06-28 13:25+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: bg\n"
 "Language-Team: bg <LL@li.org>\n"
-"Plural-Forms: nplurals=2; plural=n != 1\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.9.1\n"
+"Generated-By: Babel 2.10.1\n"
 
 #: app.py:417
 msgid "program_contains_error"
@@ -22,7 +22,7 @@ msgstr "В тази програма има грешка, сигурни ли с
 msgid "title_achievements"
 msgstr "Хеди - Мойте постижения"
 
-#: app.py:644 app.py:748 app.py:1090 website/teacher.py:361
+#: app.py:644 app.py:746 app.py:1088 website/teacher.py:361
 #: website/teacher.py:372
 msgid "not_teacher"
 msgstr "Изглежда, че ти не си учител!"
@@ -31,11 +31,11 @@ msgstr "Изглежда, че ти не си учител!"
 msgid "not_enrolled"
 msgstr "Изжлежда, че не си в този клас!"
 
-#: app.py:686
+#: app.py:684
 msgid "title_programs"
 msgstr "Хеди - Мойте програми"
 
-#: app.py:696 app.py:706 app.py:710 app.py:725 app.py:1005 app.py:1550
+#: app.py:694 app.py:704 app.py:708 app.py:723 app.py:1003 app.py:1548
 #: website/admin.py:17 website/admin.py:24 website/admin.py:92
 #: website/admin.py:111 website/admin.py:129 website/admin.py:136
 #: website/admin.py:144 website/auth.py:716 website/auth.py:743
@@ -43,306 +43,306 @@ msgstr "Хеди - Мойте програми"
 msgid "unauthorized"
 msgstr "Нямаш достъп до тази страница"
 
-#: app.py:762 app.py:1107
+#: app.py:760 app.py:1105
 msgid "title_for-teacher"
 msgstr "Хеди - За учители"
 
-#: app.py:779 app.py:781 app.py:923 app.py:945 app.py:947
+#: app.py:777 app.py:779 app.py:921 app.py:943 app.py:945
 msgid "no_such_level"
 msgstr "Няма такова ниво в Хеди!"
 
-#: app.py:789 app.py:796 app.py:877 app.py:883
+#: app.py:787 app.py:794 app.py:875 app.py:881
 msgid "no_such_program"
 msgstr "Няма такава Хеди програма!"
 
-#: app.py:819
+#: app.py:817
 msgid "level_not_class"
 msgstr "Това ниво не е налично в твоя клас все още"
 
-#: app.py:928 website/teacher.py:421 website/teacher.py:437
+#: app.py:926 website/teacher.py:421 website/teacher.py:437
 #: website/teacher.py:466 website/teacher.py:492
 msgid "no_such_adventure"
 msgstr "Това приключение не съществува!"
 
-#: app.py:956 app.py:1209
+#: app.py:954 app.py:1207
 msgid "page_not_found"
 msgstr "Не можахме да намерим тази страница!"
 
-#: app.py:976
+#: app.py:974
 msgid "title_signup"
 msgstr "Хеди - Създай акаунт"
 
-#: app.py:983
+#: app.py:981
 msgid "title_login"
 msgstr "Хеди - Влез"
 
-#: app.py:990
+#: app.py:988
 msgid "title_recover"
 msgstr "Хеди - Възстанови акаунт"
 
-#: app.py:1006
+#: app.py:1004
 msgid "title_reset"
 msgstr "Хеди - Възстанови парола"
 
-#: app.py:1032
+#: app.py:1030
 msgid "title_my-profile"
 msgstr "Хеди - Моят акаунт"
 
-#: app.py:1048
+#: app.py:1046
 msgid "title_learn-more"
 msgstr "Хеди - Научи повече"
 
-#: app.py:1054
+#: app.py:1052
 msgid "title_privacy"
 msgstr "Хеди - Условия за поверителност"
 
-#: app.py:1064
+#: app.py:1062
 msgid "title_start"
 msgstr "Хеди - Постепеннен език за програмиране"
 
-#: app.py:1082
+#: app.py:1080
 msgid "title_landing-page"
 msgstr "Добре дошъл в Хеди!"
 
-#: app.py:1200
+#: app.py:1198
 msgid "title_explore"
 msgstr "Хеди - Разучи"
 
-#: app.py:1221 app.py:1226
+#: app.py:1219 app.py:1224
 #, fuzzy
 msgid "no_such_highscore"
 msgstr "Няма такова ниво в Хеди!"
 
-#: app.py:1255 app.py:1257
+#: app.py:1253 app.py:1255
 msgid "translate_error"
 msgstr ""
 "Изникна проблем при превеждането на кода. Опитай се да компилираш кода за"
 " да видиш дали има грешка. Код с грешки не може да се преведе."
 
-#: app.py:1262 app.py:1296
+#: app.py:1260 app.py:1294
 msgid "tutorial_start_title"
 msgstr "Добре дошъл в Хеди!"
 
-#: app.py:1262
+#: app.py:1260
 msgid "tutorial_start_message"
 msgstr "В този урок, ще обясним всички възможности на Хеди стъпка по стъпка."
 
-#: app.py:1264
+#: app.py:1262
 msgid "tutorial_editor_title"
 msgstr "Редакторът на кода"
 
-#: app.py:1264
+#: app.py:1262
 msgid "tutorial_editor_message"
 msgstr ""
 "В този прозорец ще пишеш целия код, пробвай да напишеш нещо на мястото на"
 " подчертата!"
 
-#: app.py:1266
+#: app.py:1264
 #, fuzzy
 msgid "tutorial_output_title"
 msgstr "The output window"
 
-#: app.py:1266
+#: app.py:1264
 #, fuzzy
 msgid "tutorial_output_message"
 msgstr "The result of the code you execute will be shown here"
 
-#: app.py:1268
+#: app.py:1266
 #, fuzzy
 msgid "tutorial_run_title"
 msgstr "The run button"
 
-#: app.py:1268
+#: app.py:1266
 #, fuzzy
 msgid "tutorial_run_message"
 msgstr "With this button you can run your program! Shall we give it a try?"
 
-#: app.py:1270
+#: app.py:1268
 #, fuzzy
 msgid "tutorial_tryit_title"
 msgstr "Try it out!"
 
-#: app.py:1270
+#: app.py:1268
 #, fuzzy
 msgid "tutorial_tryit_message"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1272
+#: app.py:1270
 #, fuzzy
 msgid "tutorial_speakaloud_title"
 msgstr "The end!"
 
-#: app.py:1272
+#: app.py:1270
 #, fuzzy
 msgid "tutorial_speakaloud_message"
 msgstr "Click on 'next step' to really start coding with Hedy!"
 
-#: app.py:1274
+#: app.py:1272
 #, fuzzy
 msgid "tutorial_speakaloud_run_title"
 msgstr "The end!"
 
-#: app.py:1274
+#: app.py:1272
 #, fuzzy
 msgid "tutorial_speakaloud_run_message"
 msgstr "Click on 'next step' to really start coding with Hedy!"
 
-#: app.py:1276
+#: app.py:1274
 #, fuzzy
 msgid "tutorial_nextlevel_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1276
+#: app.py:1274
 #, fuzzy
 msgid "tutorial_nextlevel_message"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1278
+#: app.py:1276
 #, fuzzy
 msgid "tutorial_leveldefault_title"
 msgstr "Level explanation"
 
-#: app.py:1278
+#: app.py:1276
 #, fuzzy
 msgid "tutorial_leveldefault_message"
 msgstr ""
 "The first tab always contains the level explanation. In each level new "
 "commands will be explained here."
 
-#: app.py:1280
+#: app.py:1278
 #, fuzzy
 msgid "tutorial_adventures_title"
 msgstr "Customize adventure"
 
-#: app.py:1280
+#: app.py:1278
 #, fuzzy
 msgid "tutorial_adventures_message"
 msgstr "Customize adventure"
 
-#: app.py:1282
+#: app.py:1280
 #, fuzzy
 msgid "tutorial_quiz_title"
 msgstr "Quiz"
 
-#: app.py:1282
+#: app.py:1280
 #, fuzzy
 msgid "tutorial_quiz_message"
 msgstr ""
 "At the end of each level you can make the quiz. This way you can verify "
 "if you understand everything."
 
-#: app.py:1284
+#: app.py:1282
 #, fuzzy
 msgid "tutorial_saveshare_title"
 msgstr "Saving & sharing"
 
-#: app.py:1284
+#: app.py:1282
 #, fuzzy
 msgid "tutorial_saveshare_message"
 msgstr "You can save and share all your created programs with other Hedy users."
 
-#: app.py:1286
+#: app.py:1284
 #, fuzzy
 msgid "tutorial_cheatsheet_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1286
+#: app.py:1284
 #, fuzzy
 msgid "tutorial_cheatsheet_message"
 msgstr ""
 "If you forgot a command you can always use the cheatsheet. It shows a "
 "list of all commands you can use in the current level."
 
-#: app.py:1288 app.py:1308
+#: app.py:1286 app.py:1306
 #, fuzzy
 msgid "tutorial_end_title"
 msgstr "The end!"
 
-#: app.py:1288
+#: app.py:1286
 #, fuzzy
 msgid "tutorial_end_message"
 msgstr "Click on 'next step' to really start coding with Hedy!"
 
-#: app.py:1290 app.py:1310
+#: app.py:1288 app.py:1308
 #, fuzzy
 msgid "tutorial_title_not_found"
 msgstr "We could not find that page!"
 
-#: app.py:1290 app.py:1310
+#: app.py:1288 app.py:1308
 #, fuzzy
 msgid "tutorial_message_not_found"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1296
+#: app.py:1294
 #, fuzzy
 msgid "teacher_tutorial_start_message"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1298
+#: app.py:1296
 #, fuzzy
 msgid "tutorial_class_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1298
+#: app.py:1296
 #, fuzzy
 msgid "tutorial_class_message"
 msgstr "Customize adventure"
 
-#: app.py:1300
+#: app.py:1298
 #, fuzzy
 msgid "tutorial_customize_class_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1300
+#: app.py:1298
 #, fuzzy
 msgid "tutorial_customize_class_message"
 msgstr "Customize adventure"
 
-#: app.py:1302
+#: app.py:1300
 #, fuzzy
 msgid "tutorial_own_adventures_title"
 msgstr "Customize adventure"
 
-#: app.py:1302
+#: app.py:1300
 #, fuzzy
 msgid "tutorial_own_adventures_message"
 msgstr "Customize adventure"
 
-#: app.py:1304
+#: app.py:1302
 #, fuzzy
 msgid "tutorial_accounts_title"
 msgstr "Customize adventure"
 
-#: app.py:1304
+#: app.py:1302
 #, fuzzy
 msgid "tutorial_accounts_message"
 msgstr "Customize adventure"
 
-#: app.py:1306
+#: app.py:1304
 #, fuzzy
 msgid "tutorial_documentation_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1306
+#: app.py:1304
 #, fuzzy
 msgid "tutorial_documentation_message"
 msgstr "Customize adventure"
 
-#: app.py:1308
+#: app.py:1306
 #, fuzzy
 msgid "teacher_tutorial_end_message"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1318
+#: app.py:1316
 #, fuzzy
 msgid "tutorial_code_snippet"
 msgstr "Hide cheatsheet"
 
-#: app.py:1322 app.py:1332
+#: app.py:1320 app.py:1330
 msgid "invalid_tutorial_step"
 msgstr ""
 
-#: app.py:1489 website/auth.py:278 website/auth.py:333 website/auth.py:469
+#: app.py:1487 website/auth.py:278 website/auth.py:333 website/auth.py:469
 #: website/auth.py:494 website/auth.py:524 website/auth.py:637
 #: website/auth.py:675 website/auth.py:722 website/auth.py:749
 #: website/quiz.py:43 website/quiz.py:69 website/teacher.py:88
@@ -353,32 +353,32 @@ msgstr ""
 msgid "ajax_error"
 msgstr "There was an error, please try again."
 
-#: app.py:1492
+#: app.py:1490
 #, fuzzy
 msgid "image_invalid"
 msgstr "Your chosen image is invalid."
 
-#: app.py:1494
+#: app.py:1492
 #, fuzzy
 msgid "personal_text_invalid"
 msgstr "Your personal text is invalid."
 
-#: app.py:1496 app.py:1502
+#: app.py:1494 app.py:1500
 #, fuzzy
 msgid "favourite_program_invalid"
 msgstr "Your chosen favourite program is invalid."
 
-#: app.py:1516 app.py:1517
+#: app.py:1514 app.py:1515
 #, fuzzy
 msgid "public_profile_updated"
 msgstr "Public profile updated."
 
-#: app.py:1554 app.py:1579
+#: app.py:1552 app.py:1577
 #, fuzzy
 msgid "user_not_private"
 msgstr "This user doesn't exist or doesn't have a public profile"
 
-#: app.py:1587
+#: app.py:1585
 msgid "invalid_teacher_invitation_code"
 msgstr "Този код не е валиден."
 
@@ -712,151 +712,151 @@ msgstr "Hide cheatsheet"
 msgid "back_to_class"
 msgstr "Go back to class"
 
-#: templates/class-overview.html:13 templates/for-teachers.html:35
+#: templates/class-overview.html:14 templates/for-teachers.html:35
 #, fuzzy
 msgid "class_name_prompt"
 msgstr "Please enter the name of the class"
 
-#: templates/class-overview.html:19 templates/class-overview.html:66
+#: templates/class-overview.html:20 templates/class-overview.html:71
 #: templates/create-accounts.html:16 templates/highscores.html:25
 #: templates/login.html:12 templates/profile.html:89 templates/recover.html:8
 #: templates/signup.html:10
 msgid "username"
 msgstr "Потребителско име"
 
-#: templates/class-overview.html:20
+#: templates/class-overview.html:21
 #, fuzzy
 msgid "last_login"
 msgstr "Last login"
 
-#: templates/class-overview.html:21
+#: templates/class-overview.html:22
 #, fuzzy
 msgid "highest_level_reached"
 msgstr "Highest level reached"
 
-#: templates/class-overview.html:22
+#: templates/class-overview.html:23
 #, fuzzy
 msgid "number_programs"
 msgstr "Number of programs"
 
-#: templates/class-overview.html:23
+#: templates/class-overview.html:24
 #, fuzzy
 msgid "programs"
 msgstr "Programs"
 
-#: templates/class-overview.html:24 templates/create-accounts.html:17
+#: templates/class-overview.html:25 templates/create-accounts.html:17
 #: templates/login.html:15 templates/reset.html:8 templates/signup.html:19
 msgid "password"
 msgstr "Парола"
 
-#: templates/class-overview.html:25 templates/class-overview.html:69
+#: templates/class-overview.html:26 templates/class-overview.html:74
 #: templates/customize-adventure.html:52 templates/for-teachers.html:46
 #: templates/for-teachers.html:56
 #, fuzzy
 msgid "remove"
 msgstr "Remove"
 
-#: templates/class-overview.html:35
+#: templates/class-overview.html:36
 #, fuzzy
 msgid "page"
 msgstr "page"
 
-#: templates/class-overview.html:36
+#: templates/class-overview.html:37
 #, fuzzy
 msgid "enter_password"
 msgstr "Enter a new password for"
 
-#: templates/class-overview.html:36
+#: templates/class-overview.html:37
 #, fuzzy
 msgid "password_change_prompt"
 msgstr "Are you sure you want to change this password?"
 
-#: templates/class-overview.html:37
+#: templates/class-overview.html:38
 #, fuzzy
 msgid "remove_student_prompt"
 msgstr "Are you sure you want to remove the student from the class?"
 
-#: templates/class-overview.html:44
+#: templates/class-overview.html:46
 #, fuzzy
 msgid "add_students"
 msgstr "students"
 
-#: templates/class-overview.html:45 templates/customize-class.html:5
+#: templates/class-overview.html:47 templates/customize-class.html:5
 #, fuzzy
 msgid "customize_class"
 msgstr "Customize class"
 
-#: templates/class-overview.html:46
+#: templates/class-overview.html:48
 #, fuzzy
 msgid "class_stats"
 msgstr "Show class statistics"
 
-#: templates/class-overview.html:47
+#: templates/class-overview.html:49
 #, fuzzy
 msgid "class_logs"
 msgstr "Last login"
 
-#: templates/class-overview.html:48 templates/customize-adventure.html:59
+#: templates/class-overview.html:52 templates/customize-adventure.html:59
 #, fuzzy
 msgid "back_to_teachers_page"
 msgstr "Go back to teachers page"
 
-#: templates/class-overview.html:49
+#: templates/class-overview.html:53
 #, fuzzy
 msgid "delete_class_prompt"
 msgstr "Are you sure you want to delete the class?"
 
-#: templates/class-overview.html:49
+#: templates/class-overview.html:53
 #, fuzzy
 msgid "delete_class"
 msgstr "Delete class permanently"
 
-#: templates/class-overview.html:52
+#: templates/class-overview.html:57
 #, fuzzy
 msgid "add_students_options"
 msgstr "Create student accounts"
 
-#: templates/class-overview.html:54
+#: templates/class-overview.html:59
 #, fuzzy
 msgid "copy_link_success"
 msgstr "Copy link to share"
 
-#: templates/class-overview.html:54
+#: templates/class-overview.html:59
 #, fuzzy
 msgid "copy_join_link"
 msgstr "Please copy and paste this link into a new tab:"
 
-#: templates/class-overview.html:55
+#: templates/class-overview.html:60
 #, fuzzy
 msgid "invite_prompt"
 msgstr "Enter a username"
 
-#: templates/class-overview.html:55
+#: templates/class-overview.html:60
 #, fuzzy
 msgid "invite_by_username"
 msgstr "All usernames need to be unique."
 
-#: templates/class-overview.html:56 templates/create-accounts.html:45
+#: templates/class-overview.html:61 templates/create-accounts.html:45
 #, fuzzy
 msgid "create_accounts"
 msgstr "Create multiple accounts"
 
-#: templates/class-overview.html:61
+#: templates/class-overview.html:66
 #, fuzzy
 msgid "pending_invites"
 msgstr "Pending invites"
 
-#: templates/class-overview.html:67
+#: templates/class-overview.html:72
 #, fuzzy
 msgid "invite_date"
 msgstr "Invite date"
 
-#: templates/class-overview.html:68
+#: templates/class-overview.html:73
 #, fuzzy
 msgid "expiration_date"
 msgstr "Expiration date"
 
-#: templates/class-overview.html:78 templates/profile.html:16
+#: templates/class-overview.html:83 templates/profile.html:16
 #, fuzzy
 msgid "delete_invite_prompt"
 msgstr "Are you sure you want to remove this class invitation?"
@@ -1311,10 +1311,10 @@ msgstr "My classes"
 msgid "achievements"
 msgstr "achievements"
 
-#: templates/highscores.html:27 templates/learn-more.html:22
-#: templates/profile.html:131 templates/signup.html:52
-msgid "country"
-msgstr "Държава"
+#: templates/highscores.html:27
+#, fuzzy
+msgid "country_title"
+msgstr "Please select a valid country."
 
 #: templates/highscores.html:28 templates/landing-page.html:88
 #: templates/public-page.html:50
@@ -1603,6 +1603,11 @@ msgstr "Потребителско име"
 #, fuzzy
 msgid "lastname"
 msgstr "Name"
+
+#: templates/learn-more.html:22 templates/profile.html:131
+#: templates/signup.html:52
+msgid "country"
+msgstr "Държава"
 
 #: templates/learn-more.html:31
 #, fuzzy

--- a/translations/bn/LC_MESSAGES/messages.po
+++ b/translations/bn/LC_MESSAGES/messages.po
@@ -3,16 +3,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-28 18:38+0300\n"
+"POT-Creation-Date: 2022-06-29 14:20+0200\n"
 "PO-Revision-Date: 2022-06-28 13:25+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: bn\n"
 "Language-Team: bn <LL@li.org>\n"
-"Plural-Forms: nplurals=2; plural=n > 1\n"
+"Plural-Forms: nplurals=2; plural=n > 1;\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.9.1\n"
+"Generated-By: Babel 2.10.1\n"
 
 #: app.py:417
 #, fuzzy
@@ -24,7 +24,7 @@ msgstr "This program contains an error, are you sure you want to share it?"
 msgid "title_achievements"
 msgstr "Hedy - My achievements"
 
-#: app.py:644 app.py:748 app.py:1090 website/teacher.py:361
+#: app.py:644 app.py:746 app.py:1088 website/teacher.py:361
 #: website/teacher.py:372
 #, fuzzy
 msgid "not_teacher"
@@ -35,12 +35,12 @@ msgstr "Looks like you are not a teacher!"
 msgid "not_enrolled"
 msgstr "Looks like you are not in this class!"
 
-#: app.py:686
+#: app.py:684
 #, fuzzy
 msgid "title_programs"
 msgstr "Hedy - My programs"
 
-#: app.py:696 app.py:706 app.py:710 app.py:725 app.py:1005 app.py:1550
+#: app.py:694 app.py:704 app.py:708 app.py:723 app.py:1003 app.py:1548
 #: website/admin.py:17 website/admin.py:24 website/admin.py:92
 #: website/admin.py:111 website/admin.py:129 website/admin.py:136
 #: website/admin.py:144 website/auth.py:716 website/auth.py:743
@@ -49,325 +49,325 @@ msgstr "Hedy - My programs"
 msgid "unauthorized"
 msgstr "You don't have access rights for this page"
 
-#: app.py:762 app.py:1107
+#: app.py:760 app.py:1105
 #, fuzzy
 msgid "title_for-teacher"
 msgstr "Hedy - For teachers"
 
-#: app.py:779 app.py:781 app.py:923 app.py:945 app.py:947
+#: app.py:777 app.py:779 app.py:921 app.py:943 app.py:945
 #, fuzzy
 msgid "no_such_level"
 msgstr "No such Hedy level!"
 
-#: app.py:789 app.py:796 app.py:877 app.py:883
+#: app.py:787 app.py:794 app.py:875 app.py:881
 #, fuzzy
 msgid "no_such_program"
 msgstr "No such Hedy program!"
 
-#: app.py:819
+#: app.py:817
 #, fuzzy
 msgid "level_not_class"
 msgstr "You're in a class where this level has not been made available yet"
 
-#: app.py:928 website/teacher.py:421 website/teacher.py:437
+#: app.py:926 website/teacher.py:421 website/teacher.py:437
 #: website/teacher.py:466 website/teacher.py:492
 #, fuzzy
 msgid "no_such_adventure"
 msgstr "This adventure doesn't exist!"
 
-#: app.py:956 app.py:1209
+#: app.py:954 app.py:1207
 #, fuzzy
 msgid "page_not_found"
 msgstr "We could not find that page!"
 
-#: app.py:976
+#: app.py:974
 #, fuzzy
 msgid "title_signup"
 msgstr "Hedy - Create an account"
 
-#: app.py:983
+#: app.py:981
 #, fuzzy
 msgid "title_login"
 msgstr "Hedy - Login"
 
-#: app.py:990
+#: app.py:988
 #, fuzzy
 msgid "title_recover"
 msgstr "Hedy - Recover account"
 
-#: app.py:1006
+#: app.py:1004
 #, fuzzy
 msgid "title_reset"
 msgstr "Hedy - Reset password"
 
-#: app.py:1032
+#: app.py:1030
 #, fuzzy
 msgid "title_my-profile"
 msgstr "Hedy - My account"
 
-#: app.py:1048
+#: app.py:1046
 #, fuzzy
 msgid "title_learn-more"
 msgstr "Hedy - Learn more"
 
-#: app.py:1054
+#: app.py:1052
 #, fuzzy
 msgid "title_privacy"
 msgstr "Hedy - Privacy terms"
 
-#: app.py:1064
+#: app.py:1062
 #, fuzzy
 msgid "title_start"
 msgstr "Hedy - A gradual programming language"
 
-#: app.py:1082
+#: app.py:1080
 #, fuzzy
 msgid "title_landing-page"
 msgstr "Welcome to Hedy!"
 
-#: app.py:1200
+#: app.py:1198
 #, fuzzy
 msgid "title_explore"
 msgstr "Hedy - Explore"
 
-#: app.py:1221 app.py:1226
+#: app.py:1219 app.py:1224
 #, fuzzy
 msgid "no_such_highscore"
 msgstr "No such Hedy level!"
 
-#: app.py:1255 app.py:1257
+#: app.py:1253 app.py:1255
 #, fuzzy
 msgid "translate_error"
 msgstr ""
 "Something went wrong while translating the code. Try running the code to "
 "see if it has an error. Code with errors can not be translated."
 
-#: app.py:1262 app.py:1296
+#: app.py:1260 app.py:1294
 #, fuzzy
 msgid "tutorial_start_title"
 msgstr "Welcome to Hedy!"
 
-#: app.py:1262
+#: app.py:1260
 #, fuzzy
 msgid "tutorial_start_message"
 msgstr "In this tutorial we will explain all the Hedy features step-by-step."
 
-#: app.py:1264
+#: app.py:1262
 #, fuzzy
 msgid "tutorial_editor_title"
 msgstr "The code editor"
 
-#: app.py:1264
+#: app.py:1262
 #, fuzzy
 msgid "tutorial_editor_message"
 msgstr "In this window you write all the code, try typing something!"
 
-#: app.py:1266
+#: app.py:1264
 #, fuzzy
 msgid "tutorial_output_title"
 msgstr "The output window"
 
-#: app.py:1266
+#: app.py:1264
 #, fuzzy
 msgid "tutorial_output_message"
 msgstr "The result of the code you execute will be shown here"
 
-#: app.py:1268
+#: app.py:1266
 #, fuzzy
 msgid "tutorial_run_title"
 msgstr "The run button"
 
-#: app.py:1268
+#: app.py:1266
 #, fuzzy
 msgid "tutorial_run_message"
 msgstr "With this button you can run your program! Shall we give it a try?"
 
-#: app.py:1270
+#: app.py:1268
 #, fuzzy
 msgid "tutorial_tryit_title"
 msgstr "Try it out!"
 
-#: app.py:1270
+#: app.py:1268
 #, fuzzy
 msgid "tutorial_tryit_message"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1272
+#: app.py:1270
 #, fuzzy
 msgid "tutorial_speakaloud_title"
 msgstr "The end!"
 
-#: app.py:1272
+#: app.py:1270
 #, fuzzy
 msgid "tutorial_speakaloud_message"
 msgstr "Click on 'next step' to really start coding with Hedy!"
 
-#: app.py:1274
+#: app.py:1272
 #, fuzzy
 msgid "tutorial_speakaloud_run_title"
 msgstr "The end!"
 
-#: app.py:1274
+#: app.py:1272
 #, fuzzy
 msgid "tutorial_speakaloud_run_message"
 msgstr "Click on 'next step' to really start coding with Hedy!"
 
-#: app.py:1276
+#: app.py:1274
 #, fuzzy
 msgid "tutorial_nextlevel_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1276
+#: app.py:1274
 #, fuzzy
 msgid "tutorial_nextlevel_message"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1278
+#: app.py:1276
 #, fuzzy
 msgid "tutorial_leveldefault_title"
 msgstr "Level explanation"
 
-#: app.py:1278
+#: app.py:1276
 #, fuzzy
 msgid "tutorial_leveldefault_message"
 msgstr ""
 "The first tab always contains the level explanation. In each level new "
 "commands will be explained here."
 
-#: app.py:1280
+#: app.py:1278
 #, fuzzy
 msgid "tutorial_adventures_title"
 msgstr "Customize adventure"
 
-#: app.py:1280
+#: app.py:1278
 #, fuzzy
 msgid "tutorial_adventures_message"
 msgstr "Customize adventure"
 
-#: app.py:1282
+#: app.py:1280
 #, fuzzy
 msgid "tutorial_quiz_title"
 msgstr "Quiz"
 
-#: app.py:1282
+#: app.py:1280
 #, fuzzy
 msgid "tutorial_quiz_message"
 msgstr ""
 "At the end of each level you can make the quiz. This way you can verify "
 "if you understand everything."
 
-#: app.py:1284
+#: app.py:1282
 #, fuzzy
 msgid "tutorial_saveshare_title"
 msgstr "Saving & sharing"
 
-#: app.py:1284
+#: app.py:1282
 #, fuzzy
 msgid "tutorial_saveshare_message"
 msgstr "You can save and share all your created programs with other Hedy users."
 
-#: app.py:1286
+#: app.py:1284
 #, fuzzy
 msgid "tutorial_cheatsheet_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1286
+#: app.py:1284
 #, fuzzy
 msgid "tutorial_cheatsheet_message"
 msgstr ""
 "If you forgot a command you can always use the cheatsheet. It shows a "
 "list of all commands you can use in the current level."
 
-#: app.py:1288 app.py:1308
+#: app.py:1286 app.py:1306
 #, fuzzy
 msgid "tutorial_end_title"
 msgstr "The end!"
 
-#: app.py:1288
+#: app.py:1286
 #, fuzzy
 msgid "tutorial_end_message"
 msgstr "Click on 'next step' to really start coding with Hedy!"
 
-#: app.py:1290 app.py:1310
+#: app.py:1288 app.py:1308
 #, fuzzy
 msgid "tutorial_title_not_found"
 msgstr "We could not find that page!"
 
-#: app.py:1290 app.py:1310
+#: app.py:1288 app.py:1308
 #, fuzzy
 msgid "tutorial_message_not_found"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1296
+#: app.py:1294
 #, fuzzy
 msgid "teacher_tutorial_start_message"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1298
+#: app.py:1296
 #, fuzzy
 msgid "tutorial_class_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1298
+#: app.py:1296
 #, fuzzy
 msgid "tutorial_class_message"
 msgstr "Customize adventure"
 
-#: app.py:1300
+#: app.py:1298
 #, fuzzy
 msgid "tutorial_customize_class_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1300
+#: app.py:1298
 #, fuzzy
 msgid "tutorial_customize_class_message"
 msgstr "Customize adventure"
 
-#: app.py:1302
+#: app.py:1300
 #, fuzzy
 msgid "tutorial_own_adventures_title"
 msgstr "Customize adventure"
 
-#: app.py:1302
+#: app.py:1300
 #, fuzzy
 msgid "tutorial_own_adventures_message"
 msgstr "Customize adventure"
 
-#: app.py:1304
+#: app.py:1302
 #, fuzzy
 msgid "tutorial_accounts_title"
 msgstr "Customize adventure"
 
-#: app.py:1304
+#: app.py:1302
 #, fuzzy
 msgid "tutorial_accounts_message"
 msgstr "Customize adventure"
 
-#: app.py:1306
+#: app.py:1304
 #, fuzzy
 msgid "tutorial_documentation_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1306
+#: app.py:1304
 #, fuzzy
 msgid "tutorial_documentation_message"
 msgstr "Customize adventure"
 
-#: app.py:1308
+#: app.py:1306
 #, fuzzy
 msgid "teacher_tutorial_end_message"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1318
+#: app.py:1316
 #, fuzzy
 msgid "tutorial_code_snippet"
 msgstr "Hide cheatsheet"
 
-#: app.py:1322 app.py:1332
+#: app.py:1320 app.py:1330
 msgid "invalid_tutorial_step"
 msgstr ""
 
-#: app.py:1489 website/auth.py:278 website/auth.py:333 website/auth.py:469
+#: app.py:1487 website/auth.py:278 website/auth.py:333 website/auth.py:469
 #: website/auth.py:494 website/auth.py:524 website/auth.py:637
 #: website/auth.py:675 website/auth.py:722 website/auth.py:749
 #: website/quiz.py:43 website/quiz.py:69 website/teacher.py:88
@@ -378,32 +378,32 @@ msgstr ""
 msgid "ajax_error"
 msgstr "There was an error, please try again."
 
-#: app.py:1492
+#: app.py:1490
 #, fuzzy
 msgid "image_invalid"
 msgstr "Your chosen image is invalid."
 
-#: app.py:1494
+#: app.py:1492
 #, fuzzy
 msgid "personal_text_invalid"
 msgstr "Your personal text is invalid."
 
-#: app.py:1496 app.py:1502
+#: app.py:1494 app.py:1500
 #, fuzzy
 msgid "favourite_program_invalid"
 msgstr "Your chosen favourite program is invalid."
 
-#: app.py:1516 app.py:1517
+#: app.py:1514 app.py:1515
 #, fuzzy
 msgid "public_profile_updated"
 msgstr "Public profile updated."
 
-#: app.py:1554 app.py:1579
+#: app.py:1552 app.py:1577
 #, fuzzy
 msgid "user_not_private"
 msgstr "This user doesn't exist or doesn't have a public profile"
 
-#: app.py:1587
+#: app.py:1585
 #, fuzzy
 msgid "invalid_teacher_invitation_code"
 msgstr ""
@@ -765,12 +765,12 @@ msgstr "Hide cheatsheet"
 msgid "back_to_class"
 msgstr "Go back to class"
 
-#: templates/class-overview.html:13 templates/for-teachers.html:35
+#: templates/class-overview.html:14 templates/for-teachers.html:35
 #, fuzzy
 msgid "class_name_prompt"
 msgstr "Please enter the name of the class"
 
-#: templates/class-overview.html:19 templates/class-overview.html:66
+#: templates/class-overview.html:20 templates/class-overview.html:71
 #: templates/create-accounts.html:16 templates/highscores.html:25
 #: templates/login.html:12 templates/profile.html:89 templates/recover.html:8
 #: templates/signup.html:10
@@ -778,140 +778,140 @@ msgstr "Please enter the name of the class"
 msgid "username"
 msgstr "Username"
 
-#: templates/class-overview.html:20
+#: templates/class-overview.html:21
 #, fuzzy
 msgid "last_login"
 msgstr "Last login"
 
-#: templates/class-overview.html:21
+#: templates/class-overview.html:22
 #, fuzzy
 msgid "highest_level_reached"
 msgstr "Highest level reached"
 
-#: templates/class-overview.html:22
+#: templates/class-overview.html:23
 #, fuzzy
 msgid "number_programs"
 msgstr "Number of programs"
 
-#: templates/class-overview.html:23
+#: templates/class-overview.html:24
 #, fuzzy
 msgid "programs"
 msgstr "Programs"
 
-#: templates/class-overview.html:24 templates/create-accounts.html:17
+#: templates/class-overview.html:25 templates/create-accounts.html:17
 #: templates/login.html:15 templates/reset.html:8 templates/signup.html:19
 #, fuzzy
 msgid "password"
 msgstr "Password"
 
-#: templates/class-overview.html:25 templates/class-overview.html:69
+#: templates/class-overview.html:26 templates/class-overview.html:74
 #: templates/customize-adventure.html:52 templates/for-teachers.html:46
 #: templates/for-teachers.html:56
 #, fuzzy
 msgid "remove"
 msgstr "Remove"
 
-#: templates/class-overview.html:35
+#: templates/class-overview.html:36
 #, fuzzy
 msgid "page"
 msgstr "page"
 
-#: templates/class-overview.html:36
+#: templates/class-overview.html:37
 #, fuzzy
 msgid "enter_password"
 msgstr "Enter a new password for"
 
-#: templates/class-overview.html:36
+#: templates/class-overview.html:37
 #, fuzzy
 msgid "password_change_prompt"
 msgstr "Are you sure you want to change this password?"
 
-#: templates/class-overview.html:37
+#: templates/class-overview.html:38
 #, fuzzy
 msgid "remove_student_prompt"
 msgstr "Are you sure you want to remove the student from the class?"
 
-#: templates/class-overview.html:44
+#: templates/class-overview.html:46
 #, fuzzy
 msgid "add_students"
 msgstr "students"
 
-#: templates/class-overview.html:45 templates/customize-class.html:5
+#: templates/class-overview.html:47 templates/customize-class.html:5
 #, fuzzy
 msgid "customize_class"
 msgstr "Customize class"
 
-#: templates/class-overview.html:46
+#: templates/class-overview.html:48
 #, fuzzy
 msgid "class_stats"
 msgstr "Show class statistics"
 
-#: templates/class-overview.html:47
+#: templates/class-overview.html:49
 #, fuzzy
 msgid "class_logs"
 msgstr "Last login"
 
-#: templates/class-overview.html:48 templates/customize-adventure.html:59
+#: templates/class-overview.html:52 templates/customize-adventure.html:59
 #, fuzzy
 msgid "back_to_teachers_page"
 msgstr "Go back to teachers page"
 
-#: templates/class-overview.html:49
+#: templates/class-overview.html:53
 #, fuzzy
 msgid "delete_class_prompt"
 msgstr "Are you sure you want to delete the class?"
 
-#: templates/class-overview.html:49
+#: templates/class-overview.html:53
 #, fuzzy
 msgid "delete_class"
 msgstr "Delete class permanently"
 
-#: templates/class-overview.html:52
+#: templates/class-overview.html:57
 #, fuzzy
 msgid "add_students_options"
 msgstr "Create student accounts"
 
-#: templates/class-overview.html:54
+#: templates/class-overview.html:59
 #, fuzzy
 msgid "copy_link_success"
 msgstr "Copy link to share"
 
-#: templates/class-overview.html:54
+#: templates/class-overview.html:59
 #, fuzzy
 msgid "copy_join_link"
 msgstr "Please copy and paste this link into a new tab:"
 
-#: templates/class-overview.html:55
+#: templates/class-overview.html:60
 #, fuzzy
 msgid "invite_prompt"
 msgstr "Enter a username"
 
-#: templates/class-overview.html:55
+#: templates/class-overview.html:60
 #, fuzzy
 msgid "invite_by_username"
 msgstr "All usernames need to be unique."
 
-#: templates/class-overview.html:56 templates/create-accounts.html:45
+#: templates/class-overview.html:61 templates/create-accounts.html:45
 #, fuzzy
 msgid "create_accounts"
 msgstr "Create multiple accounts"
 
-#: templates/class-overview.html:61
+#: templates/class-overview.html:66
 #, fuzzy
 msgid "pending_invites"
 msgstr "Pending invites"
 
-#: templates/class-overview.html:67
+#: templates/class-overview.html:72
 #, fuzzy
 msgid "invite_date"
 msgstr "Invite date"
 
-#: templates/class-overview.html:68
+#: templates/class-overview.html:73
 #, fuzzy
 msgid "expiration_date"
 msgstr "Expiration date"
 
-#: templates/class-overview.html:78 templates/profile.html:16
+#: templates/class-overview.html:83 templates/profile.html:16
 #, fuzzy
 msgid "delete_invite_prompt"
 msgstr "Are you sure you want to remove this class invitation?"
@@ -1372,11 +1372,10 @@ msgstr "My classes"
 msgid "achievements"
 msgstr "achievements"
 
-#: templates/highscores.html:27 templates/learn-more.html:22
-#: templates/profile.html:131 templates/signup.html:52
+#: templates/highscores.html:27
 #, fuzzy
-msgid "country"
-msgstr "Country"
+msgid "country_title"
+msgstr "Please select a valid country."
 
 #: templates/highscores.html:28 templates/landing-page.html:88
 #: templates/public-page.html:50
@@ -1679,6 +1678,12 @@ msgstr "Username"
 #, fuzzy
 msgid "lastname"
 msgstr "Name"
+
+#: templates/learn-more.html:22 templates/profile.html:131
+#: templates/signup.html:52
+#, fuzzy
+msgid "country"
+msgstr "Country"
 
 #: templates/learn-more.html:31
 #, fuzzy

--- a/translations/cs/LC_MESSAGES/messages.po
+++ b/translations/cs/LC_MESSAGES/messages.po
@@ -3,16 +3,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-28 18:38+0300\n"
+"POT-Creation-Date: 2022-06-29 14:20+0200\n"
 "PO-Revision-Date: 2022-06-28 13:25+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: cs\n"
 "Language-Team: cs <LL@li.org>\n"
-"Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2\n"
+"Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.9.1\n"
+"Generated-By: Babel 2.10.1\n"
 
 #: app.py:417
 msgid "program_contains_error"
@@ -22,7 +22,7 @@ msgstr "Tento program obsahuje chybu, přesto jej chcete sdílet?"
 msgid "title_achievements"
 msgstr "Hedy - Moje úspěchy"
 
-#: app.py:644 app.py:748 app.py:1090 website/teacher.py:361
+#: app.py:644 app.py:746 app.py:1088 website/teacher.py:361
 #: website/teacher.py:372
 msgid "not_teacher"
 msgstr "Zdá se, že nejste učitel!"
@@ -31,11 +31,11 @@ msgstr "Zdá se, že nejste učitel!"
 msgid "not_enrolled"
 msgstr "Zdá se, že do této třídy nepatříte!"
 
-#: app.py:686
+#: app.py:684
 msgid "title_programs"
 msgstr "Hedy - Moje programy"
 
-#: app.py:696 app.py:706 app.py:710 app.py:725 app.py:1005 app.py:1550
+#: app.py:694 app.py:704 app.py:708 app.py:723 app.py:1003 app.py:1548
 #: website/admin.py:17 website/admin.py:24 website/admin.py:92
 #: website/admin.py:111 website/admin.py:129 website/admin.py:136
 #: website/admin.py:144 website/auth.py:716 website/auth.py:743
@@ -43,308 +43,308 @@ msgstr "Hedy - Moje programy"
 msgid "unauthorized"
 msgstr "Nemáte oprávnění k přístupu na tuto stránku"
 
-#: app.py:762 app.py:1107
+#: app.py:760 app.py:1105
 msgid "title_for-teacher"
 msgstr "Hedy - pro učitele"
 
-#: app.py:779 app.py:781 app.py:923 app.py:945 app.py:947
+#: app.py:777 app.py:779 app.py:921 app.py:943 app.py:945
 msgid "no_such_level"
 msgstr "Neexistující úroveň jazyka Hedy!"
 
-#: app.py:789 app.py:796 app.py:877 app.py:883
+#: app.py:787 app.py:794 app.py:875 app.py:881
 msgid "no_such_program"
 msgstr "Neexistující program jazyka Hedy!"
 
-#: app.py:819
+#: app.py:817
 msgid "level_not_class"
 msgstr "Jste ve třídě, kde tato úroveň ještě nebyla zpřístupněna"
 
-#: app.py:928 website/teacher.py:421 website/teacher.py:437
+#: app.py:926 website/teacher.py:421 website/teacher.py:437
 #: website/teacher.py:466 website/teacher.py:492
 msgid "no_such_adventure"
 msgstr "Toto dobrodružství neexistuje!"
 
-#: app.py:956 app.py:1209
+#: app.py:954 app.py:1207
 msgid "page_not_found"
 msgstr "Tuto stránku nelze najít!"
 
-#: app.py:976
+#: app.py:974
 msgid "title_signup"
 msgstr "Hedy - vytvoření účtu"
 
-#: app.py:983
+#: app.py:981
 msgid "title_login"
 msgstr "Hedy - přihlášení"
 
-#: app.py:990
+#: app.py:988
 msgid "title_recover"
 msgstr "Hedy - obnovení účtu"
 
-#: app.py:1006
+#: app.py:1004
 msgid "title_reset"
 msgstr "Hedy - obnovení hesla"
 
-#: app.py:1032
+#: app.py:1030
 msgid "title_my-profile"
 msgstr "Hedy - můj účet"
 
-#: app.py:1048
+#: app.py:1046
 msgid "title_learn-more"
 msgstr "Hedy - dozvědět se více"
 
-#: app.py:1054
+#: app.py:1052
 #, fuzzy
 msgid "title_privacy"
 msgstr "Hedy - Privacy terms"
 
-#: app.py:1064
+#: app.py:1062
 #, fuzzy
 msgid "title_start"
 msgstr "Hedy - A gradual programming language"
 
-#: app.py:1082
+#: app.py:1080
 msgid "title_landing-page"
 msgstr "Vítá vás Hedy!"
 
-#: app.py:1200
+#: app.py:1198
 #, fuzzy
 msgid "title_explore"
 msgstr "Hedy - Explore"
 
-#: app.py:1221 app.py:1226
+#: app.py:1219 app.py:1224
 #, fuzzy
 msgid "no_such_highscore"
 msgstr "Neexistující úroveň jazyka Hedy!"
 
-#: app.py:1255 app.py:1257
+#: app.py:1253 app.py:1255
 msgid "translate_error"
 msgstr ""
 "Při provádění kódu se něco pokazilo. Zkuste kód spustit a zjistit, zda "
 "neobsahuje chybu. Kód s chybami nelze provést."
 
-#: app.py:1262 app.py:1296
+#: app.py:1260 app.py:1294
 msgid "tutorial_start_title"
 msgstr "Vítá vás Hedy!"
 
-#: app.py:1262
+#: app.py:1260
 msgid "tutorial_start_message"
 msgstr "V tomto návodu vysvětlíme všechny funkce jazyka Hedy krok za krokem."
 
-#: app.py:1264
+#: app.py:1262
 msgid "tutorial_editor_title"
 msgstr "Editor kódu"
 
-#: app.py:1264
+#: app.py:1262
 #, fuzzy
 msgid "tutorial_editor_message"
 msgstr "In this window you write all the code, try typing something!"
 
-#: app.py:1266
+#: app.py:1264
 #, fuzzy
 msgid "tutorial_output_title"
 msgstr "The output window"
 
-#: app.py:1266
+#: app.py:1264
 #, fuzzy
 msgid "tutorial_output_message"
 msgstr "The result of the code you execute will be shown here"
 
-#: app.py:1268
+#: app.py:1266
 #, fuzzy
 msgid "tutorial_run_title"
 msgstr "The run button"
 
-#: app.py:1268
+#: app.py:1266
 #, fuzzy
 msgid "tutorial_run_message"
 msgstr "With this button you can run your program! Shall we give it a try?"
 
-#: app.py:1270
+#: app.py:1268
 #, fuzzy
 msgid "tutorial_tryit_title"
 msgstr "Try it out!"
 
-#: app.py:1270
+#: app.py:1268
 #, fuzzy
 msgid "tutorial_tryit_message"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1272
+#: app.py:1270
 #, fuzzy
 msgid "tutorial_speakaloud_title"
 msgstr "The end!"
 
-#: app.py:1272
+#: app.py:1270
 #, fuzzy
 msgid "tutorial_speakaloud_message"
 msgstr "Click on 'next step' to really start coding with Hedy!"
 
-#: app.py:1274
+#: app.py:1272
 #, fuzzy
 msgid "tutorial_speakaloud_run_title"
 msgstr "The end!"
 
-#: app.py:1274
+#: app.py:1272
 #, fuzzy
 msgid "tutorial_speakaloud_run_message"
 msgstr "Click on 'next step' to really start coding with Hedy!"
 
-#: app.py:1276
+#: app.py:1274
 #, fuzzy
 msgid "tutorial_nextlevel_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1276
+#: app.py:1274
 #, fuzzy
 msgid "tutorial_nextlevel_message"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1278
+#: app.py:1276
 #, fuzzy
 msgid "tutorial_leveldefault_title"
 msgstr "Level explanation"
 
-#: app.py:1278
+#: app.py:1276
 #, fuzzy
 msgid "tutorial_leveldefault_message"
 msgstr ""
 "The first tab always contains the level explanation. In each level new "
 "commands will be explained here."
 
-#: app.py:1280
+#: app.py:1278
 #, fuzzy
 msgid "tutorial_adventures_title"
 msgstr "Customize adventure"
 
-#: app.py:1280
+#: app.py:1278
 #, fuzzy
 msgid "tutorial_adventures_message"
 msgstr "Customize adventure"
 
-#: app.py:1282
+#: app.py:1280
 #, fuzzy
 msgid "tutorial_quiz_title"
 msgstr "Quiz"
 
-#: app.py:1282
+#: app.py:1280
 #, fuzzy
 msgid "tutorial_quiz_message"
 msgstr ""
 "At the end of each level you can make the quiz. This way you can verify "
 "if you understand everything."
 
-#: app.py:1284
+#: app.py:1282
 #, fuzzy
 msgid "tutorial_saveshare_title"
 msgstr "Saving & sharing"
 
-#: app.py:1284
+#: app.py:1282
 #, fuzzy
 msgid "tutorial_saveshare_message"
 msgstr "You can save and share all your created programs with other Hedy users."
 
-#: app.py:1286
+#: app.py:1284
 #, fuzzy
 msgid "tutorial_cheatsheet_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1286
+#: app.py:1284
 #, fuzzy
 msgid "tutorial_cheatsheet_message"
 msgstr ""
 "If you forgot a command you can always use the cheatsheet. It shows a "
 "list of all commands you can use in the current level."
 
-#: app.py:1288 app.py:1308
+#: app.py:1286 app.py:1306
 #, fuzzy
 msgid "tutorial_end_title"
 msgstr "The end!"
 
-#: app.py:1288
+#: app.py:1286
 #, fuzzy
 msgid "tutorial_end_message"
 msgstr "Click on 'next step' to really start coding with Hedy!"
 
-#: app.py:1290 app.py:1310
+#: app.py:1288 app.py:1308
 #, fuzzy
 msgid "tutorial_title_not_found"
 msgstr "We could not find that page!"
 
-#: app.py:1290 app.py:1310
+#: app.py:1288 app.py:1308
 #, fuzzy
 msgid "tutorial_message_not_found"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1296
+#: app.py:1294
 #, fuzzy
 msgid "teacher_tutorial_start_message"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1298
+#: app.py:1296
 #, fuzzy
 msgid "tutorial_class_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1298
+#: app.py:1296
 #, fuzzy
 msgid "tutorial_class_message"
 msgstr "Customize adventure"
 
-#: app.py:1300
+#: app.py:1298
 #, fuzzy
 msgid "tutorial_customize_class_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1300
+#: app.py:1298
 #, fuzzy
 msgid "tutorial_customize_class_message"
 msgstr "Customize adventure"
 
-#: app.py:1302
+#: app.py:1300
 #, fuzzy
 msgid "tutorial_own_adventures_title"
 msgstr "Customize adventure"
 
-#: app.py:1302
+#: app.py:1300
 #, fuzzy
 msgid "tutorial_own_adventures_message"
 msgstr "Customize adventure"
 
-#: app.py:1304
+#: app.py:1302
 #, fuzzy
 msgid "tutorial_accounts_title"
 msgstr "Customize adventure"
 
-#: app.py:1304
+#: app.py:1302
 #, fuzzy
 msgid "tutorial_accounts_message"
 msgstr "Customize adventure"
 
-#: app.py:1306
+#: app.py:1304
 #, fuzzy
 msgid "tutorial_documentation_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1306
+#: app.py:1304
 #, fuzzy
 msgid "tutorial_documentation_message"
 msgstr "Customize adventure"
 
-#: app.py:1308
+#: app.py:1306
 #, fuzzy
 msgid "teacher_tutorial_end_message"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1318
+#: app.py:1316
 #, fuzzy
 msgid "tutorial_code_snippet"
 msgstr "Hide cheatsheet"
 
-#: app.py:1322 app.py:1332
+#: app.py:1320 app.py:1330
 msgid "invalid_tutorial_step"
 msgstr ""
 
-#: app.py:1489 website/auth.py:278 website/auth.py:333 website/auth.py:469
+#: app.py:1487 website/auth.py:278 website/auth.py:333 website/auth.py:469
 #: website/auth.py:494 website/auth.py:524 website/auth.py:637
 #: website/auth.py:675 website/auth.py:722 website/auth.py:749
 #: website/quiz.py:43 website/quiz.py:69 website/teacher.py:88
@@ -354,32 +354,32 @@ msgstr ""
 msgid "ajax_error"
 msgstr "Nastala chyba, prosím zkus to znova."
 
-#: app.py:1492
+#: app.py:1490
 #, fuzzy
 msgid "image_invalid"
 msgstr "Your chosen image is invalid."
 
-#: app.py:1494
+#: app.py:1492
 #, fuzzy
 msgid "personal_text_invalid"
 msgstr "Your personal text is invalid."
 
-#: app.py:1496 app.py:1502
+#: app.py:1494 app.py:1500
 #, fuzzy
 msgid "favourite_program_invalid"
 msgstr "Your chosen favourite program is invalid."
 
-#: app.py:1516 app.py:1517
+#: app.py:1514 app.py:1515
 #, fuzzy
 msgid "public_profile_updated"
 msgstr "Public profile updated."
 
-#: app.py:1554 app.py:1579
+#: app.py:1552 app.py:1577
 #, fuzzy
 msgid "user_not_private"
 msgstr "This user doesn't exist or doesn't have a public profile"
 
-#: app.py:1587
+#: app.py:1585
 #, fuzzy
 msgid "invalid_teacher_invitation_code"
 msgstr ""
@@ -720,151 +720,151 @@ msgstr "Hide cheatsheet"
 msgid "back_to_class"
 msgstr "Go back to class"
 
-#: templates/class-overview.html:13 templates/for-teachers.html:35
+#: templates/class-overview.html:14 templates/for-teachers.html:35
 #, fuzzy
 msgid "class_name_prompt"
 msgstr "Please enter the name of the class"
 
-#: templates/class-overview.html:19 templates/class-overview.html:66
+#: templates/class-overview.html:20 templates/class-overview.html:71
 #: templates/create-accounts.html:16 templates/highscores.html:25
 #: templates/login.html:12 templates/profile.html:89 templates/recover.html:8
 #: templates/signup.html:10
 msgid "username"
 msgstr "Uživatelské jméno"
 
-#: templates/class-overview.html:20
+#: templates/class-overview.html:21
 #, fuzzy
 msgid "last_login"
 msgstr "Last login"
 
-#: templates/class-overview.html:21
+#: templates/class-overview.html:22
 #, fuzzy
 msgid "highest_level_reached"
 msgstr "Highest level reached"
 
-#: templates/class-overview.html:22
+#: templates/class-overview.html:23
 #, fuzzy
 msgid "number_programs"
 msgstr "Number of programs"
 
-#: templates/class-overview.html:23
+#: templates/class-overview.html:24
 #, fuzzy
 msgid "programs"
 msgstr "Programs"
 
-#: templates/class-overview.html:24 templates/create-accounts.html:17
+#: templates/class-overview.html:25 templates/create-accounts.html:17
 #: templates/login.html:15 templates/reset.html:8 templates/signup.html:19
 msgid "password"
 msgstr "Heslo"
 
-#: templates/class-overview.html:25 templates/class-overview.html:69
+#: templates/class-overview.html:26 templates/class-overview.html:74
 #: templates/customize-adventure.html:52 templates/for-teachers.html:46
 #: templates/for-teachers.html:56
 #, fuzzy
 msgid "remove"
 msgstr "Remove"
 
-#: templates/class-overview.html:35
+#: templates/class-overview.html:36
 #, fuzzy
 msgid "page"
 msgstr "page"
 
-#: templates/class-overview.html:36
+#: templates/class-overview.html:37
 #, fuzzy
 msgid "enter_password"
 msgstr "Enter a new password for"
 
-#: templates/class-overview.html:36
+#: templates/class-overview.html:37
 #, fuzzy
 msgid "password_change_prompt"
 msgstr "Are you sure you want to change this password?"
 
-#: templates/class-overview.html:37
+#: templates/class-overview.html:38
 #, fuzzy
 msgid "remove_student_prompt"
 msgstr "Are you sure you want to remove the student from the class?"
 
-#: templates/class-overview.html:44
+#: templates/class-overview.html:46
 #, fuzzy
 msgid "add_students"
 msgstr "students"
 
-#: templates/class-overview.html:45 templates/customize-class.html:5
+#: templates/class-overview.html:47 templates/customize-class.html:5
 #, fuzzy
 msgid "customize_class"
 msgstr "Customize class"
 
-#: templates/class-overview.html:46
+#: templates/class-overview.html:48
 #, fuzzy
 msgid "class_stats"
 msgstr "Show class statistics"
 
-#: templates/class-overview.html:47
+#: templates/class-overview.html:49
 #, fuzzy
 msgid "class_logs"
 msgstr "Last login"
 
-#: templates/class-overview.html:48 templates/customize-adventure.html:59
+#: templates/class-overview.html:52 templates/customize-adventure.html:59
 #, fuzzy
 msgid "back_to_teachers_page"
 msgstr "Go back to teachers page"
 
-#: templates/class-overview.html:49
+#: templates/class-overview.html:53
 #, fuzzy
 msgid "delete_class_prompt"
 msgstr "Are you sure you want to delete the class?"
 
-#: templates/class-overview.html:49
+#: templates/class-overview.html:53
 #, fuzzy
 msgid "delete_class"
 msgstr "Delete class permanently"
 
-#: templates/class-overview.html:52
+#: templates/class-overview.html:57
 #, fuzzy
 msgid "add_students_options"
 msgstr "Create student accounts"
 
-#: templates/class-overview.html:54
+#: templates/class-overview.html:59
 #, fuzzy
 msgid "copy_link_success"
 msgstr "Zkopírovat odkaz ke sdílení"
 
-#: templates/class-overview.html:54
+#: templates/class-overview.html:59
 #, fuzzy
 msgid "copy_join_link"
 msgstr "Please copy and paste this link into a new tab:"
 
-#: templates/class-overview.html:55
+#: templates/class-overview.html:60
 #, fuzzy
 msgid "invite_prompt"
 msgstr "Enter a username"
 
-#: templates/class-overview.html:55
+#: templates/class-overview.html:60
 #, fuzzy
 msgid "invite_by_username"
 msgstr "All usernames need to be unique."
 
-#: templates/class-overview.html:56 templates/create-accounts.html:45
+#: templates/class-overview.html:61 templates/create-accounts.html:45
 #, fuzzy
 msgid "create_accounts"
 msgstr "Create multiple accounts"
 
-#: templates/class-overview.html:61
+#: templates/class-overview.html:66
 #, fuzzy
 msgid "pending_invites"
 msgstr "Pending invites"
 
-#: templates/class-overview.html:67
+#: templates/class-overview.html:72
 #, fuzzy
 msgid "invite_date"
 msgstr "Invite date"
 
-#: templates/class-overview.html:68
+#: templates/class-overview.html:73
 #, fuzzy
 msgid "expiration_date"
 msgstr "Expiration date"
 
-#: templates/class-overview.html:78 templates/profile.html:16
+#: templates/class-overview.html:83 templates/profile.html:16
 #, fuzzy
 msgid "delete_invite_prompt"
 msgstr "Are you sure you want to remove this class invitation?"
@@ -1320,10 +1320,10 @@ msgstr "My classes"
 msgid "achievements"
 msgstr "achievements"
 
-#: templates/highscores.html:27 templates/learn-more.html:22
-#: templates/profile.html:131 templates/signup.html:52
-msgid "country"
-msgstr "Země"
+#: templates/highscores.html:27
+#, fuzzy
+msgid "country_title"
+msgstr "Please select a valid country."
 
 #: templates/highscores.html:28 templates/landing-page.html:88
 #: templates/public-page.html:50
@@ -1608,6 +1608,11 @@ msgstr "Jméno"
 #: templates/learn-more.html:18
 msgid "lastname"
 msgstr "Příjmení"
+
+#: templates/learn-more.html:22 templates/profile.html:131
+#: templates/signup.html:52
+msgid "country"
+msgstr "Země"
 
 #: templates/learn-more.html:31
 msgid "subscribe"

--- a/translations/de/LC_MESSAGES/messages.po
+++ b/translations/de/LC_MESSAGES/messages.po
@@ -3,16 +3,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-28 18:38+0300\n"
+"POT-Creation-Date: 2022-06-29 14:20+0200\n"
 "PO-Revision-Date: 2022-06-28 13:25+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: de\n"
 "Language-Team: de <LL@li.org>\n"
-"Plural-Forms: nplurals=2; plural=n != 1\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.9.1\n"
+"Generated-By: Babel 2.10.1\n"
 
 #: app.py:417
 #, fuzzy
@@ -24,7 +24,7 @@ msgstr "This program contains an error, are you sure you want to share it?"
 msgid "title_achievements"
 msgstr "Hedy - My achievements"
 
-#: app.py:644 app.py:748 app.py:1090 website/teacher.py:361
+#: app.py:644 app.py:746 app.py:1088 website/teacher.py:361
 #: website/teacher.py:372
 #, fuzzy
 msgid "not_teacher"
@@ -35,12 +35,12 @@ msgstr "Looks like you are not a teacher!"
 msgid "not_enrolled"
 msgstr "Looks like you are not in this class!"
 
-#: app.py:686
+#: app.py:684
 #, fuzzy
 msgid "title_programs"
 msgstr "Hedy - My programs"
 
-#: app.py:696 app.py:706 app.py:710 app.py:725 app.py:1005 app.py:1550
+#: app.py:694 app.py:704 app.py:708 app.py:723 app.py:1003 app.py:1548
 #: website/admin.py:17 website/admin.py:24 website/admin.py:92
 #: website/admin.py:111 website/admin.py:129 website/admin.py:136
 #: website/admin.py:144 website/auth.py:716 website/auth.py:743
@@ -49,325 +49,325 @@ msgstr "Hedy - My programs"
 msgid "unauthorized"
 msgstr "You don't have access rights for this page"
 
-#: app.py:762 app.py:1107
+#: app.py:760 app.py:1105
 #, fuzzy
 msgid "title_for-teacher"
 msgstr "Hedy - For teachers"
 
-#: app.py:779 app.py:781 app.py:923 app.py:945 app.py:947
+#: app.py:777 app.py:779 app.py:921 app.py:943 app.py:945
 #, fuzzy
 msgid "no_such_level"
 msgstr "No such Hedy level!"
 
-#: app.py:789 app.py:796 app.py:877 app.py:883
+#: app.py:787 app.py:794 app.py:875 app.py:881
 #, fuzzy
 msgid "no_such_program"
 msgstr "No such Hedy program!"
 
-#: app.py:819
+#: app.py:817
 #, fuzzy
 msgid "level_not_class"
 msgstr "You're in a class where this level has not been made available yet"
 
-#: app.py:928 website/teacher.py:421 website/teacher.py:437
+#: app.py:926 website/teacher.py:421 website/teacher.py:437
 #: website/teacher.py:466 website/teacher.py:492
 #, fuzzy
 msgid "no_such_adventure"
 msgstr "This adventure doesn't exist!"
 
-#: app.py:956 app.py:1209
+#: app.py:954 app.py:1207
 #, fuzzy
 msgid "page_not_found"
 msgstr "We could not find that page!"
 
-#: app.py:976
+#: app.py:974
 #, fuzzy
 msgid "title_signup"
 msgstr "Hedy - Create an account"
 
-#: app.py:983
+#: app.py:981
 #, fuzzy
 msgid "title_login"
 msgstr "Hedy - Login"
 
-#: app.py:990
+#: app.py:988
 #, fuzzy
 msgid "title_recover"
 msgstr "Hedy - Recover account"
 
-#: app.py:1006
+#: app.py:1004
 #, fuzzy
 msgid "title_reset"
 msgstr "Hedy - Reset password"
 
-#: app.py:1032
+#: app.py:1030
 #, fuzzy
 msgid "title_my-profile"
 msgstr "Hedy - My account"
 
-#: app.py:1048
+#: app.py:1046
 #, fuzzy
 msgid "title_learn-more"
 msgstr "Hedy - Learn more"
 
-#: app.py:1054
+#: app.py:1052
 #, fuzzy
 msgid "title_privacy"
 msgstr "Hedy - Privacy terms"
 
-#: app.py:1064
+#: app.py:1062
 #, fuzzy
 msgid "title_start"
 msgstr "Hedy - A gradual programming language"
 
-#: app.py:1082
+#: app.py:1080
 #, fuzzy
 msgid "title_landing-page"
 msgstr "Welcome to Hedy!"
 
-#: app.py:1200
+#: app.py:1198
 #, fuzzy
 msgid "title_explore"
 msgstr "Hedy - Explore"
 
-#: app.py:1221 app.py:1226
+#: app.py:1219 app.py:1224
 #, fuzzy
 msgid "no_such_highscore"
 msgstr "No such Hedy level!"
 
-#: app.py:1255 app.py:1257
+#: app.py:1253 app.py:1255
 #, fuzzy
 msgid "translate_error"
 msgstr ""
 "Something went wrong while translating the code. Try running the code to "
 "see if it has an error. Code with errors can not be translated."
 
-#: app.py:1262 app.py:1296
+#: app.py:1260 app.py:1294
 #, fuzzy
 msgid "tutorial_start_title"
 msgstr "Welcome to Hedy!"
 
-#: app.py:1262
+#: app.py:1260
 #, fuzzy
 msgid "tutorial_start_message"
 msgstr "In this tutorial we will explain all the Hedy features step-by-step."
 
-#: app.py:1264
+#: app.py:1262
 #, fuzzy
 msgid "tutorial_editor_title"
 msgstr "The code editor"
 
-#: app.py:1264
+#: app.py:1262
 #, fuzzy
 msgid "tutorial_editor_message"
 msgstr "In this window you write all the code, try typing something!"
 
-#: app.py:1266
+#: app.py:1264
 #, fuzzy
 msgid "tutorial_output_title"
 msgstr "The output window"
 
-#: app.py:1266
+#: app.py:1264
 #, fuzzy
 msgid "tutorial_output_message"
 msgstr "The result of the code you execute will be shown here"
 
-#: app.py:1268
+#: app.py:1266
 #, fuzzy
 msgid "tutorial_run_title"
 msgstr "The run button"
 
-#: app.py:1268
+#: app.py:1266
 #, fuzzy
 msgid "tutorial_run_message"
 msgstr "With this button you can run your program! Shall we give it a try?"
 
-#: app.py:1270
+#: app.py:1268
 #, fuzzy
 msgid "tutorial_tryit_title"
 msgstr "Try it out!"
 
-#: app.py:1270
+#: app.py:1268
 #, fuzzy
 msgid "tutorial_tryit_message"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1272
+#: app.py:1270
 #, fuzzy
 msgid "tutorial_speakaloud_title"
 msgstr "The end!"
 
-#: app.py:1272
+#: app.py:1270
 #, fuzzy
 msgid "tutorial_speakaloud_message"
 msgstr "Click on 'next step' to really start coding with Hedy!"
 
-#: app.py:1274
+#: app.py:1272
 #, fuzzy
 msgid "tutorial_speakaloud_run_title"
 msgstr "The end!"
 
-#: app.py:1274
+#: app.py:1272
 #, fuzzy
 msgid "tutorial_speakaloud_run_message"
 msgstr "Click on 'next step' to really start coding with Hedy!"
 
-#: app.py:1276
+#: app.py:1274
 #, fuzzy
 msgid "tutorial_nextlevel_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1276
+#: app.py:1274
 #, fuzzy
 msgid "tutorial_nextlevel_message"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1278
+#: app.py:1276
 #, fuzzy
 msgid "tutorial_leveldefault_title"
 msgstr "Level explanation"
 
-#: app.py:1278
+#: app.py:1276
 #, fuzzy
 msgid "tutorial_leveldefault_message"
 msgstr ""
 "The first tab always contains the level explanation. In each level new "
 "commands will be explained here."
 
-#: app.py:1280
+#: app.py:1278
 #, fuzzy
 msgid "tutorial_adventures_title"
 msgstr "Customize adventure"
 
-#: app.py:1280
+#: app.py:1278
 #, fuzzy
 msgid "tutorial_adventures_message"
 msgstr "Customize adventure"
 
-#: app.py:1282
+#: app.py:1280
 #, fuzzy
 msgid "tutorial_quiz_title"
 msgstr "Quiz"
 
-#: app.py:1282
+#: app.py:1280
 #, fuzzy
 msgid "tutorial_quiz_message"
 msgstr ""
 "At the end of each level you can make the quiz. This way you can verify "
 "if you understand everything."
 
-#: app.py:1284
+#: app.py:1282
 #, fuzzy
 msgid "tutorial_saveshare_title"
 msgstr "Saving & sharing"
 
-#: app.py:1284
+#: app.py:1282
 #, fuzzy
 msgid "tutorial_saveshare_message"
 msgstr "You can save and share all your created programs with other Hedy users."
 
-#: app.py:1286
+#: app.py:1284
 #, fuzzy
 msgid "tutorial_cheatsheet_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1286
+#: app.py:1284
 #, fuzzy
 msgid "tutorial_cheatsheet_message"
 msgstr ""
 "If you forgot a command you can always use the cheatsheet. It shows a "
 "list of all commands you can use in the current level."
 
-#: app.py:1288 app.py:1308
+#: app.py:1286 app.py:1306
 #, fuzzy
 msgid "tutorial_end_title"
 msgstr "The end!"
 
-#: app.py:1288
+#: app.py:1286
 #, fuzzy
 msgid "tutorial_end_message"
 msgstr "Click on 'next step' to really start coding with Hedy!"
 
-#: app.py:1290 app.py:1310
+#: app.py:1288 app.py:1308
 #, fuzzy
 msgid "tutorial_title_not_found"
 msgstr "We could not find that page!"
 
-#: app.py:1290 app.py:1310
+#: app.py:1288 app.py:1308
 #, fuzzy
 msgid "tutorial_message_not_found"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1296
+#: app.py:1294
 #, fuzzy
 msgid "teacher_tutorial_start_message"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1298
+#: app.py:1296
 #, fuzzy
 msgid "tutorial_class_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1298
+#: app.py:1296
 #, fuzzy
 msgid "tutorial_class_message"
 msgstr "Customize adventure"
 
-#: app.py:1300
+#: app.py:1298
 #, fuzzy
 msgid "tutorial_customize_class_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1300
+#: app.py:1298
 #, fuzzy
 msgid "tutorial_customize_class_message"
 msgstr "Customize adventure"
 
-#: app.py:1302
+#: app.py:1300
 #, fuzzy
 msgid "tutorial_own_adventures_title"
 msgstr "Customize adventure"
 
-#: app.py:1302
+#: app.py:1300
 #, fuzzy
 msgid "tutorial_own_adventures_message"
 msgstr "Customize adventure"
 
-#: app.py:1304
+#: app.py:1302
 #, fuzzy
 msgid "tutorial_accounts_title"
 msgstr "Customize adventure"
 
-#: app.py:1304
+#: app.py:1302
 #, fuzzy
 msgid "tutorial_accounts_message"
 msgstr "Customize adventure"
 
-#: app.py:1306
+#: app.py:1304
 #, fuzzy
 msgid "tutorial_documentation_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1306
+#: app.py:1304
 #, fuzzy
 msgid "tutorial_documentation_message"
 msgstr "Customize adventure"
 
-#: app.py:1308
+#: app.py:1306
 #, fuzzy
 msgid "teacher_tutorial_end_message"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1318
+#: app.py:1316
 #, fuzzy
 msgid "tutorial_code_snippet"
 msgstr "Hide cheatsheet"
 
-#: app.py:1322 app.py:1332
+#: app.py:1320 app.py:1330
 msgid "invalid_tutorial_step"
 msgstr ""
 
-#: app.py:1489 website/auth.py:278 website/auth.py:333 website/auth.py:469
+#: app.py:1487 website/auth.py:278 website/auth.py:333 website/auth.py:469
 #: website/auth.py:494 website/auth.py:524 website/auth.py:637
 #: website/auth.py:675 website/auth.py:722 website/auth.py:749
 #: website/quiz.py:43 website/quiz.py:69 website/teacher.py:88
@@ -377,32 +377,32 @@ msgstr ""
 msgid "ajax_error"
 msgstr "Ein Fehler ist aufgetreten. Bitte nochmal versuchen."
 
-#: app.py:1492
+#: app.py:1490
 #, fuzzy
 msgid "image_invalid"
 msgstr "Your chosen image is invalid."
 
-#: app.py:1494
+#: app.py:1492
 #, fuzzy
 msgid "personal_text_invalid"
 msgstr "Your personal text is invalid."
 
-#: app.py:1496 app.py:1502
+#: app.py:1494 app.py:1500
 #, fuzzy
 msgid "favourite_program_invalid"
 msgstr "Your chosen favourite program is invalid."
 
-#: app.py:1516 app.py:1517
+#: app.py:1514 app.py:1515
 #, fuzzy
 msgid "public_profile_updated"
 msgstr "Public profile updated."
 
-#: app.py:1554 app.py:1579
+#: app.py:1552 app.py:1577
 #, fuzzy
 msgid "user_not_private"
 msgstr "This user doesn't exist or doesn't have a public profile"
 
-#: app.py:1587
+#: app.py:1585
 #, fuzzy
 msgid "invalid_teacher_invitation_code"
 msgstr ""
@@ -726,140 +726,140 @@ msgstr "Hide cheatsheet"
 msgid "back_to_class"
 msgstr "Gehe zurück zur Klasse"
 
-#: templates/class-overview.html:13 templates/for-teachers.html:35
+#: templates/class-overview.html:14 templates/for-teachers.html:35
 msgid "class_name_prompt"
 msgstr "Bitte gib den Namen der Klasse ein"
 
-#: templates/class-overview.html:19 templates/class-overview.html:66
+#: templates/class-overview.html:20 templates/class-overview.html:71
 #: templates/create-accounts.html:16 templates/highscores.html:25
 #: templates/login.html:12 templates/profile.html:89 templates/recover.html:8
 #: templates/signup.html:10
 msgid "username"
 msgstr "Benutzername"
 
-#: templates/class-overview.html:20
+#: templates/class-overview.html:21
 msgid "last_login"
 msgstr "Zuletzt eingeloggt"
 
-#: templates/class-overview.html:21
+#: templates/class-overview.html:22
 msgid "highest_level_reached"
 msgstr "Höchstes erreichtes Level"
 
-#: templates/class-overview.html:22
+#: templates/class-overview.html:23
 msgid "number_programs"
 msgstr "Anzahl von Programmen"
 
-#: templates/class-overview.html:23
+#: templates/class-overview.html:24
 msgid "programs"
 msgstr "Programme"
 
-#: templates/class-overview.html:24 templates/create-accounts.html:17
+#: templates/class-overview.html:25 templates/create-accounts.html:17
 #: templates/login.html:15 templates/reset.html:8 templates/signup.html:19
 msgid "password"
 msgstr "Passwort"
 
-#: templates/class-overview.html:25 templates/class-overview.html:69
+#: templates/class-overview.html:26 templates/class-overview.html:74
 #: templates/customize-adventure.html:52 templates/for-teachers.html:46
 #: templates/for-teachers.html:56
 msgid "remove"
 msgstr "Löschen"
 
-#: templates/class-overview.html:35
+#: templates/class-overview.html:36
 msgid "page"
 msgstr "Seite"
 
-#: templates/class-overview.html:36
+#: templates/class-overview.html:37
 #, fuzzy
 msgid "enter_password"
 msgstr "Enter a new password for"
 
-#: templates/class-overview.html:36
+#: templates/class-overview.html:37
 #, fuzzy
 msgid "password_change_prompt"
 msgstr "Are you sure you want to change this password?"
 
-#: templates/class-overview.html:37
+#: templates/class-overview.html:38
 msgid "remove_student_prompt"
 msgstr "Soll der/die Schüler*in aus der Klasse entfernt werden?"
 
-#: templates/class-overview.html:44
+#: templates/class-overview.html:46
 #, fuzzy
 msgid "add_students"
 msgstr "Schüler*innen"
 
-#: templates/class-overview.html:45 templates/customize-class.html:5
+#: templates/class-overview.html:47 templates/customize-class.html:5
 msgid "customize_class"
 msgstr "Passe eine Klasse an"
 
-#: templates/class-overview.html:46
+#: templates/class-overview.html:48
 #, fuzzy
 msgid "class_stats"
 msgstr "Show class statistics"
 
-#: templates/class-overview.html:47
+#: templates/class-overview.html:49
 #, fuzzy
 msgid "class_logs"
 msgstr "Zuletzt eingeloggt"
 
-#: templates/class-overview.html:48 templates/customize-adventure.html:59
+#: templates/class-overview.html:52 templates/customize-adventure.html:59
 #, fuzzy
 msgid "back_to_teachers_page"
 msgstr "Go back to teachers page"
 
-#: templates/class-overview.html:49
+#: templates/class-overview.html:53
 msgid "delete_class_prompt"
 msgstr "Soll die Klasse gelöscht werden?"
 
-#: templates/class-overview.html:49
+#: templates/class-overview.html:53
 msgid "delete_class"
 msgstr "Klasse löschen"
 
-#: templates/class-overview.html:52
+#: templates/class-overview.html:57
 #, fuzzy
 msgid "add_students_options"
 msgstr "Create student accounts"
 
-#: templates/class-overview.html:54
+#: templates/class-overview.html:59
 #, fuzzy
 msgid "copy_link_success"
 msgstr "Kopiere Link zum Weitergeben"
 
-#: templates/class-overview.html:54
+#: templates/class-overview.html:59
 #, fuzzy
 msgid "copy_join_link"
 msgstr "Please copy and paste this link into a new tab:"
 
-#: templates/class-overview.html:55
+#: templates/class-overview.html:60
 #, fuzzy
 msgid "invite_prompt"
 msgstr "Enter a username"
 
-#: templates/class-overview.html:55
+#: templates/class-overview.html:60
 #, fuzzy
 msgid "invite_by_username"
 msgstr "All usernames need to be unique."
 
-#: templates/class-overview.html:56 templates/create-accounts.html:45
+#: templates/class-overview.html:61 templates/create-accounts.html:45
 #, fuzzy
 msgid "create_accounts"
 msgstr "Create multiple accounts"
 
-#: templates/class-overview.html:61
+#: templates/class-overview.html:66
 #, fuzzy
 msgid "pending_invites"
 msgstr "Pending invites"
 
-#: templates/class-overview.html:67
+#: templates/class-overview.html:72
 #, fuzzy
 msgid "invite_date"
 msgstr "Invite date"
 
-#: templates/class-overview.html:68
+#: templates/class-overview.html:73
 #, fuzzy
 msgid "expiration_date"
 msgstr "Expiration date"
 
-#: templates/class-overview.html:78 templates/profile.html:16
+#: templates/class-overview.html:83 templates/profile.html:16
 #, fuzzy
 msgid "delete_invite_prompt"
 msgstr "Are you sure you want to remove this class invitation?"
@@ -1300,10 +1300,10 @@ msgstr "Meine Klassen"
 msgid "achievements"
 msgstr "achievements"
 
-#: templates/highscores.html:27 templates/learn-more.html:22
-#: templates/profile.html:131 templates/signup.html:52
-msgid "country"
-msgstr "Land"
+#: templates/highscores.html:27
+#, fuzzy
+msgid "country_title"
+msgstr "Please select a valid country."
 
 #: templates/highscores.html:28 templates/landing-page.html:88
 #: templates/public-page.html:50
@@ -1579,6 +1579,11 @@ msgstr "Vorname"
 #: templates/learn-more.html:18
 msgid "lastname"
 msgstr "Nachname"
+
+#: templates/learn-more.html:22 templates/profile.html:131
+#: templates/signup.html:52
+msgid "country"
+msgstr "Land"
 
 #: templates/learn-more.html:31
 msgid "subscribe"

--- a/translations/el/LC_MESSAGES/messages.po
+++ b/translations/el/LC_MESSAGES/messages.po
@@ -3,16 +3,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-28 18:38+0300\n"
+"POT-Creation-Date: 2022-06-29 14:20+0200\n"
 "PO-Revision-Date: 2022-06-28 13:25+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: el\n"
 "Language-Team: el <LL@li.org>\n"
-"Plural-Forms: nplurals=2; plural=n != 1\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.9.1\n"
+"Generated-By: Babel 2.10.1\n"
 
 #: app.py:417
 #, fuzzy
@@ -24,7 +24,7 @@ msgstr "This program contains an error, are you sure you want to share it?"
 msgid "title_achievements"
 msgstr "Hedy - My achievements"
 
-#: app.py:644 app.py:748 app.py:1090 website/teacher.py:361
+#: app.py:644 app.py:746 app.py:1088 website/teacher.py:361
 #: website/teacher.py:372
 msgid "not_teacher"
 msgstr "Φαίνεται πως δεν είσαι καθηγητής!"
@@ -33,12 +33,12 @@ msgstr "Φαίνεται πως δεν είσαι καθηγητής!"
 msgid "not_enrolled"
 msgstr "Φαίνεται πως δεν είστε σ' αυτήν την τάξη!"
 
-#: app.py:686
+#: app.py:684
 #, fuzzy
 msgid "title_programs"
 msgstr "Hedy - My programs"
 
-#: app.py:696 app.py:706 app.py:710 app.py:725 app.py:1005 app.py:1550
+#: app.py:694 app.py:704 app.py:708 app.py:723 app.py:1003 app.py:1548
 #: website/admin.py:17 website/admin.py:24 website/admin.py:92
 #: website/admin.py:111 website/admin.py:129 website/admin.py:136
 #: website/admin.py:144 website/auth.py:716 website/auth.py:743
@@ -47,320 +47,320 @@ msgstr "Hedy - My programs"
 msgid "unauthorized"
 msgstr "You don't have access rights for this page"
 
-#: app.py:762 app.py:1107
+#: app.py:760 app.py:1105
 #, fuzzy
 msgid "title_for-teacher"
 msgstr "Hedy - For teachers"
 
-#: app.py:779 app.py:781 app.py:923 app.py:945 app.py:947
+#: app.py:777 app.py:779 app.py:921 app.py:943 app.py:945
 msgid "no_such_level"
 msgstr "Δεν υπάρχει τέτοιο επίπεδο Hedy!"
 
-#: app.py:789 app.py:796 app.py:877 app.py:883
+#: app.py:787 app.py:794 app.py:875 app.py:881
 msgid "no_such_program"
 msgstr "Δεν υπάρχει τέτοιο πρόγραμμα Hedy!"
 
-#: app.py:819
+#: app.py:817
 msgid "level_not_class"
 msgstr "Είσαι σε μια τάξη στην οποία δεν είναι ακόμα διαθέσιμο αυτό το επίπεδο"
 
-#: app.py:928 website/teacher.py:421 website/teacher.py:437
+#: app.py:926 website/teacher.py:421 website/teacher.py:437
 #: website/teacher.py:466 website/teacher.py:492
 msgid "no_such_adventure"
 msgstr "Αυτή η περιπέτεια δεν υπάρχει!"
 
-#: app.py:956 app.py:1209
+#: app.py:954 app.py:1207
 msgid "page_not_found"
 msgstr "Δεν μπορούμε να βρούμε αυτήν τη σελίδα!"
 
-#: app.py:976
+#: app.py:974
 #, fuzzy
 msgid "title_signup"
 msgstr "Hedy - Create an account"
 
-#: app.py:983
+#: app.py:981
 #, fuzzy
 msgid "title_login"
 msgstr "Hedy - Login"
 
-#: app.py:990
+#: app.py:988
 #, fuzzy
 msgid "title_recover"
 msgstr "Hedy - Recover account"
 
-#: app.py:1006
+#: app.py:1004
 #, fuzzy
 msgid "title_reset"
 msgstr "Hedy - Reset password"
 
-#: app.py:1032
+#: app.py:1030
 #, fuzzy
 msgid "title_my-profile"
 msgstr "Hedy - My account"
 
-#: app.py:1048
+#: app.py:1046
 #, fuzzy
 msgid "title_learn-more"
 msgstr "Hedy - Learn more"
 
-#: app.py:1054
+#: app.py:1052
 #, fuzzy
 msgid "title_privacy"
 msgstr "Hedy - Privacy terms"
 
-#: app.py:1064
+#: app.py:1062
 #, fuzzy
 msgid "title_start"
 msgstr "Hedy - A gradual programming language"
 
-#: app.py:1082
+#: app.py:1080
 #, fuzzy
 msgid "title_landing-page"
 msgstr "Welcome to Hedy!"
 
-#: app.py:1200
+#: app.py:1198
 #, fuzzy
 msgid "title_explore"
 msgstr "Hedy - Explore"
 
-#: app.py:1221 app.py:1226
+#: app.py:1219 app.py:1224
 #, fuzzy
 msgid "no_such_highscore"
 msgstr "Δεν υπάρχει τέτοιο επίπεδο Hedy!"
 
-#: app.py:1255 app.py:1257
+#: app.py:1253 app.py:1255
 msgid "translate_error"
 msgstr ""
 "Κάτι πήγε στραβά κατά τη μετάφραση του κώδικα. Δοκίμασε να εκτελέσεις τον"
 " κώδικα για να δεις αν έχει κάποιο σφάλμα. Ο κώδικας με σφάλματα δεν "
 "μπορεί να μεταφραστεί."
 
-#: app.py:1262 app.py:1296
+#: app.py:1260 app.py:1294
 #, fuzzy
 msgid "tutorial_start_title"
 msgstr "Welcome to Hedy!"
 
-#: app.py:1262
+#: app.py:1260
 #, fuzzy
 msgid "tutorial_start_message"
 msgstr "In this tutorial we will explain all the Hedy features step-by-step."
 
-#: app.py:1264
+#: app.py:1262
 #, fuzzy
 msgid "tutorial_editor_title"
 msgstr "The code editor"
 
-#: app.py:1264
+#: app.py:1262
 #, fuzzy
 msgid "tutorial_editor_message"
 msgstr "In this window you write all the code, try typing something!"
 
-#: app.py:1266
+#: app.py:1264
 #, fuzzy
 msgid "tutorial_output_title"
 msgstr "The output window"
 
-#: app.py:1266
+#: app.py:1264
 #, fuzzy
 msgid "tutorial_output_message"
 msgstr "The result of the code you execute will be shown here"
 
-#: app.py:1268
+#: app.py:1266
 #, fuzzy
 msgid "tutorial_run_title"
 msgstr "The run button"
 
-#: app.py:1268
+#: app.py:1266
 #, fuzzy
 msgid "tutorial_run_message"
 msgstr "With this button you can run your program! Shall we give it a try?"
 
-#: app.py:1270
+#: app.py:1268
 #, fuzzy
 msgid "tutorial_tryit_title"
 msgstr "Try it out!"
 
-#: app.py:1270
+#: app.py:1268
 #, fuzzy
 msgid "tutorial_tryit_message"
 msgstr "Έλαβες μια πρόσκληση για να συμμετάσχεις στην τάξη"
 
-#: app.py:1272
+#: app.py:1270
 #, fuzzy
 msgid "tutorial_speakaloud_title"
 msgstr "The end!"
 
-#: app.py:1272
+#: app.py:1270
 #, fuzzy
 msgid "tutorial_speakaloud_message"
 msgstr "Click on 'next step' to really start coding with Hedy!"
 
-#: app.py:1274
+#: app.py:1272
 #, fuzzy
 msgid "tutorial_speakaloud_run_title"
 msgstr "The end!"
 
-#: app.py:1274
+#: app.py:1272
 #, fuzzy
 msgid "tutorial_speakaloud_run_message"
 msgstr "Click on 'next step' to really start coding with Hedy!"
 
-#: app.py:1276
+#: app.py:1274
 #, fuzzy
 msgid "tutorial_nextlevel_title"
 msgstr "Απόκρυψη των σημειώσεων"
 
-#: app.py:1276
+#: app.py:1274
 #, fuzzy
 msgid "tutorial_nextlevel_message"
 msgstr "Έλαβες μια πρόσκληση για να συμμετάσχεις στην τάξη"
 
-#: app.py:1278
+#: app.py:1276
 #, fuzzy
 msgid "tutorial_leveldefault_title"
 msgstr "Level explanation"
 
-#: app.py:1278
+#: app.py:1276
 #, fuzzy
 msgid "tutorial_leveldefault_message"
 msgstr ""
 "The first tab always contains the level explanation. In each level new "
 "commands will be explained here."
 
-#: app.py:1280
+#: app.py:1278
 #, fuzzy
 msgid "tutorial_adventures_title"
 msgstr "Προσαρμογή περιπέτειας"
 
-#: app.py:1280
+#: app.py:1278
 #, fuzzy
 msgid "tutorial_adventures_message"
 msgstr "Προσαρμογή περιπέτειας"
 
-#: app.py:1282
+#: app.py:1280
 #, fuzzy
 msgid "tutorial_quiz_title"
 msgstr "Quiz"
 
-#: app.py:1282
+#: app.py:1280
 #, fuzzy
 msgid "tutorial_quiz_message"
 msgstr ""
 "At the end of each level you can make the quiz. This way you can verify "
 "if you understand everything."
 
-#: app.py:1284
+#: app.py:1282
 #, fuzzy
 msgid "tutorial_saveshare_title"
 msgstr "Saving & sharing"
 
-#: app.py:1284
+#: app.py:1282
 #, fuzzy
 msgid "tutorial_saveshare_message"
 msgstr "You can save and share all your created programs with other Hedy users."
 
-#: app.py:1286
+#: app.py:1284
 #, fuzzy
 msgid "tutorial_cheatsheet_title"
 msgstr "Απόκρυψη των σημειώσεων"
 
-#: app.py:1286
+#: app.py:1284
 #, fuzzy
 msgid "tutorial_cheatsheet_message"
 msgstr ""
 "If you forgot a command you can always use the cheatsheet. It shows a "
 "list of all commands you can use in the current level."
 
-#: app.py:1288 app.py:1308
+#: app.py:1286 app.py:1306
 #, fuzzy
 msgid "tutorial_end_title"
 msgstr "The end!"
 
-#: app.py:1288
+#: app.py:1286
 #, fuzzy
 msgid "tutorial_end_message"
 msgstr "Click on 'next step' to really start coding with Hedy!"
 
-#: app.py:1290 app.py:1310
+#: app.py:1288 app.py:1308
 #, fuzzy
 msgid "tutorial_title_not_found"
 msgstr "Δεν μπορούμε να βρούμε αυτήν τη σελίδα!"
 
-#: app.py:1290 app.py:1310
+#: app.py:1288 app.py:1308
 #, fuzzy
 msgid "tutorial_message_not_found"
 msgstr "Έλαβες μια πρόσκληση για να συμμετάσχεις στην τάξη"
 
-#: app.py:1296
+#: app.py:1294
 #, fuzzy
 msgid "teacher_tutorial_start_message"
 msgstr "Έλαβες μια πρόσκληση για να συμμετάσχεις στην τάξη"
 
-#: app.py:1298
+#: app.py:1296
 #, fuzzy
 msgid "tutorial_class_title"
 msgstr "Απόκρυψη των σημειώσεων"
 
-#: app.py:1298
+#: app.py:1296
 #, fuzzy
 msgid "tutorial_class_message"
 msgstr "Προσαρμογή περιπέτειας"
 
-#: app.py:1300
+#: app.py:1298
 #, fuzzy
 msgid "tutorial_customize_class_title"
 msgstr "Απόκρυψη των σημειώσεων"
 
-#: app.py:1300
+#: app.py:1298
 #, fuzzy
 msgid "tutorial_customize_class_message"
 msgstr "Προσαρμογή περιπέτειας"
 
-#: app.py:1302
+#: app.py:1300
 #, fuzzy
 msgid "tutorial_own_adventures_title"
 msgstr "Προσαρμογή περιπέτειας"
 
-#: app.py:1302
+#: app.py:1300
 #, fuzzy
 msgid "tutorial_own_adventures_message"
 msgstr "Προσαρμογή περιπέτειας"
 
-#: app.py:1304
+#: app.py:1302
 #, fuzzy
 msgid "tutorial_accounts_title"
 msgstr "Προσαρμογή περιπέτειας"
 
-#: app.py:1304
+#: app.py:1302
 #, fuzzy
 msgid "tutorial_accounts_message"
 msgstr "Προσαρμογή περιπέτειας"
 
-#: app.py:1306
+#: app.py:1304
 #, fuzzy
 msgid "tutorial_documentation_title"
 msgstr "Απόκρυψη των σημειώσεων"
 
-#: app.py:1306
+#: app.py:1304
 #, fuzzy
 msgid "tutorial_documentation_message"
 msgstr "Προσαρμογή περιπέτειας"
 
-#: app.py:1308
+#: app.py:1306
 #, fuzzy
 msgid "teacher_tutorial_end_message"
 msgstr "Έλαβες μια πρόσκληση για να συμμετάσχεις στην τάξη"
 
-#: app.py:1318
+#: app.py:1316
 #, fuzzy
 msgid "tutorial_code_snippet"
 msgstr "Απόκρυψη των σημειώσεων"
 
-#: app.py:1322 app.py:1332
+#: app.py:1320 app.py:1330
 msgid "invalid_tutorial_step"
 msgstr ""
 
-#: app.py:1489 website/auth.py:278 website/auth.py:333 website/auth.py:469
+#: app.py:1487 website/auth.py:278 website/auth.py:333 website/auth.py:469
 #: website/auth.py:494 website/auth.py:524 website/auth.py:637
 #: website/auth.py:675 website/auth.py:722 website/auth.py:749
 #: website/quiz.py:43 website/quiz.py:69 website/teacher.py:88
@@ -370,27 +370,27 @@ msgstr ""
 msgid "ajax_error"
 msgstr "Παρουσιάστηκε κάποιο σφάλμα, παρακαλώ ξαναπροσπάθησε."
 
-#: app.py:1492
+#: app.py:1490
 msgid "image_invalid"
 msgstr "Η εικόνα σου δεν είναι έγκυρη"
 
-#: app.py:1494
+#: app.py:1492
 msgid "personal_text_invalid"
 msgstr "Το προσωπικό σου κείμενο δεν είναι έγκυρο"
 
-#: app.py:1496 app.py:1502
+#: app.py:1494 app.py:1500
 msgid "favourite_program_invalid"
 msgstr "Το αγαπημένο σου πρόγραμμα δεν είναι έγκυρο"
 
-#: app.py:1516 app.py:1517
+#: app.py:1514 app.py:1515
 msgid "public_profile_updated"
 msgstr "Το δημόσιο προφίλ έχει ενημερωθεί."
 
-#: app.py:1554 app.py:1579
+#: app.py:1552 app.py:1577
 msgid "user_not_private"
 msgstr "Αυτός ο χρήστης δεν υπάρχει ή δεν έχει δημόσιο προφίλ"
 
-#: app.py:1587
+#: app.py:1585
 msgid "invalid_teacher_invitation_code"
 msgstr ""
 "Ο κωδικός πρόσκλησης καθηγητή δεν είναι έγκυρος. Για να γίνετε καθηγητής,"
@@ -701,132 +701,132 @@ msgstr "Απόκρυψη των σημειώσεων"
 msgid "back_to_class"
 msgstr "Επιστροφή στην τάξη"
 
-#: templates/class-overview.html:13 templates/for-teachers.html:35
+#: templates/class-overview.html:14 templates/for-teachers.html:35
 msgid "class_name_prompt"
 msgstr "Παρακαλώ δώσε το όνομα της τάξης"
 
-#: templates/class-overview.html:19 templates/class-overview.html:66
+#: templates/class-overview.html:20 templates/class-overview.html:71
 #: templates/create-accounts.html:16 templates/highscores.html:25
 #: templates/login.html:12 templates/profile.html:89 templates/recover.html:8
 #: templates/signup.html:10
 msgid "username"
 msgstr "Όνομα Χρήστη"
 
-#: templates/class-overview.html:20
+#: templates/class-overview.html:21
 msgid "last_login"
 msgstr "Τελευταία είσοδος"
 
-#: templates/class-overview.html:21
+#: templates/class-overview.html:22
 msgid "highest_level_reached"
 msgstr "Το υψηλότερο επίπεδο που έφτασες"
 
-#: templates/class-overview.html:22
+#: templates/class-overview.html:23
 msgid "number_programs"
 msgstr "Πλήθος προγραμμάτων"
 
-#: templates/class-overview.html:23
+#: templates/class-overview.html:24
 msgid "programs"
 msgstr "Προγράμματα"
 
-#: templates/class-overview.html:24 templates/create-accounts.html:17
+#: templates/class-overview.html:25 templates/create-accounts.html:17
 #: templates/login.html:15 templates/reset.html:8 templates/signup.html:19
 msgid "password"
 msgstr "Συνθηματικό"
 
-#: templates/class-overview.html:25 templates/class-overview.html:69
+#: templates/class-overview.html:26 templates/class-overview.html:74
 #: templates/customize-adventure.html:52 templates/for-teachers.html:46
 #: templates/for-teachers.html:56
 msgid "remove"
 msgstr "Αφαίρεση"
 
-#: templates/class-overview.html:35
+#: templates/class-overview.html:36
 msgid "page"
 msgstr "σελίδα"
 
-#: templates/class-overview.html:36
+#: templates/class-overview.html:37
 msgid "enter_password"
 msgstr "Δώσε ένα συνθηματικό για"
 
-#: templates/class-overview.html:36
+#: templates/class-overview.html:37
 msgid "password_change_prompt"
 msgstr "Είσαι σίγουρος ότι θέλεις να αλλάξεις το συνθηματικό;"
 
-#: templates/class-overview.html:37
+#: templates/class-overview.html:38
 msgid "remove_student_prompt"
 msgstr "Είσαι βέβαιος/α ότι θέλεις να αφαιρέσεις τον μαθητή από την τάξη;"
 
-#: templates/class-overview.html:44
+#: templates/class-overview.html:46
 #, fuzzy
 msgid "add_students"
 msgstr "μαθητών"
 
-#: templates/class-overview.html:45 templates/customize-class.html:5
+#: templates/class-overview.html:47 templates/customize-class.html:5
 msgid "customize_class"
 msgstr "Προσαρμογή της τάξης"
 
-#: templates/class-overview.html:46
+#: templates/class-overview.html:48
 msgid "class_stats"
 msgstr "Εμφάνιση στατιστικών στοιχείων της τάξης"
 
-#: templates/class-overview.html:47
+#: templates/class-overview.html:49
 #, fuzzy
 msgid "class_logs"
 msgstr "Τελευταία είσοδος"
 
-#: templates/class-overview.html:48 templates/customize-adventure.html:59
+#: templates/class-overview.html:52 templates/customize-adventure.html:59
 msgid "back_to_teachers_page"
 msgstr "Επιστροφή στη σελίδα καθηγητή"
 
-#: templates/class-overview.html:49
+#: templates/class-overview.html:53
 msgid "delete_class_prompt"
 msgstr "Είσαι βέβαις/α ότι θέλεις να διαγράψεις την τάξη;"
 
-#: templates/class-overview.html:49
+#: templates/class-overview.html:53
 msgid "delete_class"
 msgstr "Διαγραφή τάξης οριστικά"
 
-#: templates/class-overview.html:52
+#: templates/class-overview.html:57
 #, fuzzy
 msgid "add_students_options"
 msgstr "Δημιουργία λογαριασμών μαθητών"
 
-#: templates/class-overview.html:54
+#: templates/class-overview.html:59
 #, fuzzy
 msgid "copy_link_success"
 msgstr "Αντίγραψε τον σύνδεσμο για κοινή χρήση"
 
-#: templates/class-overview.html:54
+#: templates/class-overview.html:59
 #, fuzzy
 msgid "copy_join_link"
 msgstr "Please copy and paste this link into a new tab:"
 
-#: templates/class-overview.html:55
+#: templates/class-overview.html:60
 msgid "invite_prompt"
 msgstr "Δώσε όνομα χρήστη"
 
-#: templates/class-overview.html:55
+#: templates/class-overview.html:60
 #, fuzzy
 msgid "invite_by_username"
 msgstr "Όλα τα ονόματα χρηστών πρέπει να είναι μοναδικά."
 
-#: templates/class-overview.html:56 templates/create-accounts.html:45
+#: templates/class-overview.html:61 templates/create-accounts.html:45
 msgid "create_accounts"
 msgstr "Δημιουργία πολλών λογαριασμών"
 
-#: templates/class-overview.html:61
+#: templates/class-overview.html:66
 msgid "pending_invites"
 msgstr "Εκκρεμείς προσκλήσεις"
 
-#: templates/class-overview.html:67
+#: templates/class-overview.html:72
 msgid "invite_date"
 msgstr "Ημερομηνία πρόσκλησης"
 
-#: templates/class-overview.html:68
+#: templates/class-overview.html:73
 #, fuzzy
 msgid "expiration_date"
 msgstr "Expiration date"
 
-#: templates/class-overview.html:78 templates/profile.html:16
+#: templates/class-overview.html:83 templates/profile.html:16
 msgid "delete_invite_prompt"
 msgstr "Είσαι βέβαιος ότι θέλεις να καταργήσεις αυτήν την πρόσκληση τάξης;"
 
@@ -1260,10 +1260,10 @@ msgstr "Οι τάξεις μου"
 msgid "achievements"
 msgstr "επιτεύγματα"
 
-#: templates/highscores.html:27 templates/learn-more.html:22
-#: templates/profile.html:131 templates/signup.html:52
-msgid "country"
-msgstr "Χώρα"
+#: templates/highscores.html:27
+#, fuzzy
+msgid "country_title"
+msgstr "Please select a valid country."
 
 #: templates/highscores.html:28 templates/landing-page.html:88
 #: templates/public-page.html:50
@@ -1536,6 +1536,11 @@ msgstr "Μικρό Όνομα"
 #: templates/learn-more.html:18
 msgid "lastname"
 msgstr "Επίθετο"
+
+#: templates/learn-more.html:22 templates/profile.html:131
+#: templates/signup.html:52
+msgid "country"
+msgstr "Χώρα"
 
 #: templates/learn-more.html:31
 msgid "subscribe"

--- a/translations/en/LC_MESSAGES/messages.po
+++ b/translations/en/LC_MESSAGES/messages.po
@@ -8,16 +8,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-06-28 18:38+0300\n"
+"POT-Creation-Date: 2022-06-29 14:20+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: en\n"
 "Language-Team: en <LL@li.org>\n"
-"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.9.1\n"
+"Generated-By: Babel 2.10.1\n"
 
 #: app.py:417
 msgid "program_contains_error"
@@ -27,7 +27,7 @@ msgstr "This program contains an error, are you sure you want to share it?"
 msgid "title_achievements"
 msgstr "Hedy - My achievements"
 
-#: app.py:644 app.py:748 app.py:1090 website/teacher.py:361
+#: app.py:644 app.py:746 app.py:1088 website/teacher.py:361
 #: website/teacher.py:372
 msgid "not_teacher"
 msgstr "Looks like you are not a teacher!"
@@ -36,11 +36,11 @@ msgstr "Looks like you are not a teacher!"
 msgid "not_enrolled"
 msgstr "Looks like you are not in this class!"
 
-#: app.py:686
+#: app.py:684
 msgid "title_programs"
 msgstr "Hedy - My programs"
 
-#: app.py:696 app.py:706 app.py:710 app.py:725 app.py:1005 app.py:1550
+#: app.py:694 app.py:704 app.py:708 app.py:723 app.py:1003 app.py:1548
 #: website/admin.py:17 website/admin.py:24 website/admin.py:92
 #: website/admin.py:111 website/admin.py:129 website/admin.py:136
 #: website/admin.py:144 website/auth.py:716 website/auth.py:743
@@ -48,298 +48,298 @@ msgstr "Hedy - My programs"
 msgid "unauthorized"
 msgstr "You don't have access rights for this page"
 
-#: app.py:762 app.py:1107
+#: app.py:760 app.py:1105
 msgid "title_for-teacher"
 msgstr "Hedy - For teachers"
 
-#: app.py:779 app.py:781 app.py:923 app.py:945 app.py:947
+#: app.py:777 app.py:779 app.py:921 app.py:943 app.py:945
 msgid "no_such_level"
 msgstr "No such Hedy level!"
 
-#: app.py:789 app.py:796 app.py:877 app.py:883
+#: app.py:787 app.py:794 app.py:875 app.py:881
 msgid "no_such_program"
 msgstr "No such Hedy program!"
 
-#: app.py:819
+#: app.py:817
 msgid "level_not_class"
 msgstr "This level has not been made available in your class yet"
 
-#: app.py:928 website/teacher.py:421 website/teacher.py:437
+#: app.py:926 website/teacher.py:421 website/teacher.py:437
 #: website/teacher.py:466 website/teacher.py:492
 msgid "no_such_adventure"
 msgstr "This adventure doesn't exist!"
 
-#: app.py:956 app.py:1209
+#: app.py:954 app.py:1207
 msgid "page_not_found"
 msgstr "We couldn't find that page!"
 
-#: app.py:976
+#: app.py:974
 msgid "title_signup"
 msgstr "Hedy - Create an account"
 
-#: app.py:983
+#: app.py:981
 msgid "title_login"
 msgstr "Hedy - Login"
 
-#: app.py:990
+#: app.py:988
 msgid "title_recover"
 msgstr "Hedy - Recover account"
 
-#: app.py:1006
+#: app.py:1004
 msgid "title_reset"
 msgstr "Hedy - Reset password"
 
-#: app.py:1032
+#: app.py:1030
 msgid "title_my-profile"
 msgstr "Hedy - My account"
 
-#: app.py:1048
+#: app.py:1046
 msgid "title_learn-more"
 msgstr "Hedy - Learn more"
 
-#: app.py:1054
+#: app.py:1052
 msgid "title_privacy"
 msgstr "Hedy - Privacy terms"
 
-#: app.py:1064
+#: app.py:1062
 msgid "title_start"
 msgstr "Hedy - A gradual programming language"
 
-#: app.py:1082
+#: app.py:1080
 msgid "title_landing-page"
 msgstr "Welcome to Hedy!"
 
-#: app.py:1200
+#: app.py:1198
 msgid "title_explore"
 msgstr "Hedy - Explore"
 
-#: app.py:1221 app.py:1226
+#: app.py:1219 app.py:1224
 #, fuzzy
 msgid "no_such_highscore"
 msgstr "Highscores"
 
-#: app.py:1255 app.py:1257
+#: app.py:1253 app.py:1255
 msgid "translate_error"
 msgstr ""
 "Something went wrong while translating the code. Try running the code to "
 "see if it has an error. Code with errors can not be translated."
 
-#: app.py:1262 app.py:1296
+#: app.py:1260 app.py:1294
 msgid "tutorial_start_title"
 msgstr "Welcome to Hedy!"
 
-#: app.py:1262
+#: app.py:1260
 msgid "tutorial_start_message"
 msgstr "In this tutorial we will explain all the Hedy features step-by-step."
 
-#: app.py:1264
+#: app.py:1262
 msgid "tutorial_editor_title"
 msgstr "The code editor"
 
-#: app.py:1264
+#: app.py:1262
 msgid "tutorial_editor_message"
 msgstr ""
 "In this window you write all the code, try typing something on the place "
 "of the underscores!"
 
-#: app.py:1266
+#: app.py:1264
 msgid "tutorial_output_title"
 msgstr "The output window"
 
-#: app.py:1266
+#: app.py:1264
 msgid "tutorial_output_message"
 msgstr ""
 "The result of the code you execute will be shown here, you just created "
 "this!"
 
-#: app.py:1268
+#: app.py:1266
 msgid "tutorial_run_title"
 msgstr "The run button"
 
-#: app.py:1268
+#: app.py:1266
 msgid "tutorial_run_message"
 msgstr ""
 "With this button you can run your program! Shall we give it a try in the "
 "next step?"
 
-#: app.py:1270
+#: app.py:1268
 msgid "tutorial_tryit_title"
 msgstr "Try it out!"
 
-#: app.py:1270
+#: app.py:1268
 msgid "tutorial_tryit_message"
 msgstr "Run the program, click 'next step' when you're done."
 
-#: app.py:1272
+#: app.py:1270
 msgid "tutorial_speakaloud_title"
 msgstr "Read aloud your program"
 
-#: app.py:1272
+#: app.py:1270
 msgid "tutorial_speakaloud_message"
 msgstr "Choose a voice below the run button to let your program be read aloud."
 
-#: app.py:1274
+#: app.py:1272
 msgid "tutorial_speakaloud_run_title"
 msgstr "Run & listen"
 
-#: app.py:1274
+#: app.py:1272
 msgid "tutorial_speakaloud_run_message"
 msgstr ""
 "Select a voice from the dropdown menu and run your program again to hear "
 "it being read aloud."
 
-#: app.py:1276
+#: app.py:1274
 msgid "tutorial_nextlevel_title"
 msgstr "To the next level"
 
-#: app.py:1276
+#: app.py:1274
 msgid "tutorial_nextlevel_message"
 msgstr ""
 "When you think you understand everything and have practiced enough you "
 "can continue with the next level. When there is also a previous level "
 "there will be a button next to it to go back."
 
-#: app.py:1278
+#: app.py:1276
 msgid "tutorial_leveldefault_title"
 msgstr "Level explanation"
 
-#: app.py:1278
+#: app.py:1276
 msgid "tutorial_leveldefault_message"
 msgstr ""
 "The first tab always contains the level explanation. In each level new "
 "commands will be explained here."
 
-#: app.py:1280
+#: app.py:1278
 msgid "tutorial_adventures_title"
 msgstr "Adventures"
 
-#: app.py:1280
+#: app.py:1278
 msgid "tutorial_adventures_message"
 msgstr ""
 "The other tabs contain adventures, which you can code for each level. "
 "They go from easy to hard."
 
-#: app.py:1282
+#: app.py:1280
 msgid "tutorial_quiz_title"
 msgstr "Quiz"
 
-#: app.py:1282
+#: app.py:1280
 msgid "tutorial_quiz_message"
 msgstr ""
 "At the end of each level you can make the quiz. This way you can verify "
 "if you understand everything."
 
-#: app.py:1284
+#: app.py:1282
 msgid "tutorial_saveshare_title"
 msgstr "Saving & sharing"
 
-#: app.py:1284
+#: app.py:1282
 msgid "tutorial_saveshare_message"
 msgstr "You can save and share all your created programs with other Hedy users."
 
-#: app.py:1286
+#: app.py:1284
 msgid "tutorial_cheatsheet_title"
 msgstr "Cheatsheet"
 
-#: app.py:1286
+#: app.py:1284
 msgid "tutorial_cheatsheet_message"
 msgstr ""
 "If you forgot a command you can always use the cheatsheet. It shows a "
 "list of all commands you can use in the current level."
 
-#: app.py:1288 app.py:1308
+#: app.py:1286 app.py:1306
 msgid "tutorial_end_title"
 msgstr "The end!"
 
-#: app.py:1288
+#: app.py:1286
 msgid "tutorial_end_message"
 msgstr "Click on 'next step' to really start coding with Hedy!"
 
-#: app.py:1290 app.py:1310
+#: app.py:1288 app.py:1308
 #, fuzzy
 msgid "tutorial_title_not_found"
 msgstr "We couldn't find that page!"
 
-#: app.py:1290 app.py:1310
+#: app.py:1288 app.py:1308
 #, fuzzy
 msgid "tutorial_message_not_found"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1296
+#: app.py:1294
 #, fuzzy
 msgid "teacher_tutorial_start_message"
 msgstr "In this tutorial we will explain all the Hedy features step-by-step."
 
-#: app.py:1298
+#: app.py:1296
 #, fuzzy
 msgid "tutorial_class_title"
 msgstr "Class management"
 
-#: app.py:1298
+#: app.py:1296
 msgid "tutorial_class_message"
 msgstr ""
 "As a teacher you can created classes and invite student or let them join "
 "through a link. You can view the programs and statistics of all your "
 "students."
 
-#: app.py:1300
+#: app.py:1298
 msgid "tutorial_customize_class_title"
 msgstr "Customize classes"
 
-#: app.py:1300
+#: app.py:1298
 msgid "tutorial_customize_class_message"
 msgstr ""
 "You can customize classes by hiding specific levels and/or adventures as "
 "well as making them available on a specific date."
 
-#: app.py:1302
+#: app.py:1300
 msgid "tutorial_own_adventures_title"
 msgstr "Creating adventures"
 
-#: app.py:1302
+#: app.py:1300
 msgid "tutorial_own_adventures_message"
 msgstr ""
 "You can create your own adventures and use them as assignments for your "
 "students. Create them here and add them to your classes in the class "
 "customization section."
 
-#: app.py:1304
+#: app.py:1302
 msgid "tutorial_accounts_title"
 msgstr "Creating accounts"
 
-#: app.py:1304
+#: app.py:1302
 msgid "tutorial_accounts_message"
 msgstr ""
 "You can create multiple accounts at once, only needing to provide an "
 "username and password. You can also directly add these accounts to one of"
 " your classes."
 
-#: app.py:1306
+#: app.py:1304
 msgid "tutorial_documentation_title"
 msgstr "Hedy documentation"
 
-#: app.py:1306
+#: app.py:1304
 #, fuzzy
 msgid "tutorial_documentation_message"
 msgstr ""
 "Here you find a more extensive documentation with tips and tricks on how "
 "to use Hedy in the class room."
 
-#: app.py:1308
+#: app.py:1306
 msgid "teacher_tutorial_end_message"
 msgstr "Click on 'next step' to get started as a Hedy teacher!"
 
-#: app.py:1318
+#: app.py:1316
 msgid "tutorial_code_snippet"
 msgstr ""
 "print Hello world!\n"
 "print I'm learning Hedy with the tutorial!"
 
-#: app.py:1322 app.py:1332
+#: app.py:1320 app.py:1330
 msgid "invalid_tutorial_step"
 msgstr ""
 
-#: app.py:1489 website/auth.py:278 website/auth.py:333 website/auth.py:469
+#: app.py:1487 website/auth.py:278 website/auth.py:333 website/auth.py:469
 #: website/auth.py:494 website/auth.py:524 website/auth.py:637
 #: website/auth.py:675 website/auth.py:722 website/auth.py:749
 #: website/quiz.py:43 website/quiz.py:69 website/teacher.py:88
@@ -349,27 +349,27 @@ msgstr ""
 msgid "ajax_error"
 msgstr "There was an error, please try again."
 
-#: app.py:1492
+#: app.py:1490
 msgid "image_invalid"
 msgstr "The image you chose image is invalid."
 
-#: app.py:1494
+#: app.py:1492
 msgid "personal_text_invalid"
 msgstr "Your personal text is invalid."
 
-#: app.py:1496 app.py:1502
+#: app.py:1494 app.py:1500
 msgid "favourite_program_invalid"
 msgstr "Your chosen favourite program is invalid."
 
-#: app.py:1516 app.py:1517
+#: app.py:1514 app.py:1515
 msgid "public_profile_updated"
 msgstr "Public profile updated."
 
-#: app.py:1554 app.py:1579
+#: app.py:1552 app.py:1577
 msgid "user_not_private"
 msgstr "This user either doesn't exist or doesn't have a public profile"
 
-#: app.py:1587
+#: app.py:1585
 msgid "invalid_teacher_invitation_code"
 msgstr ""
 "The teacher invitation code is invalid. To become a teacher, reach out to"
@@ -669,125 +669,125 @@ msgstr "Cheatsheet"
 msgid "back_to_class"
 msgstr "Go back to class"
 
-#: templates/class-overview.html:13 templates/for-teachers.html:35
+#: templates/class-overview.html:14 templates/for-teachers.html:35
 msgid "class_name_prompt"
 msgstr "Please enter the name of the class"
 
-#: templates/class-overview.html:19 templates/class-overview.html:66
+#: templates/class-overview.html:20 templates/class-overview.html:71
 #: templates/create-accounts.html:16 templates/highscores.html:25
 #: templates/login.html:12 templates/profile.html:89 templates/recover.html:8
 #: templates/signup.html:10
 msgid "username"
 msgstr "Username"
 
-#: templates/class-overview.html:20
+#: templates/class-overview.html:21
 msgid "last_login"
 msgstr "Last login"
 
-#: templates/class-overview.html:21
+#: templates/class-overview.html:22
 msgid "highest_level_reached"
 msgstr "Highest level reached"
 
-#: templates/class-overview.html:22
+#: templates/class-overview.html:23
 msgid "number_programs"
 msgstr "Number of programs"
 
-#: templates/class-overview.html:23
+#: templates/class-overview.html:24
 msgid "programs"
 msgstr "Programs"
 
-#: templates/class-overview.html:24 templates/create-accounts.html:17
+#: templates/class-overview.html:25 templates/create-accounts.html:17
 #: templates/login.html:15 templates/reset.html:8 templates/signup.html:19
 msgid "password"
 msgstr "Password"
 
-#: templates/class-overview.html:25 templates/class-overview.html:69
+#: templates/class-overview.html:26 templates/class-overview.html:74
 #: templates/customize-adventure.html:52 templates/for-teachers.html:46
 #: templates/for-teachers.html:56
 msgid "remove"
 msgstr "Remove"
 
-#: templates/class-overview.html:35
+#: templates/class-overview.html:36
 msgid "page"
 msgstr "page"
 
-#: templates/class-overview.html:36
+#: templates/class-overview.html:37
 msgid "enter_password"
 msgstr "Enter a new password for"
 
-#: templates/class-overview.html:36
+#: templates/class-overview.html:37
 msgid "password_change_prompt"
 msgstr "Are you sure you want to change this password?"
 
-#: templates/class-overview.html:37
+#: templates/class-overview.html:38
 msgid "remove_student_prompt"
 msgstr "Are you sure you want to remove the student from the class?"
 
-#: templates/class-overview.html:44
+#: templates/class-overview.html:46
 msgid "add_students"
 msgstr "Add students"
 
-#: templates/class-overview.html:45 templates/customize-class.html:5
+#: templates/class-overview.html:47 templates/customize-class.html:5
 msgid "customize_class"
 msgstr "Customize class"
 
-#: templates/class-overview.html:46
+#: templates/class-overview.html:48
 msgid "class_stats"
 msgstr "Class statistics"
 
-#: templates/class-overview.html:47
+#: templates/class-overview.html:49
 msgid "class_logs"
 msgstr "Logs"
 
-#: templates/class-overview.html:48 templates/customize-adventure.html:59
+#: templates/class-overview.html:52 templates/customize-adventure.html:59
 msgid "back_to_teachers_page"
 msgstr "Go back to teachers page"
 
-#: templates/class-overview.html:49
+#: templates/class-overview.html:53
 msgid "delete_class_prompt"
 msgstr "Are you sure you want to delete the class?"
 
-#: templates/class-overview.html:49
+#: templates/class-overview.html:53
 msgid "delete_class"
 msgstr "Delete class permanently"
 
-#: templates/class-overview.html:52
+#: templates/class-overview.html:57
 msgid "add_students_options"
 msgstr "Add students options"
 
-#: templates/class-overview.html:54
+#: templates/class-overview.html:59
 msgid "copy_link_success"
 msgstr "Join link successfully copied to clipboard"
 
-#: templates/class-overview.html:54
+#: templates/class-overview.html:59
 msgid "copy_join_link"
 msgstr "Copy join link"
 
-#: templates/class-overview.html:55
+#: templates/class-overview.html:60
 msgid "invite_prompt"
 msgstr "Enter a username"
 
-#: templates/class-overview.html:55
+#: templates/class-overview.html:60
 msgid "invite_by_username"
 msgstr "Invite by username"
 
-#: templates/class-overview.html:56 templates/create-accounts.html:45
+#: templates/class-overview.html:61 templates/create-accounts.html:45
 msgid "create_accounts"
 msgstr "Create accounts"
 
-#: templates/class-overview.html:61
+#: templates/class-overview.html:66
 msgid "pending_invites"
 msgstr "Pending invites"
 
-#: templates/class-overview.html:67
+#: templates/class-overview.html:72
 msgid "invite_date"
 msgstr "Invite date"
 
-#: templates/class-overview.html:68
+#: templates/class-overview.html:73
 msgid "expiration_date"
 msgstr "Expiration date"
 
-#: templates/class-overview.html:78 templates/profile.html:16
+#: templates/class-overview.html:83 templates/profile.html:16
 msgid "delete_invite_prompt"
 msgstr "Are you sure you want to remove this class invitation?"
 
@@ -1177,9 +1177,8 @@ msgstr "Your class"
 msgid "achievements"
 msgstr "achievements"
 
-#: templates/highscores.html:27 templates/learn-more.html:22
-#: templates/profile.html:131 templates/signup.html:52
-msgid "country"
+#: templates/highscores.html:27
+msgid "country_title"
 msgstr "Country"
 
 #: templates/highscores.html:28 templates/landing-page.html:88
@@ -1422,6 +1421,11 @@ msgstr "First Name"
 #: templates/learn-more.html:18
 msgid "lastname"
 msgstr "Last Name"
+
+#: templates/learn-more.html:22 templates/profile.html:131
+#: templates/signup.html:52
+msgid "country"
+msgstr "Country"
 
 #: templates/learn-more.html:31
 msgid "subscribe"

--- a/translations/eo/LC_MESSAGES/messages.po
+++ b/translations/eo/LC_MESSAGES/messages.po
@@ -3,16 +3,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-06-28 18:38+0300\n"
+"POT-Creation-Date: 2022-06-29 14:20+0200\n"
 "PO-Revision-Date: 2022-06-28 13:25+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: eo\n"
 "Language-Team: none\n"
-"Plural-Forms: nplurals=2; plural=n != 1\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.9.1\n"
+"Generated-By: Babel 2.10.1\n"
 
 #: app.py:417
 #, fuzzy
@@ -24,7 +24,7 @@ msgstr "This program contains an error, are you sure you want to share it?"
 msgid "title_achievements"
 msgstr "Hedy - Miaj premioj"
 
-#: app.py:644 app.py:748 app.py:1090 website/teacher.py:361
+#: app.py:644 app.py:746 app.py:1088 website/teacher.py:361
 #: website/teacher.py:372
 #, fuzzy
 msgid "not_teacher"
@@ -35,11 +35,11 @@ msgstr "Looks like you are not a teacher!"
 msgid "not_enrolled"
 msgstr "Ŝajne vi ne apartenas al ĉi tiu klaso!"
 
-#: app.py:686
+#: app.py:684
 msgid "title_programs"
 msgstr "Hedy - Miaj programoj"
 
-#: app.py:696 app.py:706 app.py:710 app.py:725 app.py:1005 app.py:1550
+#: app.py:694 app.py:704 app.py:708 app.py:723 app.py:1003 app.py:1548
 #: website/admin.py:17 website/admin.py:24 website/admin.py:92
 #: website/admin.py:111 website/admin.py:129 website/admin.py:136
 #: website/admin.py:144 website/auth.py:716 website/auth.py:743
@@ -48,165 +48,165 @@ msgstr "Hedy - Miaj programoj"
 msgid "unauthorized"
 msgstr "You don't have access rights for this page"
 
-#: app.py:762 app.py:1107
+#: app.py:760 app.py:1105
 msgid "title_for-teacher"
 msgstr "Hedy - Por instruistoj"
 
-#: app.py:779 app.py:781 app.py:923 app.py:945 app.py:947
+#: app.py:777 app.py:779 app.py:921 app.py:943 app.py:945
 #, fuzzy
 msgid "no_such_level"
 msgstr "Nivelo ne ekzistas!"
 
-#: app.py:789 app.py:796 app.py:877 app.py:883
+#: app.py:787 app.py:794 app.py:875 app.py:881
 #, fuzzy
 msgid "no_such_program"
 msgstr "Programo ne ekzistas!"
 
-#: app.py:819
+#: app.py:817
 #, fuzzy
 msgid "level_not_class"
 msgstr "This level has not been made available in your class yet"
 
-#: app.py:928 website/teacher.py:421 website/teacher.py:437
+#: app.py:926 website/teacher.py:421 website/teacher.py:437
 #: website/teacher.py:466 website/teacher.py:492
 #, fuzzy
 msgid "no_such_adventure"
 msgstr "This adventure doesn't exist!"
 
-#: app.py:956 app.py:1209
+#: app.py:954 app.py:1207
 #, fuzzy
 msgid "page_not_found"
 msgstr "Paĝo ne ekzistas!"
 
-#: app.py:976
+#: app.py:974
 msgid "title_signup"
 msgstr "Hedy - Krei konton"
 
-#: app.py:983
+#: app.py:981
 msgid "title_login"
 msgstr "Hedy - Saluti"
 
-#: app.py:990
+#: app.py:988
 #, fuzzy
 msgid "title_recover"
 msgstr "Hedy - Recover account"
 
-#: app.py:1006
+#: app.py:1004
 #, fuzzy
 msgid "title_reset"
 msgstr "Hedy - Reset password"
 
-#: app.py:1032
+#: app.py:1030
 msgid "title_my-profile"
 msgstr "Hedy - Mia konto"
 
-#: app.py:1048
+#: app.py:1046
 msgid "title_learn-more"
 msgstr "Hedy - Lerni plu"
 
-#: app.py:1054
+#: app.py:1052
 msgid "title_privacy"
 msgstr "Hedy - Kondiĉoj pri privateco"
 
-#: app.py:1064
+#: app.py:1062
 #, fuzzy
 msgid "title_start"
 msgstr "Hedy - Laŭgrada programlingvo"
 
-#: app.py:1082
+#: app.py:1080
 msgid "title_landing-page"
 msgstr "Bonvenon al Hedy!"
 
-#: app.py:1200
+#: app.py:1198
 #, fuzzy
 msgid "title_explore"
 msgstr "Hedy - Explore"
 
-#: app.py:1221 app.py:1226
+#: app.py:1219 app.py:1224
 #, fuzzy
 msgid "no_such_highscore"
 msgstr "Nivelo ne ekzistas!"
 
-#: app.py:1255 app.py:1257
+#: app.py:1253 app.py:1255
 #, fuzzy
 msgid "translate_error"
 msgstr ""
 "Something went wrong while translating the code. Try running the code to "
 "see if it has an error. Code with errors can not be translated."
 
-#: app.py:1262 app.py:1296
+#: app.py:1260 app.py:1294
 msgid "tutorial_start_title"
 msgstr "Bonvenon al Hedy!"
 
-#: app.py:1262
+#: app.py:1260
 #, fuzzy
 msgid "tutorial_start_message"
 msgstr "In this tutorial we will explain all the Hedy features step-by-step."
 
-#: app.py:1264
+#: app.py:1262
 #, fuzzy
 msgid "tutorial_editor_title"
 msgstr "The code editor"
 
-#: app.py:1264
+#: app.py:1262
 #, fuzzy
 msgid "tutorial_editor_message"
 msgstr "In this window you write all the code, try typing something!"
 
-#: app.py:1266
+#: app.py:1264
 #, fuzzy
 msgid "tutorial_output_title"
 msgstr "The output window"
 
-#: app.py:1266
+#: app.py:1264
 #, fuzzy
 msgid "tutorial_output_message"
 msgstr "The result of the code you execute will be shown here"
 
-#: app.py:1268
+#: app.py:1266
 msgid "tutorial_run_title"
 msgstr "La butono «Ruli»"
 
-#: app.py:1268
+#: app.py:1266
 #, fuzzy
 msgid "tutorial_run_message"
 msgstr "With this button you can run your program! Shall we give it a try?"
 
-#: app.py:1270
+#: app.py:1268
 #, fuzzy
 msgid "tutorial_tryit_title"
 msgstr "Try it out!"
 
-#: app.py:1270
+#: app.py:1268
 #, fuzzy
 msgid "tutorial_tryit_message"
 msgstr "Run the program, click 'next step' when you're done."
 
-#: app.py:1272
+#: app.py:1270
 #, fuzzy
 msgid "tutorial_speakaloud_title"
 msgstr "Fino!"
 
-#: app.py:1272
+#: app.py:1270
 #, fuzzy
 msgid "tutorial_speakaloud_message"
 msgstr "Click on 'next step' to really start coding with Hedy!"
 
-#: app.py:1274
+#: app.py:1272
 #, fuzzy
 msgid "tutorial_speakaloud_run_title"
 msgstr "Fino!"
 
-#: app.py:1274
+#: app.py:1272
 #, fuzzy
 msgid "tutorial_speakaloud_run_message"
 msgstr "Click on 'next step' to really start coding with Hedy!"
 
-#: app.py:1276
+#: app.py:1274
 msgid "tutorial_nextlevel_title"
 msgstr "Al la sekva nivelo"
 
-#: app.py:1276
+#: app.py:1274
 #, fuzzy
 msgid "tutorial_nextlevel_message"
 msgstr ""
@@ -214,88 +214,88 @@ msgstr ""
 "can continue with the next level. When there is also a previous level "
 "there will be a button next to it to go back."
 
-#: app.py:1278
+#: app.py:1276
 #, fuzzy
 msgid "tutorial_leveldefault_title"
 msgstr "Level explanation"
 
-#: app.py:1278
+#: app.py:1276
 #, fuzzy
 msgid "tutorial_leveldefault_message"
 msgstr ""
 "The first tab always contains the level explanation. In each level new "
 "commands will be explained here."
 
-#: app.py:1280
+#: app.py:1278
 msgid "tutorial_adventures_title"
 msgstr "Aventuroj"
 
-#: app.py:1280
+#: app.py:1278
 #, fuzzy
 msgid "tutorial_adventures_message"
 msgstr ""
 "The other tabs contain adventures, which you can code for each level. "
 "They go from easy to hard."
 
-#: app.py:1282
+#: app.py:1280
 msgid "tutorial_quiz_title"
 msgstr "Kvizo"
 
-#: app.py:1282
+#: app.py:1280
 #, fuzzy
 msgid "tutorial_quiz_message"
 msgstr ""
 "At the end of each level you can make the quiz. This way you can verify "
 "if you understand everything."
 
-#: app.py:1284
+#: app.py:1282
 #, fuzzy
 msgid "tutorial_saveshare_title"
 msgstr "Saving & sharing"
 
-#: app.py:1284
+#: app.py:1282
 #, fuzzy
 msgid "tutorial_saveshare_message"
 msgstr "You can save and share all your created programs with other Hedy users."
 
-#: app.py:1286
+#: app.py:1284
 #, fuzzy
 msgid "tutorial_cheatsheet_title"
 msgstr "Cheatsheet"
 
-#: app.py:1286
+#: app.py:1284
 #, fuzzy
 msgid "tutorial_cheatsheet_message"
 msgstr ""
 "If you forgot a command you can always use the cheatsheet. It shows a "
 "list of all commands you can use in the current level."
 
-#: app.py:1288 app.py:1308
+#: app.py:1286 app.py:1306
 msgid "tutorial_end_title"
 msgstr "Fino!"
 
-#: app.py:1288
+#: app.py:1286
 #, fuzzy
 msgid "tutorial_end_message"
 msgstr "Click on 'next step' to really start coding with Hedy!"
 
-#: app.py:1290 app.py:1310
+#: app.py:1288 app.py:1308
 msgid "tutorial_title_not_found"
 msgstr ""
 
-#: app.py:1290 app.py:1310
+#: app.py:1288 app.py:1308
 msgid "tutorial_message_not_found"
 msgstr ""
 
-#: app.py:1296
+#: app.py:1294
 msgid "teacher_tutorial_start_message"
 msgstr ""
 
-#: app.py:1298
+#: app.py:1296
 msgid "tutorial_class_title"
 msgstr ""
 
-#: app.py:1298
+#: app.py:1296
 #, fuzzy
 msgid "tutorial_class_message"
 msgstr ""
@@ -303,24 +303,24 @@ msgstr ""
 "through a link. You can view the programs and statistics of all your "
 "students."
 
-#: app.py:1300
+#: app.py:1298
 #, fuzzy
 msgid "tutorial_customize_class_title"
 msgstr "Customize classes"
 
-#: app.py:1300
+#: app.py:1298
 #, fuzzy
 msgid "tutorial_customize_class_message"
 msgstr ""
 "You can customize classes by hiding specific levels and/or adventures as "
 "well as making them available on a specific date."
 
-#: app.py:1302
+#: app.py:1300
 #, fuzzy
 msgid "tutorial_own_adventures_title"
 msgstr "Creating adventures"
 
-#: app.py:1302
+#: app.py:1300
 #, fuzzy
 msgid "tutorial_own_adventures_message"
 msgstr ""
@@ -328,12 +328,12 @@ msgstr ""
 "students. Create them here and add them to your classes in the class "
 "customization section."
 
-#: app.py:1304
+#: app.py:1302
 #, fuzzy
 msgid "tutorial_accounts_title"
 msgstr "Creating accounts"
 
-#: app.py:1304
+#: app.py:1302
 #, fuzzy
 msgid "tutorial_accounts_message"
 msgstr ""
@@ -341,32 +341,32 @@ msgstr ""
 "username and password. You can also directly add these accounts to one of"
 " your classes."
 
-#: app.py:1306
+#: app.py:1304
 #, fuzzy
 msgid "tutorial_documentation_title"
 msgstr "Hedy documentation"
 
-#: app.py:1306
+#: app.py:1304
 msgid "tutorial_documentation_message"
 msgstr ""
 
-#: app.py:1308
+#: app.py:1306
 #, fuzzy
 msgid "teacher_tutorial_end_message"
 msgstr "Click on 'next step' to get started as a Hedy teacher!"
 
-#: app.py:1318
+#: app.py:1316
 #, fuzzy
 msgid "tutorial_code_snippet"
 msgstr ""
 "print Hello world!\n"
 "print I'm learning Hedy with the tutorial!"
 
-#: app.py:1322 app.py:1332
+#: app.py:1320 app.py:1330
 msgid "invalid_tutorial_step"
 msgstr ""
 
-#: app.py:1489 website/auth.py:278 website/auth.py:333 website/auth.py:469
+#: app.py:1487 website/auth.py:278 website/auth.py:333 website/auth.py:469
 #: website/auth.py:494 website/auth.py:524 website/auth.py:637
 #: website/auth.py:675 website/auth.py:722 website/auth.py:749
 #: website/quiz.py:43 website/quiz.py:69 website/teacher.py:88
@@ -377,32 +377,32 @@ msgstr ""
 msgid "ajax_error"
 msgstr "There was an error, please try again."
 
-#: app.py:1492
+#: app.py:1490
 #, fuzzy
 msgid "image_invalid"
 msgstr "The image you chose image is invalid."
 
-#: app.py:1494
+#: app.py:1492
 #, fuzzy
 msgid "personal_text_invalid"
 msgstr "Your personal text is invalid."
 
-#: app.py:1496 app.py:1502
+#: app.py:1494 app.py:1500
 #, fuzzy
 msgid "favourite_program_invalid"
 msgstr "Your chosen favourite program is invalid."
 
-#: app.py:1516 app.py:1517
+#: app.py:1514 app.py:1515
 #, fuzzy
 msgid "public_profile_updated"
 msgstr "Public profile updated."
 
-#: app.py:1554 app.py:1579
+#: app.py:1552 app.py:1577
 #, fuzzy
 msgid "user_not_private"
 msgstr "This user either doesn't exist or doesn't have a public profile"
 
-#: app.py:1587
+#: app.py:1585
 #, fuzzy
 msgid "invalid_teacher_invitation_code"
 msgstr ""
@@ -761,12 +761,12 @@ msgstr "Cheatsheet"
 msgid "back_to_class"
 msgstr "Go back to class"
 
-#: templates/class-overview.html:13 templates/for-teachers.html:35
+#: templates/class-overview.html:14 templates/for-teachers.html:35
 #, fuzzy
 msgid "class_name_prompt"
 msgstr "Please enter the name of the class"
 
-#: templates/class-overview.html:19 templates/class-overview.html:66
+#: templates/class-overview.html:20 templates/class-overview.html:71
 #: templates/create-accounts.html:16 templates/highscores.html:25
 #: templates/login.html:12 templates/profile.html:89 templates/recover.html:8
 #: templates/signup.html:10
@@ -774,140 +774,140 @@ msgstr "Please enter the name of the class"
 msgid "username"
 msgstr "Username"
 
-#: templates/class-overview.html:20
+#: templates/class-overview.html:21
 #, fuzzy
 msgid "last_login"
 msgstr "Last login"
 
-#: templates/class-overview.html:21
+#: templates/class-overview.html:22
 #, fuzzy
 msgid "highest_level_reached"
 msgstr "Highest level reached"
 
-#: templates/class-overview.html:22
+#: templates/class-overview.html:23
 #, fuzzy
 msgid "number_programs"
 msgstr "Number of programs"
 
-#: templates/class-overview.html:23
+#: templates/class-overview.html:24
 #, fuzzy
 msgid "programs"
 msgstr "Programs"
 
-#: templates/class-overview.html:24 templates/create-accounts.html:17
+#: templates/class-overview.html:25 templates/create-accounts.html:17
 #: templates/login.html:15 templates/reset.html:8 templates/signup.html:19
 #, fuzzy
 msgid "password"
 msgstr "Password"
 
-#: templates/class-overview.html:25 templates/class-overview.html:69
+#: templates/class-overview.html:26 templates/class-overview.html:74
 #: templates/customize-adventure.html:52 templates/for-teachers.html:46
 #: templates/for-teachers.html:56
 #, fuzzy
 msgid "remove"
 msgstr "Remove"
 
-#: templates/class-overview.html:35
+#: templates/class-overview.html:36
 #, fuzzy
 msgid "page"
 msgstr "page"
 
-#: templates/class-overview.html:36
+#: templates/class-overview.html:37
 #, fuzzy
 msgid "enter_password"
 msgstr "Enter a new password for"
 
-#: templates/class-overview.html:36
+#: templates/class-overview.html:37
 #, fuzzy
 msgid "password_change_prompt"
 msgstr "Are you sure you want to change this password?"
 
-#: templates/class-overview.html:37
+#: templates/class-overview.html:38
 #, fuzzy
 msgid "remove_student_prompt"
 msgstr "Are you sure you want to remove the student from the class?"
 
-#: templates/class-overview.html:44
+#: templates/class-overview.html:46
 #, fuzzy
 msgid "add_students"
 msgstr "lernantoj"
 
-#: templates/class-overview.html:45 templates/customize-class.html:5
+#: templates/class-overview.html:47 templates/customize-class.html:5
 #, fuzzy
 msgid "customize_class"
 msgstr "Customize class"
 
-#: templates/class-overview.html:46
+#: templates/class-overview.html:48
 #, fuzzy
 msgid "class_stats"
 msgstr "Class statistics"
 
-#: templates/class-overview.html:47
+#: templates/class-overview.html:49
 #, fuzzy
 msgid "class_logs"
 msgstr "Last login"
 
-#: templates/class-overview.html:48 templates/customize-adventure.html:59
+#: templates/class-overview.html:52 templates/customize-adventure.html:59
 #, fuzzy
 msgid "back_to_teachers_page"
 msgstr "Go back to teachers page"
 
-#: templates/class-overview.html:49
+#: templates/class-overview.html:53
 #, fuzzy
 msgid "delete_class_prompt"
 msgstr "Are you sure you want to delete the class?"
 
-#: templates/class-overview.html:49
+#: templates/class-overview.html:53
 #, fuzzy
 msgid "delete_class"
 msgstr "Delete class permanently"
 
-#: templates/class-overview.html:52
+#: templates/class-overview.html:57
 #, fuzzy
 msgid "add_students_options"
 msgstr "Create student accounts"
 
-#: templates/class-overview.html:54
+#: templates/class-overview.html:59
 #, fuzzy
 msgid "copy_link_success"
 msgstr "Copy link to share"
 
-#: templates/class-overview.html:54
+#: templates/class-overview.html:59
 #, fuzzy
 msgid "copy_join_link"
 msgstr "Please copy and paste this link into a new tab:"
 
-#: templates/class-overview.html:55
+#: templates/class-overview.html:60
 #, fuzzy
 msgid "invite_prompt"
 msgstr "Enter a username"
 
-#: templates/class-overview.html:55
+#: templates/class-overview.html:60
 #, fuzzy
 msgid "invite_by_username"
 msgstr "All usernames need to be unique."
 
-#: templates/class-overview.html:56 templates/create-accounts.html:45
+#: templates/class-overview.html:61 templates/create-accounts.html:45
 #, fuzzy
 msgid "create_accounts"
 msgstr "Create multiple accounts"
 
-#: templates/class-overview.html:61
+#: templates/class-overview.html:66
 #, fuzzy
 msgid "pending_invites"
 msgstr "Pending invites"
 
-#: templates/class-overview.html:67
+#: templates/class-overview.html:72
 #, fuzzy
 msgid "invite_date"
 msgstr "Invite date"
 
-#: templates/class-overview.html:68
+#: templates/class-overview.html:73
 #, fuzzy
 msgid "expiration_date"
 msgstr "Expiration date"
 
-#: templates/class-overview.html:78 templates/profile.html:16
+#: templates/class-overview.html:83 templates/profile.html:16
 #, fuzzy
 msgid "delete_invite_prompt"
 msgstr "Are you sure you want to remove this class invitation?"
@@ -1370,10 +1370,10 @@ msgstr "My classes"
 msgid "achievements"
 msgstr "premioj"
 
-#: templates/highscores.html:27 templates/learn-more.html:22
-#: templates/profile.html:131 templates/signup.html:52
-msgid "country"
-msgstr "Lando"
+#: templates/highscores.html:27
+#, fuzzy
+msgid "country_title"
+msgstr "Please select a valid country."
 
 #: templates/highscores.html:28 templates/landing-page.html:88
 #: templates/public-page.html:50
@@ -1652,6 +1652,11 @@ msgstr "First Name"
 #, fuzzy
 msgid "lastname"
 msgstr "Last Name"
+
+#: templates/learn-more.html:22 templates/profile.html:131
+#: templates/signup.html:52
+msgid "country"
+msgstr "Lando"
 
 #: templates/learn-more.html:31
 msgid "subscribe"

--- a/translations/es/LC_MESSAGES/messages.po
+++ b/translations/es/LC_MESSAGES/messages.po
@@ -3,16 +3,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-28 18:38+0300\n"
+"POT-Creation-Date: 2022-06-29 14:20+0200\n"
 "PO-Revision-Date: 2022-06-28 13:25+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: es\n"
 "Language-Team: es <LL@li.org>\n"
-"Plural-Forms: nplurals=2; plural=n != 1\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.9.1\n"
+"Generated-By: Babel 2.10.1\n"
 
 #: app.py:417
 #, fuzzy
@@ -24,7 +24,7 @@ msgstr "This program contains an error, are you sure you want to share it?"
 msgid "title_achievements"
 msgstr "Hedy - My achievements"
 
-#: app.py:644 app.py:748 app.py:1090 website/teacher.py:361
+#: app.py:644 app.py:746 app.py:1088 website/teacher.py:361
 #: website/teacher.py:372
 msgid "not_teacher"
 msgstr "Parece que no eres un instructor."
@@ -33,12 +33,12 @@ msgstr "Parece que no eres un instructor."
 msgid "not_enrolled"
 msgstr "No se encontró tu registro para esta clase"
 
-#: app.py:686
+#: app.py:684
 #, fuzzy
 msgid "title_programs"
 msgstr "Hedy - My programs"
 
-#: app.py:696 app.py:706 app.py:710 app.py:725 app.py:1005 app.py:1550
+#: app.py:694 app.py:704 app.py:708 app.py:723 app.py:1003 app.py:1548
 #: website/admin.py:17 website/admin.py:24 website/admin.py:92
 #: website/admin.py:111 website/admin.py:129 website/admin.py:136
 #: website/admin.py:144 website/auth.py:716 website/auth.py:743
@@ -47,322 +47,322 @@ msgstr "Hedy - My programs"
 msgid "unauthorized"
 msgstr "You don't have access rights for this page"
 
-#: app.py:762 app.py:1107
+#: app.py:760 app.py:1105
 #, fuzzy
 msgid "title_for-teacher"
 msgstr "Hedy - For teachers"
 
-#: app.py:779 app.py:781 app.py:923 app.py:945 app.py:947
+#: app.py:777 app.py:779 app.py:921 app.py:943 app.py:945
 msgid "no_such_level"
 msgstr "No se encontró ese nivel de Hedy"
 
-#: app.py:789 app.py:796 app.py:877 app.py:883
+#: app.py:787 app.py:794 app.py:875 app.py:881
 msgid "no_such_program"
 msgstr "No se encontró el programa de Hedy"
 
-#: app.py:819
+#: app.py:817
 #, fuzzy
 msgid "level_not_class"
 msgstr "You're in a class where this level has not been made available yet"
 
-#: app.py:928 website/teacher.py:421 website/teacher.py:437
+#: app.py:926 website/teacher.py:421 website/teacher.py:437
 #: website/teacher.py:466 website/teacher.py:492
 #, fuzzy
 msgid "no_such_adventure"
 msgstr "This adventure doesn't exist!"
 
-#: app.py:956 app.py:1209
+#: app.py:954 app.py:1207
 msgid "page_not_found"
 msgstr "¡No pudimos encontrar esta página!"
 
-#: app.py:976
+#: app.py:974
 #, fuzzy
 msgid "title_signup"
 msgstr "Hedy - Create an account"
 
-#: app.py:983
+#: app.py:981
 #, fuzzy
 msgid "title_login"
 msgstr "Hedy - Login"
 
-#: app.py:990
+#: app.py:988
 #, fuzzy
 msgid "title_recover"
 msgstr "Hedy - Recover account"
 
-#: app.py:1006
+#: app.py:1004
 #, fuzzy
 msgid "title_reset"
 msgstr "Hedy - Reset password"
 
-#: app.py:1032
+#: app.py:1030
 #, fuzzy
 msgid "title_my-profile"
 msgstr "Hedy - My account"
 
-#: app.py:1048
+#: app.py:1046
 #, fuzzy
 msgid "title_learn-more"
 msgstr "Hedy - Learn more"
 
-#: app.py:1054
+#: app.py:1052
 #, fuzzy
 msgid "title_privacy"
 msgstr "Hedy - Privacy terms"
 
-#: app.py:1064
+#: app.py:1062
 #, fuzzy
 msgid "title_start"
 msgstr "Hedy - A gradual programming language"
 
-#: app.py:1082
+#: app.py:1080
 #, fuzzy
 msgid "title_landing-page"
 msgstr "Welcome to Hedy!"
 
-#: app.py:1200
+#: app.py:1198
 #, fuzzy
 msgid "title_explore"
 msgstr "Hedy - Explore"
 
-#: app.py:1221 app.py:1226
+#: app.py:1219 app.py:1224
 #, fuzzy
 msgid "no_such_highscore"
 msgstr "No se encontró ese nivel de Hedy"
 
-#: app.py:1255 app.py:1257
+#: app.py:1253 app.py:1255
 #, fuzzy
 msgid "translate_error"
 msgstr ""
 "Something went wrong while translating the code. Try running the code to "
 "see if it has an error. Code with errors can not be translated."
 
-#: app.py:1262 app.py:1296
+#: app.py:1260 app.py:1294
 #, fuzzy
 msgid "tutorial_start_title"
 msgstr "Welcome to Hedy!"
 
-#: app.py:1262
+#: app.py:1260
 #, fuzzy
 msgid "tutorial_start_message"
 msgstr "In this tutorial we will explain all the Hedy features step-by-step."
 
-#: app.py:1264
+#: app.py:1262
 #, fuzzy
 msgid "tutorial_editor_title"
 msgstr "The code editor"
 
-#: app.py:1264
+#: app.py:1262
 #, fuzzy
 msgid "tutorial_editor_message"
 msgstr "In this window you write all the code, try typing something!"
 
-#: app.py:1266
+#: app.py:1264
 #, fuzzy
 msgid "tutorial_output_title"
 msgstr "The output window"
 
-#: app.py:1266
+#: app.py:1264
 #, fuzzy
 msgid "tutorial_output_message"
 msgstr "The result of the code you execute will be shown here"
 
-#: app.py:1268
+#: app.py:1266
 #, fuzzy
 msgid "tutorial_run_title"
 msgstr "The run button"
 
-#: app.py:1268
+#: app.py:1266
 #, fuzzy
 msgid "tutorial_run_message"
 msgstr "With this button you can run your program! Shall we give it a try?"
 
-#: app.py:1270
+#: app.py:1268
 #, fuzzy
 msgid "tutorial_tryit_title"
 msgstr "Try it out!"
 
-#: app.py:1270
+#: app.py:1268
 #, fuzzy
 msgid "tutorial_tryit_message"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1272
+#: app.py:1270
 #, fuzzy
 msgid "tutorial_speakaloud_title"
 msgstr "The end!"
 
-#: app.py:1272
+#: app.py:1270
 #, fuzzy
 msgid "tutorial_speakaloud_message"
 msgstr "Click on 'next step' to really start coding with Hedy!"
 
-#: app.py:1274
+#: app.py:1272
 #, fuzzy
 msgid "tutorial_speakaloud_run_title"
 msgstr "The end!"
 
-#: app.py:1274
+#: app.py:1272
 #, fuzzy
 msgid "tutorial_speakaloud_run_message"
 msgstr "Click on 'next step' to really start coding with Hedy!"
 
-#: app.py:1276
+#: app.py:1274
 #, fuzzy
 msgid "tutorial_nextlevel_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1276
+#: app.py:1274
 #, fuzzy
 msgid "tutorial_nextlevel_message"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1278
+#: app.py:1276
 #, fuzzy
 msgid "tutorial_leveldefault_title"
 msgstr "Level explanation"
 
-#: app.py:1278
+#: app.py:1276
 #, fuzzy
 msgid "tutorial_leveldefault_message"
 msgstr ""
 "The first tab always contains the level explanation. In each level new "
 "commands will be explained here."
 
-#: app.py:1280
+#: app.py:1278
 #, fuzzy
 msgid "tutorial_adventures_title"
 msgstr "Customize adventure"
 
-#: app.py:1280
+#: app.py:1278
 #, fuzzy
 msgid "tutorial_adventures_message"
 msgstr "Customize adventure"
 
-#: app.py:1282
+#: app.py:1280
 #, fuzzy
 msgid "tutorial_quiz_title"
 msgstr "Quiz"
 
-#: app.py:1282
+#: app.py:1280
 #, fuzzy
 msgid "tutorial_quiz_message"
 msgstr ""
 "At the end of each level you can make the quiz. This way you can verify "
 "if you understand everything."
 
-#: app.py:1284
+#: app.py:1282
 #, fuzzy
 msgid "tutorial_saveshare_title"
 msgstr "Saving & sharing"
 
-#: app.py:1284
+#: app.py:1282
 #, fuzzy
 msgid "tutorial_saveshare_message"
 msgstr "You can save and share all your created programs with other Hedy users."
 
-#: app.py:1286
+#: app.py:1284
 #, fuzzy
 msgid "tutorial_cheatsheet_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1286
+#: app.py:1284
 #, fuzzy
 msgid "tutorial_cheatsheet_message"
 msgstr ""
 "If you forgot a command you can always use the cheatsheet. It shows a "
 "list of all commands you can use in the current level."
 
-#: app.py:1288 app.py:1308
+#: app.py:1286 app.py:1306
 #, fuzzy
 msgid "tutorial_end_title"
 msgstr "The end!"
 
-#: app.py:1288
+#: app.py:1286
 #, fuzzy
 msgid "tutorial_end_message"
 msgstr "Click on 'next step' to really start coding with Hedy!"
 
-#: app.py:1290 app.py:1310
+#: app.py:1288 app.py:1308
 #, fuzzy
 msgid "tutorial_title_not_found"
 msgstr "¡No pudimos encontrar esta página!"
 
-#: app.py:1290 app.py:1310
+#: app.py:1288 app.py:1308
 #, fuzzy
 msgid "tutorial_message_not_found"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1296
+#: app.py:1294
 #, fuzzy
 msgid "teacher_tutorial_start_message"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1298
+#: app.py:1296
 #, fuzzy
 msgid "tutorial_class_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1298
+#: app.py:1296
 #, fuzzy
 msgid "tutorial_class_message"
 msgstr "Customize adventure"
 
-#: app.py:1300
+#: app.py:1298
 #, fuzzy
 msgid "tutorial_customize_class_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1300
+#: app.py:1298
 #, fuzzy
 msgid "tutorial_customize_class_message"
 msgstr "Customize adventure"
 
-#: app.py:1302
+#: app.py:1300
 #, fuzzy
 msgid "tutorial_own_adventures_title"
 msgstr "Customize adventure"
 
-#: app.py:1302
+#: app.py:1300
 #, fuzzy
 msgid "tutorial_own_adventures_message"
 msgstr "Customize adventure"
 
-#: app.py:1304
+#: app.py:1302
 #, fuzzy
 msgid "tutorial_accounts_title"
 msgstr "Customize adventure"
 
-#: app.py:1304
+#: app.py:1302
 #, fuzzy
 msgid "tutorial_accounts_message"
 msgstr "Customize adventure"
 
-#: app.py:1306
+#: app.py:1304
 #, fuzzy
 msgid "tutorial_documentation_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1306
+#: app.py:1304
 #, fuzzy
 msgid "tutorial_documentation_message"
 msgstr "Customize adventure"
 
-#: app.py:1308
+#: app.py:1306
 #, fuzzy
 msgid "teacher_tutorial_end_message"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1318
+#: app.py:1316
 #, fuzzy
 msgid "tutorial_code_snippet"
 msgstr "Hide cheatsheet"
 
-#: app.py:1322 app.py:1332
+#: app.py:1320 app.py:1330
 msgid "invalid_tutorial_step"
 msgstr ""
 
-#: app.py:1489 website/auth.py:278 website/auth.py:333 website/auth.py:469
+#: app.py:1487 website/auth.py:278 website/auth.py:333 website/auth.py:469
 #: website/auth.py:494 website/auth.py:524 website/auth.py:637
 #: website/auth.py:675 website/auth.py:722 website/auth.py:749
 #: website/quiz.py:43 website/quiz.py:69 website/teacher.py:88
@@ -372,32 +372,32 @@ msgstr ""
 msgid "ajax_error"
 msgstr "Hubo un error, por favor intenta nuevamente."
 
-#: app.py:1492
+#: app.py:1490
 #, fuzzy
 msgid "image_invalid"
 msgstr "Your chosen image is invalid."
 
-#: app.py:1494
+#: app.py:1492
 #, fuzzy
 msgid "personal_text_invalid"
 msgstr "Your personal text is invalid."
 
-#: app.py:1496 app.py:1502
+#: app.py:1494 app.py:1500
 #, fuzzy
 msgid "favourite_program_invalid"
 msgstr "Your chosen favourite program is invalid."
 
-#: app.py:1516 app.py:1517
+#: app.py:1514 app.py:1515
 #, fuzzy
 msgid "public_profile_updated"
 msgstr "Public profile updated."
 
-#: app.py:1554 app.py:1579
+#: app.py:1552 app.py:1577
 #, fuzzy
 msgid "user_not_private"
 msgstr "This user doesn't exist or doesn't have a public profile"
 
-#: app.py:1587
+#: app.py:1585
 msgid "invalid_teacher_invitation_code"
 msgstr ""
 "El código de instructor es inválido. Para ser instructor, por favor mande"
@@ -732,147 +732,147 @@ msgstr "Hide cheatsheet"
 msgid "back_to_class"
 msgstr "Go back to class"
 
-#: templates/class-overview.html:13 templates/for-teachers.html:35
+#: templates/class-overview.html:14 templates/for-teachers.html:35
 #, fuzzy
 msgid "class_name_prompt"
 msgstr "Please enter the name of the class"
 
-#: templates/class-overview.html:19 templates/class-overview.html:66
+#: templates/class-overview.html:20 templates/class-overview.html:71
 #: templates/create-accounts.html:16 templates/highscores.html:25
 #: templates/login.html:12 templates/profile.html:89 templates/recover.html:8
 #: templates/signup.html:10
 msgid "username"
 msgstr "Usuario"
 
-#: templates/class-overview.html:20
+#: templates/class-overview.html:21
 msgid "last_login"
 msgstr "Último ingreso"
 
-#: templates/class-overview.html:21
+#: templates/class-overview.html:22
 msgid "highest_level_reached"
 msgstr "Nivel más alto alcanzado"
 
-#: templates/class-overview.html:22
+#: templates/class-overview.html:23
 msgid "number_programs"
 msgstr "Número de programas"
 
-#: templates/class-overview.html:23
+#: templates/class-overview.html:24
 #, fuzzy
 msgid "programs"
 msgstr "Programs"
 
-#: templates/class-overview.html:24 templates/create-accounts.html:17
+#: templates/class-overview.html:25 templates/create-accounts.html:17
 #: templates/login.html:15 templates/reset.html:8 templates/signup.html:19
 msgid "password"
 msgstr "Contraseña"
 
-#: templates/class-overview.html:25 templates/class-overview.html:69
+#: templates/class-overview.html:26 templates/class-overview.html:74
 #: templates/customize-adventure.html:52 templates/for-teachers.html:46
 #: templates/for-teachers.html:56
 #, fuzzy
 msgid "remove"
 msgstr "Remove"
 
-#: templates/class-overview.html:35
+#: templates/class-overview.html:36
 #, fuzzy
 msgid "page"
 msgstr "page"
 
-#: templates/class-overview.html:36
+#: templates/class-overview.html:37
 #, fuzzy
 msgid "enter_password"
 msgstr "Enter a new password for"
 
-#: templates/class-overview.html:36
+#: templates/class-overview.html:37
 #, fuzzy
 msgid "password_change_prompt"
 msgstr "Are you sure you want to change this password?"
 
-#: templates/class-overview.html:37
+#: templates/class-overview.html:38
 #, fuzzy
 msgid "remove_student_prompt"
 msgstr "Are you sure you want to remove the student from the class?"
 
-#: templates/class-overview.html:44
+#: templates/class-overview.html:46
 #, fuzzy
 msgid "add_students"
 msgstr "estudiantes"
 
-#: templates/class-overview.html:45 templates/customize-class.html:5
+#: templates/class-overview.html:47 templates/customize-class.html:5
 #, fuzzy
 msgid "customize_class"
 msgstr "Customize class"
 
-#: templates/class-overview.html:46
+#: templates/class-overview.html:48
 #, fuzzy
 msgid "class_stats"
 msgstr "Show class statistics"
 
-#: templates/class-overview.html:47
+#: templates/class-overview.html:49
 #, fuzzy
 msgid "class_logs"
 msgstr "Último ingreso"
 
-#: templates/class-overview.html:48 templates/customize-adventure.html:59
+#: templates/class-overview.html:52 templates/customize-adventure.html:59
 #, fuzzy
 msgid "back_to_teachers_page"
 msgstr "Go back to teachers page"
 
-#: templates/class-overview.html:49
+#: templates/class-overview.html:53
 #, fuzzy
 msgid "delete_class_prompt"
 msgstr "Are you sure you want to delete the class?"
 
-#: templates/class-overview.html:49
+#: templates/class-overview.html:53
 msgid "delete_class"
 msgstr "Borrar clase permanentemente"
 
-#: templates/class-overview.html:52
+#: templates/class-overview.html:57
 #, fuzzy
 msgid "add_students_options"
 msgstr "Create student accounts"
 
-#: templates/class-overview.html:54
+#: templates/class-overview.html:59
 #, fuzzy
 msgid "copy_link_success"
 msgstr "Copiar vínculo para compartir"
 
-#: templates/class-overview.html:54
+#: templates/class-overview.html:59
 #, fuzzy
 msgid "copy_join_link"
 msgstr "Please copy and paste this link into a new tab:"
 
-#: templates/class-overview.html:55
+#: templates/class-overview.html:60
 #, fuzzy
 msgid "invite_prompt"
 msgstr "Enter a username"
 
-#: templates/class-overview.html:55
+#: templates/class-overview.html:60
 #, fuzzy
 msgid "invite_by_username"
 msgstr "All usernames need to be unique."
 
-#: templates/class-overview.html:56 templates/create-accounts.html:45
+#: templates/class-overview.html:61 templates/create-accounts.html:45
 #, fuzzy
 msgid "create_accounts"
 msgstr "Create multiple accounts"
 
-#: templates/class-overview.html:61
+#: templates/class-overview.html:66
 #, fuzzy
 msgid "pending_invites"
 msgstr "Pending invites"
 
-#: templates/class-overview.html:67
+#: templates/class-overview.html:72
 #, fuzzy
 msgid "invite_date"
 msgstr "Invite date"
 
-#: templates/class-overview.html:68
+#: templates/class-overview.html:73
 #, fuzzy
 msgid "expiration_date"
 msgstr "Expiration date"
 
-#: templates/class-overview.html:78 templates/profile.html:16
+#: templates/class-overview.html:83 templates/profile.html:16
 #, fuzzy
 msgid "delete_invite_prompt"
 msgstr "Are you sure you want to remove this class invitation?"
@@ -1319,10 +1319,10 @@ msgstr "Mis clases"
 msgid "achievements"
 msgstr "achievements"
 
-#: templates/highscores.html:27 templates/learn-more.html:22
-#: templates/profile.html:131 templates/signup.html:52
-msgid "country"
-msgstr "País"
+#: templates/highscores.html:27
+#, fuzzy
+msgid "country_title"
+msgstr "Please select a valid country."
 
 #: templates/highscores.html:28 templates/landing-page.html:88
 #: templates/public-page.html:50
@@ -1604,6 +1604,11 @@ msgstr "Usuario"
 #, fuzzy
 msgid "lastname"
 msgstr "Nombre"
+
+#: templates/learn-more.html:22 templates/profile.html:131
+#: templates/signup.html:52
+msgid "country"
+msgstr "País"
 
 #: templates/learn-more.html:31
 #, fuzzy

--- a/translations/et/LC_MESSAGES/messages.po
+++ b/translations/et/LC_MESSAGES/messages.po
@@ -7,16 +7,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-06-28 18:38+0300\n"
+"POT-Creation-Date: 2022-06-29 14:20+0200\n"
 "PO-Revision-Date: 2022-06-28 13:25+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: et\n"
 "Language-Team: none\n"
-"Plural-Forms: nplurals=2; plural=n != 1\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.9.1\n"
+"Generated-By: Babel 2.10.1\n"
 
 #: app.py:417
 msgid "program_contains_error"
@@ -26,7 +26,7 @@ msgstr "Selles programmis on viga. Oled sa kindel, et sa tahad seda jagada?"
 msgid "title_achievements"
 msgstr "Hedy - Minu saavutused"
 
-#: app.py:644 app.py:748 app.py:1090 website/teacher.py:361
+#: app.py:644 app.py:746 app.py:1088 website/teacher.py:361
 #: website/teacher.py:372
 msgid "not_teacher"
 msgstr "Sa ei ole õpetaja!"
@@ -35,11 +35,11 @@ msgstr "Sa ei ole õpetaja!"
 msgid "not_enrolled"
 msgstr "Sa ei ole selles klassis!"
 
-#: app.py:686
+#: app.py:684
 msgid "title_programs"
 msgstr "Hedy - Minu programmid"
 
-#: app.py:696 app.py:706 app.py:710 app.py:725 app.py:1005 app.py:1550
+#: app.py:694 app.py:704 app.py:708 app.py:723 app.py:1003 app.py:1548
 #: website/admin.py:17 website/admin.py:24 website/admin.py:92
 #: website/admin.py:111 website/admin.py:129 website/admin.py:136
 #: website/admin.py:144 website/auth.py:716 website/auth.py:743
@@ -47,238 +47,238 @@ msgstr "Hedy - Minu programmid"
 msgid "unauthorized"
 msgstr "Sul ei ole õigust seda lehte vaadata"
 
-#: app.py:762 app.py:1107
+#: app.py:760 app.py:1105
 msgid "title_for-teacher"
 msgstr "Hedy - Õpetajatele"
 
-#: app.py:779 app.py:781 app.py:923 app.py:945 app.py:947
+#: app.py:777 app.py:779 app.py:921 app.py:943 app.py:945
 msgid "no_such_level"
 msgstr "Sellist taset ei ole!"
 
-#: app.py:789 app.py:796 app.py:877 app.py:883
+#: app.py:787 app.py:794 app.py:875 app.py:881
 msgid "no_such_program"
 msgstr "Sellist programmi ei ole!"
 
-#: app.py:819
+#: app.py:817
 msgid "level_not_class"
 msgstr "See tase pole veel sinu klassile avatud"
 
-#: app.py:928 website/teacher.py:421 website/teacher.py:437
+#: app.py:926 website/teacher.py:421 website/teacher.py:437
 #: website/teacher.py:466 website/teacher.py:492
 msgid "no_such_adventure"
 msgstr "Seda seiklust ei ole olemas!"
 
-#: app.py:956 app.py:1209
+#: app.py:954 app.py:1207
 msgid "page_not_found"
 msgstr "Me ei leidnud seda lehte!"
 
-#: app.py:976
+#: app.py:974
 msgid "title_signup"
 msgstr "Hedy - Registreeru"
 
-#: app.py:983
+#: app.py:981
 msgid "title_login"
 msgstr "Hedy - Logi sisse"
 
-#: app.py:990
+#: app.py:988
 msgid "title_recover"
 msgstr "Hedy - Taasta oma konto"
 
-#: app.py:1006
+#: app.py:1004
 msgid "title_reset"
 msgstr "Hedy - Unustasid parooli?"
 
-#: app.py:1032
+#: app.py:1030
 msgid "title_my-profile"
 msgstr "Hedy - Minu konto"
 
-#: app.py:1048
+#: app.py:1046
 msgid "title_learn-more"
 msgstr "Hedy - Rohkem infot"
 
-#: app.py:1054
+#: app.py:1052
 msgid "title_privacy"
 msgstr "Hedy - Privaatsus"
 
-#: app.py:1064
+#: app.py:1062
 msgid "title_start"
 msgstr "Hedy - Astmeline programmeerimiskeel"
 
-#: app.py:1082
+#: app.py:1080
 msgid "title_landing-page"
 msgstr "Tere tulemast Hedy juurde!"
 
-#: app.py:1200
+#: app.py:1198
 msgid "title_explore"
 msgstr "Hedy - Vaata ringi"
 
-#: app.py:1221 app.py:1226
+#: app.py:1219 app.py:1224
 #, fuzzy
 msgid "no_such_highscore"
 msgstr "Sellist taset ei ole!"
 
-#: app.py:1255 app.py:1257
+#: app.py:1253 app.py:1255
 #, fuzzy
 msgid "translate_error"
 msgstr ""
 "Something went wrong while translating the code. Try running the code to "
 "see if it has an error. Code with errors can not be translated."
 
-#: app.py:1262 app.py:1296
+#: app.py:1260 app.py:1294
 msgid "tutorial_start_title"
 msgstr "Tere tulemast Hedy juurde!"
 
-#: app.py:1262
+#: app.py:1260
 msgid "tutorial_start_message"
 msgstr "Siin me õpetame sulle Hedy't samm-sammu haaval."
 
-#: app.py:1264
+#: app.py:1262
 msgid "tutorial_editor_title"
 msgstr "Programmeerimiskeskkond"
 
-#: app.py:1264
+#: app.py:1262
 msgid "tutorial_editor_message"
 msgstr ""
 "Sellesse aknasse kirjutad sa oma koodi. Proovi midagi allkriipsude kohale"
 " kirjutada!"
 
-#: app.py:1266
+#: app.py:1264
 msgid "tutorial_output_title"
 msgstr "Väljundi aken"
 
-#: app.py:1266
+#: app.py:1264
 msgid "tutorial_output_message"
 msgstr "Siia ilmub sinu programmi väljund. Selle oled sa just teinud!"
 
-#: app.py:1268
+#: app.py:1266
 msgid "tutorial_run_title"
 msgstr "Programmi käivitamise nupp"
 
-#: app.py:1268
+#: app.py:1266
 msgid "tutorial_run_message"
 msgstr ""
 "Selle nupuga saad sa oma programmi käivitada. Kas proovime järgmises "
 "ülesandes järgi?"
 
-#: app.py:1270
+#: app.py:1268
 msgid "tutorial_tryit_title"
 msgstr "Proovi järgi!"
 
-#: app.py:1270
+#: app.py:1268
 msgid "tutorial_tryit_message"
 msgstr ""
 "Käivita programm ning kui sa valmis oled, siis vajuta nupule 'Järgmine "
 "samm'."
 
-#: app.py:1272
+#: app.py:1270
 msgid "tutorial_speakaloud_title"
 msgstr "Lase programm tekst välja lugeda"
 
-#: app.py:1272
+#: app.py:1270
 msgid "tutorial_speakaloud_message"
 msgstr ""
 "Kui sa tahad, et sinu programm häälega välja loetakse, siis vali "
 "programmi käivitamise nupu alt üks hääl."
 
-#: app.py:1274
+#: app.py:1272
 msgid "tutorial_speakaloud_run_title"
 msgstr "Käivita ja kuula"
 
-#: app.py:1274
+#: app.py:1272
 msgid "tutorial_speakaloud_run_message"
 msgstr ""
 "Vali menüüst üks hääl ning käivita oma programm uuesti, et kuulda kuidas "
 "see välja loetakse."
 
-#: app.py:1276
+#: app.py:1274
 msgid "tutorial_nextlevel_title"
 msgstr "Järgmisele tasemele"
 
-#: app.py:1276
+#: app.py:1274
 msgid "tutorial_nextlevel_message"
 msgstr ""
 "Kui sa arvad, et saad kõigest hästi aru ja et oled piisavalt harjutanud, "
 "siis sa saad minna järgmisele tasemele. Kui eelmine tase on olemas, siis "
 "on alati olemas ka nupp, et tagasi minna."
 
-#: app.py:1278
+#: app.py:1276
 msgid "tutorial_leveldefault_title"
 msgstr "Taseme seletus"
 
-#: app.py:1278
+#: app.py:1276
 msgid "tutorial_leveldefault_message"
 msgstr ""
 "Esimeses vahekaardis on alati taseme seletus. Uusi käske tutvustatakse "
 "siin."
 
-#: app.py:1280
+#: app.py:1278
 msgid "tutorial_adventures_title"
 msgstr "Seiklused"
 
-#: app.py:1280
+#: app.py:1278
 msgid "tutorial_adventures_message"
 msgstr ""
 "Teistes vahekaartides on seiklused, mida sa igal tasemel teha saad. Nad "
 "algavad lihtsamatest ning lähevad raskemaks."
 
-#: app.py:1282
+#: app.py:1280
 msgid "tutorial_quiz_title"
 msgstr "Test"
 
-#: app.py:1282
+#: app.py:1280
 msgid "tutorial_quiz_message"
 msgstr ""
 "Iga taseme lõpus saad sa teha testi. See aitab sul näha kas sa oled "
 "kõigest õigesti aru saanud."
 
-#: app.py:1284
+#: app.py:1282
 msgid "tutorial_saveshare_title"
 msgstr "Salvesta ja jaga"
 
-#: app.py:1284
+#: app.py:1282
 msgid "tutorial_saveshare_message"
 msgstr ""
 "Sa saad kõiki oma kirjutatud programme salvestada ja teiste Hedy "
 "kasutajatega jagada."
 
-#: app.py:1286
+#: app.py:1284
 msgid "tutorial_cheatsheet_title"
 msgstr "Spikker"
 
-#: app.py:1286
+#: app.py:1284
 msgid "tutorial_cheatsheet_message"
 msgstr ""
 "Kui sa oled mingi käsu ära unustanud, siis sa saad alati spikrit "
 "kasutada. Spikker näitab kõiki käske, mida sa sellel tasemel kasutada "
 "saad."
 
-#: app.py:1288 app.py:1308
+#: app.py:1286 app.py:1306
 #, fuzzy
 msgid "tutorial_end_title"
 msgstr "The end!"
 
-#: app.py:1288
+#: app.py:1286
 #, fuzzy
 msgid "tutorial_end_message"
 msgstr "Click on 'next step' to really start coding with Hedy!"
 
-#: app.py:1290 app.py:1310
+#: app.py:1288 app.py:1308
 msgid "tutorial_title_not_found"
 msgstr ""
 
-#: app.py:1290 app.py:1310
+#: app.py:1288 app.py:1308
 msgid "tutorial_message_not_found"
 msgstr ""
 
-#: app.py:1296
+#: app.py:1294
 msgid "teacher_tutorial_start_message"
 msgstr ""
 
-#: app.py:1298
+#: app.py:1296
 msgid "tutorial_class_title"
 msgstr ""
 
-#: app.py:1298
+#: app.py:1296
 #, fuzzy
 msgid "tutorial_class_message"
 msgstr ""
@@ -286,24 +286,24 @@ msgstr ""
 "through a link. You can view the programs and statistics of all your "
 "students."
 
-#: app.py:1300
+#: app.py:1298
 #, fuzzy
 msgid "tutorial_customize_class_title"
 msgstr "Customize classes"
 
-#: app.py:1300
+#: app.py:1298
 #, fuzzy
 msgid "tutorial_customize_class_message"
 msgstr ""
 "You can customize classes by hiding specific levels and/or adventures as "
 "well as making them available on a specific date."
 
-#: app.py:1302
+#: app.py:1300
 #, fuzzy
 msgid "tutorial_own_adventures_title"
 msgstr "Creating adventures"
 
-#: app.py:1302
+#: app.py:1300
 #, fuzzy
 msgid "tutorial_own_adventures_message"
 msgstr ""
@@ -311,12 +311,12 @@ msgstr ""
 "students. Create them here and add them to your classes in the class "
 "customization section."
 
-#: app.py:1304
+#: app.py:1302
 #, fuzzy
 msgid "tutorial_accounts_title"
 msgstr "Creating accounts"
 
-#: app.py:1304
+#: app.py:1302
 #, fuzzy
 msgid "tutorial_accounts_message"
 msgstr ""
@@ -324,32 +324,32 @@ msgstr ""
 "username and password. You can also directly add these accounts to one of"
 " your classes."
 
-#: app.py:1306
+#: app.py:1304
 #, fuzzy
 msgid "tutorial_documentation_title"
 msgstr "Hedy documentation"
 
-#: app.py:1306
+#: app.py:1304
 msgid "tutorial_documentation_message"
 msgstr ""
 
-#: app.py:1308
+#: app.py:1306
 #, fuzzy
 msgid "teacher_tutorial_end_message"
 msgstr "Click on 'next step' to get started as a Hedy teacher!"
 
-#: app.py:1318
+#: app.py:1316
 #, fuzzy
 msgid "tutorial_code_snippet"
 msgstr ""
 "print Hello world!\n"
 "print I'm learning Hedy with the tutorial!"
 
-#: app.py:1322 app.py:1332
+#: app.py:1320 app.py:1330
 msgid "invalid_tutorial_step"
 msgstr ""
 
-#: app.py:1489 website/auth.py:278 website/auth.py:333 website/auth.py:469
+#: app.py:1487 website/auth.py:278 website/auth.py:333 website/auth.py:469
 #: website/auth.py:494 website/auth.py:524 website/auth.py:637
 #: website/auth.py:675 website/auth.py:722 website/auth.py:749
 #: website/quiz.py:43 website/quiz.py:69 website/teacher.py:88
@@ -360,32 +360,32 @@ msgstr ""
 msgid "ajax_error"
 msgstr "There was an error, please try again."
 
-#: app.py:1492
+#: app.py:1490
 #, fuzzy
 msgid "image_invalid"
 msgstr "The image you chose image is invalid."
 
-#: app.py:1494
+#: app.py:1492
 #, fuzzy
 msgid "personal_text_invalid"
 msgstr "Your personal text is invalid."
 
-#: app.py:1496 app.py:1502
+#: app.py:1494 app.py:1500
 #, fuzzy
 msgid "favourite_program_invalid"
 msgstr "Your chosen favourite program is invalid."
 
-#: app.py:1516 app.py:1517
+#: app.py:1514 app.py:1515
 #, fuzzy
 msgid "public_profile_updated"
 msgstr "Public profile updated."
 
-#: app.py:1554 app.py:1579
+#: app.py:1552 app.py:1577
 #, fuzzy
 msgid "user_not_private"
 msgstr "This user either doesn't exist or doesn't have a public profile"
 
-#: app.py:1587
+#: app.py:1585
 #, fuzzy
 msgid "invalid_teacher_invitation_code"
 msgstr ""
@@ -745,12 +745,12 @@ msgstr "Cheatsheet"
 msgid "back_to_class"
 msgstr "Go back to class"
 
-#: templates/class-overview.html:13 templates/for-teachers.html:35
+#: templates/class-overview.html:14 templates/for-teachers.html:35
 #, fuzzy
 msgid "class_name_prompt"
 msgstr "Please enter the name of the class"
 
-#: templates/class-overview.html:19 templates/class-overview.html:66
+#: templates/class-overview.html:20 templates/class-overview.html:71
 #: templates/create-accounts.html:16 templates/highscores.html:25
 #: templates/login.html:12 templates/profile.html:89 templates/recover.html:8
 #: templates/signup.html:10
@@ -758,140 +758,140 @@ msgstr "Please enter the name of the class"
 msgid "username"
 msgstr "Username"
 
-#: templates/class-overview.html:20
+#: templates/class-overview.html:21
 #, fuzzy
 msgid "last_login"
 msgstr "Last login"
 
-#: templates/class-overview.html:21
+#: templates/class-overview.html:22
 #, fuzzy
 msgid "highest_level_reached"
 msgstr "Highest level reached"
 
-#: templates/class-overview.html:22
+#: templates/class-overview.html:23
 #, fuzzy
 msgid "number_programs"
 msgstr "Number of programs"
 
-#: templates/class-overview.html:23
+#: templates/class-overview.html:24
 #, fuzzy
 msgid "programs"
 msgstr "Programs"
 
-#: templates/class-overview.html:24 templates/create-accounts.html:17
+#: templates/class-overview.html:25 templates/create-accounts.html:17
 #: templates/login.html:15 templates/reset.html:8 templates/signup.html:19
 #, fuzzy
 msgid "password"
 msgstr "Password"
 
-#: templates/class-overview.html:25 templates/class-overview.html:69
+#: templates/class-overview.html:26 templates/class-overview.html:74
 #: templates/customize-adventure.html:52 templates/for-teachers.html:46
 #: templates/for-teachers.html:56
 #, fuzzy
 msgid "remove"
 msgstr "Remove"
 
-#: templates/class-overview.html:35
+#: templates/class-overview.html:36
 #, fuzzy
 msgid "page"
 msgstr "page"
 
-#: templates/class-overview.html:36
+#: templates/class-overview.html:37
 #, fuzzy
 msgid "enter_password"
 msgstr "Enter a new password for"
 
-#: templates/class-overview.html:36
+#: templates/class-overview.html:37
 #, fuzzy
 msgid "password_change_prompt"
 msgstr "Are you sure you want to change this password?"
 
-#: templates/class-overview.html:37
+#: templates/class-overview.html:38
 #, fuzzy
 msgid "remove_student_prompt"
 msgstr "Are you sure you want to remove the student from the class?"
 
-#: templates/class-overview.html:44
+#: templates/class-overview.html:46
 #, fuzzy
 msgid "add_students"
 msgstr "students"
 
-#: templates/class-overview.html:45 templates/customize-class.html:5
+#: templates/class-overview.html:47 templates/customize-class.html:5
 #, fuzzy
 msgid "customize_class"
 msgstr "Customize class"
 
-#: templates/class-overview.html:46
+#: templates/class-overview.html:48
 #, fuzzy
 msgid "class_stats"
 msgstr "Class statistics"
 
-#: templates/class-overview.html:47
+#: templates/class-overview.html:49
 #, fuzzy
 msgid "class_logs"
 msgstr "Last login"
 
-#: templates/class-overview.html:48 templates/customize-adventure.html:59
+#: templates/class-overview.html:52 templates/customize-adventure.html:59
 #, fuzzy
 msgid "back_to_teachers_page"
 msgstr "Go back to teachers page"
 
-#: templates/class-overview.html:49
+#: templates/class-overview.html:53
 #, fuzzy
 msgid "delete_class_prompt"
 msgstr "Are you sure you want to delete the class?"
 
-#: templates/class-overview.html:49
+#: templates/class-overview.html:53
 #, fuzzy
 msgid "delete_class"
 msgstr "Delete class permanently"
 
-#: templates/class-overview.html:52
+#: templates/class-overview.html:57
 #, fuzzy
 msgid "add_students_options"
 msgstr "Create student accounts"
 
-#: templates/class-overview.html:54
+#: templates/class-overview.html:59
 #, fuzzy
 msgid "copy_link_success"
 msgstr "Copy link to share"
 
-#: templates/class-overview.html:54
+#: templates/class-overview.html:59
 #, fuzzy
 msgid "copy_join_link"
 msgstr "Please copy and paste this link into a new tab:"
 
-#: templates/class-overview.html:55
+#: templates/class-overview.html:60
 #, fuzzy
 msgid "invite_prompt"
 msgstr "Enter a username"
 
-#: templates/class-overview.html:55
+#: templates/class-overview.html:60
 #, fuzzy
 msgid "invite_by_username"
 msgstr "All usernames need to be unique."
 
-#: templates/class-overview.html:56 templates/create-accounts.html:45
+#: templates/class-overview.html:61 templates/create-accounts.html:45
 #, fuzzy
 msgid "create_accounts"
 msgstr "Create multiple accounts"
 
-#: templates/class-overview.html:61
+#: templates/class-overview.html:66
 #, fuzzy
 msgid "pending_invites"
 msgstr "Pending invites"
 
-#: templates/class-overview.html:67
+#: templates/class-overview.html:72
 #, fuzzy
 msgid "invite_date"
 msgstr "Invite date"
 
-#: templates/class-overview.html:68
+#: templates/class-overview.html:73
 #, fuzzy
 msgid "expiration_date"
 msgstr "Expiration date"
 
-#: templates/class-overview.html:78 templates/profile.html:16
+#: templates/class-overview.html:83 templates/profile.html:16
 #, fuzzy
 msgid "delete_invite_prompt"
 msgstr "Are you sure you want to remove this class invitation?"
@@ -1365,11 +1365,10 @@ msgstr "My classes"
 msgid "achievements"
 msgstr "achievements"
 
-#: templates/highscores.html:27 templates/learn-more.html:22
-#: templates/profile.html:131 templates/signup.html:52
+#: templates/highscores.html:27
 #, fuzzy
-msgid "country"
-msgstr "Country"
+msgid "country_title"
+msgstr "Please select a valid country."
 
 #: templates/highscores.html:28 templates/landing-page.html:88
 #: templates/public-page.html:50
@@ -1667,6 +1666,12 @@ msgstr "First Name"
 #, fuzzy
 msgid "lastname"
 msgstr "Last Name"
+
+#: templates/learn-more.html:22 templates/profile.html:131
+#: templates/signup.html:52
+#, fuzzy
+msgid "country"
+msgstr "Country"
 
 #: templates/learn-more.html:31
 #, fuzzy

--- a/translations/fa/LC_MESSAGES/messages.po
+++ b/translations/fa/LC_MESSAGES/messages.po
@@ -3,16 +3,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-28 18:38+0300\n"
+"POT-Creation-Date: 2022-06-29 14:20+0200\n"
 "PO-Revision-Date: 2022-06-28 13:25+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: fa\n"
 "Language-Team: fa <LL@li.org>\n"
-"Plural-Forms: nplurals=2; plural=n > 1\n"
+"Plural-Forms: nplurals=2; plural=n > 1;\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.9.1\n"
+"Generated-By: Babel 2.10.1\n"
 
 #: app.py:417
 msgid "program_contains_error"
@@ -23,7 +23,7 @@ msgstr "برنامه خطا داره، مطمئنی میخوای به اشترا
 msgid "title_achievements"
 msgstr "Hedy - My achievements"
 
-#: app.py:644 app.py:748 app.py:1090 website/teacher.py:361
+#: app.py:644 app.py:746 app.py:1088 website/teacher.py:361
 #: website/teacher.py:372
 msgid "not_teacher"
 msgstr "به نظر میاد که شما معلم نیستی!"
@@ -32,12 +32,12 @@ msgstr "به نظر میاد که شما معلم نیستی!"
 msgid "not_enrolled"
 msgstr "به نظر میاد که شما در کلاس نیستی!"
 
-#: app.py:686
+#: app.py:684
 #, fuzzy
 msgid "title_programs"
 msgstr "Hedy - My programs"
 
-#: app.py:696 app.py:706 app.py:710 app.py:725 app.py:1005 app.py:1550
+#: app.py:694 app.py:704 app.py:708 app.py:723 app.py:1003 app.py:1548
 #: website/admin.py:17 website/admin.py:24 website/admin.py:92
 #: website/admin.py:111 website/admin.py:129 website/admin.py:136
 #: website/admin.py:144 website/auth.py:716 website/auth.py:743
@@ -45,325 +45,325 @@ msgstr "Hedy - My programs"
 msgid "unauthorized"
 msgstr "شما اجازه دسترسی به این صفحه را نداری."
 
-#: app.py:762 app.py:1107
+#: app.py:760 app.py:1105
 #, fuzzy
 msgid "title_for-teacher"
 msgstr "Hedy - For teachers"
 
-#: app.py:779 app.py:781 app.py:923 app.py:945 app.py:947
+#: app.py:777 app.py:779 app.py:921 app.py:943 app.py:945
 #, fuzzy
 msgid "no_such_level"
 msgstr "No such Hedy level!"
 
-#: app.py:789 app.py:796 app.py:877 app.py:883
+#: app.py:787 app.py:794 app.py:875 app.py:881
 #, fuzzy
 msgid "no_such_program"
 msgstr "No such Hedy program!"
 
-#: app.py:819
+#: app.py:817
 #, fuzzy
 msgid "level_not_class"
 msgstr "You're in a class where this level has not been made available yet"
 
-#: app.py:928 website/teacher.py:421 website/teacher.py:437
+#: app.py:926 website/teacher.py:421 website/teacher.py:437
 #: website/teacher.py:466 website/teacher.py:492
 #, fuzzy
 msgid "no_such_adventure"
 msgstr "This adventure doesn't exist!"
 
-#: app.py:956 app.py:1209
+#: app.py:954 app.py:1207
 #, fuzzy
 msgid "page_not_found"
 msgstr "We could not find that page!"
 
-#: app.py:976
+#: app.py:974
 #, fuzzy
 msgid "title_signup"
 msgstr "Hedy - Create an account"
 
-#: app.py:983
+#: app.py:981
 #, fuzzy
 msgid "title_login"
 msgstr "Hedy - Login"
 
-#: app.py:990
+#: app.py:988
 #, fuzzy
 msgid "title_recover"
 msgstr "Hedy - Recover account"
 
-#: app.py:1006
+#: app.py:1004
 #, fuzzy
 msgid "title_reset"
 msgstr "Hedy - Reset password"
 
-#: app.py:1032
+#: app.py:1030
 #, fuzzy
 msgid "title_my-profile"
 msgstr "Hedy - My account"
 
-#: app.py:1048
+#: app.py:1046
 #, fuzzy
 msgid "title_learn-more"
 msgstr "Hedy - Learn more"
 
-#: app.py:1054
+#: app.py:1052
 #, fuzzy
 msgid "title_privacy"
 msgstr "Hedy - Privacy terms"
 
-#: app.py:1064
+#: app.py:1062
 #, fuzzy
 msgid "title_start"
 msgstr "Hedy - A gradual programming language"
 
-#: app.py:1082
+#: app.py:1080
 #, fuzzy
 msgid "title_landing-page"
 msgstr "Welcome to Hedy!"
 
-#: app.py:1200
+#: app.py:1198
 #, fuzzy
 msgid "title_explore"
 msgstr "Hedy - Explore"
 
-#: app.py:1221 app.py:1226
+#: app.py:1219 app.py:1224
 #, fuzzy
 msgid "no_such_highscore"
 msgstr "No such Hedy level!"
 
-#: app.py:1255 app.py:1257
+#: app.py:1253 app.py:1255
 #, fuzzy
 msgid "translate_error"
 msgstr ""
 "Something went wrong while translating the code. Try running the code to "
 "see if it has an error. Code with errors can not be translated."
 
-#: app.py:1262 app.py:1296
+#: app.py:1260 app.py:1294
 #, fuzzy
 msgid "tutorial_start_title"
 msgstr "Welcome to Hedy!"
 
-#: app.py:1262
+#: app.py:1260
 #, fuzzy
 msgid "tutorial_start_message"
 msgstr "In this tutorial we will explain all the Hedy features step-by-step."
 
-#: app.py:1264
+#: app.py:1262
 #, fuzzy
 msgid "tutorial_editor_title"
 msgstr "The code editor"
 
-#: app.py:1264
+#: app.py:1262
 #, fuzzy
 msgid "tutorial_editor_message"
 msgstr "In this window you write all the code, try typing something!"
 
-#: app.py:1266
+#: app.py:1264
 #, fuzzy
 msgid "tutorial_output_title"
 msgstr "The output window"
 
-#: app.py:1266
+#: app.py:1264
 #, fuzzy
 msgid "tutorial_output_message"
 msgstr "The result of the code you execute will be shown here"
 
-#: app.py:1268
+#: app.py:1266
 #, fuzzy
 msgid "tutorial_run_title"
 msgstr "The run button"
 
-#: app.py:1268
+#: app.py:1266
 #, fuzzy
 msgid "tutorial_run_message"
 msgstr "With this button you can run your program! Shall we give it a try?"
 
-#: app.py:1270
+#: app.py:1268
 #, fuzzy
 msgid "tutorial_tryit_title"
 msgstr "Try it out!"
 
-#: app.py:1270
+#: app.py:1268
 #, fuzzy
 msgid "tutorial_tryit_message"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1272
+#: app.py:1270
 #, fuzzy
 msgid "tutorial_speakaloud_title"
 msgstr "The end!"
 
-#: app.py:1272
+#: app.py:1270
 #, fuzzy
 msgid "tutorial_speakaloud_message"
 msgstr "Click on 'next step' to really start coding with Hedy!"
 
-#: app.py:1274
+#: app.py:1272
 #, fuzzy
 msgid "tutorial_speakaloud_run_title"
 msgstr "The end!"
 
-#: app.py:1274
+#: app.py:1272
 #, fuzzy
 msgid "tutorial_speakaloud_run_message"
 msgstr "Click on 'next step' to really start coding with Hedy!"
 
-#: app.py:1276
+#: app.py:1274
 #, fuzzy
 msgid "tutorial_nextlevel_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1276
+#: app.py:1274
 #, fuzzy
 msgid "tutorial_nextlevel_message"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1278
+#: app.py:1276
 #, fuzzy
 msgid "tutorial_leveldefault_title"
 msgstr "Level explanation"
 
-#: app.py:1278
+#: app.py:1276
 #, fuzzy
 msgid "tutorial_leveldefault_message"
 msgstr ""
 "The first tab always contains the level explanation. In each level new "
 "commands will be explained here."
 
-#: app.py:1280
+#: app.py:1278
 #, fuzzy
 msgid "tutorial_adventures_title"
 msgstr "Customize adventure"
 
-#: app.py:1280
+#: app.py:1278
 #, fuzzy
 msgid "tutorial_adventures_message"
 msgstr "Customize adventure"
 
-#: app.py:1282
+#: app.py:1280
 #, fuzzy
 msgid "tutorial_quiz_title"
 msgstr "Quiz"
 
-#: app.py:1282
+#: app.py:1280
 #, fuzzy
 msgid "tutorial_quiz_message"
 msgstr ""
 "At the end of each level you can make the quiz. This way you can verify "
 "if you understand everything."
 
-#: app.py:1284
+#: app.py:1282
 #, fuzzy
 msgid "tutorial_saveshare_title"
 msgstr "Saving & sharing"
 
-#: app.py:1284
+#: app.py:1282
 #, fuzzy
 msgid "tutorial_saveshare_message"
 msgstr "You can save and share all your created programs with other Hedy users."
 
-#: app.py:1286
+#: app.py:1284
 #, fuzzy
 msgid "tutorial_cheatsheet_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1286
+#: app.py:1284
 #, fuzzy
 msgid "tutorial_cheatsheet_message"
 msgstr ""
 "If you forgot a command you can always use the cheatsheet. It shows a "
 "list of all commands you can use in the current level."
 
-#: app.py:1288 app.py:1308
+#: app.py:1286 app.py:1306
 #, fuzzy
 msgid "tutorial_end_title"
 msgstr "The end!"
 
-#: app.py:1288
+#: app.py:1286
 #, fuzzy
 msgid "tutorial_end_message"
 msgstr "Click on 'next step' to really start coding with Hedy!"
 
-#: app.py:1290 app.py:1310
+#: app.py:1288 app.py:1308
 #, fuzzy
 msgid "tutorial_title_not_found"
 msgstr "We could not find that page!"
 
-#: app.py:1290 app.py:1310
+#: app.py:1288 app.py:1308
 #, fuzzy
 msgid "tutorial_message_not_found"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1296
+#: app.py:1294
 #, fuzzy
 msgid "teacher_tutorial_start_message"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1298
+#: app.py:1296
 #, fuzzy
 msgid "tutorial_class_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1298
+#: app.py:1296
 #, fuzzy
 msgid "tutorial_class_message"
 msgstr "Customize adventure"
 
-#: app.py:1300
+#: app.py:1298
 #, fuzzy
 msgid "tutorial_customize_class_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1300
+#: app.py:1298
 #, fuzzy
 msgid "tutorial_customize_class_message"
 msgstr "Customize adventure"
 
-#: app.py:1302
+#: app.py:1300
 #, fuzzy
 msgid "tutorial_own_adventures_title"
 msgstr "Customize adventure"
 
-#: app.py:1302
+#: app.py:1300
 #, fuzzy
 msgid "tutorial_own_adventures_message"
 msgstr "Customize adventure"
 
-#: app.py:1304
+#: app.py:1302
 #, fuzzy
 msgid "tutorial_accounts_title"
 msgstr "Customize adventure"
 
-#: app.py:1304
+#: app.py:1302
 #, fuzzy
 msgid "tutorial_accounts_message"
 msgstr "Customize adventure"
 
-#: app.py:1306
+#: app.py:1304
 #, fuzzy
 msgid "tutorial_documentation_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1306
+#: app.py:1304
 #, fuzzy
 msgid "tutorial_documentation_message"
 msgstr "Customize adventure"
 
-#: app.py:1308
+#: app.py:1306
 #, fuzzy
 msgid "teacher_tutorial_end_message"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1318
+#: app.py:1316
 #, fuzzy
 msgid "tutorial_code_snippet"
 msgstr "Hide cheatsheet"
 
-#: app.py:1322 app.py:1332
+#: app.py:1320 app.py:1330
 msgid "invalid_tutorial_step"
 msgstr ""
 
-#: app.py:1489 website/auth.py:278 website/auth.py:333 website/auth.py:469
+#: app.py:1487 website/auth.py:278 website/auth.py:333 website/auth.py:469
 #: website/auth.py:494 website/auth.py:524 website/auth.py:637
 #: website/auth.py:675 website/auth.py:722 website/auth.py:749
 #: website/quiz.py:43 website/quiz.py:69 website/teacher.py:88
@@ -374,32 +374,32 @@ msgstr ""
 msgid "ajax_error"
 msgstr "There was an error, please try again."
 
-#: app.py:1492
+#: app.py:1490
 #, fuzzy
 msgid "image_invalid"
 msgstr "Your chosen image is invalid."
 
-#: app.py:1494
+#: app.py:1492
 #, fuzzy
 msgid "personal_text_invalid"
 msgstr "Your personal text is invalid."
 
-#: app.py:1496 app.py:1502
+#: app.py:1494 app.py:1500
 #, fuzzy
 msgid "favourite_program_invalid"
 msgstr "Your chosen favourite program is invalid."
 
-#: app.py:1516 app.py:1517
+#: app.py:1514 app.py:1515
 #, fuzzy
 msgid "public_profile_updated"
 msgstr "Public profile updated."
 
-#: app.py:1554 app.py:1579
+#: app.py:1552 app.py:1577
 #, fuzzy
 msgid "user_not_private"
 msgstr "This user doesn't exist or doesn't have a public profile"
 
-#: app.py:1587
+#: app.py:1585
 #, fuzzy
 msgid "invalid_teacher_invitation_code"
 msgstr ""
@@ -754,12 +754,12 @@ msgstr "Hide cheatsheet"
 msgid "back_to_class"
 msgstr "Go back to class"
 
-#: templates/class-overview.html:13 templates/for-teachers.html:35
+#: templates/class-overview.html:14 templates/for-teachers.html:35
 #, fuzzy
 msgid "class_name_prompt"
 msgstr "Please enter the name of the class"
 
-#: templates/class-overview.html:19 templates/class-overview.html:66
+#: templates/class-overview.html:20 templates/class-overview.html:71
 #: templates/create-accounts.html:16 templates/highscores.html:25
 #: templates/login.html:12 templates/profile.html:89 templates/recover.html:8
 #: templates/signup.html:10
@@ -767,140 +767,140 @@ msgstr "Please enter the name of the class"
 msgid "username"
 msgstr "Username"
 
-#: templates/class-overview.html:20
+#: templates/class-overview.html:21
 #, fuzzy
 msgid "last_login"
 msgstr "Last login"
 
-#: templates/class-overview.html:21
+#: templates/class-overview.html:22
 #, fuzzy
 msgid "highest_level_reached"
 msgstr "Highest level reached"
 
-#: templates/class-overview.html:22
+#: templates/class-overview.html:23
 #, fuzzy
 msgid "number_programs"
 msgstr "Number of programs"
 
-#: templates/class-overview.html:23
+#: templates/class-overview.html:24
 #, fuzzy
 msgid "programs"
 msgstr "Programs"
 
-#: templates/class-overview.html:24 templates/create-accounts.html:17
+#: templates/class-overview.html:25 templates/create-accounts.html:17
 #: templates/login.html:15 templates/reset.html:8 templates/signup.html:19
 #, fuzzy
 msgid "password"
 msgstr "Password"
 
-#: templates/class-overview.html:25 templates/class-overview.html:69
+#: templates/class-overview.html:26 templates/class-overview.html:74
 #: templates/customize-adventure.html:52 templates/for-teachers.html:46
 #: templates/for-teachers.html:56
 #, fuzzy
 msgid "remove"
 msgstr "Remove"
 
-#: templates/class-overview.html:35
+#: templates/class-overview.html:36
 #, fuzzy
 msgid "page"
 msgstr "page"
 
-#: templates/class-overview.html:36
+#: templates/class-overview.html:37
 #, fuzzy
 msgid "enter_password"
 msgstr "Enter a new password for"
 
-#: templates/class-overview.html:36
+#: templates/class-overview.html:37
 #, fuzzy
 msgid "password_change_prompt"
 msgstr "Are you sure you want to change this password?"
 
-#: templates/class-overview.html:37
+#: templates/class-overview.html:38
 #, fuzzy
 msgid "remove_student_prompt"
 msgstr "Are you sure you want to remove the student from the class?"
 
-#: templates/class-overview.html:44
+#: templates/class-overview.html:46
 #, fuzzy
 msgid "add_students"
 msgstr "students"
 
-#: templates/class-overview.html:45 templates/customize-class.html:5
+#: templates/class-overview.html:47 templates/customize-class.html:5
 #, fuzzy
 msgid "customize_class"
 msgstr "Customize class"
 
-#: templates/class-overview.html:46
+#: templates/class-overview.html:48
 #, fuzzy
 msgid "class_stats"
 msgstr "Class statistics"
 
-#: templates/class-overview.html:47
+#: templates/class-overview.html:49
 #, fuzzy
 msgid "class_logs"
 msgstr "Last login"
 
-#: templates/class-overview.html:48 templates/customize-adventure.html:59
+#: templates/class-overview.html:52 templates/customize-adventure.html:59
 #, fuzzy
 msgid "back_to_teachers_page"
 msgstr "Go back to teachers page"
 
-#: templates/class-overview.html:49
+#: templates/class-overview.html:53
 #, fuzzy
 msgid "delete_class_prompt"
 msgstr "Are you sure you want to delete the class?"
 
-#: templates/class-overview.html:49
+#: templates/class-overview.html:53
 #, fuzzy
 msgid "delete_class"
 msgstr "Delete class permanently"
 
-#: templates/class-overview.html:52
+#: templates/class-overview.html:57
 #, fuzzy
 msgid "add_students_options"
 msgstr "Create student accounts"
 
-#: templates/class-overview.html:54
+#: templates/class-overview.html:59
 #, fuzzy
 msgid "copy_link_success"
 msgstr "Copy link to share"
 
-#: templates/class-overview.html:54
+#: templates/class-overview.html:59
 #, fuzzy
 msgid "copy_join_link"
 msgstr "Please copy and paste this link into a new tab:"
 
-#: templates/class-overview.html:55
+#: templates/class-overview.html:60
 #, fuzzy
 msgid "invite_prompt"
 msgstr "Enter a username"
 
-#: templates/class-overview.html:55
+#: templates/class-overview.html:60
 #, fuzzy
 msgid "invite_by_username"
 msgstr "All usernames need to be unique."
 
-#: templates/class-overview.html:56 templates/create-accounts.html:45
+#: templates/class-overview.html:61 templates/create-accounts.html:45
 #, fuzzy
 msgid "create_accounts"
 msgstr "Create multiple accounts"
 
-#: templates/class-overview.html:61
+#: templates/class-overview.html:66
 #, fuzzy
 msgid "pending_invites"
 msgstr "Pending invites"
 
-#: templates/class-overview.html:67
+#: templates/class-overview.html:72
 #, fuzzy
 msgid "invite_date"
 msgstr "Invite date"
 
-#: templates/class-overview.html:68
+#: templates/class-overview.html:73
 #, fuzzy
 msgid "expiration_date"
 msgstr "Expiration date"
 
-#: templates/class-overview.html:78 templates/profile.html:16
+#: templates/class-overview.html:83 templates/profile.html:16
 #, fuzzy
 msgid "delete_invite_prompt"
 msgstr "Are you sure you want to remove this class invitation?"
@@ -1373,11 +1373,10 @@ msgstr "My classes"
 msgid "achievements"
 msgstr "achievements"
 
-#: templates/highscores.html:27 templates/learn-more.html:22
-#: templates/profile.html:131 templates/signup.html:52
+#: templates/highscores.html:27
 #, fuzzy
-msgid "country"
-msgstr "Country"
+msgid "country_title"
+msgstr "Please select a valid country."
 
 #: templates/highscores.html:28 templates/landing-page.html:88
 #: templates/public-page.html:50
@@ -1679,6 +1678,12 @@ msgstr "First Name"
 #, fuzzy
 msgid "lastname"
 msgstr "Last Name"
+
+#: templates/learn-more.html:22 templates/profile.html:131
+#: templates/signup.html:52
+#, fuzzy
+msgid "country"
+msgstr "Country"
 
 #: templates/learn-more.html:31
 #, fuzzy

--- a/translations/fr/LC_MESSAGES/messages.po
+++ b/translations/fr/LC_MESSAGES/messages.po
@@ -3,16 +3,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-28 18:38+0300\n"
+"POT-Creation-Date: 2022-06-29 14:20+0200\n"
 "PO-Revision-Date: 2022-06-28 13:25+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: fr\n"
 "Language-Team: fr <LL@li.org>\n"
-"Plural-Forms: nplurals=2; plural=n > 1\n"
+"Plural-Forms: nplurals=2; plural=n > 1;\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.9.1\n"
+"Generated-By: Babel 2.10.1\n"
 
 #: app.py:417
 msgid "program_contains_error"
@@ -22,7 +22,7 @@ msgstr "Ce programme contient une erreur, êtes-vous sûr de vouloir le partager
 msgid "title_achievements"
 msgstr "Hedy - Mes réalisations"
 
-#: app.py:644 app.py:748 app.py:1090 website/teacher.py:361
+#: app.py:644 app.py:746 app.py:1088 website/teacher.py:361
 #: website/teacher.py:372
 msgid "not_teacher"
 msgstr "On dirait que vous n'êtes pas enseignant !"
@@ -31,11 +31,11 @@ msgstr "On dirait que vous n'êtes pas enseignant !"
 msgid "not_enrolled"
 msgstr "On dirait que vous n'êtes pas dans cette classe !"
 
-#: app.py:686
+#: app.py:684
 msgid "title_programs"
 msgstr "Hedy - Mes programmes"
 
-#: app.py:696 app.py:706 app.py:710 app.py:725 app.py:1005 app.py:1550
+#: app.py:694 app.py:704 app.py:708 app.py:723 app.py:1003 app.py:1548
 #: website/admin.py:17 website/admin.py:24 website/admin.py:92
 #: website/admin.py:111 website/admin.py:129 website/admin.py:136
 #: website/admin.py:144 website/auth.py:716 website/auth.py:743
@@ -43,309 +43,309 @@ msgstr "Hedy - Mes programmes"
 msgid "unauthorized"
 msgstr "Vous n'avez pas les droits d'accès à cette page."
 
-#: app.py:762 app.py:1107
+#: app.py:760 app.py:1105
 msgid "title_for-teacher"
 msgstr "Hedy - Pour les professeurs"
 
-#: app.py:779 app.py:781 app.py:923 app.py:945 app.py:947
+#: app.py:777 app.py:779 app.py:921 app.py:943 app.py:945
 #, fuzzy
 msgid "no_such_level"
 msgstr "No such Hedy level!"
 
-#: app.py:789 app.py:796 app.py:877 app.py:883
+#: app.py:787 app.py:794 app.py:875 app.py:881
 #, fuzzy
 msgid "no_such_program"
 msgstr "No such Hedy program!"
 
-#: app.py:819
+#: app.py:817
 msgid "level_not_class"
 msgstr "Ce niveau n'a pas encore été rendu disponible dans votre classe."
 
-#: app.py:928 website/teacher.py:421 website/teacher.py:437
+#: app.py:926 website/teacher.py:421 website/teacher.py:437
 #: website/teacher.py:466 website/teacher.py:492
 msgid "no_such_adventure"
 msgstr "Cette aventure n’existe pas !"
 
-#: app.py:956 app.py:1209
+#: app.py:954 app.py:1207
 msgid "page_not_found"
 msgstr "Nous n'avons pas pu trouver cette page !"
 
-#: app.py:976
+#: app.py:974
 msgid "title_signup"
 msgstr "Hedy - Créer un compte"
 
-#: app.py:983
+#: app.py:981
 msgid "title_login"
 msgstr "Hedy - Connexion"
 
-#: app.py:990
+#: app.py:988
 msgid "title_recover"
 msgstr "Hedy - Récupérer le compte"
 
-#: app.py:1006
+#: app.py:1004
 msgid "title_reset"
 msgstr "Hedy - Réinitialiser le mot de passe"
 
-#: app.py:1032
+#: app.py:1030
 msgid "title_my-profile"
 msgstr "Hedy - Mon compte"
 
-#: app.py:1048
+#: app.py:1046
 msgid "title_learn-more"
 msgstr "Hedy - En savoir plus"
 
-#: app.py:1054
+#: app.py:1052
 msgid "title_privacy"
 msgstr "Hedy - Conditions de confidentialité"
 
-#: app.py:1064
+#: app.py:1062
 msgid "title_start"
 msgstr "Hedy - Un langage de programmation graduel"
 
-#: app.py:1082
+#: app.py:1080
 msgid "title_landing-page"
 msgstr "Bienvenue chez Hedy!"
 
-#: app.py:1200
+#: app.py:1198
 msgid "title_explore"
 msgstr "Hedy - Explorer"
 
-#: app.py:1221 app.py:1226
+#: app.py:1219 app.py:1224
 #, fuzzy
 msgid "no_such_highscore"
 msgstr "No such Hedy level!"
 
-#: app.py:1255 app.py:1257
+#: app.py:1253 app.py:1255
 msgid "translate_error"
 msgstr ""
 "Quelque chose s'est mal passé lors de la traduction du code. Essaye "
 "d'exécuter le code pour voir s'il contient une erreur. Le code avec des "
 "erreurs ne peut pas être traduit."
 
-#: app.py:1262 app.py:1296
+#: app.py:1260 app.py:1294
 msgid "tutorial_start_title"
 msgstr "Bienvenue à Hedy !"
 
-#: app.py:1262
+#: app.py:1260
 msgid "tutorial_start_message"
 msgstr ""
 "Dans ce tutoriel, nous allons expliquer toutes les caractéristiques "
 "d'Hedy étape par étape."
 
-#: app.py:1264
+#: app.py:1262
 msgid "tutorial_editor_title"
 msgstr "L'éditeur de code"
 
-#: app.py:1264
+#: app.py:1262
 msgid "tutorial_editor_message"
 msgstr ""
 "Dans cette fenêtre tu peux écrire ton code, essaye de taper quelque chose"
 " !"
 
-#: app.py:1266
+#: app.py:1264
 msgid "tutorial_output_title"
 msgstr "La fenêtre de sortie"
 
-#: app.py:1266
+#: app.py:1264
 msgid "tutorial_output_message"
 msgstr "Le résultat du code que vous exécutez sera affiché ici"
 
-#: app.py:1268
+#: app.py:1266
 #, fuzzy
 msgid "tutorial_run_title"
 msgstr "The run button"
 
-#: app.py:1268
+#: app.py:1266
 #, fuzzy
 msgid "tutorial_run_message"
 msgstr "With this button you can run your program! Shall we give it a try?"
 
-#: app.py:1270
+#: app.py:1268
 #, fuzzy
 msgid "tutorial_tryit_title"
 msgstr "Try it out!"
 
-#: app.py:1270
+#: app.py:1268
 #, fuzzy
 msgid "tutorial_tryit_message"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1272
+#: app.py:1270
 #, fuzzy
 msgid "tutorial_speakaloud_title"
 msgstr "The end!"
 
-#: app.py:1272
+#: app.py:1270
 #, fuzzy
 msgid "tutorial_speakaloud_message"
 msgstr "Click on 'next step' to really start coding with Hedy!"
 
-#: app.py:1274
+#: app.py:1272
 #, fuzzy
 msgid "tutorial_speakaloud_run_title"
 msgstr "The end!"
 
-#: app.py:1274
+#: app.py:1272
 #, fuzzy
 msgid "tutorial_speakaloud_run_message"
 msgstr "Click on 'next step' to really start coding with Hedy!"
 
-#: app.py:1276
+#: app.py:1274
 #, fuzzy
 msgid "tutorial_nextlevel_title"
 msgstr "Cheatsheet"
 
-#: app.py:1276
+#: app.py:1274
 #, fuzzy
 msgid "tutorial_nextlevel_message"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1278
+#: app.py:1276
 #, fuzzy
 msgid "tutorial_leveldefault_title"
 msgstr "Level explanation"
 
-#: app.py:1278
+#: app.py:1276
 #, fuzzy
 msgid "tutorial_leveldefault_message"
 msgstr ""
 "The first tab always contains the level explanation. In each level new "
 "commands will be explained here."
 
-#: app.py:1280
+#: app.py:1278
 #, fuzzy
 msgid "tutorial_adventures_title"
 msgstr "Customize adventure"
 
-#: app.py:1280
+#: app.py:1278
 #, fuzzy
 msgid "tutorial_adventures_message"
 msgstr "Customize adventure"
 
-#: app.py:1282
+#: app.py:1280
 #, fuzzy
 msgid "tutorial_quiz_title"
 msgstr "Quiz"
 
-#: app.py:1282
+#: app.py:1280
 #, fuzzy
 msgid "tutorial_quiz_message"
 msgstr ""
 "At the end of each level you can make the quiz. This way you can verify "
 "if you understand everything."
 
-#: app.py:1284
+#: app.py:1282
 #, fuzzy
 msgid "tutorial_saveshare_title"
 msgstr "Saving & sharing"
 
-#: app.py:1284
+#: app.py:1282
 #, fuzzy
 msgid "tutorial_saveshare_message"
 msgstr "You can save and share all your created programs with other Hedy users."
 
-#: app.py:1286
+#: app.py:1284
 #, fuzzy
 msgid "tutorial_cheatsheet_title"
 msgstr "Cheatsheet"
 
-#: app.py:1286
+#: app.py:1284
 #, fuzzy
 msgid "tutorial_cheatsheet_message"
 msgstr ""
 "If you forgot a command you can always use the cheatsheet. It shows a "
 "list of all commands you can use in the current level."
 
-#: app.py:1288 app.py:1308
+#: app.py:1286 app.py:1306
 #, fuzzy
 msgid "tutorial_end_title"
 msgstr "The end!"
 
-#: app.py:1288
+#: app.py:1286
 #, fuzzy
 msgid "tutorial_end_message"
 msgstr "Click on 'next step' to really start coding with Hedy!"
 
-#: app.py:1290 app.py:1310
+#: app.py:1288 app.py:1308
 #, fuzzy
 msgid "tutorial_title_not_found"
 msgstr "We couldn't find that page!"
 
-#: app.py:1290 app.py:1310
+#: app.py:1288 app.py:1308
 #, fuzzy
 msgid "tutorial_message_not_found"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1296
+#: app.py:1294
 #, fuzzy
 msgid "teacher_tutorial_start_message"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1298
+#: app.py:1296
 #, fuzzy
 msgid "tutorial_class_title"
 msgstr "Cheatsheet"
 
-#: app.py:1298
+#: app.py:1296
 #, fuzzy
 msgid "tutorial_class_message"
 msgstr "Customize adventure"
 
-#: app.py:1300
+#: app.py:1298
 #, fuzzy
 msgid "tutorial_customize_class_title"
 msgstr "Cheatsheet"
 
-#: app.py:1300
+#: app.py:1298
 #, fuzzy
 msgid "tutorial_customize_class_message"
 msgstr "Customize adventure"
 
-#: app.py:1302
+#: app.py:1300
 #, fuzzy
 msgid "tutorial_own_adventures_title"
 msgstr "Customize adventure"
 
-#: app.py:1302
+#: app.py:1300
 #, fuzzy
 msgid "tutorial_own_adventures_message"
 msgstr "Customize adventure"
 
-#: app.py:1304
+#: app.py:1302
 #, fuzzy
 msgid "tutorial_accounts_title"
 msgstr "Customize adventure"
 
-#: app.py:1304
+#: app.py:1302
 #, fuzzy
 msgid "tutorial_accounts_message"
 msgstr "Customize adventure"
 
-#: app.py:1306
+#: app.py:1304
 #, fuzzy
 msgid "tutorial_documentation_title"
 msgstr "Cheatsheet"
 
-#: app.py:1306
+#: app.py:1304
 #, fuzzy
 msgid "tutorial_documentation_message"
 msgstr "Customize adventure"
 
-#: app.py:1308
+#: app.py:1306
 #, fuzzy
 msgid "teacher_tutorial_end_message"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1318
+#: app.py:1316
 #, fuzzy
 msgid "tutorial_code_snippet"
 msgstr "Cheatsheet"
 
-#: app.py:1322 app.py:1332
+#: app.py:1320 app.py:1330
 msgid "invalid_tutorial_step"
 msgstr ""
 
-#: app.py:1489 website/auth.py:278 website/auth.py:333 website/auth.py:469
+#: app.py:1487 website/auth.py:278 website/auth.py:333 website/auth.py:469
 #: website/auth.py:494 website/auth.py:524 website/auth.py:637
 #: website/auth.py:675 website/auth.py:722 website/auth.py:749
 #: website/quiz.py:43 website/quiz.py:69 website/teacher.py:88
@@ -356,32 +356,32 @@ msgstr ""
 msgid "ajax_error"
 msgstr "There was an error, please try again."
 
-#: app.py:1492
+#: app.py:1490
 #, fuzzy
 msgid "image_invalid"
 msgstr "The image you chose image is invalid."
 
-#: app.py:1494
+#: app.py:1492
 #, fuzzy
 msgid "personal_text_invalid"
 msgstr "Your personal text is invalid."
 
-#: app.py:1496 app.py:1502
+#: app.py:1494 app.py:1500
 #, fuzzy
 msgid "favourite_program_invalid"
 msgstr "Your chosen favourite program is invalid."
 
-#: app.py:1516 app.py:1517
+#: app.py:1514 app.py:1515
 #, fuzzy
 msgid "public_profile_updated"
 msgstr "Public profile updated."
 
-#: app.py:1554 app.py:1579
+#: app.py:1552 app.py:1577
 #, fuzzy
 msgid "user_not_private"
 msgstr "This user either doesn't exist or doesn't have a public profile"
 
-#: app.py:1587
+#: app.py:1585
 #, fuzzy
 msgid "invalid_teacher_invitation_code"
 msgstr ""
@@ -733,12 +733,12 @@ msgstr "Cheatsheet"
 msgid "back_to_class"
 msgstr "Go back to class"
 
-#: templates/class-overview.html:13 templates/for-teachers.html:35
+#: templates/class-overview.html:14 templates/for-teachers.html:35
 #, fuzzy
 msgid "class_name_prompt"
 msgstr "Please enter the name of the class"
 
-#: templates/class-overview.html:19 templates/class-overview.html:66
+#: templates/class-overview.html:20 templates/class-overview.html:71
 #: templates/create-accounts.html:16 templates/highscores.html:25
 #: templates/login.html:12 templates/profile.html:89 templates/recover.html:8
 #: templates/signup.html:10
@@ -746,140 +746,140 @@ msgstr "Please enter the name of the class"
 msgid "username"
 msgstr "Username"
 
-#: templates/class-overview.html:20
+#: templates/class-overview.html:21
 #, fuzzy
 msgid "last_login"
 msgstr "Last login"
 
-#: templates/class-overview.html:21
+#: templates/class-overview.html:22
 #, fuzzy
 msgid "highest_level_reached"
 msgstr "Highest level reached"
 
-#: templates/class-overview.html:22
+#: templates/class-overview.html:23
 #, fuzzy
 msgid "number_programs"
 msgstr "Number of programs"
 
-#: templates/class-overview.html:23
+#: templates/class-overview.html:24
 #, fuzzy
 msgid "programs"
 msgstr "Programs"
 
-#: templates/class-overview.html:24 templates/create-accounts.html:17
+#: templates/class-overview.html:25 templates/create-accounts.html:17
 #: templates/login.html:15 templates/reset.html:8 templates/signup.html:19
 #, fuzzy
 msgid "password"
 msgstr "Password"
 
-#: templates/class-overview.html:25 templates/class-overview.html:69
+#: templates/class-overview.html:26 templates/class-overview.html:74
 #: templates/customize-adventure.html:52 templates/for-teachers.html:46
 #: templates/for-teachers.html:56
 #, fuzzy
 msgid "remove"
 msgstr "Remove"
 
-#: templates/class-overview.html:35
+#: templates/class-overview.html:36
 #, fuzzy
 msgid "page"
 msgstr "page"
 
-#: templates/class-overview.html:36
+#: templates/class-overview.html:37
 #, fuzzy
 msgid "enter_password"
 msgstr "Enter a new password for"
 
-#: templates/class-overview.html:36
+#: templates/class-overview.html:37
 #, fuzzy
 msgid "password_change_prompt"
 msgstr "Are you sure you want to change this password?"
 
-#: templates/class-overview.html:37
+#: templates/class-overview.html:38
 #, fuzzy
 msgid "remove_student_prompt"
 msgstr "Are you sure you want to remove the student from the class?"
 
-#: templates/class-overview.html:44
+#: templates/class-overview.html:46
 #, fuzzy
 msgid "add_students"
 msgstr "students"
 
-#: templates/class-overview.html:45 templates/customize-class.html:5
+#: templates/class-overview.html:47 templates/customize-class.html:5
 #, fuzzy
 msgid "customize_class"
 msgstr "Customize class"
 
-#: templates/class-overview.html:46
+#: templates/class-overview.html:48
 #, fuzzy
 msgid "class_stats"
 msgstr "Class statistics"
 
-#: templates/class-overview.html:47
+#: templates/class-overview.html:49
 #, fuzzy
 msgid "class_logs"
 msgstr "Last login"
 
-#: templates/class-overview.html:48 templates/customize-adventure.html:59
+#: templates/class-overview.html:52 templates/customize-adventure.html:59
 #, fuzzy
 msgid "back_to_teachers_page"
 msgstr "Go back to teachers page"
 
-#: templates/class-overview.html:49
+#: templates/class-overview.html:53
 #, fuzzy
 msgid "delete_class_prompt"
 msgstr "Are you sure you want to delete the class?"
 
-#: templates/class-overview.html:49
+#: templates/class-overview.html:53
 #, fuzzy
 msgid "delete_class"
 msgstr "Delete class permanently"
 
-#: templates/class-overview.html:52
+#: templates/class-overview.html:57
 #, fuzzy
 msgid "add_students_options"
 msgstr "Create student accounts"
 
-#: templates/class-overview.html:54
+#: templates/class-overview.html:59
 #, fuzzy
 msgid "copy_link_success"
 msgstr "Copy link to share"
 
-#: templates/class-overview.html:54
+#: templates/class-overview.html:59
 #, fuzzy
 msgid "copy_join_link"
 msgstr "Please copy and paste this link into a new tab:"
 
-#: templates/class-overview.html:55
+#: templates/class-overview.html:60
 #, fuzzy
 msgid "invite_prompt"
 msgstr "Enter a username"
 
-#: templates/class-overview.html:55
+#: templates/class-overview.html:60
 #, fuzzy
 msgid "invite_by_username"
 msgstr "All usernames need to be unique."
 
-#: templates/class-overview.html:56 templates/create-accounts.html:45
+#: templates/class-overview.html:61 templates/create-accounts.html:45
 #, fuzzy
 msgid "create_accounts"
 msgstr "Create multiple accounts"
 
-#: templates/class-overview.html:61
+#: templates/class-overview.html:66
 #, fuzzy
 msgid "pending_invites"
 msgstr "Pending invites"
 
-#: templates/class-overview.html:67
+#: templates/class-overview.html:72
 #, fuzzy
 msgid "invite_date"
 msgstr "Invite date"
 
-#: templates/class-overview.html:68
+#: templates/class-overview.html:73
 #, fuzzy
 msgid "expiration_date"
 msgstr "Expiration date"
 
-#: templates/class-overview.html:78 templates/profile.html:16
+#: templates/class-overview.html:83 templates/profile.html:16
 #, fuzzy
 msgid "delete_invite_prompt"
 msgstr "Are you sure you want to remove this class invitation?"
@@ -1353,11 +1353,10 @@ msgstr "My classes"
 msgid "achievements"
 msgstr "achievements"
 
-#: templates/highscores.html:27 templates/learn-more.html:22
-#: templates/profile.html:131 templates/signup.html:52
+#: templates/highscores.html:27
 #, fuzzy
-msgid "country"
-msgstr "Country"
+msgid "country_title"
+msgstr "Please select a valid country."
 
 #: templates/highscores.html:28 templates/landing-page.html:88
 #: templates/public-page.html:50
@@ -1658,6 +1657,12 @@ msgstr "First Name"
 #, fuzzy
 msgid "lastname"
 msgstr "Last Name"
+
+#: templates/learn-more.html:22 templates/profile.html:131
+#: templates/signup.html:52
+#, fuzzy
+msgid "country"
+msgstr "Country"
 
 #: templates/learn-more.html:31
 #, fuzzy

--- a/translations/fy/LC_MESSAGES/messages.po
+++ b/translations/fy/LC_MESSAGES/messages.po
@@ -3,16 +3,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-28 18:38+0300\n"
+"POT-Creation-Date: 2022-06-29 14:20+0200\n"
 "PO-Revision-Date: 2022-06-28 13:25+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: fy\n"
 "Language-Team: fy <LL@li.org>\n"
-"Plural-Forms: nplurals=2; plural=n != 1\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.9.1\n"
+"Generated-By: Babel 2.10.1\n"
 
 #: app.py:417
 #, fuzzy
@@ -24,7 +24,7 @@ msgstr "This program contains an error, are you sure you want to share it?"
 msgid "title_achievements"
 msgstr "Hedy - My achievements"
 
-#: app.py:644 app.py:748 app.py:1090 website/teacher.py:361
+#: app.py:644 app.py:746 app.py:1088 website/teacher.py:361
 #: website/teacher.py:372
 #, fuzzy
 msgid "not_teacher"
@@ -35,12 +35,12 @@ msgstr "Looks like you are not a teacher!"
 msgid "not_enrolled"
 msgstr "Looks like you are not in this class!"
 
-#: app.py:686
+#: app.py:684
 #, fuzzy
 msgid "title_programs"
 msgstr "Hedy - My programs"
 
-#: app.py:696 app.py:706 app.py:710 app.py:725 app.py:1005 app.py:1550
+#: app.py:694 app.py:704 app.py:708 app.py:723 app.py:1003 app.py:1548
 #: website/admin.py:17 website/admin.py:24 website/admin.py:92
 #: website/admin.py:111 website/admin.py:129 website/admin.py:136
 #: website/admin.py:144 website/auth.py:716 website/auth.py:743
@@ -49,325 +49,325 @@ msgstr "Hedy - My programs"
 msgid "unauthorized"
 msgstr "You don't have access rights for this page"
 
-#: app.py:762 app.py:1107
+#: app.py:760 app.py:1105
 #, fuzzy
 msgid "title_for-teacher"
 msgstr "Hedy - For teachers"
 
-#: app.py:779 app.py:781 app.py:923 app.py:945 app.py:947
+#: app.py:777 app.py:779 app.py:921 app.py:943 app.py:945
 #, fuzzy
 msgid "no_such_level"
 msgstr "No such Hedy level!"
 
-#: app.py:789 app.py:796 app.py:877 app.py:883
+#: app.py:787 app.py:794 app.py:875 app.py:881
 #, fuzzy
 msgid "no_such_program"
 msgstr "No such Hedy program!"
 
-#: app.py:819
+#: app.py:817
 #, fuzzy
 msgid "level_not_class"
 msgstr "You're in a class where this level has not been made available yet"
 
-#: app.py:928 website/teacher.py:421 website/teacher.py:437
+#: app.py:926 website/teacher.py:421 website/teacher.py:437
 #: website/teacher.py:466 website/teacher.py:492
 #, fuzzy
 msgid "no_such_adventure"
 msgstr "This adventure doesn't exist!"
 
-#: app.py:956 app.py:1209
+#: app.py:954 app.py:1207
 #, fuzzy
 msgid "page_not_found"
 msgstr "We could not find that page!"
 
-#: app.py:976
+#: app.py:974
 #, fuzzy
 msgid "title_signup"
 msgstr "Hedy - Create an account"
 
-#: app.py:983
+#: app.py:981
 #, fuzzy
 msgid "title_login"
 msgstr "Hedy - Login"
 
-#: app.py:990
+#: app.py:988
 #, fuzzy
 msgid "title_recover"
 msgstr "Hedy - Recover account"
 
-#: app.py:1006
+#: app.py:1004
 #, fuzzy
 msgid "title_reset"
 msgstr "Hedy - Reset password"
 
-#: app.py:1032
+#: app.py:1030
 #, fuzzy
 msgid "title_my-profile"
 msgstr "Hedy - My account"
 
-#: app.py:1048
+#: app.py:1046
 #, fuzzy
 msgid "title_learn-more"
 msgstr "Hedy - Learn more"
 
-#: app.py:1054
+#: app.py:1052
 #, fuzzy
 msgid "title_privacy"
 msgstr "Hedy - Privacy terms"
 
-#: app.py:1064
+#: app.py:1062
 #, fuzzy
 msgid "title_start"
 msgstr "Hedy - A gradual programming language"
 
-#: app.py:1082
+#: app.py:1080
 #, fuzzy
 msgid "title_landing-page"
 msgstr "Welcome to Hedy!"
 
-#: app.py:1200
+#: app.py:1198
 #, fuzzy
 msgid "title_explore"
 msgstr "Hedy - Explore"
 
-#: app.py:1221 app.py:1226
+#: app.py:1219 app.py:1224
 #, fuzzy
 msgid "no_such_highscore"
 msgstr "No such Hedy level!"
 
-#: app.py:1255 app.py:1257
+#: app.py:1253 app.py:1255
 #, fuzzy
 msgid "translate_error"
 msgstr ""
 "Something went wrong while translating the code. Try running the code to "
 "see if it has an error. Code with errors can not be translated."
 
-#: app.py:1262 app.py:1296
+#: app.py:1260 app.py:1294
 #, fuzzy
 msgid "tutorial_start_title"
 msgstr "Welcome to Hedy!"
 
-#: app.py:1262
+#: app.py:1260
 #, fuzzy
 msgid "tutorial_start_message"
 msgstr "In this tutorial we will explain all the Hedy features step-by-step."
 
-#: app.py:1264
+#: app.py:1262
 #, fuzzy
 msgid "tutorial_editor_title"
 msgstr "The code editor"
 
-#: app.py:1264
+#: app.py:1262
 #, fuzzy
 msgid "tutorial_editor_message"
 msgstr "In this window you write all the code, try typing something!"
 
-#: app.py:1266
+#: app.py:1264
 #, fuzzy
 msgid "tutorial_output_title"
 msgstr "The output window"
 
-#: app.py:1266
+#: app.py:1264
 #, fuzzy
 msgid "tutorial_output_message"
 msgstr "The result of the code you execute will be shown here"
 
-#: app.py:1268
+#: app.py:1266
 #, fuzzy
 msgid "tutorial_run_title"
 msgstr "The run button"
 
-#: app.py:1268
+#: app.py:1266
 #, fuzzy
 msgid "tutorial_run_message"
 msgstr "With this button you can run your program! Shall we give it a try?"
 
-#: app.py:1270
+#: app.py:1268
 #, fuzzy
 msgid "tutorial_tryit_title"
 msgstr "Try it out!"
 
-#: app.py:1270
+#: app.py:1268
 #, fuzzy
 msgid "tutorial_tryit_message"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1272
+#: app.py:1270
 #, fuzzy
 msgid "tutorial_speakaloud_title"
 msgstr "The end!"
 
-#: app.py:1272
+#: app.py:1270
 #, fuzzy
 msgid "tutorial_speakaloud_message"
 msgstr "Click on 'next step' to really start coding with Hedy!"
 
-#: app.py:1274
+#: app.py:1272
 #, fuzzy
 msgid "tutorial_speakaloud_run_title"
 msgstr "The end!"
 
-#: app.py:1274
+#: app.py:1272
 #, fuzzy
 msgid "tutorial_speakaloud_run_message"
 msgstr "Click on 'next step' to really start coding with Hedy!"
 
-#: app.py:1276
+#: app.py:1274
 #, fuzzy
 msgid "tutorial_nextlevel_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1276
+#: app.py:1274
 #, fuzzy
 msgid "tutorial_nextlevel_message"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1278
+#: app.py:1276
 #, fuzzy
 msgid "tutorial_leveldefault_title"
 msgstr "Level explanation"
 
-#: app.py:1278
+#: app.py:1276
 #, fuzzy
 msgid "tutorial_leveldefault_message"
 msgstr ""
 "The first tab always contains the level explanation. In each level new "
 "commands will be explained here."
 
-#: app.py:1280
+#: app.py:1278
 #, fuzzy
 msgid "tutorial_adventures_title"
 msgstr "Customize adventure"
 
-#: app.py:1280
+#: app.py:1278
 #, fuzzy
 msgid "tutorial_adventures_message"
 msgstr "Customize adventure"
 
-#: app.py:1282
+#: app.py:1280
 #, fuzzy
 msgid "tutorial_quiz_title"
 msgstr "Quiz"
 
-#: app.py:1282
+#: app.py:1280
 #, fuzzy
 msgid "tutorial_quiz_message"
 msgstr ""
 "At the end of each level you can make the quiz. This way you can verify "
 "if you understand everything."
 
-#: app.py:1284
+#: app.py:1282
 #, fuzzy
 msgid "tutorial_saveshare_title"
 msgstr "Saving & sharing"
 
-#: app.py:1284
+#: app.py:1282
 #, fuzzy
 msgid "tutorial_saveshare_message"
 msgstr "You can save and share all your created programs with other Hedy users."
 
-#: app.py:1286
+#: app.py:1284
 #, fuzzy
 msgid "tutorial_cheatsheet_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1286
+#: app.py:1284
 #, fuzzy
 msgid "tutorial_cheatsheet_message"
 msgstr ""
 "If you forgot a command you can always use the cheatsheet. It shows a "
 "list of all commands you can use in the current level."
 
-#: app.py:1288 app.py:1308
+#: app.py:1286 app.py:1306
 #, fuzzy
 msgid "tutorial_end_title"
 msgstr "The end!"
 
-#: app.py:1288
+#: app.py:1286
 #, fuzzy
 msgid "tutorial_end_message"
 msgstr "Click on 'next step' to really start coding with Hedy!"
 
-#: app.py:1290 app.py:1310
+#: app.py:1288 app.py:1308
 #, fuzzy
 msgid "tutorial_title_not_found"
 msgstr "We could not find that page!"
 
-#: app.py:1290 app.py:1310
+#: app.py:1288 app.py:1308
 #, fuzzy
 msgid "tutorial_message_not_found"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1296
+#: app.py:1294
 #, fuzzy
 msgid "teacher_tutorial_start_message"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1298
+#: app.py:1296
 #, fuzzy
 msgid "tutorial_class_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1298
+#: app.py:1296
 #, fuzzy
 msgid "tutorial_class_message"
 msgstr "Customize adventure"
 
-#: app.py:1300
+#: app.py:1298
 #, fuzzy
 msgid "tutorial_customize_class_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1300
+#: app.py:1298
 #, fuzzy
 msgid "tutorial_customize_class_message"
 msgstr "Customize adventure"
 
-#: app.py:1302
+#: app.py:1300
 #, fuzzy
 msgid "tutorial_own_adventures_title"
 msgstr "Customize adventure"
 
-#: app.py:1302
+#: app.py:1300
 #, fuzzy
 msgid "tutorial_own_adventures_message"
 msgstr "Customize adventure"
 
-#: app.py:1304
+#: app.py:1302
 #, fuzzy
 msgid "tutorial_accounts_title"
 msgstr "Customize adventure"
 
-#: app.py:1304
+#: app.py:1302
 #, fuzzy
 msgid "tutorial_accounts_message"
 msgstr "Customize adventure"
 
-#: app.py:1306
+#: app.py:1304
 #, fuzzy
 msgid "tutorial_documentation_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1306
+#: app.py:1304
 #, fuzzy
 msgid "tutorial_documentation_message"
 msgstr "Customize adventure"
 
-#: app.py:1308
+#: app.py:1306
 #, fuzzy
 msgid "teacher_tutorial_end_message"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1318
+#: app.py:1316
 #, fuzzy
 msgid "tutorial_code_snippet"
 msgstr "Hide cheatsheet"
 
-#: app.py:1322 app.py:1332
+#: app.py:1320 app.py:1330
 msgid "invalid_tutorial_step"
 msgstr ""
 
-#: app.py:1489 website/auth.py:278 website/auth.py:333 website/auth.py:469
+#: app.py:1487 website/auth.py:278 website/auth.py:333 website/auth.py:469
 #: website/auth.py:494 website/auth.py:524 website/auth.py:637
 #: website/auth.py:675 website/auth.py:722 website/auth.py:749
 #: website/quiz.py:43 website/quiz.py:69 website/teacher.py:88
@@ -377,32 +377,32 @@ msgstr ""
 msgid "ajax_error"
 msgstr "Der gong wat mis, besykje it nochris."
 
-#: app.py:1492
+#: app.py:1490
 #, fuzzy
 msgid "image_invalid"
 msgstr "Your chosen image is invalid."
 
-#: app.py:1494
+#: app.py:1492
 #, fuzzy
 msgid "personal_text_invalid"
 msgstr "Your personal text is invalid."
 
-#: app.py:1496 app.py:1502
+#: app.py:1494 app.py:1500
 #, fuzzy
 msgid "favourite_program_invalid"
 msgstr "Your chosen favourite program is invalid."
 
-#: app.py:1516 app.py:1517
+#: app.py:1514 app.py:1515
 #, fuzzy
 msgid "public_profile_updated"
 msgstr "Public profile updated."
 
-#: app.py:1554 app.py:1579
+#: app.py:1552 app.py:1577
 #, fuzzy
 msgid "user_not_private"
 msgstr "This user doesn't exist or doesn't have a public profile"
 
-#: app.py:1587
+#: app.py:1585
 #, fuzzy
 msgid "invalid_teacher_invitation_code"
 msgstr ""
@@ -740,144 +740,144 @@ msgstr "Hide cheatsheet"
 msgid "back_to_class"
 msgstr "Go back to class"
 
-#: templates/class-overview.html:13 templates/for-teachers.html:35
+#: templates/class-overview.html:14 templates/for-teachers.html:35
 msgid "class_name_prompt"
 msgstr "Graach de namme fan de klas ynfiere"
 
-#: templates/class-overview.html:19 templates/class-overview.html:66
+#: templates/class-overview.html:20 templates/class-overview.html:71
 #: templates/create-accounts.html:16 templates/highscores.html:25
 #: templates/login.html:12 templates/profile.html:89 templates/recover.html:8
 #: templates/signup.html:10
 msgid "username"
 msgstr "Brûkersnamme"
 
-#: templates/class-overview.html:20
+#: templates/class-overview.html:21
 msgid "last_login"
 msgstr "Lêst ynlogd"
 
-#: templates/class-overview.html:21
+#: templates/class-overview.html:22
 msgid "highest_level_reached"
 msgstr "Heechste level berikke"
 
-#: templates/class-overview.html:22
+#: templates/class-overview.html:23
 msgid "number_programs"
 msgstr "Tal programma's"
 
-#: templates/class-overview.html:23
+#: templates/class-overview.html:24
 #, fuzzy
 msgid "programs"
 msgstr "Programs"
 
-#: templates/class-overview.html:24 templates/create-accounts.html:17
+#: templates/class-overview.html:25 templates/create-accounts.html:17
 #: templates/login.html:15 templates/reset.html:8 templates/signup.html:19
 msgid "password"
 msgstr "Wachtwurd"
 
-#: templates/class-overview.html:25 templates/class-overview.html:69
+#: templates/class-overview.html:26 templates/class-overview.html:74
 #: templates/customize-adventure.html:52 templates/for-teachers.html:46
 #: templates/for-teachers.html:56
 #, fuzzy
 msgid "remove"
 msgstr "Remove"
 
-#: templates/class-overview.html:35
+#: templates/class-overview.html:36
 #, fuzzy
 msgid "page"
 msgstr "page"
 
-#: templates/class-overview.html:36
+#: templates/class-overview.html:37
 #, fuzzy
 msgid "enter_password"
 msgstr "Enter a new password for"
 
-#: templates/class-overview.html:36
+#: templates/class-overview.html:37
 #, fuzzy
 msgid "password_change_prompt"
 msgstr "Are you sure you want to change this password?"
 
-#: templates/class-overview.html:37
+#: templates/class-overview.html:38
 msgid "remove_student_prompt"
 msgstr "Witst seker datst de learling út de klas fuorthelje wolst?"
 
-#: templates/class-overview.html:44
+#: templates/class-overview.html:46
 #, fuzzy
 msgid "add_students"
 msgstr "learlingen"
 
-#: templates/class-overview.html:45 templates/customize-class.html:5
+#: templates/class-overview.html:47 templates/customize-class.html:5
 #, fuzzy
 msgid "customize_class"
 msgstr "Customize class"
 
-#: templates/class-overview.html:46
+#: templates/class-overview.html:48
 #, fuzzy
 msgid "class_stats"
 msgstr "Show class statistics"
 
-#: templates/class-overview.html:47
+#: templates/class-overview.html:49
 #, fuzzy
 msgid "class_logs"
 msgstr "Lêst ynlogd"
 
-#: templates/class-overview.html:48 templates/customize-adventure.html:59
+#: templates/class-overview.html:52 templates/customize-adventure.html:59
 #, fuzzy
 msgid "back_to_teachers_page"
 msgstr "Go back to teachers page"
 
-#: templates/class-overview.html:49
+#: templates/class-overview.html:53
 msgid "delete_class_prompt"
 msgstr "Witst seker datst de klas fuortsmite wolst?"
 
-#: templates/class-overview.html:49
+#: templates/class-overview.html:53
 msgid "delete_class"
 msgstr "Klas fuortsmite"
 
-#: templates/class-overview.html:52
+#: templates/class-overview.html:57
 #, fuzzy
 msgid "add_students_options"
 msgstr "Create student accounts"
 
-#: templates/class-overview.html:54
+#: templates/class-overview.html:59
 #, fuzzy
 msgid "copy_link_success"
 msgstr "Diellink kopiëare"
 
-#: templates/class-overview.html:54
+#: templates/class-overview.html:59
 #, fuzzy
 msgid "copy_join_link"
 msgstr "Please copy and paste this link into a new tab:"
 
-#: templates/class-overview.html:55
+#: templates/class-overview.html:60
 #, fuzzy
 msgid "invite_prompt"
 msgstr "Enter a username"
 
-#: templates/class-overview.html:55
+#: templates/class-overview.html:60
 #, fuzzy
 msgid "invite_by_username"
 msgstr "All usernames need to be unique."
 
-#: templates/class-overview.html:56 templates/create-accounts.html:45
+#: templates/class-overview.html:61 templates/create-accounts.html:45
 #, fuzzy
 msgid "create_accounts"
 msgstr "Create multiple accounts"
 
-#: templates/class-overview.html:61
+#: templates/class-overview.html:66
 #, fuzzy
 msgid "pending_invites"
 msgstr "Pending invites"
 
-#: templates/class-overview.html:67
+#: templates/class-overview.html:72
 #, fuzzy
 msgid "invite_date"
 msgstr "Invite date"
 
-#: templates/class-overview.html:68
+#: templates/class-overview.html:73
 #, fuzzy
 msgid "expiration_date"
 msgstr "Expiration date"
 
-#: templates/class-overview.html:78 templates/profile.html:16
+#: templates/class-overview.html:83 templates/profile.html:16
 #, fuzzy
 msgid "delete_invite_prompt"
 msgstr "Are you sure you want to remove this class invitation?"
@@ -1327,10 +1327,10 @@ msgstr "Myn lessen"
 msgid "achievements"
 msgstr "achievements"
 
-#: templates/highscores.html:27 templates/learn-more.html:22
-#: templates/profile.html:131 templates/signup.html:52
-msgid "country"
-msgstr "Lân wêrst wennest"
+#: templates/highscores.html:27
+#, fuzzy
+msgid "country_title"
+msgstr "Please select a valid country."
 
 #: templates/highscores.html:28 templates/landing-page.html:88
 #: templates/public-page.html:50
@@ -1614,6 +1614,11 @@ msgstr "Brûkersnamme"
 #, fuzzy
 msgid "lastname"
 msgstr "Namme"
+
+#: templates/learn-more.html:22 templates/profile.html:131
+#: templates/signup.html:52
+msgid "country"
+msgstr "Lân wêrst wennest"
 
 #: templates/learn-more.html:31
 #, fuzzy

--- a/translations/hi/LC_MESSAGES/messages.po
+++ b/translations/hi/LC_MESSAGES/messages.po
@@ -3,16 +3,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-28 18:38+0300\n"
+"POT-Creation-Date: 2022-06-29 14:20+0200\n"
 "PO-Revision-Date: 2022-06-28 13:25+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: hi\n"
 "Language-Team: hi <LL@li.org>\n"
-"Plural-Forms: nplurals=2; plural=n > 1\n"
+"Plural-Forms: nplurals=2; plural=n > 1;\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.9.1\n"
+"Generated-By: Babel 2.10.1\n"
 
 #: app.py:417
 #, fuzzy
@@ -24,7 +24,7 @@ msgstr "This program contains an error, are you sure you want to share it?"
 msgid "title_achievements"
 msgstr "Hedy - My achievements"
 
-#: app.py:644 app.py:748 app.py:1090 website/teacher.py:361
+#: app.py:644 app.py:746 app.py:1088 website/teacher.py:361
 #: website/teacher.py:372
 msgid "not_teacher"
 msgstr "लगता है आप शिक्षक नहीं हैं!"
@@ -33,12 +33,12 @@ msgstr "लगता है आप शिक्षक नहीं हैं!"
 msgid "not_enrolled"
 msgstr "ऐसा लगता है कि आप इस कक्षा में नहीं हैं!"
 
-#: app.py:686
+#: app.py:684
 #, fuzzy
 msgid "title_programs"
 msgstr "Hedy - My programs"
 
-#: app.py:696 app.py:706 app.py:710 app.py:725 app.py:1005 app.py:1550
+#: app.py:694 app.py:704 app.py:708 app.py:723 app.py:1003 app.py:1548
 #: website/admin.py:17 website/admin.py:24 website/admin.py:92
 #: website/admin.py:111 website/admin.py:129 website/admin.py:136
 #: website/admin.py:144 website/auth.py:716 website/auth.py:743
@@ -47,322 +47,322 @@ msgstr "Hedy - My programs"
 msgid "unauthorized"
 msgstr "You don't have access rights for this page"
 
-#: app.py:762 app.py:1107
+#: app.py:760 app.py:1105
 #, fuzzy
 msgid "title_for-teacher"
 msgstr "Hedy - For teachers"
 
-#: app.py:779 app.py:781 app.py:923 app.py:945 app.py:947
+#: app.py:777 app.py:779 app.py:921 app.py:943 app.py:945
 msgid "no_such_level"
 msgstr "ऐसा कोई हेडी स्तर नहीं!"
 
-#: app.py:789 app.py:796 app.py:877 app.py:883
+#: app.py:787 app.py:794 app.py:875 app.py:881
 msgid "no_such_program"
 msgstr "ऐसा कोई हेडी प्रोग्राम नहीं!"
 
-#: app.py:819
+#: app.py:817
 #, fuzzy
 msgid "level_not_class"
 msgstr "You're in a class where this level has not been made available yet"
 
-#: app.py:928 website/teacher.py:421 website/teacher.py:437
+#: app.py:926 website/teacher.py:421 website/teacher.py:437
 #: website/teacher.py:466 website/teacher.py:492
 #, fuzzy
 msgid "no_such_adventure"
 msgstr "This adventure doesn't exist!"
 
-#: app.py:956 app.py:1209
+#: app.py:954 app.py:1207
 msgid "page_not_found"
 msgstr "हमें वह पृष्ठ नहीं मिला!"
 
-#: app.py:976
+#: app.py:974
 #, fuzzy
 msgid "title_signup"
 msgstr "Hedy - Create an account"
 
-#: app.py:983
+#: app.py:981
 #, fuzzy
 msgid "title_login"
 msgstr "Hedy - Login"
 
-#: app.py:990
+#: app.py:988
 #, fuzzy
 msgid "title_recover"
 msgstr "Hedy - Recover account"
 
-#: app.py:1006
+#: app.py:1004
 #, fuzzy
 msgid "title_reset"
 msgstr "Hedy - Reset password"
 
-#: app.py:1032
+#: app.py:1030
 #, fuzzy
 msgid "title_my-profile"
 msgstr "Hedy - My account"
 
-#: app.py:1048
+#: app.py:1046
 #, fuzzy
 msgid "title_learn-more"
 msgstr "Hedy - Learn more"
 
-#: app.py:1054
+#: app.py:1052
 #, fuzzy
 msgid "title_privacy"
 msgstr "Hedy - Privacy terms"
 
-#: app.py:1064
+#: app.py:1062
 #, fuzzy
 msgid "title_start"
 msgstr "Hedy - A gradual programming language"
 
-#: app.py:1082
+#: app.py:1080
 #, fuzzy
 msgid "title_landing-page"
 msgstr "Welcome to Hedy!"
 
-#: app.py:1200
+#: app.py:1198
 #, fuzzy
 msgid "title_explore"
 msgstr "Hedy - Explore"
 
-#: app.py:1221 app.py:1226
+#: app.py:1219 app.py:1224
 #, fuzzy
 msgid "no_such_highscore"
 msgstr "ऐसा कोई हेडी स्तर नहीं!"
 
-#: app.py:1255 app.py:1257
+#: app.py:1253 app.py:1255
 #, fuzzy
 msgid "translate_error"
 msgstr ""
 "Something went wrong while translating the code. Try running the code to "
 "see if it has an error. Code with errors can not be translated."
 
-#: app.py:1262 app.py:1296
+#: app.py:1260 app.py:1294
 #, fuzzy
 msgid "tutorial_start_title"
 msgstr "Welcome to Hedy!"
 
-#: app.py:1262
+#: app.py:1260
 #, fuzzy
 msgid "tutorial_start_message"
 msgstr "In this tutorial we will explain all the Hedy features step-by-step."
 
-#: app.py:1264
+#: app.py:1262
 #, fuzzy
 msgid "tutorial_editor_title"
 msgstr "The code editor"
 
-#: app.py:1264
+#: app.py:1262
 #, fuzzy
 msgid "tutorial_editor_message"
 msgstr "In this window you write all the code, try typing something!"
 
-#: app.py:1266
+#: app.py:1264
 #, fuzzy
 msgid "tutorial_output_title"
 msgstr "The output window"
 
-#: app.py:1266
+#: app.py:1264
 #, fuzzy
 msgid "tutorial_output_message"
 msgstr "The result of the code you execute will be shown here"
 
-#: app.py:1268
+#: app.py:1266
 #, fuzzy
 msgid "tutorial_run_title"
 msgstr "The run button"
 
-#: app.py:1268
+#: app.py:1266
 #, fuzzy
 msgid "tutorial_run_message"
 msgstr "With this button you can run your program! Shall we give it a try?"
 
-#: app.py:1270
+#: app.py:1268
 #, fuzzy
 msgid "tutorial_tryit_title"
 msgstr "Try it out!"
 
-#: app.py:1270
+#: app.py:1268
 #, fuzzy
 msgid "tutorial_tryit_message"
 msgstr "आपको कक्षा में शामिल होने का निमंत्रण मिला है"
 
-#: app.py:1272
+#: app.py:1270
 #, fuzzy
 msgid "tutorial_speakaloud_title"
 msgstr "The end!"
 
-#: app.py:1272
+#: app.py:1270
 #, fuzzy
 msgid "tutorial_speakaloud_message"
 msgstr "Click on 'next step' to really start coding with Hedy!"
 
-#: app.py:1274
+#: app.py:1272
 #, fuzzy
 msgid "tutorial_speakaloud_run_title"
 msgstr "The end!"
 
-#: app.py:1274
+#: app.py:1272
 #, fuzzy
 msgid "tutorial_speakaloud_run_message"
 msgstr "Click on 'next step' to really start coding with Hedy!"
 
-#: app.py:1276
+#: app.py:1274
 #, fuzzy
 msgid "tutorial_nextlevel_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1276
+#: app.py:1274
 #, fuzzy
 msgid "tutorial_nextlevel_message"
 msgstr "आपको कक्षा में शामिल होने का निमंत्रण मिला है"
 
-#: app.py:1278
+#: app.py:1276
 #, fuzzy
 msgid "tutorial_leveldefault_title"
 msgstr "Level explanation"
 
-#: app.py:1278
+#: app.py:1276
 #, fuzzy
 msgid "tutorial_leveldefault_message"
 msgstr ""
 "The first tab always contains the level explanation. In each level new "
 "commands will be explained here."
 
-#: app.py:1280
+#: app.py:1278
 #, fuzzy
 msgid "tutorial_adventures_title"
 msgstr "adventures अनुकूलित करें"
 
-#: app.py:1280
+#: app.py:1278
 #, fuzzy
 msgid "tutorial_adventures_message"
 msgstr "adventures अनुकूलित करें"
 
-#: app.py:1282
+#: app.py:1280
 #, fuzzy
 msgid "tutorial_quiz_title"
 msgstr "Quiz"
 
-#: app.py:1282
+#: app.py:1280
 #, fuzzy
 msgid "tutorial_quiz_message"
 msgstr ""
 "At the end of each level you can make the quiz. This way you can verify "
 "if you understand everything."
 
-#: app.py:1284
+#: app.py:1282
 #, fuzzy
 msgid "tutorial_saveshare_title"
 msgstr "Saving & sharing"
 
-#: app.py:1284
+#: app.py:1282
 #, fuzzy
 msgid "tutorial_saveshare_message"
 msgstr "You can save and share all your created programs with other Hedy users."
 
-#: app.py:1286
+#: app.py:1284
 #, fuzzy
 msgid "tutorial_cheatsheet_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1286
+#: app.py:1284
 #, fuzzy
 msgid "tutorial_cheatsheet_message"
 msgstr ""
 "If you forgot a command you can always use the cheatsheet. It shows a "
 "list of all commands you can use in the current level."
 
-#: app.py:1288 app.py:1308
+#: app.py:1286 app.py:1306
 #, fuzzy
 msgid "tutorial_end_title"
 msgstr "The end!"
 
-#: app.py:1288
+#: app.py:1286
 #, fuzzy
 msgid "tutorial_end_message"
 msgstr "Click on 'next step' to really start coding with Hedy!"
 
-#: app.py:1290 app.py:1310
+#: app.py:1288 app.py:1308
 #, fuzzy
 msgid "tutorial_title_not_found"
 msgstr "हमें वह पृष्ठ नहीं मिला!"
 
-#: app.py:1290 app.py:1310
+#: app.py:1288 app.py:1308
 #, fuzzy
 msgid "tutorial_message_not_found"
 msgstr "आपको कक्षा में शामिल होने का निमंत्रण मिला है"
 
-#: app.py:1296
+#: app.py:1294
 #, fuzzy
 msgid "teacher_tutorial_start_message"
 msgstr "आपको कक्षा में शामिल होने का निमंत्रण मिला है"
 
-#: app.py:1298
+#: app.py:1296
 #, fuzzy
 msgid "tutorial_class_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1298
+#: app.py:1296
 #, fuzzy
 msgid "tutorial_class_message"
 msgstr "adventures अनुकूलित करें"
 
-#: app.py:1300
+#: app.py:1298
 #, fuzzy
 msgid "tutorial_customize_class_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1300
+#: app.py:1298
 #, fuzzy
 msgid "tutorial_customize_class_message"
 msgstr "adventures अनुकूलित करें"
 
-#: app.py:1302
+#: app.py:1300
 #, fuzzy
 msgid "tutorial_own_adventures_title"
 msgstr "adventures अनुकूलित करें"
 
-#: app.py:1302
+#: app.py:1300
 #, fuzzy
 msgid "tutorial_own_adventures_message"
 msgstr "adventures अनुकूलित करें"
 
-#: app.py:1304
+#: app.py:1302
 #, fuzzy
 msgid "tutorial_accounts_title"
 msgstr "adventures अनुकूलित करें"
 
-#: app.py:1304
+#: app.py:1302
 #, fuzzy
 msgid "tutorial_accounts_message"
 msgstr "adventures अनुकूलित करें"
 
-#: app.py:1306
+#: app.py:1304
 #, fuzzy
 msgid "tutorial_documentation_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1306
+#: app.py:1304
 #, fuzzy
 msgid "tutorial_documentation_message"
 msgstr "adventures अनुकूलित करें"
 
-#: app.py:1308
+#: app.py:1306
 #, fuzzy
 msgid "teacher_tutorial_end_message"
 msgstr "आपको कक्षा में शामिल होने का निमंत्रण मिला है"
 
-#: app.py:1318
+#: app.py:1316
 #, fuzzy
 msgid "tutorial_code_snippet"
 msgstr "Hide cheatsheet"
 
-#: app.py:1322 app.py:1332
+#: app.py:1320 app.py:1330
 msgid "invalid_tutorial_step"
 msgstr ""
 
-#: app.py:1489 website/auth.py:278 website/auth.py:333 website/auth.py:469
+#: app.py:1487 website/auth.py:278 website/auth.py:333 website/auth.py:469
 #: website/auth.py:494 website/auth.py:524 website/auth.py:637
 #: website/auth.py:675 website/auth.py:722 website/auth.py:749
 #: website/quiz.py:43 website/quiz.py:69 website/teacher.py:88
@@ -372,27 +372,27 @@ msgstr ""
 msgid "ajax_error"
 msgstr "एक त्रुटि थी, कृपया पुनः प्रयास करें।"
 
-#: app.py:1492
+#: app.py:1490
 msgid "image_invalid"
 msgstr "आपकी फोटो अमान्य है"
 
-#: app.py:1494
+#: app.py:1492
 msgid "personal_text_invalid"
 msgstr "आपका व्यक्तिगत पाठ अमान्य है"
 
-#: app.py:1496 app.py:1502
+#: app.py:1494 app.py:1500
 msgid "favourite_program_invalid"
 msgstr "आपका पसंदीदा प्रोग्राम अमान्य है"
 
-#: app.py:1516 app.py:1517
+#: app.py:1514 app.py:1515
 msgid "public_profile_updated"
 msgstr "सार्वजनिक प्रोफ़ाइल अद्यतन की गई।"
 
-#: app.py:1554 app.py:1579
+#: app.py:1552 app.py:1577
 msgid "user_not_private"
 msgstr "यह उपयोगकर्ता मौजूद नहीं है या उसकी कोई सार्वजनिक प्रोफ़ाइल नहीं है"
 
-#: app.py:1587
+#: app.py:1585
 msgid "invalid_teacher_invitation_code"
 msgstr ""
 "िक्षक आमंत्रण कोड अमान्य है| शिक्षक बनने के लिए, hedy@felienne.com पर "
@@ -705,133 +705,133 @@ msgstr "Hide cheatsheet"
 msgid "back_to_class"
 msgstr "कक्षा में वापस जाएं"
 
-#: templates/class-overview.html:13 templates/for-teachers.html:35
+#: templates/class-overview.html:14 templates/for-teachers.html:35
 msgid "class_name_prompt"
 msgstr "कृपया कक्षा का नाम दर्ज करें"
 
-#: templates/class-overview.html:19 templates/class-overview.html:66
+#: templates/class-overview.html:20 templates/class-overview.html:71
 #: templates/create-accounts.html:16 templates/highscores.html:25
 #: templates/login.html:12 templates/profile.html:89 templates/recover.html:8
 #: templates/signup.html:10
 msgid "username"
 msgstr "उपयोगकर्ता नाम"
 
-#: templates/class-overview.html:20
+#: templates/class-overview.html:21
 msgid "last_login"
 msgstr "आखरी लॉगइन"
 
-#: templates/class-overview.html:21
+#: templates/class-overview.html:22
 msgid "highest_level_reached"
 msgstr "पहुंचा गया उच्चतम स्तर"
 
-#: templates/class-overview.html:22
+#: templates/class-overview.html:23
 msgid "number_programs"
 msgstr "प्रोग्राम्स की संख्या"
 
-#: templates/class-overview.html:23
+#: templates/class-overview.html:24
 msgid "programs"
 msgstr "प्रोग्राम्स"
 
-#: templates/class-overview.html:24 templates/create-accounts.html:17
+#: templates/class-overview.html:25 templates/create-accounts.html:17
 #: templates/login.html:15 templates/reset.html:8 templates/signup.html:19
 msgid "password"
 msgstr "सांकेतिक शब्द"
 
-#: templates/class-overview.html:25 templates/class-overview.html:69
+#: templates/class-overview.html:26 templates/class-overview.html:74
 #: templates/customize-adventure.html:52 templates/for-teachers.html:46
 #: templates/for-teachers.html:56
 msgid "remove"
 msgstr "हटा दें"
 
-#: templates/class-overview.html:35
+#: templates/class-overview.html:36
 msgid "page"
 msgstr "पृष्ठ"
 
-#: templates/class-overview.html:36
+#: templates/class-overview.html:37
 msgid "enter_password"
 msgstr "एक नया सांकेतिक शब्द दर्ज करें इस के लिए "
 
-#: templates/class-overview.html:36
+#: templates/class-overview.html:37
 msgid "password_change_prompt"
 msgstr "क्या आप वाकई इस सांकेतिक शब्द को बदलना चाहते हैं?"
 
-#: templates/class-overview.html:37
+#: templates/class-overview.html:38
 msgid "remove_student_prompt"
 msgstr "क्या आप वाकई छात्र को कक्षा से बाहर निकलना चाहते हैं?"
 
-#: templates/class-overview.html:44
+#: templates/class-overview.html:46
 #, fuzzy
 msgid "add_students"
 msgstr "छात्र"
 
-#: templates/class-overview.html:45 templates/customize-class.html:5
+#: templates/class-overview.html:47 templates/customize-class.html:5
 msgid "customize_class"
 msgstr "कक्षा को अनुकूलित करें"
 
-#: templates/class-overview.html:46
+#: templates/class-overview.html:48
 msgid "class_stats"
 msgstr "कक्षा के आँकड़े दिखाएँ"
 
-#: templates/class-overview.html:47
+#: templates/class-overview.html:49
 #, fuzzy
 msgid "class_logs"
 msgstr "आखरी लॉगइन"
 
-#: templates/class-overview.html:48 templates/customize-adventure.html:59
+#: templates/class-overview.html:52 templates/customize-adventure.html:59
 msgid "back_to_teachers_page"
 msgstr "शिक्षक पृष्ठ पर वापस जाएं"
 
-#: templates/class-overview.html:49
+#: templates/class-overview.html:53
 msgid "delete_class_prompt"
 msgstr "क्या आप वाकई कक्षा को हटाना चाहते हैं?"
 
-#: templates/class-overview.html:49
+#: templates/class-overview.html:53
 msgid "delete_class"
 msgstr "कक्षा को स्थाई रूप से हटाएँ"
 
-#: templates/class-overview.html:52
+#: templates/class-overview.html:57
 #, fuzzy
 msgid "add_students_options"
 msgstr "Create student accounts"
 
-#: templates/class-overview.html:54
+#: templates/class-overview.html:59
 #, fuzzy
 msgid "copy_link_success"
 msgstr "शेयर करने के लिए लिंक कॉपी करें"
 
-#: templates/class-overview.html:54
+#: templates/class-overview.html:59
 #, fuzzy
 msgid "copy_join_link"
 msgstr "Please copy and paste this link into a new tab:"
 
-#: templates/class-overview.html:55
+#: templates/class-overview.html:60
 msgid "invite_prompt"
 msgstr "एक उपयोगकर्ता नाम दर्ज करें"
 
-#: templates/class-overview.html:55
+#: templates/class-overview.html:60
 #, fuzzy
 msgid "invite_by_username"
 msgstr "All usernames need to be unique."
 
-#: templates/class-overview.html:56 templates/create-accounts.html:45
+#: templates/class-overview.html:61 templates/create-accounts.html:45
 #, fuzzy
 msgid "create_accounts"
 msgstr "Create multiple accounts"
 
-#: templates/class-overview.html:61
+#: templates/class-overview.html:66
 msgid "pending_invites"
 msgstr "लंबित आमंत्रण"
 
-#: templates/class-overview.html:67
+#: templates/class-overview.html:72
 msgid "invite_date"
 msgstr "आमंत्रण तिथि"
 
-#: templates/class-overview.html:68
+#: templates/class-overview.html:73
 #, fuzzy
 msgid "expiration_date"
 msgstr "Expiration date"
 
-#: templates/class-overview.html:78 templates/profile.html:16
+#: templates/class-overview.html:83 templates/profile.html:16
 msgid "delete_invite_prompt"
 msgstr "क्या आप वाकई इस कक्षा आमंत्रण को हटाना चाहते हैं?"
 
@@ -1253,10 +1253,10 @@ msgstr "मेरी कक्षाएँ"
 msgid "achievements"
 msgstr "उपलब्धियां"
 
-#: templates/highscores.html:27 templates/learn-more.html:22
-#: templates/profile.html:131 templates/signup.html:52
-msgid "country"
-msgstr "देश"
+#: templates/highscores.html:27
+#, fuzzy
+msgid "country_title"
+msgstr "Please select a valid country."
 
 #: templates/highscores.html:28 templates/landing-page.html:88
 #: templates/public-page.html:50
@@ -1534,6 +1534,11 @@ msgstr "उपयोगकर्ता नाम"
 #, fuzzy
 msgid "lastname"
 msgstr "नाम"
+
+#: templates/learn-more.html:22 templates/profile.html:131
+#: templates/signup.html:52
+msgid "country"
+msgstr "देश"
 
 #: templates/learn-more.html:31
 #, fuzzy

--- a/translations/hu/LC_MESSAGES/messages.po
+++ b/translations/hu/LC_MESSAGES/messages.po
@@ -3,16 +3,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-28 18:38+0300\n"
+"POT-Creation-Date: 2022-06-29 14:20+0200\n"
 "PO-Revision-Date: 2022-06-28 13:25+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: hu\n"
 "Language-Team: hu <LL@li.org>\n"
-"Plural-Forms: nplurals=2; plural=n != 1\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.9.1\n"
+"Generated-By: Babel 2.10.1\n"
 
 #: app.py:417
 #, fuzzy
@@ -24,7 +24,7 @@ msgstr "This program contains an error, are you sure you want to share it?"
 msgid "title_achievements"
 msgstr "Hedy - My achievements"
 
-#: app.py:644 app.py:748 app.py:1090 website/teacher.py:361
+#: app.py:644 app.py:746 app.py:1088 website/teacher.py:361
 #: website/teacher.py:372
 #, fuzzy
 msgid "not_teacher"
@@ -35,12 +35,12 @@ msgstr "Looks like you are not a teacher!"
 msgid "not_enrolled"
 msgstr "Looks like you are not in this class!"
 
-#: app.py:686
+#: app.py:684
 #, fuzzy
 msgid "title_programs"
 msgstr "Hedy - My programs"
 
-#: app.py:696 app.py:706 app.py:710 app.py:725 app.py:1005 app.py:1550
+#: app.py:694 app.py:704 app.py:708 app.py:723 app.py:1003 app.py:1548
 #: website/admin.py:17 website/admin.py:24 website/admin.py:92
 #: website/admin.py:111 website/admin.py:129 website/admin.py:136
 #: website/admin.py:144 website/auth.py:716 website/auth.py:743
@@ -49,325 +49,325 @@ msgstr "Hedy - My programs"
 msgid "unauthorized"
 msgstr "You don't have access rights for this page"
 
-#: app.py:762 app.py:1107
+#: app.py:760 app.py:1105
 #, fuzzy
 msgid "title_for-teacher"
 msgstr "Hedy - For teachers"
 
-#: app.py:779 app.py:781 app.py:923 app.py:945 app.py:947
+#: app.py:777 app.py:779 app.py:921 app.py:943 app.py:945
 #, fuzzy
 msgid "no_such_level"
 msgstr "No such Hedy level!"
 
-#: app.py:789 app.py:796 app.py:877 app.py:883
+#: app.py:787 app.py:794 app.py:875 app.py:881
 #, fuzzy
 msgid "no_such_program"
 msgstr "No such Hedy program!"
 
-#: app.py:819
+#: app.py:817
 #, fuzzy
 msgid "level_not_class"
 msgstr "You're in a class where this level has not been made available yet"
 
-#: app.py:928 website/teacher.py:421 website/teacher.py:437
+#: app.py:926 website/teacher.py:421 website/teacher.py:437
 #: website/teacher.py:466 website/teacher.py:492
 #, fuzzy
 msgid "no_such_adventure"
 msgstr "This adventure doesn't exist!"
 
-#: app.py:956 app.py:1209
+#: app.py:954 app.py:1207
 #, fuzzy
 msgid "page_not_found"
 msgstr "We could not find that page!"
 
-#: app.py:976
+#: app.py:974
 #, fuzzy
 msgid "title_signup"
 msgstr "Hedy - Create an account"
 
-#: app.py:983
+#: app.py:981
 #, fuzzy
 msgid "title_login"
 msgstr "Hedy - Login"
 
-#: app.py:990
+#: app.py:988
 #, fuzzy
 msgid "title_recover"
 msgstr "Hedy - Recover account"
 
-#: app.py:1006
+#: app.py:1004
 #, fuzzy
 msgid "title_reset"
 msgstr "Hedy - Reset password"
 
-#: app.py:1032
+#: app.py:1030
 #, fuzzy
 msgid "title_my-profile"
 msgstr "Hedy - My account"
 
-#: app.py:1048
+#: app.py:1046
 #, fuzzy
 msgid "title_learn-more"
 msgstr "Hedy - Learn more"
 
-#: app.py:1054
+#: app.py:1052
 #, fuzzy
 msgid "title_privacy"
 msgstr "Hedy - Privacy terms"
 
-#: app.py:1064
+#: app.py:1062
 #, fuzzy
 msgid "title_start"
 msgstr "Hedy - A gradual programming language"
 
-#: app.py:1082
+#: app.py:1080
 #, fuzzy
 msgid "title_landing-page"
 msgstr "Welcome to Hedy!"
 
-#: app.py:1200
+#: app.py:1198
 #, fuzzy
 msgid "title_explore"
 msgstr "Hedy - Explore"
 
-#: app.py:1221 app.py:1226
+#: app.py:1219 app.py:1224
 #, fuzzy
 msgid "no_such_highscore"
 msgstr "No such Hedy level!"
 
-#: app.py:1255 app.py:1257
+#: app.py:1253 app.py:1255
 #, fuzzy
 msgid "translate_error"
 msgstr ""
 "Something went wrong while translating the code. Try running the code to "
 "see if it has an error. Code with errors can not be translated."
 
-#: app.py:1262 app.py:1296
+#: app.py:1260 app.py:1294
 #, fuzzy
 msgid "tutorial_start_title"
 msgstr "Welcome to Hedy!"
 
-#: app.py:1262
+#: app.py:1260
 #, fuzzy
 msgid "tutorial_start_message"
 msgstr "In this tutorial we will explain all the Hedy features step-by-step."
 
-#: app.py:1264
+#: app.py:1262
 #, fuzzy
 msgid "tutorial_editor_title"
 msgstr "The code editor"
 
-#: app.py:1264
+#: app.py:1262
 #, fuzzy
 msgid "tutorial_editor_message"
 msgstr "In this window you write all the code, try typing something!"
 
-#: app.py:1266
+#: app.py:1264
 #, fuzzy
 msgid "tutorial_output_title"
 msgstr "The output window"
 
-#: app.py:1266
+#: app.py:1264
 #, fuzzy
 msgid "tutorial_output_message"
 msgstr "The result of the code you execute will be shown here"
 
-#: app.py:1268
+#: app.py:1266
 #, fuzzy
 msgid "tutorial_run_title"
 msgstr "The run button"
 
-#: app.py:1268
+#: app.py:1266
 #, fuzzy
 msgid "tutorial_run_message"
 msgstr "With this button you can run your program! Shall we give it a try?"
 
-#: app.py:1270
+#: app.py:1268
 #, fuzzy
 msgid "tutorial_tryit_title"
 msgstr "Try it out!"
 
-#: app.py:1270
+#: app.py:1268
 #, fuzzy
 msgid "tutorial_tryit_message"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1272
+#: app.py:1270
 #, fuzzy
 msgid "tutorial_speakaloud_title"
 msgstr "The end!"
 
-#: app.py:1272
+#: app.py:1270
 #, fuzzy
 msgid "tutorial_speakaloud_message"
 msgstr "Click on 'next step' to really start coding with Hedy!"
 
-#: app.py:1274
+#: app.py:1272
 #, fuzzy
 msgid "tutorial_speakaloud_run_title"
 msgstr "The end!"
 
-#: app.py:1274
+#: app.py:1272
 #, fuzzy
 msgid "tutorial_speakaloud_run_message"
 msgstr "Click on 'next step' to really start coding with Hedy!"
 
-#: app.py:1276
+#: app.py:1274
 #, fuzzy
 msgid "tutorial_nextlevel_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1276
+#: app.py:1274
 #, fuzzy
 msgid "tutorial_nextlevel_message"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1278
+#: app.py:1276
 #, fuzzy
 msgid "tutorial_leveldefault_title"
 msgstr "Level explanation"
 
-#: app.py:1278
+#: app.py:1276
 #, fuzzy
 msgid "tutorial_leveldefault_message"
 msgstr ""
 "The first tab always contains the level explanation. In each level new "
 "commands will be explained here."
 
-#: app.py:1280
+#: app.py:1278
 #, fuzzy
 msgid "tutorial_adventures_title"
 msgstr "Customize adventure"
 
-#: app.py:1280
+#: app.py:1278
 #, fuzzy
 msgid "tutorial_adventures_message"
 msgstr "Customize adventure"
 
-#: app.py:1282
+#: app.py:1280
 #, fuzzy
 msgid "tutorial_quiz_title"
 msgstr "Quiz"
 
-#: app.py:1282
+#: app.py:1280
 #, fuzzy
 msgid "tutorial_quiz_message"
 msgstr ""
 "At the end of each level you can make the quiz. This way you can verify "
 "if you understand everything."
 
-#: app.py:1284
+#: app.py:1282
 #, fuzzy
 msgid "tutorial_saveshare_title"
 msgstr "Saving & sharing"
 
-#: app.py:1284
+#: app.py:1282
 #, fuzzy
 msgid "tutorial_saveshare_message"
 msgstr "You can save and share all your created programs with other Hedy users."
 
-#: app.py:1286
+#: app.py:1284
 #, fuzzy
 msgid "tutorial_cheatsheet_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1286
+#: app.py:1284
 #, fuzzy
 msgid "tutorial_cheatsheet_message"
 msgstr ""
 "If you forgot a command you can always use the cheatsheet. It shows a "
 "list of all commands you can use in the current level."
 
-#: app.py:1288 app.py:1308
+#: app.py:1286 app.py:1306
 #, fuzzy
 msgid "tutorial_end_title"
 msgstr "The end!"
 
-#: app.py:1288
+#: app.py:1286
 #, fuzzy
 msgid "tutorial_end_message"
 msgstr "Click on 'next step' to really start coding with Hedy!"
 
-#: app.py:1290 app.py:1310
+#: app.py:1288 app.py:1308
 #, fuzzy
 msgid "tutorial_title_not_found"
 msgstr "We could not find that page!"
 
-#: app.py:1290 app.py:1310
+#: app.py:1288 app.py:1308
 #, fuzzy
 msgid "tutorial_message_not_found"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1296
+#: app.py:1294
 #, fuzzy
 msgid "teacher_tutorial_start_message"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1298
+#: app.py:1296
 #, fuzzy
 msgid "tutorial_class_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1298
+#: app.py:1296
 #, fuzzy
 msgid "tutorial_class_message"
 msgstr "Customize adventure"
 
-#: app.py:1300
+#: app.py:1298
 #, fuzzy
 msgid "tutorial_customize_class_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1300
+#: app.py:1298
 #, fuzzy
 msgid "tutorial_customize_class_message"
 msgstr "Customize adventure"
 
-#: app.py:1302
+#: app.py:1300
 #, fuzzy
 msgid "tutorial_own_adventures_title"
 msgstr "Customize adventure"
 
-#: app.py:1302
+#: app.py:1300
 #, fuzzy
 msgid "tutorial_own_adventures_message"
 msgstr "Customize adventure"
 
-#: app.py:1304
+#: app.py:1302
 #, fuzzy
 msgid "tutorial_accounts_title"
 msgstr "Customize adventure"
 
-#: app.py:1304
+#: app.py:1302
 #, fuzzy
 msgid "tutorial_accounts_message"
 msgstr "Customize adventure"
 
-#: app.py:1306
+#: app.py:1304
 #, fuzzy
 msgid "tutorial_documentation_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1306
+#: app.py:1304
 #, fuzzy
 msgid "tutorial_documentation_message"
 msgstr "Customize adventure"
 
-#: app.py:1308
+#: app.py:1306
 #, fuzzy
 msgid "teacher_tutorial_end_message"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1318
+#: app.py:1316
 #, fuzzy
 msgid "tutorial_code_snippet"
 msgstr "Hide cheatsheet"
 
-#: app.py:1322 app.py:1332
+#: app.py:1320 app.py:1330
 msgid "invalid_tutorial_step"
 msgstr ""
 
-#: app.py:1489 website/auth.py:278 website/auth.py:333 website/auth.py:469
+#: app.py:1487 website/auth.py:278 website/auth.py:333 website/auth.py:469
 #: website/auth.py:494 website/auth.py:524 website/auth.py:637
 #: website/auth.py:675 website/auth.py:722 website/auth.py:749
 #: website/quiz.py:43 website/quiz.py:69 website/teacher.py:88
@@ -377,32 +377,32 @@ msgstr ""
 msgid "ajax_error"
 msgstr "Hiba történt, próbálkozz újra."
 
-#: app.py:1492
+#: app.py:1490
 #, fuzzy
 msgid "image_invalid"
 msgstr "Your chosen image is invalid."
 
-#: app.py:1494
+#: app.py:1492
 #, fuzzy
 msgid "personal_text_invalid"
 msgstr "Your personal text is invalid."
 
-#: app.py:1496 app.py:1502
+#: app.py:1494 app.py:1500
 #, fuzzy
 msgid "favourite_program_invalid"
 msgstr "Your chosen favourite program is invalid."
 
-#: app.py:1516 app.py:1517
+#: app.py:1514 app.py:1515
 #, fuzzy
 msgid "public_profile_updated"
 msgstr "Public profile updated."
 
-#: app.py:1554 app.py:1579
+#: app.py:1552 app.py:1577
 #, fuzzy
 msgid "user_not_private"
 msgstr "This user doesn't exist or doesn't have a public profile"
 
-#: app.py:1587
+#: app.py:1585
 #, fuzzy
 msgid "invalid_teacher_invitation_code"
 msgstr ""
@@ -738,143 +738,143 @@ msgstr "Hide cheatsheet"
 msgid "back_to_class"
 msgstr "Go back to class"
 
-#: templates/class-overview.html:13 templates/for-teachers.html:35
+#: templates/class-overview.html:14 templates/for-teachers.html:35
 msgid "class_name_prompt"
 msgstr "Kérlek add meg az osztály nevét"
 
-#: templates/class-overview.html:19 templates/class-overview.html:66
+#: templates/class-overview.html:20 templates/class-overview.html:71
 #: templates/create-accounts.html:16 templates/highscores.html:25
 #: templates/login.html:12 templates/profile.html:89 templates/recover.html:8
 #: templates/signup.html:10
 msgid "username"
 msgstr "Felhasználónév"
 
-#: templates/class-overview.html:20
+#: templates/class-overview.html:21
 msgid "last_login"
 msgstr "Utolsó belépés"
 
-#: templates/class-overview.html:21
+#: templates/class-overview.html:22
 msgid "highest_level_reached"
 msgstr "A legnagyobb elért szint"
 
-#: templates/class-overview.html:22
+#: templates/class-overview.html:23
 msgid "number_programs"
 msgstr "A programok száma"
 
-#: templates/class-overview.html:23
+#: templates/class-overview.html:24
 msgid "programs"
 msgstr "Programok"
 
-#: templates/class-overview.html:24 templates/create-accounts.html:17
+#: templates/class-overview.html:25 templates/create-accounts.html:17
 #: templates/login.html:15 templates/reset.html:8 templates/signup.html:19
 msgid "password"
 msgstr "Jelszó"
 
-#: templates/class-overview.html:25 templates/class-overview.html:69
+#: templates/class-overview.html:26 templates/class-overview.html:74
 #: templates/customize-adventure.html:52 templates/for-teachers.html:46
 #: templates/for-teachers.html:56
 #, fuzzy
 msgid "remove"
 msgstr "Remove"
 
-#: templates/class-overview.html:35
+#: templates/class-overview.html:36
 #, fuzzy
 msgid "page"
 msgstr "page"
 
-#: templates/class-overview.html:36
+#: templates/class-overview.html:37
 #, fuzzy
 msgid "enter_password"
 msgstr "Enter a new password for"
 
-#: templates/class-overview.html:36
+#: templates/class-overview.html:37
 #, fuzzy
 msgid "password_change_prompt"
 msgstr "Are you sure you want to change this password?"
 
-#: templates/class-overview.html:37
+#: templates/class-overview.html:38
 msgid "remove_student_prompt"
 msgstr "Biztos vagy benne, hogy eltávolítod a tanulót az osztályból?"
 
-#: templates/class-overview.html:44
+#: templates/class-overview.html:46
 #, fuzzy
 msgid "add_students"
 msgstr "tanulók"
 
-#: templates/class-overview.html:45 templates/customize-class.html:5
+#: templates/class-overview.html:47 templates/customize-class.html:5
 #, fuzzy
 msgid "customize_class"
 msgstr "Customize class"
 
-#: templates/class-overview.html:46
+#: templates/class-overview.html:48
 #, fuzzy
 msgid "class_stats"
 msgstr "Show class statistics"
 
-#: templates/class-overview.html:47
+#: templates/class-overview.html:49
 #, fuzzy
 msgid "class_logs"
 msgstr "Utolsó belépés"
 
-#: templates/class-overview.html:48 templates/customize-adventure.html:59
+#: templates/class-overview.html:52 templates/customize-adventure.html:59
 #, fuzzy
 msgid "back_to_teachers_page"
 msgstr "Go back to teachers page"
 
-#: templates/class-overview.html:49
+#: templates/class-overview.html:53
 msgid "delete_class_prompt"
 msgstr "Biztos vagy benne, hogy törlöd az osztályt?"
 
-#: templates/class-overview.html:49
+#: templates/class-overview.html:53
 msgid "delete_class"
 msgstr "Osztály végleges törlése "
 
-#: templates/class-overview.html:52
+#: templates/class-overview.html:57
 #, fuzzy
 msgid "add_students_options"
 msgstr "Create student accounts"
 
-#: templates/class-overview.html:54
+#: templates/class-overview.html:59
 #, fuzzy
 msgid "copy_link_success"
 msgstr "Link másolása a megosztáshoz"
 
-#: templates/class-overview.html:54
+#: templates/class-overview.html:59
 #, fuzzy
 msgid "copy_join_link"
 msgstr "Please copy and paste this link into a new tab:"
 
-#: templates/class-overview.html:55
+#: templates/class-overview.html:60
 #, fuzzy
 msgid "invite_prompt"
 msgstr "Enter a username"
 
-#: templates/class-overview.html:55
+#: templates/class-overview.html:60
 #, fuzzy
 msgid "invite_by_username"
 msgstr "All usernames need to be unique."
 
-#: templates/class-overview.html:56 templates/create-accounts.html:45
+#: templates/class-overview.html:61 templates/create-accounts.html:45
 #, fuzzy
 msgid "create_accounts"
 msgstr "Create multiple accounts"
 
-#: templates/class-overview.html:61
+#: templates/class-overview.html:66
 #, fuzzy
 msgid "pending_invites"
 msgstr "Pending invites"
 
-#: templates/class-overview.html:67
+#: templates/class-overview.html:72
 #, fuzzy
 msgid "invite_date"
 msgstr "Invite date"
 
-#: templates/class-overview.html:68
+#: templates/class-overview.html:73
 #, fuzzy
 msgid "expiration_date"
 msgstr "Expiration date"
 
-#: templates/class-overview.html:78 templates/profile.html:16
+#: templates/class-overview.html:83 templates/profile.html:16
 #, fuzzy
 msgid "delete_invite_prompt"
 msgstr "Are you sure you want to remove this class invitation?"
@@ -1322,10 +1322,10 @@ msgstr "Osztályaim"
 msgid "achievements"
 msgstr "achievements"
 
-#: templates/highscores.html:27 templates/learn-more.html:22
-#: templates/profile.html:131 templates/signup.html:52
-msgid "country"
-msgstr "Ország"
+#: templates/highscores.html:27
+#, fuzzy
+msgid "country_title"
+msgstr "Please select a valid country."
 
 #: templates/highscores.html:28 templates/landing-page.html:88
 #: templates/public-page.html:50
@@ -1610,6 +1610,11 @@ msgstr "Felhasználónév"
 #, fuzzy
 msgid "lastname"
 msgstr "Név"
+
+#: templates/learn-more.html:22 templates/profile.html:131
+#: templates/signup.html:52
+msgid "country"
+msgstr "Ország"
 
 #: templates/learn-more.html:31
 #, fuzzy

--- a/translations/id/LC_MESSAGES/messages.po
+++ b/translations/id/LC_MESSAGES/messages.po
@@ -3,16 +3,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-28 18:38+0300\n"
+"POT-Creation-Date: 2022-06-29 14:20+0200\n"
 "PO-Revision-Date: 2022-06-28 13:25+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: id\n"
 "Language-Team: id <LL@li.org>\n"
-"Plural-Forms: nplurals=1; plural=0\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.9.1\n"
+"Generated-By: Babel 2.10.1\n"
 
 #: app.py:417
 msgid "program_contains_error"
@@ -22,7 +22,7 @@ msgstr "Program ini berisi error, anda yakin ingin membagikannya?"
 msgid "title_achievements"
 msgstr "Hedy - Prestasi saya"
 
-#: app.py:644 app.py:748 app.py:1090 website/teacher.py:361
+#: app.py:644 app.py:746 app.py:1088 website/teacher.py:361
 #: website/teacher.py:372
 msgid "not_teacher"
 msgstr "Sepertinya Anda bukan seorang guru!"
@@ -31,11 +31,11 @@ msgstr "Sepertinya Anda bukan seorang guru!"
 msgid "not_enrolled"
 msgstr "Sepertinya anda tidak ada di kelas ini!"
 
-#: app.py:686
+#: app.py:684
 msgid "title_programs"
 msgstr "Hedy - Program saya"
 
-#: app.py:696 app.py:706 app.py:710 app.py:725 app.py:1005 app.py:1550
+#: app.py:694 app.py:704 app.py:708 app.py:723 app.py:1003 app.py:1548
 #: website/admin.py:17 website/admin.py:24 website/admin.py:92
 #: website/admin.py:111 website/admin.py:129 website/admin.py:136
 #: website/admin.py:144 website/auth.py:716 website/auth.py:743
@@ -44,325 +44,325 @@ msgstr "Hedy - Program saya"
 msgid "unauthorized"
 msgstr "You don't have access rights for this page"
 
-#: app.py:762 app.py:1107
+#: app.py:760 app.py:1105
 #, fuzzy
 msgid "title_for-teacher"
 msgstr "Hedy - For teachers"
 
-#: app.py:779 app.py:781 app.py:923 app.py:945 app.py:947
+#: app.py:777 app.py:779 app.py:921 app.py:943 app.py:945
 #, fuzzy
 msgid "no_such_level"
 msgstr "No such Hedy level!"
 
-#: app.py:789 app.py:796 app.py:877 app.py:883
+#: app.py:787 app.py:794 app.py:875 app.py:881
 #, fuzzy
 msgid "no_such_program"
 msgstr "No such Hedy program!"
 
-#: app.py:819
+#: app.py:817
 #, fuzzy
 msgid "level_not_class"
 msgstr "You're in a class where this level has not been made available yet"
 
-#: app.py:928 website/teacher.py:421 website/teacher.py:437
+#: app.py:926 website/teacher.py:421 website/teacher.py:437
 #: website/teacher.py:466 website/teacher.py:492
 #, fuzzy
 msgid "no_such_adventure"
 msgstr "This adventure doesn't exist!"
 
-#: app.py:956 app.py:1209
+#: app.py:954 app.py:1207
 #, fuzzy
 msgid "page_not_found"
 msgstr "We could not find that page!"
 
-#: app.py:976
+#: app.py:974
 #, fuzzy
 msgid "title_signup"
 msgstr "Hedy - Create an account"
 
-#: app.py:983
+#: app.py:981
 #, fuzzy
 msgid "title_login"
 msgstr "Hedy - Login"
 
-#: app.py:990
+#: app.py:988
 #, fuzzy
 msgid "title_recover"
 msgstr "Hedy - Recover account"
 
-#: app.py:1006
+#: app.py:1004
 #, fuzzy
 msgid "title_reset"
 msgstr "Hedy - Reset password"
 
-#: app.py:1032
+#: app.py:1030
 #, fuzzy
 msgid "title_my-profile"
 msgstr "Hedy - My account"
 
-#: app.py:1048
+#: app.py:1046
 #, fuzzy
 msgid "title_learn-more"
 msgstr "Hedy - Learn more"
 
-#: app.py:1054
+#: app.py:1052
 #, fuzzy
 msgid "title_privacy"
 msgstr "Hedy - Privacy terms"
 
-#: app.py:1064
+#: app.py:1062
 #, fuzzy
 msgid "title_start"
 msgstr "Hedy - A gradual programming language"
 
-#: app.py:1082
+#: app.py:1080
 #, fuzzy
 msgid "title_landing-page"
 msgstr "Welcome to Hedy!"
 
-#: app.py:1200
+#: app.py:1198
 #, fuzzy
 msgid "title_explore"
 msgstr "Hedy - Explore"
 
-#: app.py:1221 app.py:1226
+#: app.py:1219 app.py:1224
 #, fuzzy
 msgid "no_such_highscore"
 msgstr "No such Hedy level!"
 
-#: app.py:1255 app.py:1257
+#: app.py:1253 app.py:1255
 #, fuzzy
 msgid "translate_error"
 msgstr ""
 "Something went wrong while translating the code. Try running the code to "
 "see if it has an error. Code with errors can not be translated."
 
-#: app.py:1262 app.py:1296
+#: app.py:1260 app.py:1294
 #, fuzzy
 msgid "tutorial_start_title"
 msgstr "Welcome to Hedy!"
 
-#: app.py:1262
+#: app.py:1260
 #, fuzzy
 msgid "tutorial_start_message"
 msgstr "In this tutorial we will explain all the Hedy features step-by-step."
 
-#: app.py:1264
+#: app.py:1262
 #, fuzzy
 msgid "tutorial_editor_title"
 msgstr "The code editor"
 
-#: app.py:1264
+#: app.py:1262
 #, fuzzy
 msgid "tutorial_editor_message"
 msgstr "In this window you write all the code, try typing something!"
 
-#: app.py:1266
+#: app.py:1264
 #, fuzzy
 msgid "tutorial_output_title"
 msgstr "The output window"
 
-#: app.py:1266
+#: app.py:1264
 #, fuzzy
 msgid "tutorial_output_message"
 msgstr "The result of the code you execute will be shown here"
 
-#: app.py:1268
+#: app.py:1266
 #, fuzzy
 msgid "tutorial_run_title"
 msgstr "The run button"
 
-#: app.py:1268
+#: app.py:1266
 #, fuzzy
 msgid "tutorial_run_message"
 msgstr "With this button you can run your program! Shall we give it a try?"
 
-#: app.py:1270
+#: app.py:1268
 #, fuzzy
 msgid "tutorial_tryit_title"
 msgstr "Try it out!"
 
-#: app.py:1270
+#: app.py:1268
 #, fuzzy
 msgid "tutorial_tryit_message"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1272
+#: app.py:1270
 #, fuzzy
 msgid "tutorial_speakaloud_title"
 msgstr "The end!"
 
-#: app.py:1272
+#: app.py:1270
 #, fuzzy
 msgid "tutorial_speakaloud_message"
 msgstr "Click on 'next step' to really start coding with Hedy!"
 
-#: app.py:1274
+#: app.py:1272
 #, fuzzy
 msgid "tutorial_speakaloud_run_title"
 msgstr "The end!"
 
-#: app.py:1274
+#: app.py:1272
 #, fuzzy
 msgid "tutorial_speakaloud_run_message"
 msgstr "Click on 'next step' to really start coding with Hedy!"
 
-#: app.py:1276
+#: app.py:1274
 #, fuzzy
 msgid "tutorial_nextlevel_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1276
+#: app.py:1274
 #, fuzzy
 msgid "tutorial_nextlevel_message"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1278
+#: app.py:1276
 #, fuzzy
 msgid "tutorial_leveldefault_title"
 msgstr "Level explanation"
 
-#: app.py:1278
+#: app.py:1276
 #, fuzzy
 msgid "tutorial_leveldefault_message"
 msgstr ""
 "The first tab always contains the level explanation. In each level new "
 "commands will be explained here."
 
-#: app.py:1280
+#: app.py:1278
 #, fuzzy
 msgid "tutorial_adventures_title"
 msgstr "Customize adventure"
 
-#: app.py:1280
+#: app.py:1278
 #, fuzzy
 msgid "tutorial_adventures_message"
 msgstr "Customize adventure"
 
-#: app.py:1282
+#: app.py:1280
 #, fuzzy
 msgid "tutorial_quiz_title"
 msgstr "Quiz"
 
-#: app.py:1282
+#: app.py:1280
 #, fuzzy
 msgid "tutorial_quiz_message"
 msgstr ""
 "At the end of each level you can make the quiz. This way you can verify "
 "if you understand everything."
 
-#: app.py:1284
+#: app.py:1282
 #, fuzzy
 msgid "tutorial_saveshare_title"
 msgstr "Saving & sharing"
 
-#: app.py:1284
+#: app.py:1282
 #, fuzzy
 msgid "tutorial_saveshare_message"
 msgstr "You can save and share all your created programs with other Hedy users."
 
-#: app.py:1286
+#: app.py:1284
 #, fuzzy
 msgid "tutorial_cheatsheet_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1286
+#: app.py:1284
 #, fuzzy
 msgid "tutorial_cheatsheet_message"
 msgstr ""
 "If you forgot a command you can always use the cheatsheet. It shows a "
 "list of all commands you can use in the current level."
 
-#: app.py:1288 app.py:1308
+#: app.py:1286 app.py:1306
 #, fuzzy
 msgid "tutorial_end_title"
 msgstr "The end!"
 
-#: app.py:1288
+#: app.py:1286
 #, fuzzy
 msgid "tutorial_end_message"
 msgstr "Click on 'next step' to really start coding with Hedy!"
 
-#: app.py:1290 app.py:1310
+#: app.py:1288 app.py:1308
 #, fuzzy
 msgid "tutorial_title_not_found"
 msgstr "We could not find that page!"
 
-#: app.py:1290 app.py:1310
+#: app.py:1288 app.py:1308
 #, fuzzy
 msgid "tutorial_message_not_found"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1296
+#: app.py:1294
 #, fuzzy
 msgid "teacher_tutorial_start_message"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1298
+#: app.py:1296
 #, fuzzy
 msgid "tutorial_class_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1298
+#: app.py:1296
 #, fuzzy
 msgid "tutorial_class_message"
 msgstr "Customize adventure"
 
-#: app.py:1300
+#: app.py:1298
 #, fuzzy
 msgid "tutorial_customize_class_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1300
+#: app.py:1298
 #, fuzzy
 msgid "tutorial_customize_class_message"
 msgstr "Customize adventure"
 
-#: app.py:1302
+#: app.py:1300
 #, fuzzy
 msgid "tutorial_own_adventures_title"
 msgstr "Customize adventure"
 
-#: app.py:1302
+#: app.py:1300
 #, fuzzy
 msgid "tutorial_own_adventures_message"
 msgstr "Customize adventure"
 
-#: app.py:1304
+#: app.py:1302
 #, fuzzy
 msgid "tutorial_accounts_title"
 msgstr "Customize adventure"
 
-#: app.py:1304
+#: app.py:1302
 #, fuzzy
 msgid "tutorial_accounts_message"
 msgstr "Customize adventure"
 
-#: app.py:1306
+#: app.py:1304
 #, fuzzy
 msgid "tutorial_documentation_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1306
+#: app.py:1304
 #, fuzzy
 msgid "tutorial_documentation_message"
 msgstr "Customize adventure"
 
-#: app.py:1308
+#: app.py:1306
 #, fuzzy
 msgid "teacher_tutorial_end_message"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1318
+#: app.py:1316
 #, fuzzy
 msgid "tutorial_code_snippet"
 msgstr "Hide cheatsheet"
 
-#: app.py:1322 app.py:1332
+#: app.py:1320 app.py:1330
 msgid "invalid_tutorial_step"
 msgstr ""
 
-#: app.py:1489 website/auth.py:278 website/auth.py:333 website/auth.py:469
+#: app.py:1487 website/auth.py:278 website/auth.py:333 website/auth.py:469
 #: website/auth.py:494 website/auth.py:524 website/auth.py:637
 #: website/auth.py:675 website/auth.py:722 website/auth.py:749
 #: website/quiz.py:43 website/quiz.py:69 website/teacher.py:88
@@ -372,32 +372,32 @@ msgstr ""
 msgid "ajax_error"
 msgstr "Ditemukan sebuah error. Silakan coba lagi."
 
-#: app.py:1492
+#: app.py:1490
 #, fuzzy
 msgid "image_invalid"
 msgstr "Your chosen image is invalid."
 
-#: app.py:1494
+#: app.py:1492
 #, fuzzy
 msgid "personal_text_invalid"
 msgstr "Your personal text is invalid."
 
-#: app.py:1496 app.py:1502
+#: app.py:1494 app.py:1500
 #, fuzzy
 msgid "favourite_program_invalid"
 msgstr "Your chosen favourite program is invalid."
 
-#: app.py:1516 app.py:1517
+#: app.py:1514 app.py:1515
 #, fuzzy
 msgid "public_profile_updated"
 msgstr "Public profile updated."
 
-#: app.py:1554 app.py:1579
+#: app.py:1552 app.py:1577
 #, fuzzy
 msgid "user_not_private"
 msgstr "This user doesn't exist or doesn't have a public profile"
 
-#: app.py:1587
+#: app.py:1585
 #, fuzzy
 msgid "invalid_teacher_invitation_code"
 msgstr ""
@@ -737,11 +737,11 @@ msgstr "Hide cheatsheet"
 msgid "back_to_class"
 msgstr "Go back to class"
 
-#: templates/class-overview.html:13 templates/for-teachers.html:35
+#: templates/class-overview.html:14 templates/for-teachers.html:35
 msgid "class_name_prompt"
 msgstr "Silakan masukan nama dari kelas"
 
-#: templates/class-overview.html:19 templates/class-overview.html:66
+#: templates/class-overview.html:20 templates/class-overview.html:71
 #: templates/create-accounts.html:16 templates/highscores.html:25
 #: templates/login.html:12 templates/profile.html:89 templates/recover.html:8
 #: templates/signup.html:10
@@ -749,132 +749,132 @@ msgstr "Silakan masukan nama dari kelas"
 msgid "username"
 msgstr "Username"
 
-#: templates/class-overview.html:20
+#: templates/class-overview.html:21
 msgid "last_login"
 msgstr "Waktu masuk terakhir"
 
-#: templates/class-overview.html:21
+#: templates/class-overview.html:22
 msgid "highest_level_reached"
 msgstr "Level tertinggi yang berhasil dicapai"
 
-#: templates/class-overview.html:22
+#: templates/class-overview.html:23
 msgid "number_programs"
 msgstr "Jumlah program"
 
-#: templates/class-overview.html:23
+#: templates/class-overview.html:24
 msgid "programs"
 msgstr "Program terakhir yang dibagikan"
 
-#: templates/class-overview.html:24 templates/create-accounts.html:17
+#: templates/class-overview.html:25 templates/create-accounts.html:17
 #: templates/login.html:15 templates/reset.html:8 templates/signup.html:19
 msgid "password"
 msgstr "Password"
 
-#: templates/class-overview.html:25 templates/class-overview.html:69
+#: templates/class-overview.html:26 templates/class-overview.html:74
 #: templates/customize-adventure.html:52 templates/for-teachers.html:46
 #: templates/for-teachers.html:56
 #, fuzzy
 msgid "remove"
 msgstr "Remove"
 
-#: templates/class-overview.html:35
+#: templates/class-overview.html:36
 #, fuzzy
 msgid "page"
 msgstr "page"
 
-#: templates/class-overview.html:36
+#: templates/class-overview.html:37
 #, fuzzy
 msgid "enter_password"
 msgstr "Enter a new password for"
 
-#: templates/class-overview.html:36
+#: templates/class-overview.html:37
 #, fuzzy
 msgid "password_change_prompt"
 msgstr "Are you sure you want to change this password?"
 
-#: templates/class-overview.html:37
+#: templates/class-overview.html:38
 msgid "remove_student_prompt"
 msgstr "Apa kamu yakin mau mengeluarkan murid tersebut dari kelas?"
 
-#: templates/class-overview.html:44
+#: templates/class-overview.html:46
 #, fuzzy
 msgid "add_students"
 msgstr "murid-murid"
 
-#: templates/class-overview.html:45 templates/customize-class.html:5
+#: templates/class-overview.html:47 templates/customize-class.html:5
 #, fuzzy
 msgid "customize_class"
 msgstr "Customize class"
 
-#: templates/class-overview.html:46
+#: templates/class-overview.html:48
 #, fuzzy
 msgid "class_stats"
 msgstr "Show class statistics"
 
-#: templates/class-overview.html:47
+#: templates/class-overview.html:49
 #, fuzzy
 msgid "class_logs"
 msgstr "Waktu masuk terakhir"
 
-#: templates/class-overview.html:48 templates/customize-adventure.html:59
+#: templates/class-overview.html:52 templates/customize-adventure.html:59
 #, fuzzy
 msgid "back_to_teachers_page"
 msgstr "Go back to teachers page"
 
-#: templates/class-overview.html:49
+#: templates/class-overview.html:53
 msgid "delete_class_prompt"
 msgstr "Apa kamu yakin mau menghapus kelas?"
 
-#: templates/class-overview.html:49
+#: templates/class-overview.html:53
 msgid "delete_class"
 msgstr "Hapus kelas secara permanen"
 
-#: templates/class-overview.html:52
+#: templates/class-overview.html:57
 #, fuzzy
 msgid "add_students_options"
 msgstr "Create student accounts"
 
-#: templates/class-overview.html:54
+#: templates/class-overview.html:59
 #, fuzzy
 msgid "copy_link_success"
 msgstr "Salin tautan untuk berbagi"
 
-#: templates/class-overview.html:54
+#: templates/class-overview.html:59
 #, fuzzy
 msgid "copy_join_link"
 msgstr "Please copy and paste this link into a new tab:"
 
-#: templates/class-overview.html:55
+#: templates/class-overview.html:60
 #, fuzzy
 msgid "invite_prompt"
 msgstr "Enter a username"
 
-#: templates/class-overview.html:55
+#: templates/class-overview.html:60
 #, fuzzy
 msgid "invite_by_username"
 msgstr "All usernames need to be unique."
 
-#: templates/class-overview.html:56 templates/create-accounts.html:45
+#: templates/class-overview.html:61 templates/create-accounts.html:45
 #, fuzzy
 msgid "create_accounts"
 msgstr "Create multiple accounts"
 
-#: templates/class-overview.html:61
+#: templates/class-overview.html:66
 #, fuzzy
 msgid "pending_invites"
 msgstr "Pending invites"
 
-#: templates/class-overview.html:67
+#: templates/class-overview.html:72
 #, fuzzy
 msgid "invite_date"
 msgstr "Invite date"
 
-#: templates/class-overview.html:68
+#: templates/class-overview.html:73
 #, fuzzy
 msgid "expiration_date"
 msgstr "Expiration date"
 
-#: templates/class-overview.html:78 templates/profile.html:16
+#: templates/class-overview.html:83 templates/profile.html:16
 #, fuzzy
 msgid "delete_invite_prompt"
 msgstr "Are you sure you want to remove this class invitation?"
@@ -1322,10 +1322,10 @@ msgstr "Kelas-kelas saya"
 msgid "achievements"
 msgstr "achievements"
 
-#: templates/highscores.html:27 templates/learn-more.html:22
-#: templates/profile.html:131 templates/signup.html:52
-msgid "country"
-msgstr "Negara"
+#: templates/highscores.html:27
+#, fuzzy
+msgid "country_title"
+msgstr "Please select a valid country."
 
 #: templates/highscores.html:28 templates/landing-page.html:88
 #: templates/public-page.html:50
@@ -1608,6 +1608,11 @@ msgstr "Nama Depan"
 #: templates/learn-more.html:18
 msgid "lastname"
 msgstr "Nama Belakang"
+
+#: templates/learn-more.html:22 templates/profile.html:131
+#: templates/signup.html:52
+msgid "country"
+msgstr "Negara"
 
 #: templates/learn-more.html:31
 #, fuzzy

--- a/translations/it/LC_MESSAGES/messages.po
+++ b/translations/it/LC_MESSAGES/messages.po
@@ -3,16 +3,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-28 18:38+0300\n"
+"POT-Creation-Date: 2022-06-29 14:20+0200\n"
 "PO-Revision-Date: 2022-06-28 13:25+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: it\n"
 "Language-Team: it <LL@li.org>\n"
-"Plural-Forms: nplurals=2; plural=n != 1\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.9.1\n"
+"Generated-By: Babel 2.10.1\n"
 
 #: app.py:417
 #, fuzzy
@@ -24,7 +24,7 @@ msgstr "This program contains an error, are you sure you want to share it?"
 msgid "title_achievements"
 msgstr "Hedy - My achievements"
 
-#: app.py:644 app.py:748 app.py:1090 website/teacher.py:361
+#: app.py:644 app.py:746 app.py:1088 website/teacher.py:361
 #: website/teacher.py:372
 #, fuzzy
 msgid "not_teacher"
@@ -35,12 +35,12 @@ msgstr "Looks like you are not a teacher!"
 msgid "not_enrolled"
 msgstr "Looks like you are not in this class!"
 
-#: app.py:686
+#: app.py:684
 #, fuzzy
 msgid "title_programs"
 msgstr "Hedy - My programs"
 
-#: app.py:696 app.py:706 app.py:710 app.py:725 app.py:1005 app.py:1550
+#: app.py:694 app.py:704 app.py:708 app.py:723 app.py:1003 app.py:1548
 #: website/admin.py:17 website/admin.py:24 website/admin.py:92
 #: website/admin.py:111 website/admin.py:129 website/admin.py:136
 #: website/admin.py:144 website/auth.py:716 website/auth.py:743
@@ -49,325 +49,325 @@ msgstr "Hedy - My programs"
 msgid "unauthorized"
 msgstr "You don't have access rights for this page"
 
-#: app.py:762 app.py:1107
+#: app.py:760 app.py:1105
 #, fuzzy
 msgid "title_for-teacher"
 msgstr "Hedy - For teachers"
 
-#: app.py:779 app.py:781 app.py:923 app.py:945 app.py:947
+#: app.py:777 app.py:779 app.py:921 app.py:943 app.py:945
 #, fuzzy
 msgid "no_such_level"
 msgstr "No such Hedy level!"
 
-#: app.py:789 app.py:796 app.py:877 app.py:883
+#: app.py:787 app.py:794 app.py:875 app.py:881
 #, fuzzy
 msgid "no_such_program"
 msgstr "No such Hedy program!"
 
-#: app.py:819
+#: app.py:817
 #, fuzzy
 msgid "level_not_class"
 msgstr "You're in a class where this level has not been made available yet"
 
-#: app.py:928 website/teacher.py:421 website/teacher.py:437
+#: app.py:926 website/teacher.py:421 website/teacher.py:437
 #: website/teacher.py:466 website/teacher.py:492
 #, fuzzy
 msgid "no_such_adventure"
 msgstr "This adventure doesn't exist!"
 
-#: app.py:956 app.py:1209
+#: app.py:954 app.py:1207
 #, fuzzy
 msgid "page_not_found"
 msgstr "We could not find that page!"
 
-#: app.py:976
+#: app.py:974
 #, fuzzy
 msgid "title_signup"
 msgstr "Hedy - Create an account"
 
-#: app.py:983
+#: app.py:981
 #, fuzzy
 msgid "title_login"
 msgstr "Hedy - Login"
 
-#: app.py:990
+#: app.py:988
 #, fuzzy
 msgid "title_recover"
 msgstr "Hedy - Recover account"
 
-#: app.py:1006
+#: app.py:1004
 #, fuzzy
 msgid "title_reset"
 msgstr "Hedy - Reset password"
 
-#: app.py:1032
+#: app.py:1030
 #, fuzzy
 msgid "title_my-profile"
 msgstr "Hedy - My account"
 
-#: app.py:1048
+#: app.py:1046
 #, fuzzy
 msgid "title_learn-more"
 msgstr "Hedy - Learn more"
 
-#: app.py:1054
+#: app.py:1052
 #, fuzzy
 msgid "title_privacy"
 msgstr "Hedy - Privacy terms"
 
-#: app.py:1064
+#: app.py:1062
 #, fuzzy
 msgid "title_start"
 msgstr "Hedy - A gradual programming language"
 
-#: app.py:1082
+#: app.py:1080
 #, fuzzy
 msgid "title_landing-page"
 msgstr "Welcome to Hedy!"
 
-#: app.py:1200
+#: app.py:1198
 #, fuzzy
 msgid "title_explore"
 msgstr "Hedy - Explore"
 
-#: app.py:1221 app.py:1226
+#: app.py:1219 app.py:1224
 #, fuzzy
 msgid "no_such_highscore"
 msgstr "No such Hedy level!"
 
-#: app.py:1255 app.py:1257
+#: app.py:1253 app.py:1255
 #, fuzzy
 msgid "translate_error"
 msgstr ""
 "Something went wrong while translating the code. Try running the code to "
 "see if it has an error. Code with errors can not be translated."
 
-#: app.py:1262 app.py:1296
+#: app.py:1260 app.py:1294
 #, fuzzy
 msgid "tutorial_start_title"
 msgstr "Welcome to Hedy!"
 
-#: app.py:1262
+#: app.py:1260
 #, fuzzy
 msgid "tutorial_start_message"
 msgstr "In this tutorial we will explain all the Hedy features step-by-step."
 
-#: app.py:1264
+#: app.py:1262
 #, fuzzy
 msgid "tutorial_editor_title"
 msgstr "The code editor"
 
-#: app.py:1264
+#: app.py:1262
 #, fuzzy
 msgid "tutorial_editor_message"
 msgstr "In this window you write all the code, try typing something!"
 
-#: app.py:1266
+#: app.py:1264
 #, fuzzy
 msgid "tutorial_output_title"
 msgstr "The output window"
 
-#: app.py:1266
+#: app.py:1264
 #, fuzzy
 msgid "tutorial_output_message"
 msgstr "The result of the code you execute will be shown here"
 
-#: app.py:1268
+#: app.py:1266
 #, fuzzy
 msgid "tutorial_run_title"
 msgstr "The run button"
 
-#: app.py:1268
+#: app.py:1266
 #, fuzzy
 msgid "tutorial_run_message"
 msgstr "With this button you can run your program! Shall we give it a try?"
 
-#: app.py:1270
+#: app.py:1268
 #, fuzzy
 msgid "tutorial_tryit_title"
 msgstr "Try it out!"
 
-#: app.py:1270
+#: app.py:1268
 #, fuzzy
 msgid "tutorial_tryit_message"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1272
+#: app.py:1270
 #, fuzzy
 msgid "tutorial_speakaloud_title"
 msgstr "The end!"
 
-#: app.py:1272
+#: app.py:1270
 #, fuzzy
 msgid "tutorial_speakaloud_message"
 msgstr "Click on 'next step' to really start coding with Hedy!"
 
-#: app.py:1274
+#: app.py:1272
 #, fuzzy
 msgid "tutorial_speakaloud_run_title"
 msgstr "The end!"
 
-#: app.py:1274
+#: app.py:1272
 #, fuzzy
 msgid "tutorial_speakaloud_run_message"
 msgstr "Click on 'next step' to really start coding with Hedy!"
 
-#: app.py:1276
+#: app.py:1274
 #, fuzzy
 msgid "tutorial_nextlevel_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1276
+#: app.py:1274
 #, fuzzy
 msgid "tutorial_nextlevel_message"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1278
+#: app.py:1276
 #, fuzzy
 msgid "tutorial_leveldefault_title"
 msgstr "Level explanation"
 
-#: app.py:1278
+#: app.py:1276
 #, fuzzy
 msgid "tutorial_leveldefault_message"
 msgstr ""
 "The first tab always contains the level explanation. In each level new "
 "commands will be explained here."
 
-#: app.py:1280
+#: app.py:1278
 #, fuzzy
 msgid "tutorial_adventures_title"
 msgstr "Customize adventure"
 
-#: app.py:1280
+#: app.py:1278
 #, fuzzy
 msgid "tutorial_adventures_message"
 msgstr "Customize adventure"
 
-#: app.py:1282
+#: app.py:1280
 #, fuzzy
 msgid "tutorial_quiz_title"
 msgstr "Quiz"
 
-#: app.py:1282
+#: app.py:1280
 #, fuzzy
 msgid "tutorial_quiz_message"
 msgstr ""
 "At the end of each level you can make the quiz. This way you can verify "
 "if you understand everything."
 
-#: app.py:1284
+#: app.py:1282
 #, fuzzy
 msgid "tutorial_saveshare_title"
 msgstr "Saving & sharing"
 
-#: app.py:1284
+#: app.py:1282
 #, fuzzy
 msgid "tutorial_saveshare_message"
 msgstr "You can save and share all your created programs with other Hedy users."
 
-#: app.py:1286
+#: app.py:1284
 #, fuzzy
 msgid "tutorial_cheatsheet_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1286
+#: app.py:1284
 #, fuzzy
 msgid "tutorial_cheatsheet_message"
 msgstr ""
 "If you forgot a command you can always use the cheatsheet. It shows a "
 "list of all commands you can use in the current level."
 
-#: app.py:1288 app.py:1308
+#: app.py:1286 app.py:1306
 #, fuzzy
 msgid "tutorial_end_title"
 msgstr "The end!"
 
-#: app.py:1288
+#: app.py:1286
 #, fuzzy
 msgid "tutorial_end_message"
 msgstr "Click on 'next step' to really start coding with Hedy!"
 
-#: app.py:1290 app.py:1310
+#: app.py:1288 app.py:1308
 #, fuzzy
 msgid "tutorial_title_not_found"
 msgstr "We could not find that page!"
 
-#: app.py:1290 app.py:1310
+#: app.py:1288 app.py:1308
 #, fuzzy
 msgid "tutorial_message_not_found"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1296
+#: app.py:1294
 #, fuzzy
 msgid "teacher_tutorial_start_message"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1298
+#: app.py:1296
 #, fuzzy
 msgid "tutorial_class_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1298
+#: app.py:1296
 #, fuzzy
 msgid "tutorial_class_message"
 msgstr "Customize adventure"
 
-#: app.py:1300
+#: app.py:1298
 #, fuzzy
 msgid "tutorial_customize_class_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1300
+#: app.py:1298
 #, fuzzy
 msgid "tutorial_customize_class_message"
 msgstr "Customize adventure"
 
-#: app.py:1302
+#: app.py:1300
 #, fuzzy
 msgid "tutorial_own_adventures_title"
 msgstr "Customize adventure"
 
-#: app.py:1302
+#: app.py:1300
 #, fuzzy
 msgid "tutorial_own_adventures_message"
 msgstr "Customize adventure"
 
-#: app.py:1304
+#: app.py:1302
 #, fuzzy
 msgid "tutorial_accounts_title"
 msgstr "Customize adventure"
 
-#: app.py:1304
+#: app.py:1302
 #, fuzzy
 msgid "tutorial_accounts_message"
 msgstr "Customize adventure"
 
-#: app.py:1306
+#: app.py:1304
 #, fuzzy
 msgid "tutorial_documentation_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1306
+#: app.py:1304
 #, fuzzy
 msgid "tutorial_documentation_message"
 msgstr "Customize adventure"
 
-#: app.py:1308
+#: app.py:1306
 #, fuzzy
 msgid "teacher_tutorial_end_message"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1318
+#: app.py:1316
 #, fuzzy
 msgid "tutorial_code_snippet"
 msgstr "Hide cheatsheet"
 
-#: app.py:1322 app.py:1332
+#: app.py:1320 app.py:1330
 msgid "invalid_tutorial_step"
 msgstr ""
 
-#: app.py:1489 website/auth.py:278 website/auth.py:333 website/auth.py:469
+#: app.py:1487 website/auth.py:278 website/auth.py:333 website/auth.py:469
 #: website/auth.py:494 website/auth.py:524 website/auth.py:637
 #: website/auth.py:675 website/auth.py:722 website/auth.py:749
 #: website/quiz.py:43 website/quiz.py:69 website/teacher.py:88
@@ -377,32 +377,32 @@ msgstr ""
 msgid "ajax_error"
 msgstr "C'è stato un problema, per favore riprova."
 
-#: app.py:1492
+#: app.py:1490
 #, fuzzy
 msgid "image_invalid"
 msgstr "Your chosen image is invalid."
 
-#: app.py:1494
+#: app.py:1492
 #, fuzzy
 msgid "personal_text_invalid"
 msgstr "Your personal text is invalid."
 
-#: app.py:1496 app.py:1502
+#: app.py:1494 app.py:1500
 #, fuzzy
 msgid "favourite_program_invalid"
 msgstr "Your chosen favourite program is invalid."
 
-#: app.py:1516 app.py:1517
+#: app.py:1514 app.py:1515
 #, fuzzy
 msgid "public_profile_updated"
 msgstr "Public profile updated."
 
-#: app.py:1554 app.py:1579
+#: app.py:1552 app.py:1577
 #, fuzzy
 msgid "user_not_private"
 msgstr "This user doesn't exist or doesn't have a public profile"
 
-#: app.py:1587
+#: app.py:1585
 #, fuzzy
 msgid "invalid_teacher_invitation_code"
 msgstr ""
@@ -741,151 +741,151 @@ msgstr "Hide cheatsheet"
 msgid "back_to_class"
 msgstr "Go back to class"
 
-#: templates/class-overview.html:13 templates/for-teachers.html:35
+#: templates/class-overview.html:14 templates/for-teachers.html:35
 #, fuzzy
 msgid "class_name_prompt"
 msgstr "Please enter the name of the class"
 
-#: templates/class-overview.html:19 templates/class-overview.html:66
+#: templates/class-overview.html:20 templates/class-overview.html:71
 #: templates/create-accounts.html:16 templates/highscores.html:25
 #: templates/login.html:12 templates/profile.html:89 templates/recover.html:8
 #: templates/signup.html:10
 msgid "username"
 msgstr "Nome utente"
 
-#: templates/class-overview.html:20
+#: templates/class-overview.html:21
 #, fuzzy
 msgid "last_login"
 msgstr "Last login"
 
-#: templates/class-overview.html:21
+#: templates/class-overview.html:22
 #, fuzzy
 msgid "highest_level_reached"
 msgstr "Highest level reached"
 
-#: templates/class-overview.html:22
+#: templates/class-overview.html:23
 #, fuzzy
 msgid "number_programs"
 msgstr "Number of programs"
 
-#: templates/class-overview.html:23
+#: templates/class-overview.html:24
 #, fuzzy
 msgid "programs"
 msgstr "Programs"
 
-#: templates/class-overview.html:24 templates/create-accounts.html:17
+#: templates/class-overview.html:25 templates/create-accounts.html:17
 #: templates/login.html:15 templates/reset.html:8 templates/signup.html:19
 msgid "password"
 msgstr "Password"
 
-#: templates/class-overview.html:25 templates/class-overview.html:69
+#: templates/class-overview.html:26 templates/class-overview.html:74
 #: templates/customize-adventure.html:52 templates/for-teachers.html:46
 #: templates/for-teachers.html:56
 #, fuzzy
 msgid "remove"
 msgstr "Remove"
 
-#: templates/class-overview.html:35
+#: templates/class-overview.html:36
 #, fuzzy
 msgid "page"
 msgstr "page"
 
-#: templates/class-overview.html:36
+#: templates/class-overview.html:37
 #, fuzzy
 msgid "enter_password"
 msgstr "Enter a new password for"
 
-#: templates/class-overview.html:36
+#: templates/class-overview.html:37
 #, fuzzy
 msgid "password_change_prompt"
 msgstr "Are you sure you want to change this password?"
 
-#: templates/class-overview.html:37
+#: templates/class-overview.html:38
 #, fuzzy
 msgid "remove_student_prompt"
 msgstr "Are you sure you want to remove the student from the class?"
 
-#: templates/class-overview.html:44
+#: templates/class-overview.html:46
 #, fuzzy
 msgid "add_students"
 msgstr "students"
 
-#: templates/class-overview.html:45 templates/customize-class.html:5
+#: templates/class-overview.html:47 templates/customize-class.html:5
 #, fuzzy
 msgid "customize_class"
 msgstr "Customize class"
 
-#: templates/class-overview.html:46
+#: templates/class-overview.html:48
 #, fuzzy
 msgid "class_stats"
 msgstr "Show class statistics"
 
-#: templates/class-overview.html:47
+#: templates/class-overview.html:49
 #, fuzzy
 msgid "class_logs"
 msgstr "Last login"
 
-#: templates/class-overview.html:48 templates/customize-adventure.html:59
+#: templates/class-overview.html:52 templates/customize-adventure.html:59
 #, fuzzy
 msgid "back_to_teachers_page"
 msgstr "Go back to teachers page"
 
-#: templates/class-overview.html:49
+#: templates/class-overview.html:53
 #, fuzzy
 msgid "delete_class_prompt"
 msgstr "Are you sure you want to delete the class?"
 
-#: templates/class-overview.html:49
+#: templates/class-overview.html:53
 #, fuzzy
 msgid "delete_class"
 msgstr "Delete class permanently"
 
-#: templates/class-overview.html:52
+#: templates/class-overview.html:57
 #, fuzzy
 msgid "add_students_options"
 msgstr "Create student accounts"
 
-#: templates/class-overview.html:54
+#: templates/class-overview.html:59
 #, fuzzy
 msgid "copy_link_success"
 msgstr "Copy link to share"
 
-#: templates/class-overview.html:54
+#: templates/class-overview.html:59
 #, fuzzy
 msgid "copy_join_link"
 msgstr "Please copy and paste this link into a new tab:"
 
-#: templates/class-overview.html:55
+#: templates/class-overview.html:60
 #, fuzzy
 msgid "invite_prompt"
 msgstr "Enter a username"
 
-#: templates/class-overview.html:55
+#: templates/class-overview.html:60
 #, fuzzy
 msgid "invite_by_username"
 msgstr "All usernames need to be unique."
 
-#: templates/class-overview.html:56 templates/create-accounts.html:45
+#: templates/class-overview.html:61 templates/create-accounts.html:45
 #, fuzzy
 msgid "create_accounts"
 msgstr "Create multiple accounts"
 
-#: templates/class-overview.html:61
+#: templates/class-overview.html:66
 #, fuzzy
 msgid "pending_invites"
 msgstr "Pending invites"
 
-#: templates/class-overview.html:67
+#: templates/class-overview.html:72
 #, fuzzy
 msgid "invite_date"
 msgstr "Invite date"
 
-#: templates/class-overview.html:68
+#: templates/class-overview.html:73
 #, fuzzy
 msgid "expiration_date"
 msgstr "Expiration date"
 
-#: templates/class-overview.html:78 templates/profile.html:16
+#: templates/class-overview.html:83 templates/profile.html:16
 #, fuzzy
 msgid "delete_invite_prompt"
 msgstr "Are you sure you want to remove this class invitation?"
@@ -1343,10 +1343,10 @@ msgstr "My classes"
 msgid "achievements"
 msgstr "achievements"
 
-#: templates/highscores.html:27 templates/learn-more.html:22
-#: templates/profile.html:131 templates/signup.html:52
-msgid "country"
-msgstr "Paese"
+#: templates/highscores.html:27
+#, fuzzy
+msgid "country_title"
+msgstr "Please select a valid country."
 
 #: templates/highscores.html:28 templates/landing-page.html:88
 #: templates/public-page.html:50
@@ -1637,6 +1637,11 @@ msgstr "Nome utente"
 #, fuzzy
 msgid "lastname"
 msgstr "Name"
+
+#: templates/learn-more.html:22 templates/profile.html:131
+#: templates/signup.html:52
+msgid "country"
+msgstr "Paese"
 
 #: templates/learn-more.html:31
 #, fuzzy

--- a/translations/ja/LC_MESSAGES/messages.po
+++ b/translations/ja/LC_MESSAGES/messages.po
@@ -7,16 +7,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-06-28 18:38+0300\n"
+"POT-Creation-Date: 2022-06-29 14:20+0200\n"
 "PO-Revision-Date: 2022-06-28 13:25+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: ja\n"
 "Language-Team: none\n"
-"Plural-Forms: nplurals=1; plural=0\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.9.1\n"
+"Generated-By: Babel 2.10.1\n"
 
 #: app.py:417
 msgid "program_contains_error"
@@ -26,7 +26,7 @@ msgstr "このプログラムにはエラーがあります。本当にシェア
 msgid "title_achievements"
 msgstr "Hedy - 実績"
 
-#: app.py:644 app.py:748 app.py:1090 website/teacher.py:361
+#: app.py:644 app.py:746 app.py:1088 website/teacher.py:361
 #: website/teacher.py:372
 msgid "not_teacher"
 msgstr "あなたは先生じゃないみたい！"
@@ -35,12 +35,12 @@ msgstr "あなたは先生じゃないみたい！"
 msgid "not_enrolled"
 msgstr "このクラスのメンバーじゃないよ！"
 
-#: app.py:686
+#: app.py:684
 #, fuzzy
 msgid "title_programs"
 msgstr "Hedy - My programs"
 
-#: app.py:696 app.py:706 app.py:710 app.py:725 app.py:1005 app.py:1550
+#: app.py:694 app.py:704 app.py:708 app.py:723 app.py:1003 app.py:1548
 #: website/admin.py:17 website/admin.py:24 website/admin.py:92
 #: website/admin.py:111 website/admin.py:129 website/admin.py:136
 #: website/admin.py:144 website/auth.py:716 website/auth.py:743
@@ -48,169 +48,169 @@ msgstr "Hedy - My programs"
 msgid "unauthorized"
 msgstr "このページへのアクセス権がありません"
 
-#: app.py:762 app.py:1107
+#: app.py:760 app.py:1105
 msgid "title_for-teacher"
 msgstr "Hedy - 教師用"
 
-#: app.py:779 app.py:781 app.py:923 app.py:945 app.py:947
+#: app.py:777 app.py:779 app.py:921 app.py:943 app.py:945
 msgid "no_such_level"
 msgstr "このレベルは存在しません！"
 
-#: app.py:789 app.py:796 app.py:877 app.py:883
+#: app.py:787 app.py:794 app.py:875 app.py:881
 msgid "no_such_program"
 msgstr "そのプログラムはありません！"
 
-#: app.py:819
+#: app.py:817
 msgid "level_not_class"
 msgstr "まだこのレベルはあなたのクラスで使えません"
 
-#: app.py:928 website/teacher.py:421 website/teacher.py:437
+#: app.py:926 website/teacher.py:421 website/teacher.py:437
 #: website/teacher.py:466 website/teacher.py:492
 msgid "no_such_adventure"
 msgstr "この冒険は存在しません！"
 
-#: app.py:956 app.py:1209
+#: app.py:954 app.py:1207
 msgid "page_not_found"
 msgstr "そのページを見つけられませんでした！"
 
-#: app.py:976
+#: app.py:974
 #, fuzzy
 msgid "title_signup"
 msgstr "Hedy - Create an account"
 
-#: app.py:983
+#: app.py:981
 #, fuzzy
 msgid "title_login"
 msgstr "Hedy - Login"
 
-#: app.py:990
+#: app.py:988
 msgid "title_recover"
 msgstr "Hedy - アカウントの回復"
 
-#: app.py:1006
+#: app.py:1004
 msgid "title_reset"
 msgstr "Hedy - パスワードをリセット"
 
-#: app.py:1032
+#: app.py:1030
 msgid "title_my-profile"
 msgstr "Hedy - 自分のアカウント"
 
-#: app.py:1048
+#: app.py:1046
 msgid "title_learn-more"
 msgstr "Hedy - もっと知る"
 
-#: app.py:1054
+#: app.py:1052
 msgid "title_privacy"
 msgstr "Hedy - プライバシーポリシー"
 
-#: app.py:1064
+#: app.py:1062
 msgid "title_start"
 msgstr "Hedy - 段階的プログラミング言語"
 
-#: app.py:1082
+#: app.py:1080
 msgid "title_landing-page"
 msgstr "Hedyへようこそ！"
 
-#: app.py:1200
+#: app.py:1198
 msgid "title_explore"
 msgstr "Hedy - 探検"
 
-#: app.py:1221 app.py:1226
+#: app.py:1219 app.py:1224
 #, fuzzy
 msgid "no_such_highscore"
 msgstr "このレベルは存在しません！"
 
-#: app.py:1255 app.py:1257
+#: app.py:1253 app.py:1255
 #, fuzzy
 msgid "translate_error"
 msgstr ""
 "Something went wrong while translating the code. Try running the code to "
 "see if it has an error. Code with errors can not be translated."
 
-#: app.py:1262 app.py:1296
+#: app.py:1260 app.py:1294
 #, fuzzy
 msgid "tutorial_start_title"
 msgstr "Welcome to Hedy!"
 
-#: app.py:1262
+#: app.py:1260
 #, fuzzy
 msgid "tutorial_start_message"
 msgstr "In this tutorial we will explain all the Hedy features step-by-step."
 
-#: app.py:1264
+#: app.py:1262
 #, fuzzy
 msgid "tutorial_editor_title"
 msgstr "The code editor"
 
-#: app.py:1264
+#: app.py:1262
 #, fuzzy
 msgid "tutorial_editor_message"
 msgstr ""
 "In this window you write all the code, try typing something on the place "
 "of the underscores!"
 
-#: app.py:1266
+#: app.py:1264
 #, fuzzy
 msgid "tutorial_output_title"
 msgstr "The output window"
 
-#: app.py:1266
+#: app.py:1264
 #, fuzzy
 msgid "tutorial_output_message"
 msgstr ""
 "The result of the code you execute will be shown here, you just created "
 "this!"
 
-#: app.py:1268
+#: app.py:1266
 #, fuzzy
 msgid "tutorial_run_title"
 msgstr "The run button"
 
-#: app.py:1268
+#: app.py:1266
 #, fuzzy
 msgid "tutorial_run_message"
 msgstr ""
 "With this button you can run your program! Shall we give it a try in the "
 "next step?"
 
-#: app.py:1270
+#: app.py:1268
 #, fuzzy
 msgid "tutorial_tryit_title"
 msgstr "Try it out!"
 
-#: app.py:1270
+#: app.py:1268
 #, fuzzy
 msgid "tutorial_tryit_message"
 msgstr "Run the program, click 'next step' when you're done."
 
-#: app.py:1272
+#: app.py:1270
 #, fuzzy
 msgid "tutorial_speakaloud_title"
 msgstr "Read aloud your program"
 
-#: app.py:1272
+#: app.py:1270
 #, fuzzy
 msgid "tutorial_speakaloud_message"
 msgstr "Choose a voice below the run button to let your program be read aloud."
 
-#: app.py:1274
+#: app.py:1272
 #, fuzzy
 msgid "tutorial_speakaloud_run_title"
 msgstr "Run & listen"
 
-#: app.py:1274
+#: app.py:1272
 #, fuzzy
 msgid "tutorial_speakaloud_run_message"
 msgstr ""
 "Select a voice from the dropdown menu and run your program again to hear "
 "it being read aloud."
 
-#: app.py:1276
+#: app.py:1274
 #, fuzzy
 msgid "tutorial_nextlevel_title"
 msgstr "To the next level"
 
-#: app.py:1276
+#: app.py:1274
 #, fuzzy
 msgid "tutorial_nextlevel_message"
 msgstr ""
@@ -218,91 +218,91 @@ msgstr ""
 "can continue with the next level. When there is also a previous level "
 "there will be a button next to it to go back."
 
-#: app.py:1278
+#: app.py:1276
 #, fuzzy
 msgid "tutorial_leveldefault_title"
 msgstr "Level explanation"
 
-#: app.py:1278
+#: app.py:1276
 #, fuzzy
 msgid "tutorial_leveldefault_message"
 msgstr ""
 "The first tab always contains the level explanation. In each level new "
 "commands will be explained here."
 
-#: app.py:1280
+#: app.py:1278
 #, fuzzy
 msgid "tutorial_adventures_title"
 msgstr "Adventures"
 
-#: app.py:1280
+#: app.py:1278
 #, fuzzy
 msgid "tutorial_adventures_message"
 msgstr ""
 "The other tabs contain adventures, which you can code for each level. "
 "They go from easy to hard."
 
-#: app.py:1282
+#: app.py:1280
 #, fuzzy
 msgid "tutorial_quiz_title"
 msgstr "Quiz"
 
-#: app.py:1282
+#: app.py:1280
 #, fuzzy
 msgid "tutorial_quiz_message"
 msgstr ""
 "At the end of each level you can make the quiz. This way you can verify "
 "if you understand everything."
 
-#: app.py:1284
+#: app.py:1282
 #, fuzzy
 msgid "tutorial_saveshare_title"
 msgstr "Saving & sharing"
 
-#: app.py:1284
+#: app.py:1282
 #, fuzzy
 msgid "tutorial_saveshare_message"
 msgstr "You can save and share all your created programs with other Hedy users."
 
-#: app.py:1286
+#: app.py:1284
 #, fuzzy
 msgid "tutorial_cheatsheet_title"
 msgstr "Cheatsheet"
 
-#: app.py:1286
+#: app.py:1284
 #, fuzzy
 msgid "tutorial_cheatsheet_message"
 msgstr ""
 "If you forgot a command you can always use the cheatsheet. It shows a "
 "list of all commands you can use in the current level."
 
-#: app.py:1288 app.py:1308
+#: app.py:1286 app.py:1306
 #, fuzzy
 msgid "tutorial_end_title"
 msgstr "The end!"
 
-#: app.py:1288
+#: app.py:1286
 #, fuzzy
 msgid "tutorial_end_message"
 msgstr "Click on 'next step' to really start coding with Hedy!"
 
-#: app.py:1290 app.py:1310
+#: app.py:1288 app.py:1308
 msgid "tutorial_title_not_found"
 msgstr ""
 
-#: app.py:1290 app.py:1310
+#: app.py:1288 app.py:1308
 msgid "tutorial_message_not_found"
 msgstr ""
 
-#: app.py:1296
+#: app.py:1294
 msgid "teacher_tutorial_start_message"
 msgstr ""
 
-#: app.py:1298
+#: app.py:1296
 msgid "tutorial_class_title"
 msgstr ""
 
-#: app.py:1298
+#: app.py:1296
 #, fuzzy
 msgid "tutorial_class_message"
 msgstr ""
@@ -310,24 +310,24 @@ msgstr ""
 "through a link. You can view the programs and statistics of all your "
 "students."
 
-#: app.py:1300
+#: app.py:1298
 #, fuzzy
 msgid "tutorial_customize_class_title"
 msgstr "Customize classes"
 
-#: app.py:1300
+#: app.py:1298
 #, fuzzy
 msgid "tutorial_customize_class_message"
 msgstr ""
 "You can customize classes by hiding specific levels and/or adventures as "
 "well as making them available on a specific date."
 
-#: app.py:1302
+#: app.py:1300
 #, fuzzy
 msgid "tutorial_own_adventures_title"
 msgstr "Creating adventures"
 
-#: app.py:1302
+#: app.py:1300
 #, fuzzy
 msgid "tutorial_own_adventures_message"
 msgstr ""
@@ -335,12 +335,12 @@ msgstr ""
 "students. Create them here and add them to your classes in the class "
 "customization section."
 
-#: app.py:1304
+#: app.py:1302
 #, fuzzy
 msgid "tutorial_accounts_title"
 msgstr "Creating accounts"
 
-#: app.py:1304
+#: app.py:1302
 #, fuzzy
 msgid "tutorial_accounts_message"
 msgstr ""
@@ -348,32 +348,32 @@ msgstr ""
 "username and password. You can also directly add these accounts to one of"
 " your classes."
 
-#: app.py:1306
+#: app.py:1304
 #, fuzzy
 msgid "tutorial_documentation_title"
 msgstr "Hedy documentation"
 
-#: app.py:1306
+#: app.py:1304
 msgid "tutorial_documentation_message"
 msgstr ""
 
-#: app.py:1308
+#: app.py:1306
 #, fuzzy
 msgid "teacher_tutorial_end_message"
 msgstr "Click on 'next step' to get started as a Hedy teacher!"
 
-#: app.py:1318
+#: app.py:1316
 #, fuzzy
 msgid "tutorial_code_snippet"
 msgstr ""
 "print Hello world!\n"
 "print I'm learning Hedy with the tutorial!"
 
-#: app.py:1322 app.py:1332
+#: app.py:1320 app.py:1330
 msgid "invalid_tutorial_step"
 msgstr ""
 
-#: app.py:1489 website/auth.py:278 website/auth.py:333 website/auth.py:469
+#: app.py:1487 website/auth.py:278 website/auth.py:333 website/auth.py:469
 #: website/auth.py:494 website/auth.py:524 website/auth.py:637
 #: website/auth.py:675 website/auth.py:722 website/auth.py:749
 #: website/quiz.py:43 website/quiz.py:69 website/teacher.py:88
@@ -384,32 +384,32 @@ msgstr ""
 msgid "ajax_error"
 msgstr "There was an error, please try again."
 
-#: app.py:1492
+#: app.py:1490
 #, fuzzy
 msgid "image_invalid"
 msgstr "The image you chose image is invalid."
 
-#: app.py:1494
+#: app.py:1492
 #, fuzzy
 msgid "personal_text_invalid"
 msgstr "Your personal text is invalid."
 
-#: app.py:1496 app.py:1502
+#: app.py:1494 app.py:1500
 #, fuzzy
 msgid "favourite_program_invalid"
 msgstr "Your chosen favourite program is invalid."
 
-#: app.py:1516 app.py:1517
+#: app.py:1514 app.py:1515
 #, fuzzy
 msgid "public_profile_updated"
 msgstr "Public profile updated."
 
-#: app.py:1554 app.py:1579
+#: app.py:1552 app.py:1577
 #, fuzzy
 msgid "user_not_private"
 msgstr "This user either doesn't exist or doesn't have a public profile"
 
-#: app.py:1587
+#: app.py:1585
 #, fuzzy
 msgid "invalid_teacher_invitation_code"
 msgstr ""
@@ -769,12 +769,12 @@ msgstr "Cheatsheet"
 msgid "back_to_class"
 msgstr "Go back to class"
 
-#: templates/class-overview.html:13 templates/for-teachers.html:35
+#: templates/class-overview.html:14 templates/for-teachers.html:35
 #, fuzzy
 msgid "class_name_prompt"
 msgstr "Please enter the name of the class"
 
-#: templates/class-overview.html:19 templates/class-overview.html:66
+#: templates/class-overview.html:20 templates/class-overview.html:71
 #: templates/create-accounts.html:16 templates/highscores.html:25
 #: templates/login.html:12 templates/profile.html:89 templates/recover.html:8
 #: templates/signup.html:10
@@ -782,140 +782,140 @@ msgstr "Please enter the name of the class"
 msgid "username"
 msgstr "Username"
 
-#: templates/class-overview.html:20
+#: templates/class-overview.html:21
 #, fuzzy
 msgid "last_login"
 msgstr "Last login"
 
-#: templates/class-overview.html:21
+#: templates/class-overview.html:22
 #, fuzzy
 msgid "highest_level_reached"
 msgstr "Highest level reached"
 
-#: templates/class-overview.html:22
+#: templates/class-overview.html:23
 #, fuzzy
 msgid "number_programs"
 msgstr "Number of programs"
 
-#: templates/class-overview.html:23
+#: templates/class-overview.html:24
 #, fuzzy
 msgid "programs"
 msgstr "Programs"
 
-#: templates/class-overview.html:24 templates/create-accounts.html:17
+#: templates/class-overview.html:25 templates/create-accounts.html:17
 #: templates/login.html:15 templates/reset.html:8 templates/signup.html:19
 #, fuzzy
 msgid "password"
 msgstr "Password"
 
-#: templates/class-overview.html:25 templates/class-overview.html:69
+#: templates/class-overview.html:26 templates/class-overview.html:74
 #: templates/customize-adventure.html:52 templates/for-teachers.html:46
 #: templates/for-teachers.html:56
 #, fuzzy
 msgid "remove"
 msgstr "Remove"
 
-#: templates/class-overview.html:35
+#: templates/class-overview.html:36
 #, fuzzy
 msgid "page"
 msgstr "page"
 
-#: templates/class-overview.html:36
+#: templates/class-overview.html:37
 #, fuzzy
 msgid "enter_password"
 msgstr "Enter a new password for"
 
-#: templates/class-overview.html:36
+#: templates/class-overview.html:37
 #, fuzzy
 msgid "password_change_prompt"
 msgstr "Are you sure you want to change this password?"
 
-#: templates/class-overview.html:37
+#: templates/class-overview.html:38
 #, fuzzy
 msgid "remove_student_prompt"
 msgstr "Are you sure you want to remove the student from the class?"
 
-#: templates/class-overview.html:44
+#: templates/class-overview.html:46
 #, fuzzy
 msgid "add_students"
 msgstr "students"
 
-#: templates/class-overview.html:45 templates/customize-class.html:5
+#: templates/class-overview.html:47 templates/customize-class.html:5
 #, fuzzy
 msgid "customize_class"
 msgstr "Customize class"
 
-#: templates/class-overview.html:46
+#: templates/class-overview.html:48
 #, fuzzy
 msgid "class_stats"
 msgstr "Class statistics"
 
-#: templates/class-overview.html:47
+#: templates/class-overview.html:49
 #, fuzzy
 msgid "class_logs"
 msgstr "Last login"
 
-#: templates/class-overview.html:48 templates/customize-adventure.html:59
+#: templates/class-overview.html:52 templates/customize-adventure.html:59
 #, fuzzy
 msgid "back_to_teachers_page"
 msgstr "Go back to teachers page"
 
-#: templates/class-overview.html:49
+#: templates/class-overview.html:53
 #, fuzzy
 msgid "delete_class_prompt"
 msgstr "Are you sure you want to delete the class?"
 
-#: templates/class-overview.html:49
+#: templates/class-overview.html:53
 #, fuzzy
 msgid "delete_class"
 msgstr "Delete class permanently"
 
-#: templates/class-overview.html:52
+#: templates/class-overview.html:57
 #, fuzzy
 msgid "add_students_options"
 msgstr "Create student accounts"
 
-#: templates/class-overview.html:54
+#: templates/class-overview.html:59
 #, fuzzy
 msgid "copy_link_success"
 msgstr "Copy link to share"
 
-#: templates/class-overview.html:54
+#: templates/class-overview.html:59
 #, fuzzy
 msgid "copy_join_link"
 msgstr "Please copy and paste this link into a new tab:"
 
-#: templates/class-overview.html:55
+#: templates/class-overview.html:60
 #, fuzzy
 msgid "invite_prompt"
 msgstr "Enter a username"
 
-#: templates/class-overview.html:55
+#: templates/class-overview.html:60
 #, fuzzy
 msgid "invite_by_username"
 msgstr "All usernames need to be unique."
 
-#: templates/class-overview.html:56 templates/create-accounts.html:45
+#: templates/class-overview.html:61 templates/create-accounts.html:45
 #, fuzzy
 msgid "create_accounts"
 msgstr "Create multiple accounts"
 
-#: templates/class-overview.html:61
+#: templates/class-overview.html:66
 #, fuzzy
 msgid "pending_invites"
 msgstr "Pending invites"
 
-#: templates/class-overview.html:67
+#: templates/class-overview.html:72
 #, fuzzy
 msgid "invite_date"
 msgstr "Invite date"
 
-#: templates/class-overview.html:68
+#: templates/class-overview.html:73
 #, fuzzy
 msgid "expiration_date"
 msgstr "Expiration date"
 
-#: templates/class-overview.html:78 templates/profile.html:16
+#: templates/class-overview.html:83 templates/profile.html:16
 #, fuzzy
 msgid "delete_invite_prompt"
 msgstr "Are you sure you want to remove this class invitation?"
@@ -1389,11 +1389,10 @@ msgstr "My classes"
 msgid "achievements"
 msgstr "achievements"
 
-#: templates/highscores.html:27 templates/learn-more.html:22
-#: templates/profile.html:131 templates/signup.html:52
+#: templates/highscores.html:27
 #, fuzzy
-msgid "country"
-msgstr "Country"
+msgid "country_title"
+msgstr "Please select a valid country."
 
 #: templates/highscores.html:28 templates/landing-page.html:88
 #: templates/public-page.html:50
@@ -1692,6 +1691,12 @@ msgstr "First Name"
 #, fuzzy
 msgid "lastname"
 msgstr "Last Name"
+
+#: templates/learn-more.html:22 templates/profile.html:131
+#: templates/signup.html:52
+#, fuzzy
+msgid "country"
+msgstr "Country"
 
 #: templates/learn-more.html:31
 #, fuzzy

--- a/translations/nb_NO/LC_MESSAGES/messages.po
+++ b/translations/nb_NO/LC_MESSAGES/messages.po
@@ -3,16 +3,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-28 18:38+0300\n"
+"POT-Creation-Date: 2022-06-29 14:20+0200\n"
 "PO-Revision-Date: 2022-06-28 13:25+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: nb_NO\n"
 "Language-Team: nb_NO <LL@li.org>\n"
-"Plural-Forms: nplurals=2; plural=n != 1\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.9.1\n"
+"Generated-By: Babel 2.10.1\n"
 
 #: app.py:417
 msgid "program_contains_error"
@@ -22,7 +22,7 @@ msgstr "Dette programmet inneholder en feil, er du sikker på at du vil dele det
 msgid "title_achievements"
 msgstr "Hedy - Mine prestasjoner"
 
-#: app.py:644 app.py:748 app.py:1090 website/teacher.py:361
+#: app.py:644 app.py:746 app.py:1088 website/teacher.py:361
 #: website/teacher.py:372
 msgid "not_teacher"
 msgstr "Ser ut til at du ikke er en lærer!"
@@ -31,11 +31,11 @@ msgstr "Ser ut til at du ikke er en lærer!"
 msgid "not_enrolled"
 msgstr "Det ser ut som at du ikke er medlem i denne klassen!"
 
-#: app.py:686
+#: app.py:684
 msgid "title_programs"
 msgstr "Hedy - Mine programmer"
 
-#: app.py:696 app.py:706 app.py:710 app.py:725 app.py:1005 app.py:1550
+#: app.py:694 app.py:704 app.py:708 app.py:723 app.py:1003 app.py:1548
 #: website/admin.py:17 website/admin.py:24 website/admin.py:92
 #: website/admin.py:111 website/admin.py:129 website/admin.py:136
 #: website/admin.py:144 website/auth.py:716 website/auth.py:743
@@ -43,308 +43,308 @@ msgstr "Hedy - Mine programmer"
 msgid "unauthorized"
 msgstr "Du har ikke rettigheter til å se denne siden"
 
-#: app.py:762 app.py:1107
+#: app.py:760 app.py:1105
 msgid "title_for-teacher"
 msgstr "Hedy - For lærere"
 
-#: app.py:779 app.py:781 app.py:923 app.py:945 app.py:947
+#: app.py:777 app.py:779 app.py:921 app.py:943 app.py:945
 msgid "no_such_level"
 msgstr "Dette Hedy nivået fins ikke!"
 
-#: app.py:789 app.py:796 app.py:877 app.py:883
+#: app.py:787 app.py:794 app.py:875 app.py:881
 msgid "no_such_program"
 msgstr "Dette Hedy programmet fins ikke!"
 
-#: app.py:819
+#: app.py:817
 msgid "level_not_class"
 msgstr "Klassen din har ikke tilgang til dette nivået enda"
 
-#: app.py:928 website/teacher.py:421 website/teacher.py:437
+#: app.py:926 website/teacher.py:421 website/teacher.py:437
 #: website/teacher.py:466 website/teacher.py:492
 msgid "no_such_adventure"
 msgstr "Dette eventyret eksisterer ikke!"
 
-#: app.py:956 app.py:1209
+#: app.py:954 app.py:1207
 msgid "page_not_found"
 msgstr "Vi klarte ikke å finne den siden!"
 
-#: app.py:976
+#: app.py:974
 msgid "title_signup"
 msgstr "Hedy - Opprett konto"
 
-#: app.py:983
+#: app.py:981
 msgid "title_login"
 msgstr "Hedy - Logg inn"
 
-#: app.py:990
+#: app.py:988
 msgid "title_recover"
 msgstr "Hedy - Gjennopprett konto"
 
-#: app.py:1006
+#: app.py:1004
 msgid "title_reset"
 msgstr "Hedy - Tilbakestill passord"
 
-#: app.py:1032
+#: app.py:1030
 msgid "title_my-profile"
 msgstr "Hedy - Min konto"
 
-#: app.py:1048
+#: app.py:1046
 msgid "title_learn-more"
 msgstr "Hedy - Lær mer"
 
-#: app.py:1054
+#: app.py:1052
 msgid "title_privacy"
 msgstr "Hedy - Personvernsvilkår"
 
-#: app.py:1064
+#: app.py:1062
 msgid "title_start"
 msgstr "Hedy - Et gradvis programmeringsspråk"
 
-#: app.py:1082
+#: app.py:1080
 msgid "title_landing-page"
 msgstr "Velkommen til Hedy!"
 
-#: app.py:1200
+#: app.py:1198
 msgid "title_explore"
 msgstr "Hedy - Utforsk"
 
-#: app.py:1221 app.py:1226
+#: app.py:1219 app.py:1224
 #, fuzzy
 msgid "no_such_highscore"
 msgstr "Dette Hedy nivået fins ikke!"
 
-#: app.py:1255 app.py:1257
+#: app.py:1253 app.py:1255
 msgid "translate_error"
 msgstr ""
 "Noe gikk galt når vi prøvde å oversette koden. Prøv å kjøre koden for å "
 "se om den inneholder en feil. Kode med feil i kan ikke oversettes."
 
-#: app.py:1262 app.py:1296
+#: app.py:1260 app.py:1294
 #, fuzzy
 msgid "tutorial_start_title"
 msgstr "Welcome to Hedy!"
 
-#: app.py:1262
+#: app.py:1260
 #, fuzzy
 msgid "tutorial_start_message"
 msgstr "In this tutorial we will explain all the Hedy features step-by-step."
 
-#: app.py:1264
+#: app.py:1262
 #, fuzzy
 msgid "tutorial_editor_title"
 msgstr "The code editor"
 
-#: app.py:1264
+#: app.py:1262
 #, fuzzy
 msgid "tutorial_editor_message"
 msgstr "In this window you write all the code, try typing something!"
 
-#: app.py:1266
+#: app.py:1264
 #, fuzzy
 msgid "tutorial_output_title"
 msgstr "The output window"
 
-#: app.py:1266
+#: app.py:1264
 #, fuzzy
 msgid "tutorial_output_message"
 msgstr "The result of the code you execute will be shown here"
 
-#: app.py:1268
+#: app.py:1266
 #, fuzzy
 msgid "tutorial_run_title"
 msgstr "The run button"
 
-#: app.py:1268
+#: app.py:1266
 #, fuzzy
 msgid "tutorial_run_message"
 msgstr "With this button you can run your program! Shall we give it a try?"
 
-#: app.py:1270
+#: app.py:1268
 #, fuzzy
 msgid "tutorial_tryit_title"
 msgstr "Try it out!"
 
-#: app.py:1270
+#: app.py:1268
 #, fuzzy
 msgid "tutorial_tryit_message"
 msgstr "Du har mottatt en invitasjon til å bli med i en klasse"
 
-#: app.py:1272
+#: app.py:1270
 #, fuzzy
 msgid "tutorial_speakaloud_title"
 msgstr "The end!"
 
-#: app.py:1272
+#: app.py:1270
 #, fuzzy
 msgid "tutorial_speakaloud_message"
 msgstr "Click on 'next step' to really start coding with Hedy!"
 
-#: app.py:1274
+#: app.py:1272
 #, fuzzy
 msgid "tutorial_speakaloud_run_title"
 msgstr "The end!"
 
-#: app.py:1274
+#: app.py:1272
 #, fuzzy
 msgid "tutorial_speakaloud_run_message"
 msgstr "Click on 'next step' to really start coding with Hedy!"
 
-#: app.py:1276
+#: app.py:1274
 #, fuzzy
 msgid "tutorial_nextlevel_title"
 msgstr "Skjul hjelpeark"
 
-#: app.py:1276
+#: app.py:1274
 #, fuzzy
 msgid "tutorial_nextlevel_message"
 msgstr "Du har mottatt en invitasjon til å bli med i en klasse"
 
-#: app.py:1278
+#: app.py:1276
 #, fuzzy
 msgid "tutorial_leveldefault_title"
 msgstr "Level explanation"
 
-#: app.py:1278
+#: app.py:1276
 #, fuzzy
 msgid "tutorial_leveldefault_message"
 msgstr ""
 "The first tab always contains the level explanation. In each level new "
 "commands will be explained here."
 
-#: app.py:1280
+#: app.py:1278
 #, fuzzy
 msgid "tutorial_adventures_title"
 msgstr "Tilpass eventyr"
 
-#: app.py:1280
+#: app.py:1278
 #, fuzzy
 msgid "tutorial_adventures_message"
 msgstr "Tilpass eventyr"
 
-#: app.py:1282
+#: app.py:1280
 #, fuzzy
 msgid "tutorial_quiz_title"
 msgstr "Quiz"
 
-#: app.py:1282
+#: app.py:1280
 #, fuzzy
 msgid "tutorial_quiz_message"
 msgstr ""
 "At the end of each level you can make the quiz. This way you can verify "
 "if you understand everything."
 
-#: app.py:1284
+#: app.py:1282
 #, fuzzy
 msgid "tutorial_saveshare_title"
 msgstr "Saving & sharing"
 
-#: app.py:1284
+#: app.py:1282
 #, fuzzy
 msgid "tutorial_saveshare_message"
 msgstr "You can save and share all your created programs with other Hedy users."
 
-#: app.py:1286
+#: app.py:1284
 #, fuzzy
 msgid "tutorial_cheatsheet_title"
 msgstr "Skjul hjelpeark"
 
-#: app.py:1286
+#: app.py:1284
 #, fuzzy
 msgid "tutorial_cheatsheet_message"
 msgstr ""
 "If you forgot a command you can always use the cheatsheet. It shows a "
 "list of all commands you can use in the current level."
 
-#: app.py:1288 app.py:1308
+#: app.py:1286 app.py:1306
 #, fuzzy
 msgid "tutorial_end_title"
 msgstr "The end!"
 
-#: app.py:1288
+#: app.py:1286
 #, fuzzy
 msgid "tutorial_end_message"
 msgstr "Click on 'next step' to really start coding with Hedy!"
 
-#: app.py:1290 app.py:1310
+#: app.py:1288 app.py:1308
 #, fuzzy
 msgid "tutorial_title_not_found"
 msgstr "Vi klarte ikke å finne den siden!"
 
-#: app.py:1290 app.py:1310
+#: app.py:1288 app.py:1308
 #, fuzzy
 msgid "tutorial_message_not_found"
 msgstr "Du har mottatt en invitasjon til å bli med i en klasse"
 
-#: app.py:1296
+#: app.py:1294
 #, fuzzy
 msgid "teacher_tutorial_start_message"
 msgstr "Du har mottatt en invitasjon til å bli med i en klasse"
 
-#: app.py:1298
+#: app.py:1296
 #, fuzzy
 msgid "tutorial_class_title"
 msgstr "Skjul hjelpeark"
 
-#: app.py:1298
+#: app.py:1296
 #, fuzzy
 msgid "tutorial_class_message"
 msgstr "Tilpass eventyr"
 
-#: app.py:1300
+#: app.py:1298
 #, fuzzy
 msgid "tutorial_customize_class_title"
 msgstr "Skjul hjelpeark"
 
-#: app.py:1300
+#: app.py:1298
 #, fuzzy
 msgid "tutorial_customize_class_message"
 msgstr "Tilpass eventyr"
 
-#: app.py:1302
+#: app.py:1300
 #, fuzzy
 msgid "tutorial_own_adventures_title"
 msgstr "Tilpass eventyr"
 
-#: app.py:1302
+#: app.py:1300
 #, fuzzy
 msgid "tutorial_own_adventures_message"
 msgstr "Tilpass eventyr"
 
-#: app.py:1304
+#: app.py:1302
 #, fuzzy
 msgid "tutorial_accounts_title"
 msgstr "Tilpass eventyr"
 
-#: app.py:1304
+#: app.py:1302
 #, fuzzy
 msgid "tutorial_accounts_message"
 msgstr "Tilpass eventyr"
 
-#: app.py:1306
+#: app.py:1304
 #, fuzzy
 msgid "tutorial_documentation_title"
 msgstr "Skjul hjelpeark"
 
-#: app.py:1306
+#: app.py:1304
 #, fuzzy
 msgid "tutorial_documentation_message"
 msgstr "Tilpass eventyr"
 
-#: app.py:1308
+#: app.py:1306
 #, fuzzy
 msgid "teacher_tutorial_end_message"
 msgstr "Du har mottatt en invitasjon til å bli med i en klasse"
 
-#: app.py:1318
+#: app.py:1316
 #, fuzzy
 msgid "tutorial_code_snippet"
 msgstr "Skjul hjelpeark"
 
-#: app.py:1322 app.py:1332
+#: app.py:1320 app.py:1330
 msgid "invalid_tutorial_step"
 msgstr ""
 
-#: app.py:1489 website/auth.py:278 website/auth.py:333 website/auth.py:469
+#: app.py:1487 website/auth.py:278 website/auth.py:333 website/auth.py:469
 #: website/auth.py:494 website/auth.py:524 website/auth.py:637
 #: website/auth.py:675 website/auth.py:722 website/auth.py:749
 #: website/quiz.py:43 website/quiz.py:69 website/teacher.py:88
@@ -354,29 +354,29 @@ msgstr ""
 msgid "ajax_error"
 msgstr "Det skjedde noe feil, vennligst prøv igjen."
 
-#: app.py:1492
+#: app.py:1490
 msgid "image_invalid"
 msgstr "Bildet du valgte er ugyldig."
 
-#: app.py:1494
+#: app.py:1492
 msgid "personal_text_invalid"
 msgstr "Din personlige tekst er ugyldig."
 
-#: app.py:1496 app.py:1502
+#: app.py:1494 app.py:1500
 msgid "favourite_program_invalid"
 msgstr "Ditt valgte favorittprogram er ugyldig."
 
-#: app.py:1516 app.py:1517
+#: app.py:1514 app.py:1515
 msgid "public_profile_updated"
 msgstr "Din offentlige profil ble oppdatert."
 
-#: app.py:1554 app.py:1579
+#: app.py:1552 app.py:1577
 msgid "user_not_private"
 msgstr ""
 "Denne brukeren eksisterer ikke, eller så har de ikke opprettet en "
 "offentlig profil"
 
-#: app.py:1587
+#: app.py:1585
 msgid "invalid_teacher_invitation_code"
 msgstr ""
 "Invitasjonskoden til å bli lærer er ugyldig. For å bli en Hedy-lærer, ta "
@@ -678,131 +678,131 @@ msgstr "Skjul hjelpeark"
 msgid "back_to_class"
 msgstr "Gå tilbake til klassen"
 
-#: templates/class-overview.html:13 templates/for-teachers.html:35
+#: templates/class-overview.html:14 templates/for-teachers.html:35
 msgid "class_name_prompt"
 msgstr "Vennligst oppgi navnet på klassen"
 
-#: templates/class-overview.html:19 templates/class-overview.html:66
+#: templates/class-overview.html:20 templates/class-overview.html:71
 #: templates/create-accounts.html:16 templates/highscores.html:25
 #: templates/login.html:12 templates/profile.html:89 templates/recover.html:8
 #: templates/signup.html:10
 msgid "username"
 msgstr "Brukernavn"
 
-#: templates/class-overview.html:20
+#: templates/class-overview.html:21
 msgid "last_login"
 msgstr "Forrige innlogging"
 
-#: templates/class-overview.html:21
+#: templates/class-overview.html:22
 msgid "highest_level_reached"
 msgstr "Høyeste nivå nådd"
 
-#: templates/class-overview.html:22
+#: templates/class-overview.html:23
 msgid "number_programs"
 msgstr "Antall programmer"
 
-#: templates/class-overview.html:23
+#: templates/class-overview.html:24
 msgid "programs"
 msgstr "Program"
 
-#: templates/class-overview.html:24 templates/create-accounts.html:17
+#: templates/class-overview.html:25 templates/create-accounts.html:17
 #: templates/login.html:15 templates/reset.html:8 templates/signup.html:19
 msgid "password"
 msgstr "Passord"
 
-#: templates/class-overview.html:25 templates/class-overview.html:69
+#: templates/class-overview.html:26 templates/class-overview.html:74
 #: templates/customize-adventure.html:52 templates/for-teachers.html:46
 #: templates/for-teachers.html:56
 msgid "remove"
 msgstr "Fjern"
 
-#: templates/class-overview.html:35
+#: templates/class-overview.html:36
 msgid "page"
 msgstr "side"
 
-#: templates/class-overview.html:36
+#: templates/class-overview.html:37
 msgid "enter_password"
 msgstr "Oppgi ett nytt passord for"
 
-#: templates/class-overview.html:36
+#: templates/class-overview.html:37
 msgid "password_change_prompt"
 msgstr "Er du sikker på du vil endre dette passordet?"
 
-#: templates/class-overview.html:37
+#: templates/class-overview.html:38
 msgid "remove_student_prompt"
 msgstr "Er du sikker du vil fjerne eleven fra klassen?"
 
-#: templates/class-overview.html:44
+#: templates/class-overview.html:46
 #, fuzzy
 msgid "add_students"
 msgstr "elever"
 
-#: templates/class-overview.html:45 templates/customize-class.html:5
+#: templates/class-overview.html:47 templates/customize-class.html:5
 msgid "customize_class"
 msgstr "Tilpass innstillingene for klassen"
 
-#: templates/class-overview.html:46
+#: templates/class-overview.html:48
 msgid "class_stats"
 msgstr "Statistikk over klassen"
 
-#: templates/class-overview.html:47
+#: templates/class-overview.html:49
 #, fuzzy
 msgid "class_logs"
 msgstr "Forrige innlogging"
 
-#: templates/class-overview.html:48 templates/customize-adventure.html:59
+#: templates/class-overview.html:52 templates/customize-adventure.html:59
 msgid "back_to_teachers_page"
 msgstr "Gå tilbake til lærersiden"
 
-#: templates/class-overview.html:49
+#: templates/class-overview.html:53
 msgid "delete_class_prompt"
 msgstr "Er du sikker på at du vil slette klassen?"
 
-#: templates/class-overview.html:49
+#: templates/class-overview.html:53
 msgid "delete_class"
 msgstr "Slett klassen for alltid"
 
-#: templates/class-overview.html:52
+#: templates/class-overview.html:57
 #, fuzzy
 msgid "add_students_options"
 msgstr "Opprett kontoer til elever"
 
-#: templates/class-overview.html:54
+#: templates/class-overview.html:59
 #, fuzzy
 msgid "copy_link_success"
 msgstr "Kopier lenken for å dele"
 
-#: templates/class-overview.html:54
+#: templates/class-overview.html:59
 #, fuzzy
 msgid "copy_join_link"
 msgstr "Please copy and paste this link into a new tab:"
 
-#: templates/class-overview.html:55
+#: templates/class-overview.html:60
 msgid "invite_prompt"
 msgstr "Oppgi et brukernavn"
 
-#: templates/class-overview.html:55
+#: templates/class-overview.html:60
 #, fuzzy
 msgid "invite_by_username"
 msgstr "Alle brukernavnene må være unike."
 
-#: templates/class-overview.html:56 templates/create-accounts.html:45
+#: templates/class-overview.html:61 templates/create-accounts.html:45
 msgid "create_accounts"
 msgstr "Opprett flere kontoer"
 
-#: templates/class-overview.html:61
+#: templates/class-overview.html:66
 msgid "pending_invites"
 msgstr "Ubesvarte invitasjoner"
 
-#: templates/class-overview.html:67
+#: templates/class-overview.html:72
 msgid "invite_date"
 msgstr "Invitasjonsdato"
 
-#: templates/class-overview.html:68
+#: templates/class-overview.html:73
 msgid "expiration_date"
 msgstr "Utløpsdato"
 
-#: templates/class-overview.html:78 templates/profile.html:16
+#: templates/class-overview.html:83 templates/profile.html:16
 msgid "delete_invite_prompt"
 msgstr "Er du sikker på at du vil fjerne denne klasseinvitasjonen?"
 
@@ -1217,10 +1217,10 @@ msgstr "Mine klasser"
 msgid "achievements"
 msgstr "prestasjoner"
 
-#: templates/highscores.html:27 templates/learn-more.html:22
-#: templates/profile.html:131 templates/signup.html:52
-msgid "country"
-msgstr "Land"
+#: templates/highscores.html:27
+#, fuzzy
+msgid "country_title"
+msgstr "Vennligst velg et gyldig land."
 
 #: templates/highscores.html:28 templates/landing-page.html:88
 #: templates/public-page.html:50
@@ -1489,6 +1489,11 @@ msgstr "Fornavn"
 #: templates/learn-more.html:18
 msgid "lastname"
 msgstr "Etternavn"
+
+#: templates/learn-more.html:22 templates/profile.html:131
+#: templates/signup.html:52
+msgid "country"
+msgstr "Land"
 
 #: templates/learn-more.html:31
 msgid "subscribe"

--- a/translations/nl/LC_MESSAGES/messages.po
+++ b/translations/nl/LC_MESSAGES/messages.po
@@ -8,16 +8,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-06-28 18:38+0300\n"
+"POT-Creation-Date: 2022-06-29 14:20+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: nl\n"
 "Language-Team: nl <LL@li.org>\n"
-"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.9.1\n"
+"Generated-By: Babel 2.10.1\n"
 
 #: app.py:417
 msgid "program_contains_error"
@@ -27,7 +27,7 @@ msgstr "Dit programma bevat een foutje, weet je zeker dat je hem wilt delen?"
 msgid "title_achievements"
 msgstr "Hedy - Mijn badges"
 
-#: app.py:644 app.py:748 app.py:1090 website/teacher.py:361
+#: app.py:644 app.py:746 app.py:1088 website/teacher.py:361
 #: website/teacher.py:372
 msgid "not_teacher"
 msgstr "Jij bent geen leraar!"
@@ -36,11 +36,11 @@ msgstr "Jij bent geen leraar!"
 msgid "not_enrolled"
 msgstr "Jij zit niet in deze klas!"
 
-#: app.py:686
+#: app.py:684
 msgid "title_programs"
 msgstr "Hedy - Mijn programma's"
 
-#: app.py:696 app.py:706 app.py:710 app.py:725 app.py:1005 app.py:1550
+#: app.py:694 app.py:704 app.py:708 app.py:723 app.py:1003 app.py:1548
 #: website/admin.py:17 website/admin.py:24 website/admin.py:92
 #: website/admin.py:111 website/admin.py:129 website/admin.py:136
 #: website/admin.py:144 website/auth.py:716 website/auth.py:743
@@ -48,300 +48,300 @@ msgstr "Hedy - Mijn programma's"
 msgid "unauthorized"
 msgstr "Jij hebt geen rechten voor deze pagina"
 
-#: app.py:762 app.py:1107
+#: app.py:760 app.py:1105
 msgid "title_for-teacher"
 msgstr "Hedy - Voor leerkrachten"
 
-#: app.py:779 app.py:781 app.py:923 app.py:945 app.py:947
+#: app.py:777 app.py:779 app.py:921 app.py:943 app.py:945
 msgid "no_such_level"
 msgstr "Dit level bestaat niet!"
 
-#: app.py:789 app.py:796 app.py:877 app.py:883
+#: app.py:787 app.py:794 app.py:875 app.py:881
 msgid "no_such_program"
 msgstr "Dit programma bestaat niet!"
 
-#: app.py:819
+#: app.py:817
 msgid "level_not_class"
 msgstr "Je zit in een klas waar dit level nog niet beschikbaar is gemaakt"
 
-#: app.py:928 website/teacher.py:421 website/teacher.py:437
+#: app.py:926 website/teacher.py:421 website/teacher.py:437
 #: website/teacher.py:466 website/teacher.py:492
 msgid "no_such_adventure"
 msgstr "Dit avontuur bestaat niet!"
 
-#: app.py:956 app.py:1209
+#: app.py:954 app.py:1207
 msgid "page_not_found"
 msgstr "We konden deze pagina niet vinden!"
 
-#: app.py:976
+#: app.py:974
 msgid "title_signup"
 msgstr "Hedy - Account aanmaken"
 
-#: app.py:983
+#: app.py:981
 msgid "title_login"
 msgstr "Hedy - Inloggen"
 
-#: app.py:990
+#: app.py:988
 msgid "title_recover"
 msgstr "Hedy - Account herstellen"
 
-#: app.py:1006
+#: app.py:1004
 msgid "title_reset"
 msgstr "Hedy - Wachtwoord resetten"
 
-#: app.py:1032
+#: app.py:1030
 msgid "title_my-profile"
 msgstr "Hedy - Mijn account"
 
-#: app.py:1048
+#: app.py:1046
 msgid "title_learn-more"
 msgstr "Hedy - Meer info"
 
-#: app.py:1054
+#: app.py:1052
 msgid "title_privacy"
 msgstr "Hedy - Privacyverklaring"
 
-#: app.py:1064
+#: app.py:1062
 msgid "title_start"
 msgstr "Hedy - Een graduele programmeertaal"
 
-#: app.py:1082
+#: app.py:1080
 msgid "title_landing-page"
 msgstr "Welkom bij Hedy!"
 
-#: app.py:1200
+#: app.py:1198
 msgid "title_explore"
 msgstr "Hedy - Ontdekken"
 
-#: app.py:1221 app.py:1226
+#: app.py:1219 app.py:1224
 #, fuzzy
 msgid "no_such_highscore"
 msgstr "Highscores"
 
-#: app.py:1255 app.py:1257
+#: app.py:1253 app.py:1255
 msgid "translate_error"
 msgstr ""
 "Er is iets misgegaan met het vertalen van de code. Probeer je code te "
 "runnen om te kijken of er misschien een foutje in zit. Code met foutjes "
 "kan niet vertaald worden."
 
-#: app.py:1262 app.py:1296
+#: app.py:1260 app.py:1294
 msgid "tutorial_start_title"
 msgstr "Welkom bij Hedy!"
 
-#: app.py:1262
+#: app.py:1260
 msgid "tutorial_start_message"
 msgstr "In deze uitleg leggen we stap voor stap uit wat je allemaal kunt doen"
 
-#: app.py:1264
+#: app.py:1262
 msgid "tutorial_editor_title"
 msgstr "De code editor"
 
-#: app.py:1264
+#: app.py:1262
 msgid "tutorial_editor_message"
 msgstr ""
 "In dit venster schrijf je alle code, probeer maar wat in te vullen op de "
 "plaats van de lage streepjes!"
 
-#: app.py:1266
+#: app.py:1264
 msgid "tutorial_output_title"
 msgstr "Het output venster"
 
-#: app.py:1266
+#: app.py:1264
 msgid "tutorial_output_message"
 msgstr "De code die je uitvoert wordt hier weergegeven, dit heb jij net gemaakt!"
 
-#: app.py:1268
+#: app.py:1266
 msgid "tutorial_run_title"
 msgstr "De uitvoer knop"
 
-#: app.py:1268
+#: app.py:1266
 msgid "tutorial_run_message"
 msgstr ""
 "Met deze knop kun je een programma uitvoeren, zullen we het proberen in "
 "de volgende stap?"
 
-#: app.py:1270
+#: app.py:1268
 msgid "tutorial_tryit_title"
 msgstr "Probeer het uit!"
 
-#: app.py:1270
+#: app.py:1268
 msgid "tutorial_tryit_message"
 msgstr "Voer het programma uit, klik op 'volgende stap' als je klaar bent."
 
-#: app.py:1272
+#: app.py:1270
 msgid "tutorial_speakaloud_title"
 msgstr "Laat je programma voorlezen"
 
-#: app.py:1272
+#: app.py:1270
 msgid "tutorial_speakaloud_message"
 msgstr ""
 "Kies onder de uitvoer knop een stem als je jouw programma wilt laten "
 "voorlezen."
 
-#: app.py:1274
+#: app.py:1272
 msgid "tutorial_speakaloud_run_title"
 msgstr "Voer uit & luister"
 
-#: app.py:1274
+#: app.py:1272
 msgid "tutorial_speakaloud_run_message"
 msgstr "Kies een stem en voer je programma opnieuw uit om te laten voorlezen."
 
-#: app.py:1276
+#: app.py:1274
 msgid "tutorial_nextlevel_title"
 msgstr "Naar het volgende level"
 
-#: app.py:1276
+#: app.py:1274
 msgid "tutorial_nextlevel_message"
 msgstr ""
 "Wanneer je denkt dat je alles goed snapt en genoeg hebt geoefend kun je "
 "naar het volgende level. Wanneer er een vorig level is zal er ook een "
 "knop zijn voor terug."
 
-#: app.py:1278
+#: app.py:1276
 msgid "tutorial_leveldefault_title"
 msgstr "Level uitleg"
 
-#: app.py:1278
+#: app.py:1276
 msgid "tutorial_leveldefault_message"
 msgstr ""
 "In het eerste tabje vind je altijd de level uitleg. Hier worden in elk "
 "level de nieuwe commando's uitgelegd."
 
-#: app.py:1280
+#: app.py:1278
 #, fuzzy
 msgid "tutorial_adventures_title"
 msgstr "Avonturen"
 
-#: app.py:1280
+#: app.py:1278
 msgid "tutorial_adventures_message"
 msgstr ""
 "De andere tabjes bevatten avonturen, deze kun je per level maken. Ze gaan"
 " van makkelijk naar moeilijk!"
 
-#: app.py:1282
+#: app.py:1280
 #, fuzzy
 msgid "tutorial_quiz_title"
 msgstr "Quiz"
 
-#: app.py:1282
+#: app.py:1280
 msgid "tutorial_quiz_message"
 msgstr ""
 "Aan het einde van elk level kun je een quiz maken, zo kun je goed testen "
 "of je alles snapt!"
 
-#: app.py:1284
+#: app.py:1282
 msgid "tutorial_saveshare_title"
 msgstr "Opslaan en delen"
 
-#: app.py:1284
+#: app.py:1282
 msgid "tutorial_saveshare_message"
 msgstr ""
 "Je kunt al jouw gemaakt programma's opslaan en delen met andere Hedy "
 "gebruikers."
 
-#: app.py:1286
+#: app.py:1284
 msgid "tutorial_cheatsheet_title"
 msgstr "Spiekbriefje"
 
-#: app.py:1286
+#: app.py:1284
 msgid "tutorial_cheatsheet_message"
 msgstr ""
 "Als je iets bent vergeten kun je het spiekbriefje gebruiken om te kijken "
 "welke commando's je mag gebruiken."
 
-#: app.py:1288 app.py:1308
+#: app.py:1286 app.py:1306
 msgid "tutorial_end_title"
 msgstr "Einde!"
 
-#: app.py:1288
+#: app.py:1286
 msgid "tutorial_end_message"
 msgstr "Klik op 'Volgende stap' om echt aan de slag te gaan met Hedy!"
 
-#: app.py:1290 app.py:1310
+#: app.py:1288 app.py:1308
 msgid "tutorial_title_not_found"
 msgstr "Oeps! Er gaat iets mis..."
 
-#: app.py:1290 app.py:1310
+#: app.py:1288 app.py:1308
 msgid "tutorial_message_not_found"
 msgstr ""
 "Het lijkt erop dat we de volgende stap voor de tutorial niet kunnen "
 "ophalen, probeer het later opnieuw."
 
-#: app.py:1296
+#: app.py:1294
 msgid "teacher_tutorial_start_message"
 msgstr ""
 "In deze uitleg leggen we stap voor stap uit wat je allemaal (extra) kunt "
 "doen als leraar."
 
-#: app.py:1298
+#: app.py:1296
 msgid "tutorial_class_title"
 msgstr "Beheren van klassen"
 
-#: app.py:1298
+#: app.py:1296
 msgid "tutorial_class_message"
 msgstr ""
 "Als leraar kun je klassen aanmaken en studenten hiervoor uitnodigen of "
 "laten inschrijven via een link. Van jouw studenten kun je alle "
 "programma's en statistieken bekijken."
 
-#: app.py:1300
+#: app.py:1298
 msgid "tutorial_customize_class_title"
 msgstr "Klassen personaliseren"
 
-#: app.py:1300
+#: app.py:1298
 msgid "tutorial_customize_class_message"
 msgstr ""
 "Je kunt klassen personaliseren door levels en/of avonturen te verbergen "
 "of op specifieke data beschikbaar te maken."
 
-#: app.py:1302
+#: app.py:1300
 msgid "tutorial_own_adventures_title"
 msgstr "Avonturen aanmaken"
 
-#: app.py:1302
+#: app.py:1300
 msgid "tutorial_own_adventures_message"
 msgstr ""
 "Je kunt eigen avonturen maken en gebruiken als opdrachten voor je "
 "leerlingen. Maak ze hier, voeg ze vervolgens aan je klassen toe via de "
 "klassen personaliatie."
 
-#: app.py:1304
+#: app.py:1302
 msgid "tutorial_accounts_title"
 msgstr "Accounts aanmaken"
 
-#: app.py:1304
+#: app.py:1302
 msgid "tutorial_accounts_message"
 msgstr ""
 "Je kunt meerdere accounts tegelijk aanmaken voor jouw leerlingen, je "
 "hoeft alleen een gebruikersnaam en wachtwoord op te geven. Deze accounts "
 "kun je ook gelijk toevoegen aan een van jouw klassen."
 
-#: app.py:1306
+#: app.py:1304
 msgid "tutorial_documentation_title"
 msgstr "Hedy documentatie"
 
-#: app.py:1306
+#: app.py:1304
 msgid "tutorial_documentation_message"
 msgstr ""
 "Hier vindt je een uitgebreidere documentatie met tips en tricks voor het "
 "gebruik van Hedy in de klas."
 
-#: app.py:1308
+#: app.py:1306
 msgid "teacher_tutorial_end_message"
 msgstr "Klik op 'volgende stap' om als leraar aan de slag te gaan met Hedy!"
 
-#: app.py:1318
+#: app.py:1316
 msgid "tutorial_code_snippet"
 msgstr ""
 "print Hallo wereld!\n"
 "print Ik volg de Hedy tutorial"
 
-#: app.py:1322 app.py:1332
+#: app.py:1320 app.py:1330
 msgid "invalid_tutorial_step"
 msgstr "Dit is geen geldige tutorial stap, probeer het opnieuw."
 
-#: app.py:1489 website/auth.py:278 website/auth.py:333 website/auth.py:469
+#: app.py:1487 website/auth.py:278 website/auth.py:333 website/auth.py:469
 #: website/auth.py:494 website/auth.py:524 website/auth.py:637
 #: website/auth.py:675 website/auth.py:722 website/auth.py:749
 #: website/quiz.py:43 website/quiz.py:69 website/teacher.py:88
@@ -351,27 +351,27 @@ msgstr "Dit is geen geldige tutorial stap, probeer het opnieuw."
 msgid "ajax_error"
 msgstr "Er is een fout opgetreden, probeer het nog eens."
 
-#: app.py:1492
+#: app.py:1490
 msgid "image_invalid"
 msgstr "Jouw gekozen profielfoto is ongeldig."
 
-#: app.py:1494
+#: app.py:1492
 msgid "personal_text_invalid"
 msgstr "Jouw persoonlijke tekst is ongeldig."
 
-#: app.py:1496 app.py:1502
+#: app.py:1494 app.py:1500
 msgid "favourite_program_invalid"
 msgstr "Jouw gekozen favoriete programma is ongeldig."
 
-#: app.py:1516 app.py:1517
+#: app.py:1514 app.py:1515
 msgid "public_profile_updated"
 msgstr "Je openbare profiel is aangepast."
 
-#: app.py:1554 app.py:1579
+#: app.py:1552 app.py:1577
 msgid "user_not_private"
 msgstr "Deze gebruiker bestaat niet of heeft geen openbaar profiel"
 
-#: app.py:1587
+#: app.py:1585
 msgid "invalid_teacher_invitation_code"
 msgstr ""
 "Deze leerkrachtenuitnodigingscode is niet geldig. Als je een nieuwe "
@@ -675,126 +675,126 @@ msgstr "Spiekbriefje"
 msgid "back_to_class"
 msgstr "Ga terug naar klas"
 
-#: templates/class-overview.html:13 templates/for-teachers.html:35
+#: templates/class-overview.html:14 templates/for-teachers.html:35
 msgid "class_name_prompt"
 msgstr "Vul de naam in van de klas"
 
-#: templates/class-overview.html:19 templates/class-overview.html:66
+#: templates/class-overview.html:20 templates/class-overview.html:71
 #: templates/create-accounts.html:16 templates/highscores.html:25
 #: templates/login.html:12 templates/profile.html:89 templates/recover.html:8
 #: templates/signup.html:10
 msgid "username"
 msgstr "Gebruikersnaam"
 
-#: templates/class-overview.html:20
+#: templates/class-overview.html:21
 msgid "last_login"
 msgstr "Laatste login"
 
-#: templates/class-overview.html:21
+#: templates/class-overview.html:22
 msgid "highest_level_reached"
 msgstr "Hoogste level"
 
-#: templates/class-overview.html:22
+#: templates/class-overview.html:23
 msgid "number_programs"
 msgstr "Aantal programma's"
 
-#: templates/class-overview.html:23
+#: templates/class-overview.html:24
 msgid "programs"
 msgstr "Programma's"
 
-#: templates/class-overview.html:24 templates/create-accounts.html:17
+#: templates/class-overview.html:25 templates/create-accounts.html:17
 #: templates/login.html:15 templates/reset.html:8 templates/signup.html:19
 msgid "password"
 msgstr "Wachtwoord"
 
-#: templates/class-overview.html:25 templates/class-overview.html:69
+#: templates/class-overview.html:26 templates/class-overview.html:74
 #: templates/customize-adventure.html:52 templates/for-teachers.html:46
 #: templates/for-teachers.html:56
 msgid "remove"
 msgstr "Verwijder"
 
-#: templates/class-overview.html:35
+#: templates/class-overview.html:36
 msgid "page"
 msgstr "pagina"
 
-#: templates/class-overview.html:36
+#: templates/class-overview.html:37
 msgid "enter_password"
 msgstr "Vul een nieuw wachtwoord in voor"
 
-#: templates/class-overview.html:36
+#: templates/class-overview.html:37
 msgid "password_change_prompt"
 msgstr "Weet je zeker dat je dit wachtwoord wilt wijzigen?"
 
-#: templates/class-overview.html:37
+#: templates/class-overview.html:38
 msgid "remove_student_prompt"
 msgstr "Weet je zeker dat je deze leerling uit de klas wilt verwijderen?"
 
-#: templates/class-overview.html:44
+#: templates/class-overview.html:46
 msgid "add_students"
 msgstr "Leerlingen toevoegen"
 
-#: templates/class-overview.html:45 templates/customize-class.html:5
+#: templates/class-overview.html:47 templates/customize-class.html:5
 msgid "customize_class"
 msgstr "Klas personaliseren"
 
-#: templates/class-overview.html:46
+#: templates/class-overview.html:48
 msgid "class_stats"
 msgstr "Klas statistieken"
 
-#: templates/class-overview.html:47
+#: templates/class-overview.html:49
 msgid "class_logs"
 msgstr "Logs"
 
-#: templates/class-overview.html:48 templates/customize-adventure.html:59
+#: templates/class-overview.html:52 templates/customize-adventure.html:59
 msgid "back_to_teachers_page"
 msgstr "Terug naar lerarenpagina"
 
-#: templates/class-overview.html:49
+#: templates/class-overview.html:53
 msgid "delete_class_prompt"
 msgstr "Weet je zeker dat je deze klas wilt verwijderen?"
 
-#: templates/class-overview.html:49
+#: templates/class-overview.html:53
 msgid "delete_class"
 msgstr "Klas permanent verwijderen"
 
-#: templates/class-overview.html:52
+#: templates/class-overview.html:57
 #, fuzzy
 msgid "add_students_options"
 msgstr "Maak leerling accounts"
 
-#: templates/class-overview.html:54
+#: templates/class-overview.html:59
 msgid "copy_link_success"
 msgstr "Inschrijflink succesvol gekopieerd naar klembord"
 
-#: templates/class-overview.html:54
+#: templates/class-overview.html:59
 msgid "copy_join_link"
 msgstr "Kopieer inschrijflink"
 
-#: templates/class-overview.html:55
+#: templates/class-overview.html:60
 msgid "invite_prompt"
 msgstr "Vul een gebruikersnaam in"
 
-#: templates/class-overview.html:55
+#: templates/class-overview.html:60
 msgid "invite_by_username"
 msgstr "Uitnodigen bij gebruikersnaam"
 
-#: templates/class-overview.html:56 templates/create-accounts.html:45
+#: templates/class-overview.html:61 templates/create-accounts.html:45
 msgid "create_accounts"
 msgstr "Accounts aanmaken"
 
-#: templates/class-overview.html:61
+#: templates/class-overview.html:66
 msgid "pending_invites"
 msgstr "Openstaande uitnodigingen"
 
-#: templates/class-overview.html:67
+#: templates/class-overview.html:72
 msgid "invite_date"
 msgstr "Uitnodigingsdatum"
 
-#: templates/class-overview.html:68
+#: templates/class-overview.html:73
 msgid "expiration_date"
 msgstr "Vervaldatum"
 
-#: templates/class-overview.html:78 templates/profile.html:16
+#: templates/class-overview.html:83 templates/profile.html:16
 msgid "delete_invite_prompt"
 msgstr "Weet je zeker dat je deze uitnodiging wilt verwijderen?"
 
@@ -1193,10 +1193,9 @@ msgstr "Jouw class"
 msgid "achievements"
 msgstr "badges"
 
-#: templates/highscores.html:27 templates/learn-more.html:22
-#: templates/profile.html:131 templates/signup.html:52
-msgid "country"
-msgstr "Land waarin je woont"
+#: templates/highscores.html:27
+msgid "country_title"
+msgstr "Land"
 
 #: templates/highscores.html:28 templates/landing-page.html:88
 #: templates/public-page.html:50
@@ -1438,6 +1437,11 @@ msgstr "Voornaam"
 #: templates/learn-more.html:18
 msgid "lastname"
 msgstr "Achternaam"
+
+#: templates/learn-more.html:22 templates/profile.html:131
+#: templates/signup.html:52
+msgid "country"
+msgstr "Land waarin je woont"
 
 #: templates/learn-more.html:31
 msgid "subscribe"

--- a/translations/pl/LC_MESSAGES/messages.po
+++ b/translations/pl/LC_MESSAGES/messages.po
@@ -3,17 +3,17 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-28 18:38+0300\n"
+"POT-Creation-Date: 2022-06-29 14:20+0200\n"
 "PO-Revision-Date: 2022-06-28 13:25+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: pl\n"
 "Language-Team: pl <LL@li.org>\n"
 "Plural-Forms: nplurals=3; plural=n==1 ? 0 : n%10>=2 && n%10<=4 && "
-"(n%100<10 || n%100>=20) ? 1 : 2\n"
+"(n%100<10 || n%100>=20) ? 1 : 2;\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.9.1\n"
+"Generated-By: Babel 2.10.1\n"
 
 #: app.py:417
 #, fuzzy
@@ -24,7 +24,7 @@ msgstr "Ten program zawiera błędy, czy na pewno chcesz go udostępnić?"
 msgid "title_achievements"
 msgstr "Hedy - Moje osiągnięcia"
 
-#: app.py:644 app.py:748 app.py:1090 website/teacher.py:361
+#: app.py:644 app.py:746 app.py:1088 website/teacher.py:361
 #: website/teacher.py:372
 msgid "not_teacher"
 msgstr "Wygląda na to, że nie jesteś nauczycielem!"
@@ -33,11 +33,11 @@ msgstr "Wygląda na to, że nie jesteś nauczycielem!"
 msgid "not_enrolled"
 msgstr "Wygląda na to, że nie jesteś członkiem tej klasy!"
 
-#: app.py:686
+#: app.py:684
 msgid "title_programs"
 msgstr "Hedy - Moje programy"
 
-#: app.py:696 app.py:706 app.py:710 app.py:725 app.py:1005 app.py:1550
+#: app.py:694 app.py:704 app.py:708 app.py:723 app.py:1003 app.py:1548
 #: website/admin.py:17 website/admin.py:24 website/admin.py:92
 #: website/admin.py:111 website/admin.py:129 website/admin.py:136
 #: website/admin.py:144 website/auth.py:716 website/auth.py:743
@@ -45,317 +45,317 @@ msgstr "Hedy - Moje programy"
 msgid "unauthorized"
 msgstr "Nie masz dostępu do tej strony"
 
-#: app.py:762 app.py:1107
+#: app.py:760 app.py:1105
 msgid "title_for-teacher"
 msgstr "Hedy - Dla nauczycieli"
 
-#: app.py:779 app.py:781 app.py:923 app.py:945 app.py:947
+#: app.py:777 app.py:779 app.py:921 app.py:943 app.py:945
 msgid "no_such_level"
 msgstr "Nie ma takiego poziomu!"
 
-#: app.py:789 app.py:796 app.py:877 app.py:883
+#: app.py:787 app.py:794 app.py:875 app.py:881
 msgid "no_such_program"
 msgstr "Nie ma takiego programu!"
 
-#: app.py:819
+#: app.py:817
 #, fuzzy
 msgid "level_not_class"
 msgstr "Ten poziom nie jest jeszcze dostępny w twojej klasie"
 
-#: app.py:928 website/teacher.py:421 website/teacher.py:437
+#: app.py:926 website/teacher.py:421 website/teacher.py:437
 #: website/teacher.py:466 website/teacher.py:492
 msgid "no_such_adventure"
 msgstr "Ta przygoda nie istnieje!"
 
-#: app.py:956 app.py:1209
+#: app.py:954 app.py:1207
 msgid "page_not_found"
 msgstr "Nie możemy odnaleźć tej strony!"
 
-#: app.py:976
+#: app.py:974
 msgid "title_signup"
 msgstr "Hedy - Utwórz konto"
 
-#: app.py:983
+#: app.py:981
 msgid "title_login"
 msgstr "Hedy - Logowanie"
 
-#: app.py:990
+#: app.py:988
 msgid "title_recover"
 msgstr "Hedy - Odzyskaj konto"
 
-#: app.py:1006
+#: app.py:1004
 msgid "title_reset"
 msgstr "Hedy - Zresetuj hasło"
 
-#: app.py:1032
+#: app.py:1030
 msgid "title_my-profile"
 msgstr "Hedy - Moje konto"
 
-#: app.py:1048
+#: app.py:1046
 msgid "title_learn-more"
 msgstr "Hedy - Dowiedz się więcej"
 
-#: app.py:1054
+#: app.py:1052
 #, fuzzy
 msgid "title_privacy"
 msgstr "Hedy - Polityka prywatności"
 
-#: app.py:1064
+#: app.py:1062
 msgid "title_start"
 msgstr "Hedy - Stopniowany język programowania"
 
-#: app.py:1082
+#: app.py:1080
 #, fuzzy
 msgid "title_landing-page"
 msgstr "Witaj w Hedy!"
 
-#: app.py:1200
+#: app.py:1198
 #, fuzzy
 msgid "title_explore"
 msgstr "Hedy - Odkrywaj"
 
-#: app.py:1221 app.py:1226
+#: app.py:1219 app.py:1224
 #, fuzzy
 msgid "no_such_highscore"
 msgstr "Nie ma takiego poziomu!"
 
-#: app.py:1255 app.py:1257
+#: app.py:1253 app.py:1255
 #, fuzzy
 msgid "translate_error"
 msgstr ""
 "Something went wrong while translating the code. Try running the code to "
 "see if it has an error. Code with errors can not be translated."
 
-#: app.py:1262 app.py:1296
+#: app.py:1260 app.py:1294
 msgid "tutorial_start_title"
 msgstr "Witaj w Hedy!"
 
-#: app.py:1262
+#: app.py:1260
 #, fuzzy
 msgid "tutorial_start_message"
 msgstr "W tym samouczku wytłumaczymy Ci wszystkie funkcje Hedy'ego krok po kroku."
 
-#: app.py:1264
+#: app.py:1262
 #, fuzzy
 msgid "tutorial_editor_title"
 msgstr "Edytor kodu"
 
-#: app.py:1264
+#: app.py:1262
 msgid "tutorial_editor_message"
 msgstr ""
 "W tym oknie będziesz pisał swój kod. Spróbuj napisać coś w miejsce "
 "podkreślników!"
 
-#: app.py:1266
+#: app.py:1264
 #, fuzzy
 msgid "tutorial_output_title"
 msgstr "Widok odpowiedzi"
 
-#: app.py:1266
+#: app.py:1264
 msgid "tutorial_output_message"
 msgstr "Wynik wykonania twojego kodu pokaże się tutaj."
 
-#: app.py:1268
+#: app.py:1266
 #, fuzzy
 msgid "tutorial_run_title"
 msgstr "Przycisk uruchamiania"
 
-#: app.py:1268
+#: app.py:1266
 #, fuzzy
 msgid "tutorial_run_message"
 msgstr ""
 "Klikając w ten przycisk, uruchomisz swój program. Spróbujemy w następnym "
 "kroku?"
 
-#: app.py:1270
+#: app.py:1268
 #, fuzzy
 msgid "tutorial_tryit_title"
 msgstr "Spróbuj!"
 
-#: app.py:1270
+#: app.py:1268
 #, fuzzy
 msgid "tutorial_tryit_message"
 msgstr ""
 "Uruchom program i naciśnij przycisk 'następny krok', kiedy będziesz "
 "gotowy."
 
-#: app.py:1272
+#: app.py:1270
 msgid "tutorial_speakaloud_title"
 msgstr "Przeczytaj program"
 
-#: app.py:1272
+#: app.py:1270
 #, fuzzy
 msgid "tutorial_speakaloud_message"
 msgstr ""
 "Wybierz głos z listy poniżej przycisku uruchamiania, by twój program "
 "został przeczytany."
 
-#: app.py:1274
+#: app.py:1272
 #, fuzzy
 msgid "tutorial_speakaloud_run_title"
 msgstr "Uruchom i posłuchaj"
 
-#: app.py:1274
+#: app.py:1272
 #, fuzzy
 msgid "tutorial_speakaloud_run_message"
 msgstr "Wybierz głos z listy i uruchom twój program jeszcze raz."
 
-#: app.py:1276
+#: app.py:1274
 #, fuzzy
 msgid "tutorial_nextlevel_title"
 msgstr "Do następnego poziomu"
 
-#: app.py:1276
+#: app.py:1274
 #, fuzzy
 msgid "tutorial_nextlevel_message"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1278
+#: app.py:1276
 #, fuzzy
 msgid "tutorial_leveldefault_title"
 msgstr "Level explanation"
 
-#: app.py:1278
+#: app.py:1276
 #, fuzzy
 msgid "tutorial_leveldefault_message"
 msgstr ""
 "The first tab always contains the level explanation. In each level new "
 "commands will be explained here."
 
-#: app.py:1280
+#: app.py:1278
 #, fuzzy
 msgid "tutorial_adventures_title"
 msgstr "Customize adventure"
 
-#: app.py:1280
+#: app.py:1278
 #, fuzzy
 msgid "tutorial_adventures_message"
 msgstr "Customize adventure"
 
-#: app.py:1282
+#: app.py:1280
 #, fuzzy
 msgid "tutorial_quiz_title"
 msgstr "Quiz"
 
-#: app.py:1282
+#: app.py:1280
 #, fuzzy
 msgid "tutorial_quiz_message"
 msgstr ""
 "At the end of each level you can make the quiz. This way you can verify "
 "if you understand everything."
 
-#: app.py:1284
+#: app.py:1282
 #, fuzzy
 msgid "tutorial_saveshare_title"
 msgstr "Saving & sharing"
 
-#: app.py:1284
+#: app.py:1282
 #, fuzzy
 msgid "tutorial_saveshare_message"
 msgstr "You can save and share all your created programs with other Hedy users."
 
-#: app.py:1286
+#: app.py:1284
 #, fuzzy
 msgid "tutorial_cheatsheet_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1286
+#: app.py:1284
 #, fuzzy
 msgid "tutorial_cheatsheet_message"
 msgstr ""
 "If you forgot a command you can always use the cheatsheet. It shows a "
 "list of all commands you can use in the current level."
 
-#: app.py:1288 app.py:1308
+#: app.py:1286 app.py:1306
 #, fuzzy
 msgid "tutorial_end_title"
 msgstr "The end!"
 
-#: app.py:1288
+#: app.py:1286
 #, fuzzy
 msgid "tutorial_end_message"
 msgstr "Click on 'next step' to really start coding with Hedy!"
 
-#: app.py:1290 app.py:1310
+#: app.py:1288 app.py:1308
 #, fuzzy
 msgid "tutorial_title_not_found"
 msgstr "Nie możemy odnaleźć tej strony!"
 
-#: app.py:1290 app.py:1310
+#: app.py:1288 app.py:1308
 #, fuzzy
 msgid "tutorial_message_not_found"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1296
+#: app.py:1294
 #, fuzzy
 msgid "teacher_tutorial_start_message"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1298
+#: app.py:1296
 #, fuzzy
 msgid "tutorial_class_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1298
+#: app.py:1296
 #, fuzzy
 msgid "tutorial_class_message"
 msgstr "Customize adventure"
 
-#: app.py:1300
+#: app.py:1298
 #, fuzzy
 msgid "tutorial_customize_class_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1300
+#: app.py:1298
 #, fuzzy
 msgid "tutorial_customize_class_message"
 msgstr "Customize adventure"
 
-#: app.py:1302
+#: app.py:1300
 #, fuzzy
 msgid "tutorial_own_adventures_title"
 msgstr "Customize adventure"
 
-#: app.py:1302
+#: app.py:1300
 #, fuzzy
 msgid "tutorial_own_adventures_message"
 msgstr "Customize adventure"
 
-#: app.py:1304
+#: app.py:1302
 #, fuzzy
 msgid "tutorial_accounts_title"
 msgstr "Customize adventure"
 
-#: app.py:1304
+#: app.py:1302
 #, fuzzy
 msgid "tutorial_accounts_message"
 msgstr "Customize adventure"
 
-#: app.py:1306
+#: app.py:1304
 #, fuzzy
 msgid "tutorial_documentation_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1306
+#: app.py:1304
 #, fuzzy
 msgid "tutorial_documentation_message"
 msgstr "Customize adventure"
 
-#: app.py:1308
+#: app.py:1306
 #, fuzzy
 msgid "teacher_tutorial_end_message"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1318
+#: app.py:1316
 #, fuzzy
 msgid "tutorial_code_snippet"
 msgstr "Hide cheatsheet"
 
-#: app.py:1322 app.py:1332
+#: app.py:1320 app.py:1330
 msgid "invalid_tutorial_step"
 msgstr ""
 
-#: app.py:1489 website/auth.py:278 website/auth.py:333 website/auth.py:469
+#: app.py:1487 website/auth.py:278 website/auth.py:333 website/auth.py:469
 #: website/auth.py:494 website/auth.py:524 website/auth.py:637
 #: website/auth.py:675 website/auth.py:722 website/auth.py:749
 #: website/quiz.py:43 website/quiz.py:69 website/teacher.py:88
@@ -365,32 +365,32 @@ msgstr ""
 msgid "ajax_error"
 msgstr "Wystąpił błąd, proszę spróbować ponownie."
 
-#: app.py:1492
+#: app.py:1490
 #, fuzzy
 msgid "image_invalid"
 msgstr "Your chosen image is invalid."
 
-#: app.py:1494
+#: app.py:1492
 #, fuzzy
 msgid "personal_text_invalid"
 msgstr "Your personal text is invalid."
 
-#: app.py:1496 app.py:1502
+#: app.py:1494 app.py:1500
 #, fuzzy
 msgid "favourite_program_invalid"
 msgstr "Your chosen favourite program is invalid."
 
-#: app.py:1516 app.py:1517
+#: app.py:1514 app.py:1515
 #, fuzzy
 msgid "public_profile_updated"
 msgstr "Public profile updated."
 
-#: app.py:1554 app.py:1579
+#: app.py:1552 app.py:1577
 #, fuzzy
 msgid "user_not_private"
 msgstr "This user doesn't exist or doesn't have a public profile"
 
-#: app.py:1587
+#: app.py:1585
 #, fuzzy
 msgid "invalid_teacher_invitation_code"
 msgstr ""
@@ -732,140 +732,140 @@ msgstr "Hide cheatsheet"
 msgid "back_to_class"
 msgstr "Powróć do klasy"
 
-#: templates/class-overview.html:13 templates/for-teachers.html:35
+#: templates/class-overview.html:14 templates/for-teachers.html:35
 #, fuzzy
 msgid "class_name_prompt"
 msgstr "Please enter the name of the class"
 
-#: templates/class-overview.html:19 templates/class-overview.html:66
+#: templates/class-overview.html:20 templates/class-overview.html:71
 #: templates/create-accounts.html:16 templates/highscores.html:25
 #: templates/login.html:12 templates/profile.html:89 templates/recover.html:8
 #: templates/signup.html:10
 msgid "username"
 msgstr "Nazwa użytkownika"
 
-#: templates/class-overview.html:20
+#: templates/class-overview.html:21
 #, fuzzy
 msgid "last_login"
 msgstr "Last login"
 
-#: templates/class-overview.html:21
+#: templates/class-overview.html:22
 msgid "highest_level_reached"
 msgstr "Najwyższy osiągnięty poziom"
 
-#: templates/class-overview.html:22
+#: templates/class-overview.html:23
 msgid "number_programs"
 msgstr "Liczba programów"
 
-#: templates/class-overview.html:23
+#: templates/class-overview.html:24
 msgid "programs"
 msgstr "Programy"
 
-#: templates/class-overview.html:24 templates/create-accounts.html:17
+#: templates/class-overview.html:25 templates/create-accounts.html:17
 #: templates/login.html:15 templates/reset.html:8 templates/signup.html:19
 msgid "password"
 msgstr "Hasło"
 
-#: templates/class-overview.html:25 templates/class-overview.html:69
+#: templates/class-overview.html:26 templates/class-overview.html:74
 #: templates/customize-adventure.html:52 templates/for-teachers.html:46
 #: templates/for-teachers.html:56
 msgid "remove"
 msgstr "Usuń"
 
-#: templates/class-overview.html:35
+#: templates/class-overview.html:36
 msgid "page"
 msgstr "strona"
 
-#: templates/class-overview.html:36
+#: templates/class-overview.html:37
 #, fuzzy
 msgid "enter_password"
 msgstr "Enter a new password for"
 
-#: templates/class-overview.html:36
+#: templates/class-overview.html:37
 #, fuzzy
 msgid "password_change_prompt"
 msgstr "Are you sure you want to change this password?"
 
-#: templates/class-overview.html:37
+#: templates/class-overview.html:38
 #, fuzzy
 msgid "remove_student_prompt"
 msgstr "Are you sure you want to remove the student from the class?"
 
-#: templates/class-overview.html:44
+#: templates/class-overview.html:46
 #, fuzzy
 msgid "add_students"
 msgstr "students"
 
-#: templates/class-overview.html:45 templates/customize-class.html:5
+#: templates/class-overview.html:47 templates/customize-class.html:5
 #, fuzzy
 msgid "customize_class"
 msgstr "Customize class"
 
-#: templates/class-overview.html:46
+#: templates/class-overview.html:48
 msgid "class_stats"
 msgstr "Statystyki klasy"
 
-#: templates/class-overview.html:47
+#: templates/class-overview.html:49
 #, fuzzy
 msgid "class_logs"
 msgstr "Last login"
 
-#: templates/class-overview.html:48 templates/customize-adventure.html:59
+#: templates/class-overview.html:52 templates/customize-adventure.html:59
 #, fuzzy
 msgid "back_to_teachers_page"
 msgstr "Go back to teachers page"
 
-#: templates/class-overview.html:49
+#: templates/class-overview.html:53
 #, fuzzy
 msgid "delete_class_prompt"
 msgstr "Are you sure you want to delete the class?"
 
-#: templates/class-overview.html:49
+#: templates/class-overview.html:53
 #, fuzzy
 msgid "delete_class"
 msgstr "Delete class permanently"
 
-#: templates/class-overview.html:52
+#: templates/class-overview.html:57
 #, fuzzy
 msgid "add_students_options"
 msgstr "Create student accounts"
 
-#: templates/class-overview.html:54
+#: templates/class-overview.html:59
 #, fuzzy
 msgid "copy_link_success"
 msgstr "Copy link to share"
 
-#: templates/class-overview.html:54
+#: templates/class-overview.html:59
 #, fuzzy
 msgid "copy_join_link"
 msgstr "Please copy and paste this link into a new tab:"
 
-#: templates/class-overview.html:55
+#: templates/class-overview.html:60
 msgid "invite_prompt"
 msgstr "Wprowadź nazwę użytkownika"
 
-#: templates/class-overview.html:55
+#: templates/class-overview.html:60
 #, fuzzy
 msgid "invite_by_username"
 msgstr "Wszystkie nazwy użytkowników muszą być unikalne."
 
-#: templates/class-overview.html:56 templates/create-accounts.html:45
+#: templates/class-overview.html:61 templates/create-accounts.html:45
 msgid "create_accounts"
 msgstr "Utwórz wiele kont"
 
-#: templates/class-overview.html:61
+#: templates/class-overview.html:66
 msgid "pending_invites"
 msgstr "Oczekujące zaproszenia"
 
-#: templates/class-overview.html:67
+#: templates/class-overview.html:72
 msgid "invite_date"
 msgstr "Data zaproszenia"
 
-#: templates/class-overview.html:68
+#: templates/class-overview.html:73
 msgid "expiration_date"
 msgstr "Data wygaśnięcia"
 
-#: templates/class-overview.html:78 templates/profile.html:16
+#: templates/class-overview.html:83 templates/profile.html:16
 #, fuzzy
 msgid "delete_invite_prompt"
 msgstr "Are you sure you want to remove this class invitation?"
@@ -1300,10 +1300,10 @@ msgstr "Moje klasy"
 msgid "achievements"
 msgstr "osiągnięcia"
 
-#: templates/highscores.html:27 templates/learn-more.html:22
-#: templates/profile.html:131 templates/signup.html:52
-msgid "country"
-msgstr "Kraj"
+#: templates/highscores.html:27
+#, fuzzy
+msgid "country_title"
+msgstr "Please select a valid country."
 
 #: templates/highscores.html:28 templates/landing-page.html:88
 #: templates/public-page.html:50
@@ -1582,6 +1582,11 @@ msgstr "Imię"
 #: templates/learn-more.html:18
 msgid "lastname"
 msgstr "Nazwisko"
+
+#: templates/learn-more.html:22 templates/profile.html:131
+#: templates/signup.html:52
+msgid "country"
+msgstr "Kraj"
 
 #: templates/learn-more.html:31
 #, fuzzy

--- a/translations/pt_BR/LC_MESSAGES/messages.po
+++ b/translations/pt_BR/LC_MESSAGES/messages.po
@@ -3,16 +3,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-28 18:38+0300\n"
+"POT-Creation-Date: 2022-06-29 14:20+0200\n"
 "PO-Revision-Date: 2022-06-28 13:25+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: pt_BR\n"
 "Language-Team: pt_BR <LL@li.org>\n"
-"Plural-Forms: nplurals=2; plural=n > 1\n"
+"Plural-Forms: nplurals=2; plural=n > 1;\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.9.1\n"
+"Generated-By: Babel 2.10.1\n"
 
 #: app.py:417
 #, fuzzy
@@ -24,7 +24,7 @@ msgstr "This program contains an error, are you sure you want to share it?"
 msgid "title_achievements"
 msgstr "Hedy - My achievements"
 
-#: app.py:644 app.py:748 app.py:1090 website/teacher.py:361
+#: app.py:644 app.py:746 app.py:1088 website/teacher.py:361
 #: website/teacher.py:372
 #, fuzzy
 msgid "not_teacher"
@@ -35,12 +35,12 @@ msgstr "Looks like you are not a teacher!"
 msgid "not_enrolled"
 msgstr "Looks like you are not in this class!"
 
-#: app.py:686
+#: app.py:684
 #, fuzzy
 msgid "title_programs"
 msgstr "Hedy - My programs"
 
-#: app.py:696 app.py:706 app.py:710 app.py:725 app.py:1005 app.py:1550
+#: app.py:694 app.py:704 app.py:708 app.py:723 app.py:1003 app.py:1548
 #: website/admin.py:17 website/admin.py:24 website/admin.py:92
 #: website/admin.py:111 website/admin.py:129 website/admin.py:136
 #: website/admin.py:144 website/auth.py:716 website/auth.py:743
@@ -49,325 +49,325 @@ msgstr "Hedy - My programs"
 msgid "unauthorized"
 msgstr "You don't have access rights for this page"
 
-#: app.py:762 app.py:1107
+#: app.py:760 app.py:1105
 #, fuzzy
 msgid "title_for-teacher"
 msgstr "Hedy - For teachers"
 
-#: app.py:779 app.py:781 app.py:923 app.py:945 app.py:947
+#: app.py:777 app.py:779 app.py:921 app.py:943 app.py:945
 #, fuzzy
 msgid "no_such_level"
 msgstr "No such Hedy level!"
 
-#: app.py:789 app.py:796 app.py:877 app.py:883
+#: app.py:787 app.py:794 app.py:875 app.py:881
 #, fuzzy
 msgid "no_such_program"
 msgstr "No such Hedy program!"
 
-#: app.py:819
+#: app.py:817
 #, fuzzy
 msgid "level_not_class"
 msgstr "You're in a class where this level has not been made available yet"
 
-#: app.py:928 website/teacher.py:421 website/teacher.py:437
+#: app.py:926 website/teacher.py:421 website/teacher.py:437
 #: website/teacher.py:466 website/teacher.py:492
 #, fuzzy
 msgid "no_such_adventure"
 msgstr "This adventure doesn't exist!"
 
-#: app.py:956 app.py:1209
+#: app.py:954 app.py:1207
 #, fuzzy
 msgid "page_not_found"
 msgstr "We could not find that page!"
 
-#: app.py:976
+#: app.py:974
 #, fuzzy
 msgid "title_signup"
 msgstr "Hedy - Create an account"
 
-#: app.py:983
+#: app.py:981
 #, fuzzy
 msgid "title_login"
 msgstr "Hedy - Login"
 
-#: app.py:990
+#: app.py:988
 #, fuzzy
 msgid "title_recover"
 msgstr "Hedy - Recover account"
 
-#: app.py:1006
+#: app.py:1004
 #, fuzzy
 msgid "title_reset"
 msgstr "Hedy - Reset password"
 
-#: app.py:1032
+#: app.py:1030
 #, fuzzy
 msgid "title_my-profile"
 msgstr "Hedy - My account"
 
-#: app.py:1048
+#: app.py:1046
 #, fuzzy
 msgid "title_learn-more"
 msgstr "Hedy - Learn more"
 
-#: app.py:1054
+#: app.py:1052
 #, fuzzy
 msgid "title_privacy"
 msgstr "Hedy - Privacy terms"
 
-#: app.py:1064
+#: app.py:1062
 #, fuzzy
 msgid "title_start"
 msgstr "Hedy - A gradual programming language"
 
-#: app.py:1082
+#: app.py:1080
 #, fuzzy
 msgid "title_landing-page"
 msgstr "Welcome to Hedy!"
 
-#: app.py:1200
+#: app.py:1198
 #, fuzzy
 msgid "title_explore"
 msgstr "Hedy - Explore"
 
-#: app.py:1221 app.py:1226
+#: app.py:1219 app.py:1224
 #, fuzzy
 msgid "no_such_highscore"
 msgstr "No such Hedy level!"
 
-#: app.py:1255 app.py:1257
+#: app.py:1253 app.py:1255
 #, fuzzy
 msgid "translate_error"
 msgstr ""
 "Something went wrong while translating the code. Try running the code to "
 "see if it has an error. Code with errors can not be translated."
 
-#: app.py:1262 app.py:1296
+#: app.py:1260 app.py:1294
 #, fuzzy
 msgid "tutorial_start_title"
 msgstr "Welcome to Hedy!"
 
-#: app.py:1262
+#: app.py:1260
 #, fuzzy
 msgid "tutorial_start_message"
 msgstr "In this tutorial we will explain all the Hedy features step-by-step."
 
-#: app.py:1264
+#: app.py:1262
 #, fuzzy
 msgid "tutorial_editor_title"
 msgstr "The code editor"
 
-#: app.py:1264
+#: app.py:1262
 #, fuzzy
 msgid "tutorial_editor_message"
 msgstr "In this window you write all the code, try typing something!"
 
-#: app.py:1266
+#: app.py:1264
 #, fuzzy
 msgid "tutorial_output_title"
 msgstr "The output window"
 
-#: app.py:1266
+#: app.py:1264
 #, fuzzy
 msgid "tutorial_output_message"
 msgstr "The result of the code you execute will be shown here"
 
-#: app.py:1268
+#: app.py:1266
 #, fuzzy
 msgid "tutorial_run_title"
 msgstr "The run button"
 
-#: app.py:1268
+#: app.py:1266
 #, fuzzy
 msgid "tutorial_run_message"
 msgstr "With this button you can run your program! Shall we give it a try?"
 
-#: app.py:1270
+#: app.py:1268
 #, fuzzy
 msgid "tutorial_tryit_title"
 msgstr "Try it out!"
 
-#: app.py:1270
+#: app.py:1268
 #, fuzzy
 msgid "tutorial_tryit_message"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1272
+#: app.py:1270
 #, fuzzy
 msgid "tutorial_speakaloud_title"
 msgstr "The end!"
 
-#: app.py:1272
+#: app.py:1270
 #, fuzzy
 msgid "tutorial_speakaloud_message"
 msgstr "Click on 'next step' to really start coding with Hedy!"
 
-#: app.py:1274
+#: app.py:1272
 #, fuzzy
 msgid "tutorial_speakaloud_run_title"
 msgstr "The end!"
 
-#: app.py:1274
+#: app.py:1272
 #, fuzzy
 msgid "tutorial_speakaloud_run_message"
 msgstr "Click on 'next step' to really start coding with Hedy!"
 
-#: app.py:1276
+#: app.py:1274
 #, fuzzy
 msgid "tutorial_nextlevel_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1276
+#: app.py:1274
 #, fuzzy
 msgid "tutorial_nextlevel_message"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1278
+#: app.py:1276
 #, fuzzy
 msgid "tutorial_leveldefault_title"
 msgstr "Level explanation"
 
-#: app.py:1278
+#: app.py:1276
 #, fuzzy
 msgid "tutorial_leveldefault_message"
 msgstr ""
 "The first tab always contains the level explanation. In each level new "
 "commands will be explained here."
 
-#: app.py:1280
+#: app.py:1278
 #, fuzzy
 msgid "tutorial_adventures_title"
 msgstr "Customize adventure"
 
-#: app.py:1280
+#: app.py:1278
 #, fuzzy
 msgid "tutorial_adventures_message"
 msgstr "Customize adventure"
 
-#: app.py:1282
+#: app.py:1280
 #, fuzzy
 msgid "tutorial_quiz_title"
 msgstr "Quiz"
 
-#: app.py:1282
+#: app.py:1280
 #, fuzzy
 msgid "tutorial_quiz_message"
 msgstr ""
 "At the end of each level you can make the quiz. This way you can verify "
 "if you understand everything."
 
-#: app.py:1284
+#: app.py:1282
 #, fuzzy
 msgid "tutorial_saveshare_title"
 msgstr "Saving & sharing"
 
-#: app.py:1284
+#: app.py:1282
 #, fuzzy
 msgid "tutorial_saveshare_message"
 msgstr "You can save and share all your created programs with other Hedy users."
 
-#: app.py:1286
+#: app.py:1284
 #, fuzzy
 msgid "tutorial_cheatsheet_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1286
+#: app.py:1284
 #, fuzzy
 msgid "tutorial_cheatsheet_message"
 msgstr ""
 "If you forgot a command you can always use the cheatsheet. It shows a "
 "list of all commands you can use in the current level."
 
-#: app.py:1288 app.py:1308
+#: app.py:1286 app.py:1306
 #, fuzzy
 msgid "tutorial_end_title"
 msgstr "The end!"
 
-#: app.py:1288
+#: app.py:1286
 #, fuzzy
 msgid "tutorial_end_message"
 msgstr "Click on 'next step' to really start coding with Hedy!"
 
-#: app.py:1290 app.py:1310
+#: app.py:1288 app.py:1308
 #, fuzzy
 msgid "tutorial_title_not_found"
 msgstr "We could not find that page!"
 
-#: app.py:1290 app.py:1310
+#: app.py:1288 app.py:1308
 #, fuzzy
 msgid "tutorial_message_not_found"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1296
+#: app.py:1294
 #, fuzzy
 msgid "teacher_tutorial_start_message"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1298
+#: app.py:1296
 #, fuzzy
 msgid "tutorial_class_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1298
+#: app.py:1296
 #, fuzzy
 msgid "tutorial_class_message"
 msgstr "Customize adventure"
 
-#: app.py:1300
+#: app.py:1298
 #, fuzzy
 msgid "tutorial_customize_class_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1300
+#: app.py:1298
 #, fuzzy
 msgid "tutorial_customize_class_message"
 msgstr "Customize adventure"
 
-#: app.py:1302
+#: app.py:1300
 #, fuzzy
 msgid "tutorial_own_adventures_title"
 msgstr "Customize adventure"
 
-#: app.py:1302
+#: app.py:1300
 #, fuzzy
 msgid "tutorial_own_adventures_message"
 msgstr "Customize adventure"
 
-#: app.py:1304
+#: app.py:1302
 #, fuzzy
 msgid "tutorial_accounts_title"
 msgstr "Customize adventure"
 
-#: app.py:1304
+#: app.py:1302
 #, fuzzy
 msgid "tutorial_accounts_message"
 msgstr "Customize adventure"
 
-#: app.py:1306
+#: app.py:1304
 #, fuzzy
 msgid "tutorial_documentation_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1306
+#: app.py:1304
 #, fuzzy
 msgid "tutorial_documentation_message"
 msgstr "Customize adventure"
 
-#: app.py:1308
+#: app.py:1306
 #, fuzzy
 msgid "teacher_tutorial_end_message"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1318
+#: app.py:1316
 #, fuzzy
 msgid "tutorial_code_snippet"
 msgstr "Hide cheatsheet"
 
-#: app.py:1322 app.py:1332
+#: app.py:1320 app.py:1330
 msgid "invalid_tutorial_step"
 msgstr ""
 
-#: app.py:1489 website/auth.py:278 website/auth.py:333 website/auth.py:469
+#: app.py:1487 website/auth.py:278 website/auth.py:333 website/auth.py:469
 #: website/auth.py:494 website/auth.py:524 website/auth.py:637
 #: website/auth.py:675 website/auth.py:722 website/auth.py:749
 #: website/quiz.py:43 website/quiz.py:69 website/teacher.py:88
@@ -377,32 +377,32 @@ msgstr ""
 msgid "ajax_error"
 msgstr "Ocorreu um erro, por favor, tente novamente."
 
-#: app.py:1492
+#: app.py:1490
 #, fuzzy
 msgid "image_invalid"
 msgstr "Your chosen image is invalid."
 
-#: app.py:1494
+#: app.py:1492
 #, fuzzy
 msgid "personal_text_invalid"
 msgstr "Your personal text is invalid."
 
-#: app.py:1496 app.py:1502
+#: app.py:1494 app.py:1500
 #, fuzzy
 msgid "favourite_program_invalid"
 msgstr "Your chosen favourite program is invalid."
 
-#: app.py:1516 app.py:1517
+#: app.py:1514 app.py:1515
 #, fuzzy
 msgid "public_profile_updated"
 msgstr "Public profile updated."
 
-#: app.py:1554 app.py:1579
+#: app.py:1552 app.py:1577
 #, fuzzy
 msgid "user_not_private"
 msgstr "This user doesn't exist or doesn't have a public profile"
 
-#: app.py:1587
+#: app.py:1585
 #, fuzzy
 msgid "invalid_teacher_invitation_code"
 msgstr ""
@@ -740,144 +740,144 @@ msgstr "Hide cheatsheet"
 msgid "back_to_class"
 msgstr "Go back to class"
 
-#: templates/class-overview.html:13 templates/for-teachers.html:35
+#: templates/class-overview.html:14 templates/for-teachers.html:35
 msgid "class_name_prompt"
 msgstr "Por favor, insira o nome da turma"
 
-#: templates/class-overview.html:19 templates/class-overview.html:66
+#: templates/class-overview.html:20 templates/class-overview.html:71
 #: templates/create-accounts.html:16 templates/highscores.html:25
 #: templates/login.html:12 templates/profile.html:89 templates/recover.html:8
 #: templates/signup.html:10
 msgid "username"
 msgstr "Usuário"
 
-#: templates/class-overview.html:20
+#: templates/class-overview.html:21
 msgid "last_login"
 msgstr "Último login"
 
-#: templates/class-overview.html:21
+#: templates/class-overview.html:22
 msgid "highest_level_reached"
 msgstr "Nível mais alto alcançado"
 
-#: templates/class-overview.html:22
+#: templates/class-overview.html:23
 msgid "number_programs"
 msgstr "Número de programas"
 
-#: templates/class-overview.html:23
+#: templates/class-overview.html:24
 #, fuzzy
 msgid "programs"
 msgstr "Programs"
 
-#: templates/class-overview.html:24 templates/create-accounts.html:17
+#: templates/class-overview.html:25 templates/create-accounts.html:17
 #: templates/login.html:15 templates/reset.html:8 templates/signup.html:19
 msgid "password"
 msgstr "Senha"
 
-#: templates/class-overview.html:25 templates/class-overview.html:69
+#: templates/class-overview.html:26 templates/class-overview.html:74
 #: templates/customize-adventure.html:52 templates/for-teachers.html:46
 #: templates/for-teachers.html:56
 #, fuzzy
 msgid "remove"
 msgstr "Remove"
 
-#: templates/class-overview.html:35
+#: templates/class-overview.html:36
 #, fuzzy
 msgid "page"
 msgstr "page"
 
-#: templates/class-overview.html:36
+#: templates/class-overview.html:37
 #, fuzzy
 msgid "enter_password"
 msgstr "Enter a new password for"
 
-#: templates/class-overview.html:36
+#: templates/class-overview.html:37
 #, fuzzy
 msgid "password_change_prompt"
 msgstr "Are you sure you want to change this password?"
 
-#: templates/class-overview.html:37
+#: templates/class-overview.html:38
 msgid "remove_student_prompt"
 msgstr "Você tem certeza de que deseja excluir este estudante da turma?"
 
-#: templates/class-overview.html:44
+#: templates/class-overview.html:46
 #, fuzzy
 msgid "add_students"
 msgstr "estudantes"
 
-#: templates/class-overview.html:45 templates/customize-class.html:5
+#: templates/class-overview.html:47 templates/customize-class.html:5
 #, fuzzy
 msgid "customize_class"
 msgstr "Customize class"
 
-#: templates/class-overview.html:46
+#: templates/class-overview.html:48
 #, fuzzy
 msgid "class_stats"
 msgstr "Show class statistics"
 
-#: templates/class-overview.html:47
+#: templates/class-overview.html:49
 #, fuzzy
 msgid "class_logs"
 msgstr "Último login"
 
-#: templates/class-overview.html:48 templates/customize-adventure.html:59
+#: templates/class-overview.html:52 templates/customize-adventure.html:59
 #, fuzzy
 msgid "back_to_teachers_page"
 msgstr "Go back to teachers page"
 
-#: templates/class-overview.html:49
+#: templates/class-overview.html:53
 msgid "delete_class_prompt"
 msgstr "Você tem certeza de que deseja excluir a turma?"
 
-#: templates/class-overview.html:49
+#: templates/class-overview.html:53
 msgid "delete_class"
 msgstr "Excluir a turma permanentemente"
 
-#: templates/class-overview.html:52
+#: templates/class-overview.html:57
 #, fuzzy
 msgid "add_students_options"
 msgstr "Create student accounts"
 
-#: templates/class-overview.html:54
+#: templates/class-overview.html:59
 #, fuzzy
 msgid "copy_link_success"
 msgstr "Copiar link para compartilhar"
 
-#: templates/class-overview.html:54
+#: templates/class-overview.html:59
 #, fuzzy
 msgid "copy_join_link"
 msgstr "Please copy and paste this link into a new tab:"
 
-#: templates/class-overview.html:55
+#: templates/class-overview.html:60
 #, fuzzy
 msgid "invite_prompt"
 msgstr "Enter a username"
 
-#: templates/class-overview.html:55
+#: templates/class-overview.html:60
 #, fuzzy
 msgid "invite_by_username"
 msgstr "All usernames need to be unique."
 
-#: templates/class-overview.html:56 templates/create-accounts.html:45
+#: templates/class-overview.html:61 templates/create-accounts.html:45
 #, fuzzy
 msgid "create_accounts"
 msgstr "Create multiple accounts"
 
-#: templates/class-overview.html:61
+#: templates/class-overview.html:66
 #, fuzzy
 msgid "pending_invites"
 msgstr "Pending invites"
 
-#: templates/class-overview.html:67
+#: templates/class-overview.html:72
 #, fuzzy
 msgid "invite_date"
 msgstr "Invite date"
 
-#: templates/class-overview.html:68
+#: templates/class-overview.html:73
 #, fuzzy
 msgid "expiration_date"
 msgstr "Expiration date"
 
-#: templates/class-overview.html:78 templates/profile.html:16
+#: templates/class-overview.html:83 templates/profile.html:16
 #, fuzzy
 msgid "delete_invite_prompt"
 msgstr "Are you sure you want to remove this class invitation?"
@@ -1326,10 +1326,10 @@ msgstr "Minhas Turmas"
 msgid "achievements"
 msgstr "achievements"
 
-#: templates/highscores.html:27 templates/learn-more.html:22
-#: templates/profile.html:131 templates/signup.html:52
-msgid "country"
-msgstr "País"
+#: templates/highscores.html:27
+#, fuzzy
+msgid "country_title"
+msgstr "Please select a valid country."
 
 #: templates/highscores.html:28 templates/landing-page.html:88
 #: templates/public-page.html:50
@@ -1611,6 +1611,11 @@ msgstr "Usuário"
 #, fuzzy
 msgid "lastname"
 msgstr "Name"
+
+#: templates/learn-more.html:22 templates/profile.html:131
+#: templates/signup.html:52
+msgid "country"
+msgstr "País"
 
 #: templates/learn-more.html:31
 #, fuzzy

--- a/translations/pt_PT/LC_MESSAGES/messages.po
+++ b/translations/pt_PT/LC_MESSAGES/messages.po
@@ -3,16 +3,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-28 18:38+0300\n"
+"POT-Creation-Date: 2022-06-29 14:20+0200\n"
 "PO-Revision-Date: 2022-06-28 13:25+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: pt_PT\n"
 "Language-Team: pt_PT <LL@li.org>\n"
-"Plural-Forms: nplurals=2; plural=n > 1\n"
+"Plural-Forms: nplurals=2; plural=n > 1;\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.9.1\n"
+"Generated-By: Babel 2.10.1\n"
 
 #: app.py:417
 #, fuzzy
@@ -24,7 +24,7 @@ msgstr "This program contains an error, are you sure you want to share it?"
 msgid "title_achievements"
 msgstr "Hedy - My achievements"
 
-#: app.py:644 app.py:748 app.py:1090 website/teacher.py:361
+#: app.py:644 app.py:746 app.py:1088 website/teacher.py:361
 #: website/teacher.py:372
 #, fuzzy
 msgid "not_teacher"
@@ -35,12 +35,12 @@ msgstr "Looks like you are not a teacher!"
 msgid "not_enrolled"
 msgstr "Looks like you are not in this class!"
 
-#: app.py:686
+#: app.py:684
 #, fuzzy
 msgid "title_programs"
 msgstr "Hedy - My programs"
 
-#: app.py:696 app.py:706 app.py:710 app.py:725 app.py:1005 app.py:1550
+#: app.py:694 app.py:704 app.py:708 app.py:723 app.py:1003 app.py:1548
 #: website/admin.py:17 website/admin.py:24 website/admin.py:92
 #: website/admin.py:111 website/admin.py:129 website/admin.py:136
 #: website/admin.py:144 website/auth.py:716 website/auth.py:743
@@ -49,325 +49,325 @@ msgstr "Hedy - My programs"
 msgid "unauthorized"
 msgstr "You don't have access rights for this page"
 
-#: app.py:762 app.py:1107
+#: app.py:760 app.py:1105
 #, fuzzy
 msgid "title_for-teacher"
 msgstr "Hedy - For teachers"
 
-#: app.py:779 app.py:781 app.py:923 app.py:945 app.py:947
+#: app.py:777 app.py:779 app.py:921 app.py:943 app.py:945
 #, fuzzy
 msgid "no_such_level"
 msgstr "No such Hedy level!"
 
-#: app.py:789 app.py:796 app.py:877 app.py:883
+#: app.py:787 app.py:794 app.py:875 app.py:881
 #, fuzzy
 msgid "no_such_program"
 msgstr "No such Hedy program!"
 
-#: app.py:819
+#: app.py:817
 #, fuzzy
 msgid "level_not_class"
 msgstr "You're in a class where this level has not been made available yet"
 
-#: app.py:928 website/teacher.py:421 website/teacher.py:437
+#: app.py:926 website/teacher.py:421 website/teacher.py:437
 #: website/teacher.py:466 website/teacher.py:492
 #, fuzzy
 msgid "no_such_adventure"
 msgstr "This adventure doesn't exist!"
 
-#: app.py:956 app.py:1209
+#: app.py:954 app.py:1207
 #, fuzzy
 msgid "page_not_found"
 msgstr "We could not find that page!"
 
-#: app.py:976
+#: app.py:974
 #, fuzzy
 msgid "title_signup"
 msgstr "Hedy - Create an account"
 
-#: app.py:983
+#: app.py:981
 #, fuzzy
 msgid "title_login"
 msgstr "Hedy - Login"
 
-#: app.py:990
+#: app.py:988
 #, fuzzy
 msgid "title_recover"
 msgstr "Hedy - Recover account"
 
-#: app.py:1006
+#: app.py:1004
 #, fuzzy
 msgid "title_reset"
 msgstr "Hedy - Reset password"
 
-#: app.py:1032
+#: app.py:1030
 #, fuzzy
 msgid "title_my-profile"
 msgstr "Hedy - My account"
 
-#: app.py:1048
+#: app.py:1046
 #, fuzzy
 msgid "title_learn-more"
 msgstr "Hedy - Learn more"
 
-#: app.py:1054
+#: app.py:1052
 #, fuzzy
 msgid "title_privacy"
 msgstr "Hedy - Privacy terms"
 
-#: app.py:1064
+#: app.py:1062
 #, fuzzy
 msgid "title_start"
 msgstr "Hedy - A gradual programming language"
 
-#: app.py:1082
+#: app.py:1080
 #, fuzzy
 msgid "title_landing-page"
 msgstr "Welcome to Hedy!"
 
-#: app.py:1200
+#: app.py:1198
 #, fuzzy
 msgid "title_explore"
 msgstr "Hedy - Explore"
 
-#: app.py:1221 app.py:1226
+#: app.py:1219 app.py:1224
 #, fuzzy
 msgid "no_such_highscore"
 msgstr "No such Hedy level!"
 
-#: app.py:1255 app.py:1257
+#: app.py:1253 app.py:1255
 #, fuzzy
 msgid "translate_error"
 msgstr ""
 "Something went wrong while translating the code. Try running the code to "
 "see if it has an error. Code with errors can not be translated."
 
-#: app.py:1262 app.py:1296
+#: app.py:1260 app.py:1294
 #, fuzzy
 msgid "tutorial_start_title"
 msgstr "Welcome to Hedy!"
 
-#: app.py:1262
+#: app.py:1260
 #, fuzzy
 msgid "tutorial_start_message"
 msgstr "In this tutorial we will explain all the Hedy features step-by-step."
 
-#: app.py:1264
+#: app.py:1262
 #, fuzzy
 msgid "tutorial_editor_title"
 msgstr "The code editor"
 
-#: app.py:1264
+#: app.py:1262
 #, fuzzy
 msgid "tutorial_editor_message"
 msgstr "In this window you write all the code, try typing something!"
 
-#: app.py:1266
+#: app.py:1264
 #, fuzzy
 msgid "tutorial_output_title"
 msgstr "The output window"
 
-#: app.py:1266
+#: app.py:1264
 #, fuzzy
 msgid "tutorial_output_message"
 msgstr "The result of the code you execute will be shown here"
 
-#: app.py:1268
+#: app.py:1266
 #, fuzzy
 msgid "tutorial_run_title"
 msgstr "The run button"
 
-#: app.py:1268
+#: app.py:1266
 #, fuzzy
 msgid "tutorial_run_message"
 msgstr "With this button you can run your program! Shall we give it a try?"
 
-#: app.py:1270
+#: app.py:1268
 #, fuzzy
 msgid "tutorial_tryit_title"
 msgstr "Try it out!"
 
-#: app.py:1270
+#: app.py:1268
 #, fuzzy
 msgid "tutorial_tryit_message"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1272
+#: app.py:1270
 #, fuzzy
 msgid "tutorial_speakaloud_title"
 msgstr "The end!"
 
-#: app.py:1272
+#: app.py:1270
 #, fuzzy
 msgid "tutorial_speakaloud_message"
 msgstr "Click on 'next step' to really start coding with Hedy!"
 
-#: app.py:1274
+#: app.py:1272
 #, fuzzy
 msgid "tutorial_speakaloud_run_title"
 msgstr "The end!"
 
-#: app.py:1274
+#: app.py:1272
 #, fuzzy
 msgid "tutorial_speakaloud_run_message"
 msgstr "Click on 'next step' to really start coding with Hedy!"
 
-#: app.py:1276
+#: app.py:1274
 #, fuzzy
 msgid "tutorial_nextlevel_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1276
+#: app.py:1274
 #, fuzzy
 msgid "tutorial_nextlevel_message"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1278
+#: app.py:1276
 #, fuzzy
 msgid "tutorial_leveldefault_title"
 msgstr "Level explanation"
 
-#: app.py:1278
+#: app.py:1276
 #, fuzzy
 msgid "tutorial_leveldefault_message"
 msgstr ""
 "The first tab always contains the level explanation. In each level new "
 "commands will be explained here."
 
-#: app.py:1280
+#: app.py:1278
 #, fuzzy
 msgid "tutorial_adventures_title"
 msgstr "Customize adventure"
 
-#: app.py:1280
+#: app.py:1278
 #, fuzzy
 msgid "tutorial_adventures_message"
 msgstr "Customize adventure"
 
-#: app.py:1282
+#: app.py:1280
 #, fuzzy
 msgid "tutorial_quiz_title"
 msgstr "Quiz"
 
-#: app.py:1282
+#: app.py:1280
 #, fuzzy
 msgid "tutorial_quiz_message"
 msgstr ""
 "At the end of each level you can make the quiz. This way you can verify "
 "if you understand everything."
 
-#: app.py:1284
+#: app.py:1282
 #, fuzzy
 msgid "tutorial_saveshare_title"
 msgstr "Saving & sharing"
 
-#: app.py:1284
+#: app.py:1282
 #, fuzzy
 msgid "tutorial_saveshare_message"
 msgstr "You can save and share all your created programs with other Hedy users."
 
-#: app.py:1286
+#: app.py:1284
 #, fuzzy
 msgid "tutorial_cheatsheet_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1286
+#: app.py:1284
 #, fuzzy
 msgid "tutorial_cheatsheet_message"
 msgstr ""
 "If you forgot a command you can always use the cheatsheet. It shows a "
 "list of all commands you can use in the current level."
 
-#: app.py:1288 app.py:1308
+#: app.py:1286 app.py:1306
 #, fuzzy
 msgid "tutorial_end_title"
 msgstr "The end!"
 
-#: app.py:1288
+#: app.py:1286
 #, fuzzy
 msgid "tutorial_end_message"
 msgstr "Click on 'next step' to really start coding with Hedy!"
 
-#: app.py:1290 app.py:1310
+#: app.py:1288 app.py:1308
 #, fuzzy
 msgid "tutorial_title_not_found"
 msgstr "We could not find that page!"
 
-#: app.py:1290 app.py:1310
+#: app.py:1288 app.py:1308
 #, fuzzy
 msgid "tutorial_message_not_found"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1296
+#: app.py:1294
 #, fuzzy
 msgid "teacher_tutorial_start_message"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1298
+#: app.py:1296
 #, fuzzy
 msgid "tutorial_class_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1298
+#: app.py:1296
 #, fuzzy
 msgid "tutorial_class_message"
 msgstr "Customize adventure"
 
-#: app.py:1300
+#: app.py:1298
 #, fuzzy
 msgid "tutorial_customize_class_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1300
+#: app.py:1298
 #, fuzzy
 msgid "tutorial_customize_class_message"
 msgstr "Customize adventure"
 
-#: app.py:1302
+#: app.py:1300
 #, fuzzy
 msgid "tutorial_own_adventures_title"
 msgstr "Customize adventure"
 
-#: app.py:1302
+#: app.py:1300
 #, fuzzy
 msgid "tutorial_own_adventures_message"
 msgstr "Customize adventure"
 
-#: app.py:1304
+#: app.py:1302
 #, fuzzy
 msgid "tutorial_accounts_title"
 msgstr "Customize adventure"
 
-#: app.py:1304
+#: app.py:1302
 #, fuzzy
 msgid "tutorial_accounts_message"
 msgstr "Customize adventure"
 
-#: app.py:1306
+#: app.py:1304
 #, fuzzy
 msgid "tutorial_documentation_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1306
+#: app.py:1304
 #, fuzzy
 msgid "tutorial_documentation_message"
 msgstr "Customize adventure"
 
-#: app.py:1308
+#: app.py:1306
 #, fuzzy
 msgid "teacher_tutorial_end_message"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1318
+#: app.py:1316
 #, fuzzy
 msgid "tutorial_code_snippet"
 msgstr "Hide cheatsheet"
 
-#: app.py:1322 app.py:1332
+#: app.py:1320 app.py:1330
 msgid "invalid_tutorial_step"
 msgstr ""
 
-#: app.py:1489 website/auth.py:278 website/auth.py:333 website/auth.py:469
+#: app.py:1487 website/auth.py:278 website/auth.py:333 website/auth.py:469
 #: website/auth.py:494 website/auth.py:524 website/auth.py:637
 #: website/auth.py:675 website/auth.py:722 website/auth.py:749
 #: website/quiz.py:43 website/quiz.py:69 website/teacher.py:88
@@ -377,32 +377,32 @@ msgstr ""
 msgid "ajax_error"
 msgstr "Ocorreu um erro, por favor tenta novamente."
 
-#: app.py:1492
+#: app.py:1490
 #, fuzzy
 msgid "image_invalid"
 msgstr "Your chosen image is invalid."
 
-#: app.py:1494
+#: app.py:1492
 #, fuzzy
 msgid "personal_text_invalid"
 msgstr "Your personal text is invalid."
 
-#: app.py:1496 app.py:1502
+#: app.py:1494 app.py:1500
 #, fuzzy
 msgid "favourite_program_invalid"
 msgstr "Your chosen favourite program is invalid."
 
-#: app.py:1516 app.py:1517
+#: app.py:1514 app.py:1515
 #, fuzzy
 msgid "public_profile_updated"
 msgstr "Public profile updated."
 
-#: app.py:1554 app.py:1579
+#: app.py:1552 app.py:1577
 #, fuzzy
 msgid "user_not_private"
 msgstr "This user doesn't exist or doesn't have a public profile"
 
-#: app.py:1587
+#: app.py:1585
 #, fuzzy
 msgid "invalid_teacher_invitation_code"
 msgstr ""
@@ -741,151 +741,151 @@ msgstr "Hide cheatsheet"
 msgid "back_to_class"
 msgstr "Go back to class"
 
-#: templates/class-overview.html:13 templates/for-teachers.html:35
+#: templates/class-overview.html:14 templates/for-teachers.html:35
 #, fuzzy
 msgid "class_name_prompt"
 msgstr "Please enter the name of the class"
 
-#: templates/class-overview.html:19 templates/class-overview.html:66
+#: templates/class-overview.html:20 templates/class-overview.html:71
 #: templates/create-accounts.html:16 templates/highscores.html:25
 #: templates/login.html:12 templates/profile.html:89 templates/recover.html:8
 #: templates/signup.html:10
 msgid "username"
 msgstr "Utilizador"
 
-#: templates/class-overview.html:20
+#: templates/class-overview.html:21
 #, fuzzy
 msgid "last_login"
 msgstr "Last login"
 
-#: templates/class-overview.html:21
+#: templates/class-overview.html:22
 #, fuzzy
 msgid "highest_level_reached"
 msgstr "Highest level reached"
 
-#: templates/class-overview.html:22
+#: templates/class-overview.html:23
 #, fuzzy
 msgid "number_programs"
 msgstr "Number of programs"
 
-#: templates/class-overview.html:23
+#: templates/class-overview.html:24
 #, fuzzy
 msgid "programs"
 msgstr "Programs"
 
-#: templates/class-overview.html:24 templates/create-accounts.html:17
+#: templates/class-overview.html:25 templates/create-accounts.html:17
 #: templates/login.html:15 templates/reset.html:8 templates/signup.html:19
 msgid "password"
 msgstr "Palavra-passe"
 
-#: templates/class-overview.html:25 templates/class-overview.html:69
+#: templates/class-overview.html:26 templates/class-overview.html:74
 #: templates/customize-adventure.html:52 templates/for-teachers.html:46
 #: templates/for-teachers.html:56
 #, fuzzy
 msgid "remove"
 msgstr "Remove"
 
-#: templates/class-overview.html:35
+#: templates/class-overview.html:36
 #, fuzzy
 msgid "page"
 msgstr "page"
 
-#: templates/class-overview.html:36
+#: templates/class-overview.html:37
 #, fuzzy
 msgid "enter_password"
 msgstr "Enter a new password for"
 
-#: templates/class-overview.html:36
+#: templates/class-overview.html:37
 #, fuzzy
 msgid "password_change_prompt"
 msgstr "Are you sure you want to change this password?"
 
-#: templates/class-overview.html:37
+#: templates/class-overview.html:38
 #, fuzzy
 msgid "remove_student_prompt"
 msgstr "Are you sure you want to remove the student from the class?"
 
-#: templates/class-overview.html:44
+#: templates/class-overview.html:46
 #, fuzzy
 msgid "add_students"
 msgstr "students"
 
-#: templates/class-overview.html:45 templates/customize-class.html:5
+#: templates/class-overview.html:47 templates/customize-class.html:5
 #, fuzzy
 msgid "customize_class"
 msgstr "Customize class"
 
-#: templates/class-overview.html:46
+#: templates/class-overview.html:48
 #, fuzzy
 msgid "class_stats"
 msgstr "Show class statistics"
 
-#: templates/class-overview.html:47
+#: templates/class-overview.html:49
 #, fuzzy
 msgid "class_logs"
 msgstr "Last login"
 
-#: templates/class-overview.html:48 templates/customize-adventure.html:59
+#: templates/class-overview.html:52 templates/customize-adventure.html:59
 #, fuzzy
 msgid "back_to_teachers_page"
 msgstr "Go back to teachers page"
 
-#: templates/class-overview.html:49
+#: templates/class-overview.html:53
 #, fuzzy
 msgid "delete_class_prompt"
 msgstr "Are you sure you want to delete the class?"
 
-#: templates/class-overview.html:49
+#: templates/class-overview.html:53
 #, fuzzy
 msgid "delete_class"
 msgstr "Delete class permanently"
 
-#: templates/class-overview.html:52
+#: templates/class-overview.html:57
 #, fuzzy
 msgid "add_students_options"
 msgstr "Create student accounts"
 
-#: templates/class-overview.html:54
+#: templates/class-overview.html:59
 #, fuzzy
 msgid "copy_link_success"
 msgstr "Copiar ligação de partilha"
 
-#: templates/class-overview.html:54
+#: templates/class-overview.html:59
 #, fuzzy
 msgid "copy_join_link"
 msgstr "Please copy and paste this link into a new tab:"
 
-#: templates/class-overview.html:55
+#: templates/class-overview.html:60
 #, fuzzy
 msgid "invite_prompt"
 msgstr "Enter a username"
 
-#: templates/class-overview.html:55
+#: templates/class-overview.html:60
 #, fuzzy
 msgid "invite_by_username"
 msgstr "All usernames need to be unique."
 
-#: templates/class-overview.html:56 templates/create-accounts.html:45
+#: templates/class-overview.html:61 templates/create-accounts.html:45
 #, fuzzy
 msgid "create_accounts"
 msgstr "Create multiple accounts"
 
-#: templates/class-overview.html:61
+#: templates/class-overview.html:66
 #, fuzzy
 msgid "pending_invites"
 msgstr "Pending invites"
 
-#: templates/class-overview.html:67
+#: templates/class-overview.html:72
 #, fuzzy
 msgid "invite_date"
 msgstr "Invite date"
 
-#: templates/class-overview.html:68
+#: templates/class-overview.html:73
 #, fuzzy
 msgid "expiration_date"
 msgstr "Expiration date"
 
-#: templates/class-overview.html:78 templates/profile.html:16
+#: templates/class-overview.html:83 templates/profile.html:16
 #, fuzzy
 msgid "delete_invite_prompt"
 msgstr "Are you sure you want to remove this class invitation?"
@@ -1340,10 +1340,10 @@ msgstr "My classes"
 msgid "achievements"
 msgstr "achievements"
 
-#: templates/highscores.html:27 templates/learn-more.html:22
-#: templates/profile.html:131 templates/signup.html:52
-msgid "country"
-msgstr "País"
+#: templates/highscores.html:27
+#, fuzzy
+msgid "country_title"
+msgstr "Please select a valid country."
 
 #: templates/highscores.html:28 templates/landing-page.html:88
 #: templates/public-page.html:50
@@ -1632,6 +1632,11 @@ msgstr "Utilizador"
 #, fuzzy
 msgid "lastname"
 msgstr "Name"
+
+#: templates/learn-more.html:22 templates/profile.html:131
+#: templates/signup.html:52
+msgid "country"
+msgstr "País"
 
 #: templates/learn-more.html:31
 #, fuzzy

--- a/translations/ru/LC_MESSAGES/messages.po
+++ b/translations/ru/LC_MESSAGES/messages.po
@@ -3,17 +3,17 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-28 18:38+0300\n"
+"POT-Creation-Date: 2022-06-29 14:20+0200\n"
 "PO-Revision-Date: 2022-06-28 13:25+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: ru\n"
 "Language-Team: ru <LL@li.org>\n"
 "Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
-"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2\n"
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.9.1\n"
+"Generated-By: Babel 2.10.1\n"
 
 #: app.py:417
 #, fuzzy
@@ -25,7 +25,7 @@ msgstr "This program contains an error, are you sure you want to share it?"
 msgid "title_achievements"
 msgstr "Hedy - My achievements"
 
-#: app.py:644 app.py:748 app.py:1090 website/teacher.py:361
+#: app.py:644 app.py:746 app.py:1088 website/teacher.py:361
 #: website/teacher.py:372
 #, fuzzy
 msgid "not_teacher"
@@ -36,12 +36,12 @@ msgstr "Looks like you are not a teacher!"
 msgid "not_enrolled"
 msgstr "Looks like you are not in this class!"
 
-#: app.py:686
+#: app.py:684
 #, fuzzy
 msgid "title_programs"
 msgstr "Hedy - My programs"
 
-#: app.py:696 app.py:706 app.py:710 app.py:725 app.py:1005 app.py:1550
+#: app.py:694 app.py:704 app.py:708 app.py:723 app.py:1003 app.py:1548
 #: website/admin.py:17 website/admin.py:24 website/admin.py:92
 #: website/admin.py:111 website/admin.py:129 website/admin.py:136
 #: website/admin.py:144 website/auth.py:716 website/auth.py:743
@@ -50,325 +50,325 @@ msgstr "Hedy - My programs"
 msgid "unauthorized"
 msgstr "You don't have access rights for this page"
 
-#: app.py:762 app.py:1107
+#: app.py:760 app.py:1105
 #, fuzzy
 msgid "title_for-teacher"
 msgstr "Hedy - For teachers"
 
-#: app.py:779 app.py:781 app.py:923 app.py:945 app.py:947
+#: app.py:777 app.py:779 app.py:921 app.py:943 app.py:945
 #, fuzzy
 msgid "no_such_level"
 msgstr "No such Hedy level!"
 
-#: app.py:789 app.py:796 app.py:877 app.py:883
+#: app.py:787 app.py:794 app.py:875 app.py:881
 #, fuzzy
 msgid "no_such_program"
 msgstr "No such Hedy program!"
 
-#: app.py:819
+#: app.py:817
 #, fuzzy
 msgid "level_not_class"
 msgstr "You're in a class where this level has not been made available yet"
 
-#: app.py:928 website/teacher.py:421 website/teacher.py:437
+#: app.py:926 website/teacher.py:421 website/teacher.py:437
 #: website/teacher.py:466 website/teacher.py:492
 #, fuzzy
 msgid "no_such_adventure"
 msgstr "This adventure doesn't exist!"
 
-#: app.py:956 app.py:1209
+#: app.py:954 app.py:1207
 #, fuzzy
 msgid "page_not_found"
 msgstr "We could not find that page!"
 
-#: app.py:976
+#: app.py:974
 #, fuzzy
 msgid "title_signup"
 msgstr "Hedy - Create an account"
 
-#: app.py:983
+#: app.py:981
 #, fuzzy
 msgid "title_login"
 msgstr "Hedy - Login"
 
-#: app.py:990
+#: app.py:988
 #, fuzzy
 msgid "title_recover"
 msgstr "Hedy - Recover account"
 
-#: app.py:1006
+#: app.py:1004
 #, fuzzy
 msgid "title_reset"
 msgstr "Hedy - Reset password"
 
-#: app.py:1032
+#: app.py:1030
 #, fuzzy
 msgid "title_my-profile"
 msgstr "Hedy - My account"
 
-#: app.py:1048
+#: app.py:1046
 #, fuzzy
 msgid "title_learn-more"
 msgstr "Hedy - Learn more"
 
-#: app.py:1054
+#: app.py:1052
 #, fuzzy
 msgid "title_privacy"
 msgstr "Hedy - Privacy terms"
 
-#: app.py:1064
+#: app.py:1062
 #, fuzzy
 msgid "title_start"
 msgstr "Hedy - A gradual programming language"
 
-#: app.py:1082
+#: app.py:1080
 #, fuzzy
 msgid "title_landing-page"
 msgstr "Welcome to Hedy!"
 
-#: app.py:1200
+#: app.py:1198
 #, fuzzy
 msgid "title_explore"
 msgstr "Hedy - Explore"
 
-#: app.py:1221 app.py:1226
+#: app.py:1219 app.py:1224
 #, fuzzy
 msgid "no_such_highscore"
 msgstr "No such Hedy level!"
 
-#: app.py:1255 app.py:1257
+#: app.py:1253 app.py:1255
 #, fuzzy
 msgid "translate_error"
 msgstr ""
 "Something went wrong while translating the code. Try running the code to "
 "see if it has an error. Code with errors can not be translated."
 
-#: app.py:1262 app.py:1296
+#: app.py:1260 app.py:1294
 #, fuzzy
 msgid "tutorial_start_title"
 msgstr "Welcome to Hedy!"
 
-#: app.py:1262
+#: app.py:1260
 #, fuzzy
 msgid "tutorial_start_message"
 msgstr "In this tutorial we will explain all the Hedy features step-by-step."
 
-#: app.py:1264
+#: app.py:1262
 #, fuzzy
 msgid "tutorial_editor_title"
 msgstr "The code editor"
 
-#: app.py:1264
+#: app.py:1262
 #, fuzzy
 msgid "tutorial_editor_message"
 msgstr "In this window you write all the code, try typing something!"
 
-#: app.py:1266
+#: app.py:1264
 #, fuzzy
 msgid "tutorial_output_title"
 msgstr "The output window"
 
-#: app.py:1266
+#: app.py:1264
 #, fuzzy
 msgid "tutorial_output_message"
 msgstr "The result of the code you execute will be shown here"
 
-#: app.py:1268
+#: app.py:1266
 #, fuzzy
 msgid "tutorial_run_title"
 msgstr "The run button"
 
-#: app.py:1268
+#: app.py:1266
 #, fuzzy
 msgid "tutorial_run_message"
 msgstr "With this button you can run your program! Shall we give it a try?"
 
-#: app.py:1270
+#: app.py:1268
 #, fuzzy
 msgid "tutorial_tryit_title"
 msgstr "Try it out!"
 
-#: app.py:1270
+#: app.py:1268
 #, fuzzy
 msgid "tutorial_tryit_message"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1272
+#: app.py:1270
 #, fuzzy
 msgid "tutorial_speakaloud_title"
 msgstr "The end!"
 
-#: app.py:1272
+#: app.py:1270
 #, fuzzy
 msgid "tutorial_speakaloud_message"
 msgstr "Click on 'next step' to really start coding with Hedy!"
 
-#: app.py:1274
+#: app.py:1272
 #, fuzzy
 msgid "tutorial_speakaloud_run_title"
 msgstr "The end!"
 
-#: app.py:1274
+#: app.py:1272
 #, fuzzy
 msgid "tutorial_speakaloud_run_message"
 msgstr "Click on 'next step' to really start coding with Hedy!"
 
-#: app.py:1276
+#: app.py:1274
 #, fuzzy
 msgid "tutorial_nextlevel_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1276
+#: app.py:1274
 #, fuzzy
 msgid "tutorial_nextlevel_message"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1278
+#: app.py:1276
 #, fuzzy
 msgid "tutorial_leveldefault_title"
 msgstr "Level explanation"
 
-#: app.py:1278
+#: app.py:1276
 #, fuzzy
 msgid "tutorial_leveldefault_message"
 msgstr ""
 "The first tab always contains the level explanation. In each level new "
 "commands will be explained here."
 
-#: app.py:1280
+#: app.py:1278
 #, fuzzy
 msgid "tutorial_adventures_title"
 msgstr "Customize adventure"
 
-#: app.py:1280
+#: app.py:1278
 #, fuzzy
 msgid "tutorial_adventures_message"
 msgstr "Customize adventure"
 
-#: app.py:1282
+#: app.py:1280
 #, fuzzy
 msgid "tutorial_quiz_title"
 msgstr "Quiz"
 
-#: app.py:1282
+#: app.py:1280
 #, fuzzy
 msgid "tutorial_quiz_message"
 msgstr ""
 "At the end of each level you can make the quiz. This way you can verify "
 "if you understand everything."
 
-#: app.py:1284
+#: app.py:1282
 #, fuzzy
 msgid "tutorial_saveshare_title"
 msgstr "Saving & sharing"
 
-#: app.py:1284
+#: app.py:1282
 #, fuzzy
 msgid "tutorial_saveshare_message"
 msgstr "You can save and share all your created programs with other Hedy users."
 
-#: app.py:1286
+#: app.py:1284
 #, fuzzy
 msgid "tutorial_cheatsheet_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1286
+#: app.py:1284
 #, fuzzy
 msgid "tutorial_cheatsheet_message"
 msgstr ""
 "If you forgot a command you can always use the cheatsheet. It shows a "
 "list of all commands you can use in the current level."
 
-#: app.py:1288 app.py:1308
+#: app.py:1286 app.py:1306
 #, fuzzy
 msgid "tutorial_end_title"
 msgstr "The end!"
 
-#: app.py:1288
+#: app.py:1286
 #, fuzzy
 msgid "tutorial_end_message"
 msgstr "Click on 'next step' to really start coding with Hedy!"
 
-#: app.py:1290 app.py:1310
+#: app.py:1288 app.py:1308
 #, fuzzy
 msgid "tutorial_title_not_found"
 msgstr "We could not find that page!"
 
-#: app.py:1290 app.py:1310
+#: app.py:1288 app.py:1308
 #, fuzzy
 msgid "tutorial_message_not_found"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1296
+#: app.py:1294
 #, fuzzy
 msgid "teacher_tutorial_start_message"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1298
+#: app.py:1296
 #, fuzzy
 msgid "tutorial_class_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1298
+#: app.py:1296
 #, fuzzy
 msgid "tutorial_class_message"
 msgstr "Customize adventure"
 
-#: app.py:1300
+#: app.py:1298
 #, fuzzy
 msgid "tutorial_customize_class_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1300
+#: app.py:1298
 #, fuzzy
 msgid "tutorial_customize_class_message"
 msgstr "Customize adventure"
 
-#: app.py:1302
+#: app.py:1300
 #, fuzzy
 msgid "tutorial_own_adventures_title"
 msgstr "Customize adventure"
 
-#: app.py:1302
+#: app.py:1300
 #, fuzzy
 msgid "tutorial_own_adventures_message"
 msgstr "Customize adventure"
 
-#: app.py:1304
+#: app.py:1302
 #, fuzzy
 msgid "tutorial_accounts_title"
 msgstr "Customize adventure"
 
-#: app.py:1304
+#: app.py:1302
 #, fuzzy
 msgid "tutorial_accounts_message"
 msgstr "Customize adventure"
 
-#: app.py:1306
+#: app.py:1304
 #, fuzzy
 msgid "tutorial_documentation_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1306
+#: app.py:1304
 #, fuzzy
 msgid "tutorial_documentation_message"
 msgstr "Customize adventure"
 
-#: app.py:1308
+#: app.py:1306
 #, fuzzy
 msgid "teacher_tutorial_end_message"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1318
+#: app.py:1316
 #, fuzzy
 msgid "tutorial_code_snippet"
 msgstr "Hide cheatsheet"
 
-#: app.py:1322 app.py:1332
+#: app.py:1320 app.py:1330
 msgid "invalid_tutorial_step"
 msgstr ""
 
-#: app.py:1489 website/auth.py:278 website/auth.py:333 website/auth.py:469
+#: app.py:1487 website/auth.py:278 website/auth.py:333 website/auth.py:469
 #: website/auth.py:494 website/auth.py:524 website/auth.py:637
 #: website/auth.py:675 website/auth.py:722 website/auth.py:749
 #: website/quiz.py:43 website/quiz.py:69 website/teacher.py:88
@@ -379,32 +379,32 @@ msgstr ""
 msgid "ajax_error"
 msgstr "There was an error, please try again."
 
-#: app.py:1492
+#: app.py:1490
 #, fuzzy
 msgid "image_invalid"
 msgstr "Your chosen image is invalid."
 
-#: app.py:1494
+#: app.py:1492
 #, fuzzy
 msgid "personal_text_invalid"
 msgstr "Your personal text is invalid."
 
-#: app.py:1496 app.py:1502
+#: app.py:1494 app.py:1500
 #, fuzzy
 msgid "favourite_program_invalid"
 msgstr "Your chosen favourite program is invalid."
 
-#: app.py:1516 app.py:1517
+#: app.py:1514 app.py:1515
 #, fuzzy
 msgid "public_profile_updated"
 msgstr "Public profile updated."
 
-#: app.py:1554 app.py:1579
+#: app.py:1552 app.py:1577
 #, fuzzy
 msgid "user_not_private"
 msgstr "This user doesn't exist or doesn't have a public profile"
 
-#: app.py:1587
+#: app.py:1585
 #, fuzzy
 msgid "invalid_teacher_invitation_code"
 msgstr ""
@@ -764,12 +764,12 @@ msgstr "Hide cheatsheet"
 msgid "back_to_class"
 msgstr "Go back to class"
 
-#: templates/class-overview.html:13 templates/for-teachers.html:35
+#: templates/class-overview.html:14 templates/for-teachers.html:35
 #, fuzzy
 msgid "class_name_prompt"
 msgstr "Please enter the name of the class"
 
-#: templates/class-overview.html:19 templates/class-overview.html:66
+#: templates/class-overview.html:20 templates/class-overview.html:71
 #: templates/create-accounts.html:16 templates/highscores.html:25
 #: templates/login.html:12 templates/profile.html:89 templates/recover.html:8
 #: templates/signup.html:10
@@ -777,140 +777,140 @@ msgstr "Please enter the name of the class"
 msgid "username"
 msgstr "Username"
 
-#: templates/class-overview.html:20
+#: templates/class-overview.html:21
 #, fuzzy
 msgid "last_login"
 msgstr "Last login"
 
-#: templates/class-overview.html:21
+#: templates/class-overview.html:22
 #, fuzzy
 msgid "highest_level_reached"
 msgstr "Highest level reached"
 
-#: templates/class-overview.html:22
+#: templates/class-overview.html:23
 #, fuzzy
 msgid "number_programs"
 msgstr "Number of programs"
 
-#: templates/class-overview.html:23
+#: templates/class-overview.html:24
 #, fuzzy
 msgid "programs"
 msgstr "Programs"
 
-#: templates/class-overview.html:24 templates/create-accounts.html:17
+#: templates/class-overview.html:25 templates/create-accounts.html:17
 #: templates/login.html:15 templates/reset.html:8 templates/signup.html:19
 #, fuzzy
 msgid "password"
 msgstr "Password"
 
-#: templates/class-overview.html:25 templates/class-overview.html:69
+#: templates/class-overview.html:26 templates/class-overview.html:74
 #: templates/customize-adventure.html:52 templates/for-teachers.html:46
 #: templates/for-teachers.html:56
 #, fuzzy
 msgid "remove"
 msgstr "Remove"
 
-#: templates/class-overview.html:35
+#: templates/class-overview.html:36
 #, fuzzy
 msgid "page"
 msgstr "page"
 
-#: templates/class-overview.html:36
+#: templates/class-overview.html:37
 #, fuzzy
 msgid "enter_password"
 msgstr "Enter a new password for"
 
-#: templates/class-overview.html:36
+#: templates/class-overview.html:37
 #, fuzzy
 msgid "password_change_prompt"
 msgstr "Are you sure you want to change this password?"
 
-#: templates/class-overview.html:37
+#: templates/class-overview.html:38
 #, fuzzy
 msgid "remove_student_prompt"
 msgstr "Are you sure you want to remove the student from the class?"
 
-#: templates/class-overview.html:44
+#: templates/class-overview.html:46
 #, fuzzy
 msgid "add_students"
 msgstr "students"
 
-#: templates/class-overview.html:45 templates/customize-class.html:5
+#: templates/class-overview.html:47 templates/customize-class.html:5
 #, fuzzy
 msgid "customize_class"
 msgstr "Customize class"
 
-#: templates/class-overview.html:46
+#: templates/class-overview.html:48
 #, fuzzy
 msgid "class_stats"
 msgstr "Class statistics"
 
-#: templates/class-overview.html:47
+#: templates/class-overview.html:49
 #, fuzzy
 msgid "class_logs"
 msgstr "Last login"
 
-#: templates/class-overview.html:48 templates/customize-adventure.html:59
+#: templates/class-overview.html:52 templates/customize-adventure.html:59
 #, fuzzy
 msgid "back_to_teachers_page"
 msgstr "Go back to teachers page"
 
-#: templates/class-overview.html:49
+#: templates/class-overview.html:53
 #, fuzzy
 msgid "delete_class_prompt"
 msgstr "Are you sure you want to delete the class?"
 
-#: templates/class-overview.html:49
+#: templates/class-overview.html:53
 #, fuzzy
 msgid "delete_class"
 msgstr "Delete class permanently"
 
-#: templates/class-overview.html:52
+#: templates/class-overview.html:57
 #, fuzzy
 msgid "add_students_options"
 msgstr "Create student accounts"
 
-#: templates/class-overview.html:54
+#: templates/class-overview.html:59
 #, fuzzy
 msgid "copy_link_success"
 msgstr "Copy link to share"
 
-#: templates/class-overview.html:54
+#: templates/class-overview.html:59
 #, fuzzy
 msgid "copy_join_link"
 msgstr "Please copy and paste this link into a new tab:"
 
-#: templates/class-overview.html:55
+#: templates/class-overview.html:60
 #, fuzzy
 msgid "invite_prompt"
 msgstr "Enter a username"
 
-#: templates/class-overview.html:55
+#: templates/class-overview.html:60
 #, fuzzy
 msgid "invite_by_username"
 msgstr "All usernames need to be unique."
 
-#: templates/class-overview.html:56 templates/create-accounts.html:45
+#: templates/class-overview.html:61 templates/create-accounts.html:45
 #, fuzzy
 msgid "create_accounts"
 msgstr "Create multiple accounts"
 
-#: templates/class-overview.html:61
+#: templates/class-overview.html:66
 #, fuzzy
 msgid "pending_invites"
 msgstr "Pending invites"
 
-#: templates/class-overview.html:67
+#: templates/class-overview.html:72
 #, fuzzy
 msgid "invite_date"
 msgstr "Invite date"
 
-#: templates/class-overview.html:68
+#: templates/class-overview.html:73
 #, fuzzy
 msgid "expiration_date"
 msgstr "Expiration date"
 
-#: templates/class-overview.html:78 templates/profile.html:16
+#: templates/class-overview.html:83 templates/profile.html:16
 #, fuzzy
 msgid "delete_invite_prompt"
 msgstr "Are you sure you want to remove this class invitation?"
@@ -1383,11 +1383,10 @@ msgstr "My classes"
 msgid "achievements"
 msgstr "achievements"
 
-#: templates/highscores.html:27 templates/learn-more.html:22
-#: templates/profile.html:131 templates/signup.html:52
+#: templates/highscores.html:27
 #, fuzzy
-msgid "country"
-msgstr "Country"
+msgid "country_title"
+msgstr "Please select a valid country."
 
 #: templates/highscores.html:28 templates/landing-page.html:88
 #: templates/public-page.html:50
@@ -1689,6 +1688,12 @@ msgstr "First Name"
 #, fuzzy
 msgid "lastname"
 msgstr "Last Name"
+
+#: templates/learn-more.html:22 templates/profile.html:131
+#: templates/signup.html:52
+#, fuzzy
+msgid "country"
+msgstr "Country"
 
 #: templates/learn-more.html:31
 #, fuzzy

--- a/translations/sw/LC_MESSAGES/messages.po
+++ b/translations/sw/LC_MESSAGES/messages.po
@@ -3,16 +3,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-28 18:38+0300\n"
+"POT-Creation-Date: 2022-06-29 14:20+0200\n"
 "PO-Revision-Date: 2022-06-28 13:25+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: sw\n"
 "Language-Team: sw <LL@li.org>\n"
-"Plural-Forms: nplurals=2; plural=n != 1\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.9.1\n"
+"Generated-By: Babel 2.10.1\n"
 
 #: app.py:417
 #, fuzzy
@@ -24,7 +24,7 @@ msgstr "This program contains an error, are you sure you want to share it?"
 msgid "title_achievements"
 msgstr "Hedy - My achievements"
 
-#: app.py:644 app.py:748 app.py:1090 website/teacher.py:361
+#: app.py:644 app.py:746 app.py:1088 website/teacher.py:361
 #: website/teacher.py:372
 #, fuzzy
 msgid "not_teacher"
@@ -35,12 +35,12 @@ msgstr "Looks like you are not a teacher!"
 msgid "not_enrolled"
 msgstr "Looks like you are not in this class!"
 
-#: app.py:686
+#: app.py:684
 #, fuzzy
 msgid "title_programs"
 msgstr "Hedy - My programs"
 
-#: app.py:696 app.py:706 app.py:710 app.py:725 app.py:1005 app.py:1550
+#: app.py:694 app.py:704 app.py:708 app.py:723 app.py:1003 app.py:1548
 #: website/admin.py:17 website/admin.py:24 website/admin.py:92
 #: website/admin.py:111 website/admin.py:129 website/admin.py:136
 #: website/admin.py:144 website/auth.py:716 website/auth.py:743
@@ -49,325 +49,325 @@ msgstr "Hedy - My programs"
 msgid "unauthorized"
 msgstr "You don't have access rights for this page"
 
-#: app.py:762 app.py:1107
+#: app.py:760 app.py:1105
 #, fuzzy
 msgid "title_for-teacher"
 msgstr "Hedy - For teachers"
 
-#: app.py:779 app.py:781 app.py:923 app.py:945 app.py:947
+#: app.py:777 app.py:779 app.py:921 app.py:943 app.py:945
 #, fuzzy
 msgid "no_such_level"
 msgstr "No such Hedy level!"
 
-#: app.py:789 app.py:796 app.py:877 app.py:883
+#: app.py:787 app.py:794 app.py:875 app.py:881
 #, fuzzy
 msgid "no_such_program"
 msgstr "No such Hedy program!"
 
-#: app.py:819
+#: app.py:817
 #, fuzzy
 msgid "level_not_class"
 msgstr "You're in a class where this level has not been made available yet"
 
-#: app.py:928 website/teacher.py:421 website/teacher.py:437
+#: app.py:926 website/teacher.py:421 website/teacher.py:437
 #: website/teacher.py:466 website/teacher.py:492
 #, fuzzy
 msgid "no_such_adventure"
 msgstr "This adventure doesn't exist!"
 
-#: app.py:956 app.py:1209
+#: app.py:954 app.py:1207
 #, fuzzy
 msgid "page_not_found"
 msgstr "We could not find that page!"
 
-#: app.py:976
+#: app.py:974
 #, fuzzy
 msgid "title_signup"
 msgstr "Hedy - Create an account"
 
-#: app.py:983
+#: app.py:981
 #, fuzzy
 msgid "title_login"
 msgstr "Hedy - Login"
 
-#: app.py:990
+#: app.py:988
 #, fuzzy
 msgid "title_recover"
 msgstr "Hedy - Recover account"
 
-#: app.py:1006
+#: app.py:1004
 #, fuzzy
 msgid "title_reset"
 msgstr "Hedy - Reset password"
 
-#: app.py:1032
+#: app.py:1030
 #, fuzzy
 msgid "title_my-profile"
 msgstr "Hedy - My account"
 
-#: app.py:1048
+#: app.py:1046
 #, fuzzy
 msgid "title_learn-more"
 msgstr "Hedy - Learn more"
 
-#: app.py:1054
+#: app.py:1052
 #, fuzzy
 msgid "title_privacy"
 msgstr "Hedy - Privacy terms"
 
-#: app.py:1064
+#: app.py:1062
 #, fuzzy
 msgid "title_start"
 msgstr "Hedy - A gradual programming language"
 
-#: app.py:1082
+#: app.py:1080
 #, fuzzy
 msgid "title_landing-page"
 msgstr "Welcome to Hedy!"
 
-#: app.py:1200
+#: app.py:1198
 #, fuzzy
 msgid "title_explore"
 msgstr "Hedy - Explore"
 
-#: app.py:1221 app.py:1226
+#: app.py:1219 app.py:1224
 #, fuzzy
 msgid "no_such_highscore"
 msgstr "No such Hedy level!"
 
-#: app.py:1255 app.py:1257
+#: app.py:1253 app.py:1255
 #, fuzzy
 msgid "translate_error"
 msgstr ""
 "Something went wrong while translating the code. Try running the code to "
 "see if it has an error. Code with errors can not be translated."
 
-#: app.py:1262 app.py:1296
+#: app.py:1260 app.py:1294
 #, fuzzy
 msgid "tutorial_start_title"
 msgstr "Welcome to Hedy!"
 
-#: app.py:1262
+#: app.py:1260
 #, fuzzy
 msgid "tutorial_start_message"
 msgstr "In this tutorial we will explain all the Hedy features step-by-step."
 
-#: app.py:1264
+#: app.py:1262
 #, fuzzy
 msgid "tutorial_editor_title"
 msgstr "The code editor"
 
-#: app.py:1264
+#: app.py:1262
 #, fuzzy
 msgid "tutorial_editor_message"
 msgstr "In this window you write all the code, try typing something!"
 
-#: app.py:1266
+#: app.py:1264
 #, fuzzy
 msgid "tutorial_output_title"
 msgstr "The output window"
 
-#: app.py:1266
+#: app.py:1264
 #, fuzzy
 msgid "tutorial_output_message"
 msgstr "The result of the code you execute will be shown here"
 
-#: app.py:1268
+#: app.py:1266
 #, fuzzy
 msgid "tutorial_run_title"
 msgstr "The run button"
 
-#: app.py:1268
+#: app.py:1266
 #, fuzzy
 msgid "tutorial_run_message"
 msgstr "With this button you can run your program! Shall we give it a try?"
 
-#: app.py:1270
+#: app.py:1268
 #, fuzzy
 msgid "tutorial_tryit_title"
 msgstr "Try it out!"
 
-#: app.py:1270
+#: app.py:1268
 #, fuzzy
 msgid "tutorial_tryit_message"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1272
+#: app.py:1270
 #, fuzzy
 msgid "tutorial_speakaloud_title"
 msgstr "The end!"
 
-#: app.py:1272
+#: app.py:1270
 #, fuzzy
 msgid "tutorial_speakaloud_message"
 msgstr "Click on 'next step' to really start coding with Hedy!"
 
-#: app.py:1274
+#: app.py:1272
 #, fuzzy
 msgid "tutorial_speakaloud_run_title"
 msgstr "The end!"
 
-#: app.py:1274
+#: app.py:1272
 #, fuzzy
 msgid "tutorial_speakaloud_run_message"
 msgstr "Click on 'next step' to really start coding with Hedy!"
 
-#: app.py:1276
+#: app.py:1274
 #, fuzzy
 msgid "tutorial_nextlevel_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1276
+#: app.py:1274
 #, fuzzy
 msgid "tutorial_nextlevel_message"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1278
+#: app.py:1276
 #, fuzzy
 msgid "tutorial_leveldefault_title"
 msgstr "Level explanation"
 
-#: app.py:1278
+#: app.py:1276
 #, fuzzy
 msgid "tutorial_leveldefault_message"
 msgstr ""
 "The first tab always contains the level explanation. In each level new "
 "commands will be explained here."
 
-#: app.py:1280
+#: app.py:1278
 #, fuzzy
 msgid "tutorial_adventures_title"
 msgstr "Customize adventure"
 
-#: app.py:1280
+#: app.py:1278
 #, fuzzy
 msgid "tutorial_adventures_message"
 msgstr "Customize adventure"
 
-#: app.py:1282
+#: app.py:1280
 #, fuzzy
 msgid "tutorial_quiz_title"
 msgstr "Quiz"
 
-#: app.py:1282
+#: app.py:1280
 #, fuzzy
 msgid "tutorial_quiz_message"
 msgstr ""
 "At the end of each level you can make the quiz. This way you can verify "
 "if you understand everything."
 
-#: app.py:1284
+#: app.py:1282
 #, fuzzy
 msgid "tutorial_saveshare_title"
 msgstr "Saving & sharing"
 
-#: app.py:1284
+#: app.py:1282
 #, fuzzy
 msgid "tutorial_saveshare_message"
 msgstr "You can save and share all your created programs with other Hedy users."
 
-#: app.py:1286
+#: app.py:1284
 #, fuzzy
 msgid "tutorial_cheatsheet_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1286
+#: app.py:1284
 #, fuzzy
 msgid "tutorial_cheatsheet_message"
 msgstr ""
 "If you forgot a command you can always use the cheatsheet. It shows a "
 "list of all commands you can use in the current level."
 
-#: app.py:1288 app.py:1308
+#: app.py:1286 app.py:1306
 #, fuzzy
 msgid "tutorial_end_title"
 msgstr "The end!"
 
-#: app.py:1288
+#: app.py:1286
 #, fuzzy
 msgid "tutorial_end_message"
 msgstr "Click on 'next step' to really start coding with Hedy!"
 
-#: app.py:1290 app.py:1310
+#: app.py:1288 app.py:1308
 #, fuzzy
 msgid "tutorial_title_not_found"
 msgstr "We could not find that page!"
 
-#: app.py:1290 app.py:1310
+#: app.py:1288 app.py:1308
 #, fuzzy
 msgid "tutorial_message_not_found"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1296
+#: app.py:1294
 #, fuzzy
 msgid "teacher_tutorial_start_message"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1298
+#: app.py:1296
 #, fuzzy
 msgid "tutorial_class_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1298
+#: app.py:1296
 #, fuzzy
 msgid "tutorial_class_message"
 msgstr "Customize adventure"
 
-#: app.py:1300
+#: app.py:1298
 #, fuzzy
 msgid "tutorial_customize_class_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1300
+#: app.py:1298
 #, fuzzy
 msgid "tutorial_customize_class_message"
 msgstr "Customize adventure"
 
-#: app.py:1302
+#: app.py:1300
 #, fuzzy
 msgid "tutorial_own_adventures_title"
 msgstr "Customize adventure"
 
-#: app.py:1302
+#: app.py:1300
 #, fuzzy
 msgid "tutorial_own_adventures_message"
 msgstr "Customize adventure"
 
-#: app.py:1304
+#: app.py:1302
 #, fuzzy
 msgid "tutorial_accounts_title"
 msgstr "Customize adventure"
 
-#: app.py:1304
+#: app.py:1302
 #, fuzzy
 msgid "tutorial_accounts_message"
 msgstr "Customize adventure"
 
-#: app.py:1306
+#: app.py:1304
 #, fuzzy
 msgid "tutorial_documentation_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1306
+#: app.py:1304
 #, fuzzy
 msgid "tutorial_documentation_message"
 msgstr "Customize adventure"
 
-#: app.py:1308
+#: app.py:1306
 #, fuzzy
 msgid "teacher_tutorial_end_message"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1318
+#: app.py:1316
 #, fuzzy
 msgid "tutorial_code_snippet"
 msgstr "Hide cheatsheet"
 
-#: app.py:1322 app.py:1332
+#: app.py:1320 app.py:1330
 msgid "invalid_tutorial_step"
 msgstr ""
 
-#: app.py:1489 website/auth.py:278 website/auth.py:333 website/auth.py:469
+#: app.py:1487 website/auth.py:278 website/auth.py:333 website/auth.py:469
 #: website/auth.py:494 website/auth.py:524 website/auth.py:637
 #: website/auth.py:675 website/auth.py:722 website/auth.py:749
 #: website/quiz.py:43 website/quiz.py:69 website/teacher.py:88
@@ -377,32 +377,32 @@ msgstr ""
 msgid "ajax_error"
 msgstr "Kulikuwa na hitilafu, tafadhali jaribu tena."
 
-#: app.py:1492
+#: app.py:1490
 #, fuzzy
 msgid "image_invalid"
 msgstr "Your chosen image is invalid."
 
-#: app.py:1494
+#: app.py:1492
 #, fuzzy
 msgid "personal_text_invalid"
 msgstr "Your personal text is invalid."
 
-#: app.py:1496 app.py:1502
+#: app.py:1494 app.py:1500
 #, fuzzy
 msgid "favourite_program_invalid"
 msgstr "Your chosen favourite program is invalid."
 
-#: app.py:1516 app.py:1517
+#: app.py:1514 app.py:1515
 #, fuzzy
 msgid "public_profile_updated"
 msgstr "Public profile updated."
 
-#: app.py:1554 app.py:1579
+#: app.py:1552 app.py:1577
 #, fuzzy
 msgid "user_not_private"
 msgstr "This user doesn't exist or doesn't have a public profile"
 
-#: app.py:1587
+#: app.py:1585
 #, fuzzy
 msgid "invalid_teacher_invitation_code"
 msgstr ""
@@ -744,151 +744,151 @@ msgstr "Hide cheatsheet"
 msgid "back_to_class"
 msgstr "Go back to class"
 
-#: templates/class-overview.html:13 templates/for-teachers.html:35
+#: templates/class-overview.html:14 templates/for-teachers.html:35
 #, fuzzy
 msgid "class_name_prompt"
 msgstr "Please enter the name of the class"
 
-#: templates/class-overview.html:19 templates/class-overview.html:66
+#: templates/class-overview.html:20 templates/class-overview.html:71
 #: templates/create-accounts.html:16 templates/highscores.html:25
 #: templates/login.html:12 templates/profile.html:89 templates/recover.html:8
 #: templates/signup.html:10
 msgid "username"
 msgstr "Jina la mtumiaji"
 
-#: templates/class-overview.html:20
+#: templates/class-overview.html:21
 #, fuzzy
 msgid "last_login"
 msgstr "Last login"
 
-#: templates/class-overview.html:21
+#: templates/class-overview.html:22
 #, fuzzy
 msgid "highest_level_reached"
 msgstr "Highest level reached"
 
-#: templates/class-overview.html:22
+#: templates/class-overview.html:23
 #, fuzzy
 msgid "number_programs"
 msgstr "Number of programs"
 
-#: templates/class-overview.html:23
+#: templates/class-overview.html:24
 #, fuzzy
 msgid "programs"
 msgstr "Programs"
 
-#: templates/class-overview.html:24 templates/create-accounts.html:17
+#: templates/class-overview.html:25 templates/create-accounts.html:17
 #: templates/login.html:15 templates/reset.html:8 templates/signup.html:19
 msgid "password"
 msgstr "Nenosiri"
 
-#: templates/class-overview.html:25 templates/class-overview.html:69
+#: templates/class-overview.html:26 templates/class-overview.html:74
 #: templates/customize-adventure.html:52 templates/for-teachers.html:46
 #: templates/for-teachers.html:56
 #, fuzzy
 msgid "remove"
 msgstr "Remove"
 
-#: templates/class-overview.html:35
+#: templates/class-overview.html:36
 #, fuzzy
 msgid "page"
 msgstr "page"
 
-#: templates/class-overview.html:36
+#: templates/class-overview.html:37
 #, fuzzy
 msgid "enter_password"
 msgstr "Enter a new password for"
 
-#: templates/class-overview.html:36
+#: templates/class-overview.html:37
 #, fuzzy
 msgid "password_change_prompt"
 msgstr "Are you sure you want to change this password?"
 
-#: templates/class-overview.html:37
+#: templates/class-overview.html:38
 #, fuzzy
 msgid "remove_student_prompt"
 msgstr "Are you sure you want to remove the student from the class?"
 
-#: templates/class-overview.html:44
+#: templates/class-overview.html:46
 #, fuzzy
 msgid "add_students"
 msgstr "students"
 
-#: templates/class-overview.html:45 templates/customize-class.html:5
+#: templates/class-overview.html:47 templates/customize-class.html:5
 #, fuzzy
 msgid "customize_class"
 msgstr "Customize class"
 
-#: templates/class-overview.html:46
+#: templates/class-overview.html:48
 #, fuzzy
 msgid "class_stats"
 msgstr "Show class statistics"
 
-#: templates/class-overview.html:47
+#: templates/class-overview.html:49
 #, fuzzy
 msgid "class_logs"
 msgstr "Last login"
 
-#: templates/class-overview.html:48 templates/customize-adventure.html:59
+#: templates/class-overview.html:52 templates/customize-adventure.html:59
 #, fuzzy
 msgid "back_to_teachers_page"
 msgstr "Go back to teachers page"
 
-#: templates/class-overview.html:49
+#: templates/class-overview.html:53
 #, fuzzy
 msgid "delete_class_prompt"
 msgstr "Are you sure you want to delete the class?"
 
-#: templates/class-overview.html:49
+#: templates/class-overview.html:53
 #, fuzzy
 msgid "delete_class"
 msgstr "Delete class permanently"
 
-#: templates/class-overview.html:52
+#: templates/class-overview.html:57
 #, fuzzy
 msgid "add_students_options"
 msgstr "Create student accounts"
 
-#: templates/class-overview.html:54
+#: templates/class-overview.html:59
 #, fuzzy
 msgid "copy_link_success"
 msgstr "Copy link to share"
 
-#: templates/class-overview.html:54
+#: templates/class-overview.html:59
 #, fuzzy
 msgid "copy_join_link"
 msgstr "Please copy and paste this link into a new tab:"
 
-#: templates/class-overview.html:55
+#: templates/class-overview.html:60
 #, fuzzy
 msgid "invite_prompt"
 msgstr "Enter a username"
 
-#: templates/class-overview.html:55
+#: templates/class-overview.html:60
 #, fuzzy
 msgid "invite_by_username"
 msgstr "All usernames need to be unique."
 
-#: templates/class-overview.html:56 templates/create-accounts.html:45
+#: templates/class-overview.html:61 templates/create-accounts.html:45
 #, fuzzy
 msgid "create_accounts"
 msgstr "Create multiple accounts"
 
-#: templates/class-overview.html:61
+#: templates/class-overview.html:66
 #, fuzzy
 msgid "pending_invites"
 msgstr "Pending invites"
 
-#: templates/class-overview.html:67
+#: templates/class-overview.html:72
 #, fuzzy
 msgid "invite_date"
 msgstr "Invite date"
 
-#: templates/class-overview.html:68
+#: templates/class-overview.html:73
 #, fuzzy
 msgid "expiration_date"
 msgstr "Expiration date"
 
-#: templates/class-overview.html:78 templates/profile.html:16
+#: templates/class-overview.html:83 templates/profile.html:16
 #, fuzzy
 msgid "delete_invite_prompt"
 msgstr "Are you sure you want to remove this class invitation?"
@@ -1346,10 +1346,10 @@ msgstr "My classes"
 msgid "achievements"
 msgstr "achievements"
 
-#: templates/highscores.html:27 templates/learn-more.html:22
-#: templates/profile.html:131 templates/signup.html:52
-msgid "country"
-msgstr "Nchi"
+#: templates/highscores.html:27
+#, fuzzy
+msgid "country_title"
+msgstr "Please select a valid country."
 
 #: templates/highscores.html:28 templates/landing-page.html:88
 #: templates/public-page.html:50
@@ -1638,6 +1638,11 @@ msgstr "Jina la mtumiaji"
 #, fuzzy
 msgid "lastname"
 msgstr "Name"
+
+#: templates/learn-more.html:22 templates/profile.html:131
+#: templates/signup.html:52
+msgid "country"
+msgstr "Nchi"
 
 #: templates/learn-more.html:31
 #, fuzzy

--- a/translations/tr/LC_MESSAGES/messages.po
+++ b/translations/tr/LC_MESSAGES/messages.po
@@ -3,16 +3,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-28 18:38+0300\n"
+"POT-Creation-Date: 2022-06-29 14:20+0200\n"
 "PO-Revision-Date: 2022-06-28 13:25+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: tr\n"
 "Language-Team: tr <LL@li.org>\n"
-"Plural-Forms: nplurals=2; plural=n != 1\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.9.1\n"
+"Generated-By: Babel 2.10.1\n"
 
 #: app.py:417
 #, fuzzy
@@ -24,7 +24,7 @@ msgstr "This program contains an error, are you sure you want to share it?"
 msgid "title_achievements"
 msgstr "Hedy - My achievements"
 
-#: app.py:644 app.py:748 app.py:1090 website/teacher.py:361
+#: app.py:644 app.py:746 app.py:1088 website/teacher.py:361
 #: website/teacher.py:372
 #, fuzzy
 msgid "not_teacher"
@@ -35,12 +35,12 @@ msgstr "Looks like you are not a teacher!"
 msgid "not_enrolled"
 msgstr "Looks like you are not in this class!"
 
-#: app.py:686
+#: app.py:684
 #, fuzzy
 msgid "title_programs"
 msgstr "Hedy - My programs"
 
-#: app.py:696 app.py:706 app.py:710 app.py:725 app.py:1005 app.py:1550
+#: app.py:694 app.py:704 app.py:708 app.py:723 app.py:1003 app.py:1548
 #: website/admin.py:17 website/admin.py:24 website/admin.py:92
 #: website/admin.py:111 website/admin.py:129 website/admin.py:136
 #: website/admin.py:144 website/auth.py:716 website/auth.py:743
@@ -49,325 +49,325 @@ msgstr "Hedy - My programs"
 msgid "unauthorized"
 msgstr "You don't have access rights for this page"
 
-#: app.py:762 app.py:1107
+#: app.py:760 app.py:1105
 #, fuzzy
 msgid "title_for-teacher"
 msgstr "Hedy - For teachers"
 
-#: app.py:779 app.py:781 app.py:923 app.py:945 app.py:947
+#: app.py:777 app.py:779 app.py:921 app.py:943 app.py:945
 #, fuzzy
 msgid "no_such_level"
 msgstr "No such Hedy level!"
 
-#: app.py:789 app.py:796 app.py:877 app.py:883
+#: app.py:787 app.py:794 app.py:875 app.py:881
 #, fuzzy
 msgid "no_such_program"
 msgstr "No such Hedy program!"
 
-#: app.py:819
+#: app.py:817
 #, fuzzy
 msgid "level_not_class"
 msgstr "You're in a class where this level has not been made available yet"
 
-#: app.py:928 website/teacher.py:421 website/teacher.py:437
+#: app.py:926 website/teacher.py:421 website/teacher.py:437
 #: website/teacher.py:466 website/teacher.py:492
 #, fuzzy
 msgid "no_such_adventure"
 msgstr "This adventure doesn't exist!"
 
-#: app.py:956 app.py:1209
+#: app.py:954 app.py:1207
 #, fuzzy
 msgid "page_not_found"
 msgstr "We could not find that page!"
 
-#: app.py:976
+#: app.py:974
 #, fuzzy
 msgid "title_signup"
 msgstr "Hedy - Create an account"
 
-#: app.py:983
+#: app.py:981
 #, fuzzy
 msgid "title_login"
 msgstr "Hedy - Login"
 
-#: app.py:990
+#: app.py:988
 #, fuzzy
 msgid "title_recover"
 msgstr "Hedy - Recover account"
 
-#: app.py:1006
+#: app.py:1004
 #, fuzzy
 msgid "title_reset"
 msgstr "Hedy - Reset password"
 
-#: app.py:1032
+#: app.py:1030
 #, fuzzy
 msgid "title_my-profile"
 msgstr "Hedy - My account"
 
-#: app.py:1048
+#: app.py:1046
 #, fuzzy
 msgid "title_learn-more"
 msgstr "Hedy - Learn more"
 
-#: app.py:1054
+#: app.py:1052
 #, fuzzy
 msgid "title_privacy"
 msgstr "Hedy - Privacy terms"
 
-#: app.py:1064
+#: app.py:1062
 #, fuzzy
 msgid "title_start"
 msgstr "Hedy - A gradual programming language"
 
-#: app.py:1082
+#: app.py:1080
 #, fuzzy
 msgid "title_landing-page"
 msgstr "Welcome to Hedy!"
 
-#: app.py:1200
+#: app.py:1198
 #, fuzzy
 msgid "title_explore"
 msgstr "Hedy - Explore"
 
-#: app.py:1221 app.py:1226
+#: app.py:1219 app.py:1224
 #, fuzzy
 msgid "no_such_highscore"
 msgstr "No such Hedy level!"
 
-#: app.py:1255 app.py:1257
+#: app.py:1253 app.py:1255
 #, fuzzy
 msgid "translate_error"
 msgstr ""
 "Something went wrong while translating the code. Try running the code to "
 "see if it has an error. Code with errors can not be translated."
 
-#: app.py:1262 app.py:1296
+#: app.py:1260 app.py:1294
 #, fuzzy
 msgid "tutorial_start_title"
 msgstr "Welcome to Hedy!"
 
-#: app.py:1262
+#: app.py:1260
 #, fuzzy
 msgid "tutorial_start_message"
 msgstr "In this tutorial we will explain all the Hedy features step-by-step."
 
-#: app.py:1264
+#: app.py:1262
 #, fuzzy
 msgid "tutorial_editor_title"
 msgstr "The code editor"
 
-#: app.py:1264
+#: app.py:1262
 #, fuzzy
 msgid "tutorial_editor_message"
 msgstr "In this window you write all the code, try typing something!"
 
-#: app.py:1266
+#: app.py:1264
 #, fuzzy
 msgid "tutorial_output_title"
 msgstr "The output window"
 
-#: app.py:1266
+#: app.py:1264
 #, fuzzy
 msgid "tutorial_output_message"
 msgstr "The result of the code you execute will be shown here"
 
-#: app.py:1268
+#: app.py:1266
 #, fuzzy
 msgid "tutorial_run_title"
 msgstr "The run button"
 
-#: app.py:1268
+#: app.py:1266
 #, fuzzy
 msgid "tutorial_run_message"
 msgstr "With this button you can run your program! Shall we give it a try?"
 
-#: app.py:1270
+#: app.py:1268
 #, fuzzy
 msgid "tutorial_tryit_title"
 msgstr "Try it out!"
 
-#: app.py:1270
+#: app.py:1268
 #, fuzzy
 msgid "tutorial_tryit_message"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1272
+#: app.py:1270
 #, fuzzy
 msgid "tutorial_speakaloud_title"
 msgstr "The end!"
 
-#: app.py:1272
+#: app.py:1270
 #, fuzzy
 msgid "tutorial_speakaloud_message"
 msgstr "Click on 'next step' to really start coding with Hedy!"
 
-#: app.py:1274
+#: app.py:1272
 #, fuzzy
 msgid "tutorial_speakaloud_run_title"
 msgstr "The end!"
 
-#: app.py:1274
+#: app.py:1272
 #, fuzzy
 msgid "tutorial_speakaloud_run_message"
 msgstr "Click on 'next step' to really start coding with Hedy!"
 
-#: app.py:1276
+#: app.py:1274
 #, fuzzy
 msgid "tutorial_nextlevel_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1276
+#: app.py:1274
 #, fuzzy
 msgid "tutorial_nextlevel_message"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1278
+#: app.py:1276
 #, fuzzy
 msgid "tutorial_leveldefault_title"
 msgstr "Level explanation"
 
-#: app.py:1278
+#: app.py:1276
 #, fuzzy
 msgid "tutorial_leveldefault_message"
 msgstr ""
 "The first tab always contains the level explanation. In each level new "
 "commands will be explained here."
 
-#: app.py:1280
+#: app.py:1278
 #, fuzzy
 msgid "tutorial_adventures_title"
 msgstr "Customize adventure"
 
-#: app.py:1280
+#: app.py:1278
 #, fuzzy
 msgid "tutorial_adventures_message"
 msgstr "Customize adventure"
 
-#: app.py:1282
+#: app.py:1280
 #, fuzzy
 msgid "tutorial_quiz_title"
 msgstr "Quiz"
 
-#: app.py:1282
+#: app.py:1280
 #, fuzzy
 msgid "tutorial_quiz_message"
 msgstr ""
 "At the end of each level you can make the quiz. This way you can verify "
 "if you understand everything."
 
-#: app.py:1284
+#: app.py:1282
 #, fuzzy
 msgid "tutorial_saveshare_title"
 msgstr "Saving & sharing"
 
-#: app.py:1284
+#: app.py:1282
 #, fuzzy
 msgid "tutorial_saveshare_message"
 msgstr "You can save and share all your created programs with other Hedy users."
 
-#: app.py:1286
+#: app.py:1284
 #, fuzzy
 msgid "tutorial_cheatsheet_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1286
+#: app.py:1284
 #, fuzzy
 msgid "tutorial_cheatsheet_message"
 msgstr ""
 "If you forgot a command you can always use the cheatsheet. It shows a "
 "list of all commands you can use in the current level."
 
-#: app.py:1288 app.py:1308
+#: app.py:1286 app.py:1306
 #, fuzzy
 msgid "tutorial_end_title"
 msgstr "The end!"
 
-#: app.py:1288
+#: app.py:1286
 #, fuzzy
 msgid "tutorial_end_message"
 msgstr "Click on 'next step' to really start coding with Hedy!"
 
-#: app.py:1290 app.py:1310
+#: app.py:1288 app.py:1308
 #, fuzzy
 msgid "tutorial_title_not_found"
 msgstr "We could not find that page!"
 
-#: app.py:1290 app.py:1310
+#: app.py:1288 app.py:1308
 #, fuzzy
 msgid "tutorial_message_not_found"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1296
+#: app.py:1294
 #, fuzzy
 msgid "teacher_tutorial_start_message"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1298
+#: app.py:1296
 #, fuzzy
 msgid "tutorial_class_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1298
+#: app.py:1296
 #, fuzzy
 msgid "tutorial_class_message"
 msgstr "Customize adventure"
 
-#: app.py:1300
+#: app.py:1298
 #, fuzzy
 msgid "tutorial_customize_class_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1300
+#: app.py:1298
 #, fuzzy
 msgid "tutorial_customize_class_message"
 msgstr "Customize adventure"
 
-#: app.py:1302
+#: app.py:1300
 #, fuzzy
 msgid "tutorial_own_adventures_title"
 msgstr "Customize adventure"
 
-#: app.py:1302
+#: app.py:1300
 #, fuzzy
 msgid "tutorial_own_adventures_message"
 msgstr "Customize adventure"
 
-#: app.py:1304
+#: app.py:1302
 #, fuzzy
 msgid "tutorial_accounts_title"
 msgstr "Customize adventure"
 
-#: app.py:1304
+#: app.py:1302
 #, fuzzy
 msgid "tutorial_accounts_message"
 msgstr "Customize adventure"
 
-#: app.py:1306
+#: app.py:1304
 #, fuzzy
 msgid "tutorial_documentation_title"
 msgstr "Hide cheatsheet"
 
-#: app.py:1306
+#: app.py:1304
 #, fuzzy
 msgid "tutorial_documentation_message"
 msgstr "Customize adventure"
 
-#: app.py:1308
+#: app.py:1306
 #, fuzzy
 msgid "teacher_tutorial_end_message"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1318
+#: app.py:1316
 #, fuzzy
 msgid "tutorial_code_snippet"
 msgstr "Hide cheatsheet"
 
-#: app.py:1322 app.py:1332
+#: app.py:1320 app.py:1330
 msgid "invalid_tutorial_step"
 msgstr ""
 
-#: app.py:1489 website/auth.py:278 website/auth.py:333 website/auth.py:469
+#: app.py:1487 website/auth.py:278 website/auth.py:333 website/auth.py:469
 #: website/auth.py:494 website/auth.py:524 website/auth.py:637
 #: website/auth.py:675 website/auth.py:722 website/auth.py:749
 #: website/quiz.py:43 website/quiz.py:69 website/teacher.py:88
@@ -378,32 +378,32 @@ msgstr ""
 msgid "ajax_error"
 msgstr "There was an error, please try again."
 
-#: app.py:1492
+#: app.py:1490
 #, fuzzy
 msgid "image_invalid"
 msgstr "Your chosen image is invalid."
 
-#: app.py:1494
+#: app.py:1492
 #, fuzzy
 msgid "personal_text_invalid"
 msgstr "Your personal text is invalid."
 
-#: app.py:1496 app.py:1502
+#: app.py:1494 app.py:1500
 #, fuzzy
 msgid "favourite_program_invalid"
 msgstr "Your chosen favourite program is invalid."
 
-#: app.py:1516 app.py:1517
+#: app.py:1514 app.py:1515
 #, fuzzy
 msgid "public_profile_updated"
 msgstr "Public profile updated."
 
-#: app.py:1554 app.py:1579
+#: app.py:1552 app.py:1577
 #, fuzzy
 msgid "user_not_private"
 msgstr "This user doesn't exist or doesn't have a public profile"
 
-#: app.py:1587
+#: app.py:1585
 #, fuzzy
 msgid "invalid_teacher_invitation_code"
 msgstr ""
@@ -762,151 +762,151 @@ msgstr "Hide cheatsheet"
 msgid "back_to_class"
 msgstr "Go back to class"
 
-#: templates/class-overview.html:13 templates/for-teachers.html:35
+#: templates/class-overview.html:14 templates/for-teachers.html:35
 #, fuzzy
 msgid "class_name_prompt"
 msgstr "Please enter the name of the class"
 
-#: templates/class-overview.html:19 templates/class-overview.html:66
+#: templates/class-overview.html:20 templates/class-overview.html:71
 #: templates/create-accounts.html:16 templates/highscores.html:25
 #: templates/login.html:12 templates/profile.html:89 templates/recover.html:8
 #: templates/signup.html:10
 msgid "username"
 msgstr "Kullanıcı adı"
 
-#: templates/class-overview.html:20
+#: templates/class-overview.html:21
 #, fuzzy
 msgid "last_login"
 msgstr "Last login"
 
-#: templates/class-overview.html:21
+#: templates/class-overview.html:22
 #, fuzzy
 msgid "highest_level_reached"
 msgstr "Highest level reached"
 
-#: templates/class-overview.html:22
+#: templates/class-overview.html:23
 #, fuzzy
 msgid "number_programs"
 msgstr "Number of programs"
 
-#: templates/class-overview.html:23
+#: templates/class-overview.html:24
 #, fuzzy
 msgid "programs"
 msgstr "Programs"
 
-#: templates/class-overview.html:24 templates/create-accounts.html:17
+#: templates/class-overview.html:25 templates/create-accounts.html:17
 #: templates/login.html:15 templates/reset.html:8 templates/signup.html:19
 msgid "password"
 msgstr "Parola"
 
-#: templates/class-overview.html:25 templates/class-overview.html:69
+#: templates/class-overview.html:26 templates/class-overview.html:74
 #: templates/customize-adventure.html:52 templates/for-teachers.html:46
 #: templates/for-teachers.html:56
 #, fuzzy
 msgid "remove"
 msgstr "Remove"
 
-#: templates/class-overview.html:35
+#: templates/class-overview.html:36
 #, fuzzy
 msgid "page"
 msgstr "page"
 
-#: templates/class-overview.html:36
+#: templates/class-overview.html:37
 #, fuzzy
 msgid "enter_password"
 msgstr "Enter a new password for"
 
-#: templates/class-overview.html:36
+#: templates/class-overview.html:37
 #, fuzzy
 msgid "password_change_prompt"
 msgstr "Are you sure you want to change this password?"
 
-#: templates/class-overview.html:37
+#: templates/class-overview.html:38
 #, fuzzy
 msgid "remove_student_prompt"
 msgstr "Are you sure you want to remove the student from the class?"
 
-#: templates/class-overview.html:44
+#: templates/class-overview.html:46
 #, fuzzy
 msgid "add_students"
 msgstr "students"
 
-#: templates/class-overview.html:45 templates/customize-class.html:5
+#: templates/class-overview.html:47 templates/customize-class.html:5
 #, fuzzy
 msgid "customize_class"
 msgstr "Customize class"
 
-#: templates/class-overview.html:46
+#: templates/class-overview.html:48
 #, fuzzy
 msgid "class_stats"
 msgstr "Show class statistics"
 
-#: templates/class-overview.html:47
+#: templates/class-overview.html:49
 #, fuzzy
 msgid "class_logs"
 msgstr "Last login"
 
-#: templates/class-overview.html:48 templates/customize-adventure.html:59
+#: templates/class-overview.html:52 templates/customize-adventure.html:59
 #, fuzzy
 msgid "back_to_teachers_page"
 msgstr "Go back to teachers page"
 
-#: templates/class-overview.html:49
+#: templates/class-overview.html:53
 #, fuzzy
 msgid "delete_class_prompt"
 msgstr "Are you sure you want to delete the class?"
 
-#: templates/class-overview.html:49
+#: templates/class-overview.html:53
 #, fuzzy
 msgid "delete_class"
 msgstr "Delete class permanently"
 
-#: templates/class-overview.html:52
+#: templates/class-overview.html:57
 #, fuzzy
 msgid "add_students_options"
 msgstr "Create student accounts"
 
-#: templates/class-overview.html:54
+#: templates/class-overview.html:59
 #, fuzzy
 msgid "copy_link_success"
 msgstr "Copy link to share"
 
-#: templates/class-overview.html:54
+#: templates/class-overview.html:59
 #, fuzzy
 msgid "copy_join_link"
 msgstr "Please copy and paste this link into a new tab:"
 
-#: templates/class-overview.html:55
+#: templates/class-overview.html:60
 #, fuzzy
 msgid "invite_prompt"
 msgstr "Enter a username"
 
-#: templates/class-overview.html:55
+#: templates/class-overview.html:60
 #, fuzzy
 msgid "invite_by_username"
 msgstr "All usernames need to be unique."
 
-#: templates/class-overview.html:56 templates/create-accounts.html:45
+#: templates/class-overview.html:61 templates/create-accounts.html:45
 #, fuzzy
 msgid "create_accounts"
 msgstr "Create multiple accounts"
 
-#: templates/class-overview.html:61
+#: templates/class-overview.html:66
 #, fuzzy
 msgid "pending_invites"
 msgstr "Pending invites"
 
-#: templates/class-overview.html:67
+#: templates/class-overview.html:72
 #, fuzzy
 msgid "invite_date"
 msgstr "Invite date"
 
-#: templates/class-overview.html:68
+#: templates/class-overview.html:73
 #, fuzzy
 msgid "expiration_date"
 msgstr "Expiration date"
 
-#: templates/class-overview.html:78 templates/profile.html:16
+#: templates/class-overview.html:83 templates/profile.html:16
 #, fuzzy
 msgid "delete_invite_prompt"
 msgstr "Are you sure you want to remove this class invitation?"
@@ -1367,11 +1367,10 @@ msgstr "My classes"
 msgid "achievements"
 msgstr "achievements"
 
-#: templates/highscores.html:27 templates/learn-more.html:22
-#: templates/profile.html:131 templates/signup.html:52
+#: templates/highscores.html:27
 #, fuzzy
-msgid "country"
-msgstr "Country"
+msgid "country_title"
+msgstr "Please select a valid country."
 
 #: templates/highscores.html:28 templates/landing-page.html:88
 #: templates/public-page.html:50
@@ -1672,6 +1671,12 @@ msgstr "Kullanıcı adı"
 #, fuzzy
 msgid "lastname"
 msgstr "Name"
+
+#: templates/learn-more.html:22 templates/profile.html:131
+#: templates/signup.html:52
+#, fuzzy
+msgid "country"
+msgstr "Country"
 
 #: templates/learn-more.html:31
 #, fuzzy

--- a/translations/zh_Hans/LC_MESSAGES/messages.po
+++ b/translations/zh_Hans/LC_MESSAGES/messages.po
@@ -3,16 +3,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-28 18:38+0300\n"
+"POT-Creation-Date: 2022-06-29 14:20+0200\n"
 "PO-Revision-Date: 2022-06-28 13:25+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: zh_Hans\n"
 "Language-Team: zh_Hans <LL@li.org>\n"
-"Plural-Forms: nplurals=1; plural=0\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.9.1\n"
+"Generated-By: Babel 2.10.1\n"
 
 #: app.py:417
 msgid "program_contains_error"
@@ -22,7 +22,7 @@ msgstr "这个程序包含一个错误，你确定要分享它吗？"
 msgid "title_achievements"
 msgstr "海迪 - 我的成绩"
 
-#: app.py:644 app.py:748 app.py:1090 website/teacher.py:361
+#: app.py:644 app.py:746 app.py:1088 website/teacher.py:361
 #: website/teacher.py:372
 msgid "not_teacher"
 msgstr "看来你不是一个老师!"
@@ -31,11 +31,11 @@ msgstr "看来你不是一个老师!"
 msgid "not_enrolled"
 msgstr "看来你不在这个班上！"
 
-#: app.py:686
+#: app.py:684
 msgid "title_programs"
 msgstr "海迪 - 我的程序"
 
-#: app.py:696 app.py:706 app.py:710 app.py:725 app.py:1005 app.py:1550
+#: app.py:694 app.py:704 app.py:708 app.py:723 app.py:1003 app.py:1548
 #: website/admin.py:17 website/admin.py:24 website/admin.py:92
 #: website/admin.py:111 website/admin.py:129 website/admin.py:136
 #: website/admin.py:144 website/auth.py:716 website/auth.py:743
@@ -43,312 +43,312 @@ msgstr "海迪 - 我的程序"
 msgid "unauthorized"
 msgstr "你没有此页面的访问权限"
 
-#: app.py:762 app.py:1107
+#: app.py:760 app.py:1105
 #, fuzzy
 msgid "title_for-teacher"
 msgstr "海迪 - 给教师"
 
-#: app.py:779 app.py:781 app.py:923 app.py:945 app.py:947
+#: app.py:777 app.py:779 app.py:921 app.py:943 app.py:945
 #, fuzzy
 msgid "no_such_level"
 msgstr "没有这样的海迪级别！"
 
-#: app.py:789 app.py:796 app.py:877 app.py:883
+#: app.py:787 app.py:794 app.py:875 app.py:881
 #, fuzzy
 msgid "no_such_program"
 msgstr "没有这样的海迪程序！"
 
-#: app.py:819
+#: app.py:817
 #, fuzzy
 msgid "level_not_class"
 msgstr "此级别还没有提供给你所在的班级"
 
-#: app.py:928 website/teacher.py:421 website/teacher.py:437
+#: app.py:926 website/teacher.py:421 website/teacher.py:437
 #: website/teacher.py:466 website/teacher.py:492
 #, fuzzy
 msgid "no_such_adventure"
 msgstr "这个探险活动不存在！"
 
-#: app.py:956 app.py:1209
+#: app.py:954 app.py:1207
 msgid "page_not_found"
 msgstr "无法找到该页面！"
 
-#: app.py:976
+#: app.py:974
 msgid "title_signup"
 msgstr "海迪 - 创建一个帐户"
 
-#: app.py:983
+#: app.py:981
 msgid "title_login"
 msgstr "海迪 - 登录"
 
-#: app.py:990
+#: app.py:988
 #, fuzzy
 msgid "title_recover"
 msgstr "海迪 - 恢复帐户"
 
-#: app.py:1006
+#: app.py:1004
 msgid "title_reset"
 msgstr "海迪 - 重置密码"
 
-#: app.py:1032
+#: app.py:1030
 msgid "title_my-profile"
 msgstr "海迪 - 我的账户"
 
-#: app.py:1048
+#: app.py:1046
 msgid "title_learn-more"
 msgstr "海迪 - 了解更多"
 
-#: app.py:1054
+#: app.py:1052
 msgid "title_privacy"
 msgstr "海迪 - 隐私条款"
 
-#: app.py:1064
+#: app.py:1062
 msgid "title_start"
 msgstr "海迪 - 一门循序渐进的编程语言"
 
-#: app.py:1082
+#: app.py:1080
 msgid "title_landing-page"
 msgstr "欢迎来到海迪！"
 
-#: app.py:1200
+#: app.py:1198
 msgid "title_explore"
 msgstr "海迪 - 探索"
 
-#: app.py:1221 app.py:1226
+#: app.py:1219 app.py:1224
 #, fuzzy
 msgid "no_such_highscore"
 msgstr "没有这样的海迪级别！"
 
-#: app.py:1255 app.py:1257
+#: app.py:1253 app.py:1255
 msgid "translate_error"
 msgstr "翻译代码时出了点问题。尝试运行代码以查看它是否有错误。有错误的代码无法翻译。"
 
-#: app.py:1262 app.py:1296
+#: app.py:1260 app.py:1294
 #, fuzzy
 msgid "tutorial_start_title"
 msgstr "Welcome to Hedy!"
 
-#: app.py:1262
+#: app.py:1260
 #, fuzzy
 msgid "tutorial_start_message"
 msgstr "In this tutorial we will explain all the Hedy features step-by-step."
 
-#: app.py:1264
+#: app.py:1262
 #, fuzzy
 msgid "tutorial_editor_title"
 msgstr "The code editor"
 
-#: app.py:1264
+#: app.py:1262
 #, fuzzy
 msgid "tutorial_editor_message"
 msgstr "In this window you write all the code, try typing something!"
 
-#: app.py:1266
+#: app.py:1264
 #, fuzzy
 msgid "tutorial_output_title"
 msgstr "The output window"
 
-#: app.py:1266
+#: app.py:1264
 #, fuzzy
 msgid "tutorial_output_message"
 msgstr "The result of the code you execute will be shown here"
 
-#: app.py:1268
+#: app.py:1266
 #, fuzzy
 msgid "tutorial_run_title"
 msgstr "The run button"
 
-#: app.py:1268
+#: app.py:1266
 #, fuzzy
 msgid "tutorial_run_message"
 msgstr "With this button you can run your program! Shall we give it a try?"
 
-#: app.py:1270
+#: app.py:1268
 #, fuzzy
 msgid "tutorial_tryit_title"
 msgstr "Try it out!"
 
-#: app.py:1270
+#: app.py:1268
 #, fuzzy
 msgid "tutorial_tryit_message"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1272
+#: app.py:1270
 #, fuzzy
 msgid "tutorial_speakaloud_title"
 msgstr "The end!"
 
-#: app.py:1272
+#: app.py:1270
 #, fuzzy
 msgid "tutorial_speakaloud_message"
 msgstr "Click on 'next step' to really start coding with Hedy!"
 
-#: app.py:1274
+#: app.py:1272
 #, fuzzy
 msgid "tutorial_speakaloud_run_title"
 msgstr "The end!"
 
-#: app.py:1274
+#: app.py:1272
 #, fuzzy
 msgid "tutorial_speakaloud_run_message"
 msgstr "Click on 'next step' to really start coding with Hedy!"
 
-#: app.py:1276
+#: app.py:1274
 #, fuzzy
 msgid "tutorial_nextlevel_title"
 msgstr "Cheatsheet"
 
-#: app.py:1276
+#: app.py:1274
 #, fuzzy
 msgid "tutorial_nextlevel_message"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1278
+#: app.py:1276
 #, fuzzy
 msgid "tutorial_leveldefault_title"
 msgstr "Level explanation"
 
-#: app.py:1278
+#: app.py:1276
 #, fuzzy
 msgid "tutorial_leveldefault_message"
 msgstr ""
 "The first tab always contains the level explanation. In each level new "
 "commands will be explained here."
 
-#: app.py:1280
+#: app.py:1278
 #, fuzzy
 msgid "tutorial_adventures_title"
 msgstr "自定义探险活动"
 
-#: app.py:1280
+#: app.py:1278
 #, fuzzy
 msgid "tutorial_adventures_message"
 msgstr "自定义探险活动"
 
-#: app.py:1282
+#: app.py:1280
 #, fuzzy
 msgid "tutorial_quiz_title"
 msgstr "Quiz"
 
-#: app.py:1282
+#: app.py:1280
 #, fuzzy
 msgid "tutorial_quiz_message"
 msgstr ""
 "At the end of each level you can make the quiz. This way you can verify "
 "if you understand everything."
 
-#: app.py:1284
+#: app.py:1282
 #, fuzzy
 msgid "tutorial_saveshare_title"
 msgstr "Saving & sharing"
 
-#: app.py:1284
+#: app.py:1282
 #, fuzzy
 msgid "tutorial_saveshare_message"
 msgstr "You can save and share all your created programs with other Hedy users."
 
-#: app.py:1286
+#: app.py:1284
 #, fuzzy
 msgid "tutorial_cheatsheet_title"
 msgstr "Cheatsheet"
 
-#: app.py:1286
+#: app.py:1284
 #, fuzzy
 msgid "tutorial_cheatsheet_message"
 msgstr ""
 "If you forgot a command you can always use the cheatsheet. It shows a "
 "list of all commands you can use in the current level."
 
-#: app.py:1288 app.py:1308
+#: app.py:1286 app.py:1306
 #, fuzzy
 msgid "tutorial_end_title"
 msgstr "The end!"
 
-#: app.py:1288
+#: app.py:1286
 #, fuzzy
 msgid "tutorial_end_message"
 msgstr "Click on 'next step' to really start coding with Hedy!"
 
-#: app.py:1290 app.py:1310
+#: app.py:1288 app.py:1308
 #, fuzzy
 msgid "tutorial_title_not_found"
 msgstr "无法找到该页面！"
 
-#: app.py:1290 app.py:1310
+#: app.py:1288 app.py:1308
 #, fuzzy
 msgid "tutorial_message_not_found"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1296
+#: app.py:1294
 #, fuzzy
 msgid "teacher_tutorial_start_message"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1298
+#: app.py:1296
 #, fuzzy
 msgid "tutorial_class_title"
 msgstr "Cheatsheet"
 
-#: app.py:1298
+#: app.py:1296
 #, fuzzy
 msgid "tutorial_class_message"
 msgstr "自定义探险活动"
 
-#: app.py:1300
+#: app.py:1298
 #, fuzzy
 msgid "tutorial_customize_class_title"
 msgstr "Cheatsheet"
 
-#: app.py:1300
+#: app.py:1298
 #, fuzzy
 msgid "tutorial_customize_class_message"
 msgstr "自定义探险活动"
 
-#: app.py:1302
+#: app.py:1300
 #, fuzzy
 msgid "tutorial_own_adventures_title"
 msgstr "自定义探险活动"
 
-#: app.py:1302
+#: app.py:1300
 #, fuzzy
 msgid "tutorial_own_adventures_message"
 msgstr "自定义探险活动"
 
-#: app.py:1304
+#: app.py:1302
 #, fuzzy
 msgid "tutorial_accounts_title"
 msgstr "自定义探险活动"
 
-#: app.py:1304
+#: app.py:1302
 #, fuzzy
 msgid "tutorial_accounts_message"
 msgstr "自定义探险活动"
 
-#: app.py:1306
+#: app.py:1304
 #, fuzzy
 msgid "tutorial_documentation_title"
 msgstr "Cheatsheet"
 
-#: app.py:1306
+#: app.py:1304
 #, fuzzy
 msgid "tutorial_documentation_message"
 msgstr "自定义探险活动"
 
-#: app.py:1308
+#: app.py:1306
 #, fuzzy
 msgid "teacher_tutorial_end_message"
 msgstr "You have received an invitation to join class"
 
-#: app.py:1318
+#: app.py:1316
 #, fuzzy
 msgid "tutorial_code_snippet"
 msgstr "Cheatsheet"
 
-#: app.py:1322 app.py:1332
+#: app.py:1320 app.py:1330
 msgid "invalid_tutorial_step"
 msgstr ""
 
-#: app.py:1489 website/auth.py:278 website/auth.py:333 website/auth.py:469
+#: app.py:1487 website/auth.py:278 website/auth.py:333 website/auth.py:469
 #: website/auth.py:494 website/auth.py:524 website/auth.py:637
 #: website/auth.py:675 website/auth.py:722 website/auth.py:749
 #: website/quiz.py:43 website/quiz.py:69 website/teacher.py:88
@@ -359,28 +359,28 @@ msgstr ""
 msgid "ajax_error"
 msgstr "出现了一个错误，请再试一次。"
 
-#: app.py:1492
+#: app.py:1490
 msgid "image_invalid"
 msgstr "你选择的图像是无效的。"
 
-#: app.py:1494
+#: app.py:1492
 #, fuzzy
 msgid "personal_text_invalid"
 msgstr "你的个人文档是无效的。"
 
-#: app.py:1496 app.py:1502
+#: app.py:1494 app.py:1500
 msgid "favourite_program_invalid"
 msgstr "你选择的最喜欢的程序是无效的。"
 
-#: app.py:1516 app.py:1517
+#: app.py:1514 app.py:1515
 msgid "public_profile_updated"
 msgstr "公开资料已更新。"
 
-#: app.py:1554 app.py:1579
+#: app.py:1552 app.py:1577
 msgid "user_not_private"
 msgstr "此用户不存在或没有公开个人资料"
 
-#: app.py:1587
+#: app.py:1585
 msgid "invalid_teacher_invitation_code"
 msgstr "教师邀请码无效。想要成为一名教师，请联系 hedy@felienne.com。"
 
@@ -726,12 +726,12 @@ msgstr "Cheatsheet"
 msgid "back_to_class"
 msgstr "Go back to class"
 
-#: templates/class-overview.html:13 templates/for-teachers.html:35
+#: templates/class-overview.html:14 templates/for-teachers.html:35
 #, fuzzy
 msgid "class_name_prompt"
 msgstr "Please enter the name of the class"
 
-#: templates/class-overview.html:19 templates/class-overview.html:66
+#: templates/class-overview.html:20 templates/class-overview.html:71
 #: templates/create-accounts.html:16 templates/highscores.html:25
 #: templates/login.html:12 templates/profile.html:89 templates/recover.html:8
 #: templates/signup.html:10
@@ -739,138 +739,138 @@ msgstr "Please enter the name of the class"
 msgid "username"
 msgstr "Username"
 
-#: templates/class-overview.html:20
+#: templates/class-overview.html:21
 #, fuzzy
 msgid "last_login"
 msgstr "Last login"
 
-#: templates/class-overview.html:21
+#: templates/class-overview.html:22
 #, fuzzy
 msgid "highest_level_reached"
 msgstr "Highest level reached"
 
-#: templates/class-overview.html:22
+#: templates/class-overview.html:23
 #, fuzzy
 msgid "number_programs"
 msgstr "Number of programs"
 
-#: templates/class-overview.html:23
+#: templates/class-overview.html:24
 #, fuzzy
 msgid "programs"
 msgstr "Programs"
 
-#: templates/class-overview.html:24 templates/create-accounts.html:17
+#: templates/class-overview.html:25 templates/create-accounts.html:17
 #: templates/login.html:15 templates/reset.html:8 templates/signup.html:19
 msgid "password"
 msgstr "密码"
 
-#: templates/class-overview.html:25 templates/class-overview.html:69
+#: templates/class-overview.html:26 templates/class-overview.html:74
 #: templates/customize-adventure.html:52 templates/for-teachers.html:46
 #: templates/for-teachers.html:56
 #, fuzzy
 msgid "remove"
 msgstr "Remove"
 
-#: templates/class-overview.html:35
+#: templates/class-overview.html:36
 #, fuzzy
 msgid "page"
 msgstr "page"
 
-#: templates/class-overview.html:36
+#: templates/class-overview.html:37
 #, fuzzy
 msgid "enter_password"
 msgstr "Enter a new password for"
 
-#: templates/class-overview.html:36
+#: templates/class-overview.html:37
 #, fuzzy
 msgid "password_change_prompt"
 msgstr "Are you sure you want to change this password?"
 
-#: templates/class-overview.html:37
+#: templates/class-overview.html:38
 #, fuzzy
 msgid "remove_student_prompt"
 msgstr "Are you sure you want to remove the student from the class?"
 
-#: templates/class-overview.html:44
+#: templates/class-overview.html:46
 #, fuzzy
 msgid "add_students"
 msgstr "students"
 
-#: templates/class-overview.html:45 templates/customize-class.html:5
+#: templates/class-overview.html:47 templates/customize-class.html:5
 #, fuzzy
 msgid "customize_class"
 msgstr "Customize class"
 
-#: templates/class-overview.html:46
+#: templates/class-overview.html:48
 #, fuzzy
 msgid "class_stats"
 msgstr "Class statistics"
 
-#: templates/class-overview.html:47
+#: templates/class-overview.html:49
 #, fuzzy
 msgid "class_logs"
 msgstr "Last login"
 
-#: templates/class-overview.html:48 templates/customize-adventure.html:59
+#: templates/class-overview.html:52 templates/customize-adventure.html:59
 #, fuzzy
 msgid "back_to_teachers_page"
 msgstr "Go back to teachers page"
 
-#: templates/class-overview.html:49
+#: templates/class-overview.html:53
 #, fuzzy
 msgid "delete_class_prompt"
 msgstr "Are you sure you want to delete the class?"
 
-#: templates/class-overview.html:49
+#: templates/class-overview.html:53
 #, fuzzy
 msgid "delete_class"
 msgstr "Delete class permanently"
 
-#: templates/class-overview.html:52
+#: templates/class-overview.html:57
 #, fuzzy
 msgid "add_students_options"
 msgstr "Create student accounts"
 
-#: templates/class-overview.html:54
+#: templates/class-overview.html:59
 #, fuzzy
 msgid "copy_link_success"
 msgstr "Copy link to share"
 
-#: templates/class-overview.html:54
+#: templates/class-overview.html:59
 #, fuzzy
 msgid "copy_join_link"
 msgstr "请复制并粘贴此链接到一个新的标签页："
 
-#: templates/class-overview.html:55
+#: templates/class-overview.html:60
 #, fuzzy
 msgid "invite_prompt"
 msgstr "Enter a username"
 
-#: templates/class-overview.html:55
+#: templates/class-overview.html:60
 #, fuzzy
 msgid "invite_by_username"
 msgstr "所有用户名都必须是唯一的。"
 
-#: templates/class-overview.html:56 templates/create-accounts.html:45
+#: templates/class-overview.html:61 templates/create-accounts.html:45
 msgid "create_accounts"
 msgstr "创建多个账户"
 
-#: templates/class-overview.html:61
+#: templates/class-overview.html:66
 #, fuzzy
 msgid "pending_invites"
 msgstr "Pending invites"
 
-#: templates/class-overview.html:67
+#: templates/class-overview.html:72
 #, fuzzy
 msgid "invite_date"
 msgstr "Invite date"
 
-#: templates/class-overview.html:68
+#: templates/class-overview.html:73
 #, fuzzy
 msgid "expiration_date"
 msgstr "Expiration date"
 
-#: templates/class-overview.html:78 templates/profile.html:16
+#: templates/class-overview.html:83 templates/profile.html:16
 #, fuzzy
 msgid "delete_invite_prompt"
 msgstr "Are you sure you want to remove this class invitation?"
@@ -1338,11 +1338,10 @@ msgstr "My classes"
 msgid "achievements"
 msgstr "achievements"
 
-#: templates/highscores.html:27 templates/learn-more.html:22
-#: templates/profile.html:131 templates/signup.html:52
+#: templates/highscores.html:27
 #, fuzzy
-msgid "country"
-msgstr "Country"
+msgid "country_title"
+msgstr "Please select a valid country."
 
 #: templates/highscores.html:28 templates/landing-page.html:88
 #: templates/public-page.html:50
@@ -1644,6 +1643,12 @@ msgstr "First Name"
 #, fuzzy
 msgid "lastname"
 msgstr "Last Name"
+
+#: templates/learn-more.html:22 templates/profile.html:131
+#: templates/signup.html:52
+#, fuzzy
+msgid "country"
+msgstr "Country"
 
 #: templates/learn-more.html:31
 #, fuzzy

--- a/website/database.py
+++ b/website/database.py
@@ -251,9 +251,8 @@ class Database:
                 profile['country'] = country
             if not profile.get('achievements'):
                 achievements = self.achievements_by_username(profile.get('username'))
-                amount_achievements = len(achievements) or 0
-                self.update_achievements_public_profile(profile.get('username'), amount_achievements)
-                profile['achievements'] = amount_achievements
+                self.update_achievements_public_profile(profile.get('username'), len(achievements) or 0)
+                profile['achievements'] = len(achievements) or 0
 
         # If we filter on country, make sure to filter out all non-country values
         if filter == "country":

--- a/website/database.py
+++ b/website/database.py
@@ -244,10 +244,10 @@ class Database:
                 # To be sure, surround with a try catch
                 try:
                     country = self.user_by_username(profile.get('username')).get('country')
+                    self.update_country_public_profile(profile.get('username'), country)
                 except AttributeError:
                     print("This profile username is invalid...")
                     country = None
-                self.update_country_public_profile(profile.get('username'), country)
                 profile['country'] = country
             if not profile.get('achievements'):
                 achievements = self.achievements_by_username(profile.get('username'))

--- a/website/database.py
+++ b/website/database.py
@@ -251,8 +251,9 @@ class Database:
                 profile['country'] = country
             if not profile.get('achievements'):
                 achievements = self.achievements_by_username(profile.get('username'))
-                self.update_achievements_public_profile(profile.get('username'), len(achievements) if achievements else 0)
-                profile['achievements'] = achievements if achievements else 0
+                amount_achievements = len(achievements) or 0
+                self.update_achievements_public_profile(profile.get('username'), amount_achievements)
+                profile['achievements'] = amount_achievements
 
         # If we filter on country, make sure to filter out all non-country values
         if filter == "country":

--- a/website/database.py
+++ b/website/database.py
@@ -490,24 +490,20 @@ class Database:
         ACHIEVEMENTS.update({'username': username}, {'submitted_programs': dynamo.DynamoIncrement(1)})
 
     def update_public_profile(self, username, data):
-        data['username'] = username
-        PUBLIC_PROFILES.update(data)
+        PUBLIC_PROFILES.update({'username': username}, data)
 
     def update_achievements_public_profile(self, username, achievements):
         data = PUBLIC_PROFILES.get({'username': username})
         # In the case that we make this call but there is no public profile -> don't do anything
         if data:
-            data['achievements'] = achievements
-            data['last_achievement'] = timems()
-            self.update_public_profile(username, data)
+            PUBLIC_PROFILES.update({'username': username}, {'achievements': achievements, 'last_achievement': timems()})
 
     def update_country_public_profile(self, username, country):
         data = PUBLIC_PROFILES.get({'username': username})
         # If there is no data -> we might have made this request from the /update_profile route without a public profile
         # In this case don't do anything
         if data:
-            data['country'] = country
-            self.update_public_profile(username, data)
+            PUBLIC_PROFILES.update({'username': username}, {'country': country})
 
     def set_favourite_program(self, username, program_id):
         # We can only set a favourite program is there is already a public profile

--- a/website/database.py
+++ b/website/database.py
@@ -240,7 +240,13 @@ class Database:
 
         for profile in profiles:
             if not profile.get('country'):
-                country = self.user_by_username(profile.get('username')).get('country')
+                # This seems to crash on production even if it shouldn't (all profiles should have a username)
+                # To be sure, surround with a try catch
+                try:
+                    country = self.user_by_username(profile.get('username')).get('country')
+                except AttributeError:
+                    print("This profile username is invalid...")
+                    country = None
                 self.update_country_public_profile(profile.get('username'), country)
                 profile['country'] = country
             if not profile.get('achievements'):

--- a/website/database.py
+++ b/website/database.py
@@ -491,7 +491,7 @@ class Database:
 
     def update_public_profile(self, username, data):
         data['username'] = username
-        PUBLIC_PROFILES.put(data)
+        PUBLIC_PROFILES.update(data)
 
     def update_achievements_public_profile(self, username, achievements):
         data = PUBLIC_PROFILES.get({'username': username})

--- a/website/database.py
+++ b/website/database.py
@@ -230,7 +230,7 @@ class Database:
         # If the filter is global or country -> get all public profiles
         if filter == "global" or filter == "country":
             profiles = self.get_all_public_profiles()
-        # If it's a class, only get the onces
+        # If it's a class, only get the ones from your class
         elif filter == "class":
             Class = self.get_class(filter_value)
             for student in Class.get('students', []):
@@ -240,7 +240,7 @@ class Database:
 
         for profile in profiles:
             if not profile.get('country'):
-                country = self.user_by_username(profile.get('username', {})).get('country', None)
+                country = self.user_by_username(profile.get('username')).get('country')
                 self.update_country_public_profile(profile.get('username'), country)
                 profile['country'] = country
             if not profile.get('achievements'):

--- a/website/database.py
+++ b/website/database.py
@@ -492,11 +492,11 @@ class Database:
     def update_public_profile(self, username, data):
         PUBLIC_PROFILES.update({'username': username}, data)
 
-    def update_achievements_public_profile(self, username, achievements):
+    def update_achievements_public_profile(self, username, amount_achievements):
         data = PUBLIC_PROFILES.get({'username': username})
         # In the case that we make this call but there is no public profile -> don't do anything
         if data:
-            PUBLIC_PROFILES.update({'username': username}, {'achievements': achievements, 'last_achievement': timems()})
+            PUBLIC_PROFILES.update({'username': username}, {'achievements': amount_achievements, 'last_achievement': timems()})
 
     def update_country_public_profile(self, username, country):
         data = PUBLIC_PROFILES.get({'username': username})


### PR DESCRIPTION
**Description**
In this PR we fix the highscores counter filtering. For unknown reasons there seems to be usernames that return a none value when requesting the user data. This shouldn't be possible, but it makes the page crash. We surround this by a try-except to catch the error. We also improve the code a bit and change a table header to make more sense.

**Possible issue**
The only possible issue I can think of is that a user removed their profile but their public profile remained. This shouldn't be possible, but we have to dive into this later on.

**How to test**
Can't be tested, deploy to beta and verify that it works (Alpha the error didn't happen).