### PR TITLE
[BUG FIX] Signup works again

### DIFF
--- a/templates/base_email.html
+++ b/templates/base_email.html
@@ -1,6 +1,6 @@
 <div style='border: solid; border-radius: 5px; border-color: #4299e1; background: #4299e1; font-size: 1.2em; font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";'>
   <div style="margin: 30px 20px; padding: 30px; background-color: white; border: solid; border-color: white; border-radius: 5px;">
-    <img style="max-width: 120px;" src="http://www.hedycode.com/images/Hedy-logo.png" alt="{{_('hedy_logo_alt')}}">
+    <img style="max-width: 120px;" src="http://www.hedycode.com/images/Hedy-logo.png">
     <div id="content" style="margin-top: 30px; margin-bottom: 20px; white-space: pre-line;">
         {content}
     </div>


### PR DESCRIPTION
**Description**
Sign-up was broken due to a Babel key within the mail template, crashing on the `format()` function. This is fixed.


**Fixes**
This PR fixes #3012.

**How to test**
Create an account, verify that you are correctly logged in and redirected to the landing-page.