### PR TITLE
[BUG FIX] All forms work again as expected

### DIFF
--- a/templates/login.html
+++ b/templates/login.html
@@ -4,7 +4,7 @@
 {% block message %}{% endblock %}
 <div class="w-full mx-auto flex flex-col items-center gap-4">
   <div class="bg-white shadow-md rounded-lg rounded py-4">
-      <form onsubmit="event.preventDefault (); hedyApp.auth.submit ('login')" class="flex flex-col items-center gap-2">
+      <form onsubmit="event.preventDefault (); hedyApp.auth.submit ('login')" class="js-validated-form flex flex-col items-center gap-2">
         <h2>{{_('login_long')}}</h2>
         <div class="w-full flex px-8 flex-row items-center justify-center">
             <label for="username" class="inline-block w-40">{{_('username')}}</label>

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -25,7 +25,7 @@
         <div class="flex flex-row my-2 justify-center items-center">
             <button class="green-btn {% if not public_settings %}hidden{% endif %}" onclick="window.open('/user/{{ username}}')" id="public_profile_redirect">{{_('visit_own_public_profile')}}</button>
         </div>
-         <form class="flex flex-col gap-4" onsubmit="event.preventDefault (); hedyApp.auth.submit ('public_profile')">
+         <form class="js-validated-form flex flex-col gap-4" onsubmit="event.preventDefault (); hedyApp.auth.submit ('public_profile')">
              <div class="flex flex-col">
                  <h3 class="px-2 pt-0 pb-2 my-0 font-semibold">{{_('profile_picture')}}</h3>
                  <input name="profile_picture" id="profile_picture" type=number class="hidden" required {% if public_settings.image %} value="{{ public_settings.image }}" {% else %} value="1"{% endif %}>
@@ -143,7 +143,7 @@
           <button class="red-btn" onclick="hedyApp.auth.destroy ('{{_('are_you_sure')}}')">{{_('destroy_profile')}}</button>
        </div>
       <h1 id="password_toggle" class="section-header" onclick="$ ('#change_password').toggle()">{{_('change_password')}}</h1>
-        <form class="profile-section-body" id="change_password" onsubmit="event.preventDefault (); hedyApp.auth.submit ('change_password')">
+        <form class="js-validated-form profile-section-body" id="change_password" onsubmit="event.preventDefault (); hedyApp.auth.submit ('change_password')">
             <h2 class="profile-section-body-header">{{_('change_password')}}</h2>
             <div class="flex flex-row items-center mb-2">
                 <label for="old_password" class="inline-block w-72">{{_('current_password')}}</label>

--- a/templates/recover.html
+++ b/templates/recover.html
@@ -3,7 +3,7 @@
 {% block main %}
 <div class="w-full mx-auto flex flex-col items-center gap-4">
     <div class="bg-white shadow-md rounded-lg rounded py-4">
-      <form onsubmit="event.preventDefault (); hedyApp.auth.submit ('recover')" class="flex flex-col items-center gap-2">
+      <form onsubmit="event.preventDefault (); hedyApp.auth.submit ('recover')" class="js-validated-form flex flex-col items-center gap-2">
         <h2>{{_('recover_password')}}</h2>
         <div class="w-full flex px-8 flex-row items-center justify-center gap-2">
             <label class="inline-block w-80" for="username">{{_('username')}} / {{_('email')}}</label>

--- a/templates/reset.html
+++ b/templates/reset.html
@@ -3,7 +3,7 @@
 {% block main %}
 <div class="w-full mx-auto flex flex-col items-center gap-4">
     <div class="bg-white shadow-md rounded-lg rounded py-4">
-      <form onsubmit="event.preventDefault (); hedyApp.auth.submit ('reset')">
+      <form class="js-validated-form" onsubmit="event.preventDefault (); hedyApp.auth.submit ('reset')">
         <h2>{{_('reset_password')}}</h2>
         <div class="w-full flex px-8 flex-row items-center justify-center">
             <label class="inline-block w-40">{{_('password')}}</label>

--- a/templates/signup.html
+++ b/templates/signup.html
@@ -3,7 +3,7 @@
 {% block main %}
 <div class="w-full mx-auto flex flex-col items-center gap-4 mb-4">
     <div class="bg-white shadow-md rounded-lg rounded py-4 px-0 md:px-4 lg:px-8">
-        <form id="signup" onsubmit="event.preventDefault (); hedyApp.auth.submit ('signup')" class="flex flex-col gap-2">
+        <form id="signup" onsubmit="event.preventDefault (); hedyApp.auth.submit ('signup')" class="js-validated-form flex flex-col gap-2">
             <h2 class="my-0 text-center">{{_('create_account')}}</h2>
             <h4 class="text-blue-500 mt-0 mb-2 text-center">{{_('create_account_explanation')}}</h4>
             <div class="signup-container">


### PR DESCRIPTION
**Description**
In this PR we fix an app breaking issue where are forms would no longer work as expected. This was due to our front-end template clean-up where we removed the `js-validated-form` class from all forms. This class is essential for some value matching we do before sending the package to the back-end. This is vulnerable and should be removed in the near future, but to fix all functionality we reverse this removal.

This bug was my mistake by not taking the dependency of the `js-validated-form` class in account. But, this should not have been possible in the first place. We already perform all validation on the back-end and should not rely on the front-end to also perform some form validation. All input fields are already validated by the HTML attributes themselves as well.

**Fixes**
This PR fixes #3061

**How to test**
Verify that all forms are working again: login, signup, recover, reset, profile and public_profile.
