### PR TITLE
[LANGUAGE] Adds support for empty lists starting from level 15

### DIFF
--- a/grammars/level16-Additions.lark
+++ b/grammars/level16-Additions.lark
@@ -6,4 +6,4 @@
 ?atom: NUMBER | var_access | list_access | text_in_quotes
 list_access: var_access _LEFT_SQUARE_BRACKET (INT | random | var_access) _RIGHT_SQUARE_BRACKET
 change_list_item: var_access _LEFT_SQUARE_BRACKET (INT | var_access) _RIGHT_SQUARE_BRACKET _EQUALS (var_access | textwithoutspaces)
-assign_list: var (_IS | _EQUALS) _LEFT_SQUARE_BRACKET (quoted_text | INT) (_COMMA (quoted_text | INT))+ _RIGHT_SQUARE_BRACKET
+assign_list: var (_IS | _EQUALS) _LEFT_SQUARE_BRACKET ((quoted_text | INT) (_COMMA (quoted_text | INT))*)? _RIGHT_SQUARE_BRACKET

--- a/tests/test_level/test_level_16.py
+++ b/tests/test_level/test_level_16.py
@@ -25,6 +25,7 @@ class TestsLevel16(HedyTester):
             expected=expected,
             extra_check_function=check_in_list
         )
+    
     def test_create_empty_list(self):
         code = "friends = []"
         expected = "friends = []"
@@ -33,6 +34,19 @@ class TestsLevel16(HedyTester):
             code=code,
             max_level=17,
             expected=expected
+        )
+    
+    def test_create_with_single_item(self):
+        code = "friends = ['Ashli']"
+        expected = "friends = ['Ashli']"
+
+        check_in_list = (lambda x: HedyTester.run_code(x) == 'Ashli')
+
+        self.multi_level_tester(
+            code=code,
+            max_level=17,
+            expected=expected,
+            extra_check_function=check_in_list
         )
     
     def test_add_to_empty_list(self):

--- a/tests/test_level/test_level_16.py
+++ b/tests/test_level/test_level_16.py
@@ -25,6 +25,35 @@ class TestsLevel16(HedyTester):
             expected=expected,
             extra_check_function=check_in_list
         )
+    def test_create_empty_list(self):
+        code = "friends = []"
+        expected = "friends = []"
+
+        self.multi_level_tester(
+            code=code,
+            max_level=17,
+            expected=expected
+        )
+    
+    def test_add_to_empty_list(self):
+        code = textwrap.dedent("""\
+                friends = []
+                add 'Ashli' to friends
+                print friends[1]""")
+        
+        expected = textwrap.dedent("""\
+                friends = []
+                friends.append('Ashli')
+                print(f'''{friends[1-1]}''')""")
+        
+        check_in_list = (lambda x: HedyTester.run_code(x) == 'Ashli')
+
+        self.multi_level_tester(
+            code=code,
+            max_level=17,
+            expected=expected,
+            extra_check_function=check_in_list
+        )
 
     def test_print_list_var_arabic_number(self):
         code = textwrap.dedent("""\


### PR DESCRIPTION
First, provide a one line summary of your changes in the **Title of the PR**

**Now fill out the remainder of this template by replacing all _italic_ content**

**Description**

_Changes in detail_
Changes the grammar for lists in level 15 to allow both empty lists and lists containing a single element in it. Since starting from this level we ask users to use brackets around lists, we now can allow them to create this types of lists.

**Fixes #3050*

**How to test**

I added a couple of tests to showcase this behavior.
