### PR TITLE
[BUGFIX] Fixes list access using indices on level 5+

### DIFF
--- a/hedy.py
+++ b/hedy.py
@@ -1469,10 +1469,10 @@ class ConvertToPython_4(ConvertToPython_3):
 class ConvertToPython_5(ConvertToPython_4):
     def list_access_var(self, args):
         var = hash_var(args[0])
-        if args[2].data == 'random':
+        if isinstance(args[2], Tree):
             return var + ' = random.choice(' + args[1] + ')'
         else:
-            return var + ' = ' + args[1] + '[' + args[2].children[0] + '-1]'
+            return var + ' = ' + args[1] + '[' + args[2] + '-1]'
 
     def ifs(self, args):
         return f"""if {args[0]}:

--- a/tests/test_level/test_level_05.py
+++ b/tests/test_level/test_level_05.py
@@ -598,6 +598,18 @@ class TestsLevel5(HedyTester):
 
         self.single_level_tester(code=code, expected=expected)
 
+    def test_list_access_index(self):
+      code = textwrap.dedent("""\
+      friends is Hedy, Lola, Frida
+      friend is friends at 2
+      print friend""")
+      
+      expected = textwrap.dedent("""\
+      friends = ['Hedy', 'Lola', 'Frida']
+      friend = friends[2-1]
+      print(f'{friend}')""")
+      
+      self.multi_level_tester(code=code, expected=expected, max_level=11)
     #
     # negative tests
     #


### PR DESCRIPTION
**Description**

Changes de functions that process the `list_access_var` rule to be able to parse correctly lists access using indices.

**Fixes #3110 **

Always link the number of the issue or of the discussion that your pr concerns.

**How to test**

I added a test on level 5 to test this behavior.

