### PR TITLE
[FIX] disable test requests on Heroku

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -49,7 +49,7 @@ NORMAL_PREFIX_CODE = textwrap.dedent("""\
             latin_numerals = ''.join([numerals_dict.get(letter, letter) for letter in s])
             return int_saver(latin_numerals)
         return(int_saver(s))
-        
+
     def convert_numerals(alphabet, number):
         numerals_dict_return = {
             'Latin': ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'],
@@ -75,7 +75,7 @@ NORMAL_PREFIX_CODE = textwrap.dedent("""\
             'Urdu': ['۰', '۱', '۲', '۳', '۴', '۵', '۶', '۷', '۸', '۹']
         }
 
-        number = str(number)    
+        number = str(number)
         if number.isnumeric():
             numerals_list = numerals_dict_return[alphabet]
             all_numerals_converted = [numerals_list[int(digit)] for digit in number]
@@ -165,7 +165,14 @@ def slash_join(*args):
     return ''.join(ret)
 
 def is_testing_request(request):
-    return bool('X-Testing' in request.headers and request.headers['X-Testing'])
+    """Whether the current request is a test request.
+
+    Test requests are performed by the e2e tests and have special privileges
+    to do things other requests cannot do.
+
+    Test requests are only allowed on non-Heroku instances.
+    """
+    return not is_heroku() and bool('X-Testing' in request.headers and request.headers['X-Testing'])
 
 def extract_bcrypt_rounds(hash):
     return int(re.match(r'\$2b\$\d+', hash)[0].replace('$2b$', ''))
@@ -236,7 +243,7 @@ def atomic_write_file(filename, mode='wb'):
         os.rename(tmp_file, filename)
     except IOError:
         pass
-        
+
 # This function takes a date in milliseconds from the Unix epoch and transforms it into a printable date
 # It operates by converting the date to a string, removing its last 3 digits, converting it back to an int
 # and then invoking the `isoformat` date function on it


### PR DESCRIPTION
Test requests are used for e2e tests, which run against local
debug instances. They should not be allowed on Heroku (neither
staging nor the production environment).
