### PR TITLE
[LANGUAGE] Fix for else in Russian in level 5

### DIFF
--- a/grammars/level5-Additions.lark
+++ b/grammars/level5-Additions.lark
@@ -31,13 +31,13 @@ in_list_check: textwithoutspaces _IN var_access
 
 nospace: /[^\n, ]/
 
-textwithspaces: /(?:[^#\n،,， ]| (?!else|başka|अन्यथा|否则|senão|ellers|alie|altrimenti|anders|inaczej|sinon|sino|אחרת|وإلا))+/ -> text //anything can be parsed except for a newline and a comma for list separators
+textwithspaces: /(?:[^#\n،,， ]| (?!else|başka|अन्यथा|否则|senão|ellers|alie|иначе|altrimenti|anders|inaczej|sinon|sino|אחרת|وإلا))+/ -> text //anything can be parsed except for a newline and a comma for list separators
 //a space is allowed, but it may not be followed by an else. The part " (?!else))" means space not followed by (negative look ahead) else
 //That is because allowing else in strings leads to issue #303
-textwithoutspaces: /(?:[^#\n،,， *+\-\/eiasbअ否אو]|א(?!חרת )|و(?!إلا )|否(?!则 )|अ(?!न्यथा )|b(?!aşka )|e(?!lse |llers )|s(?!inon |enão |ino )|i(?!naczej )|a(?!nders |lie |ltrimenti ))+/ -> text //anything can be parsed except for spaces (plus: a newline and a comma for list separators)
+textwithoutspaces: /(?:[^#\n،,， *+\-\/eiиasbअ否אو]|א(?!חרת )|و(?!إلا )|否(?!则 )|अ(?!न्यथा )|и(?!наче )|b(?!aşka )|e(?!lse |llers )|s(?!inon |enão |ino )|i(?!naczej )|a(?!nders |lie |ltrimenti ))+/ -> text //anything can be parsed except for spaces (plus: a newline and a comma for list separators)
 //the part e(?!lse)|i(?!f)) means e not followed by lse, and i not followed by f
 // this is because allowing else and if in invalid leads to ambiguity in the grammar
 
 
-
+//
 


### PR DESCRIPTION
It is still a mystery to me why on earth this suddenly fails (we seem to have merged the last change in Russian 2 months ago!) but this is a hotfix and I think we have an issue open for the root cause (but I still would like to understand why it can just pop up like this?!)