### PR TITLE
[BUG FIX] Prevents Edge from auto translating page

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -1,7 +1,8 @@
 <!doctype html>
-<html>
+<html lang="notranslate">
   <head>
     <title>{% if page_title %}{{page_title}}{% else %}Hedy{% endif %}</title>
+    <meta name="google" content="notranslate" />
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Zilla+Slab:ital,wght@0,300;0,400;0,500;0,600;0,700;1,300;1,400;1,600;1,700&display=swap">
     <link rel="stylesheet" href="{{static('/css/generated.css')}}">
     <link rel="stylesheet" href="{{static('/css/additional.css')}}">

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -1,8 +1,7 @@
 <!doctype html>
-<html lang="notranslate">
+<html lang="{{ g.lang }}" class="notranslate" translate="no">
   <head>
     <title>{% if page_title %}{{page_title}}{% else %}Hedy{% endif %}</title>
-    <meta name="google" content="notranslate" />
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Zilla+Slab:ital,wght@0,300;0,400;0,500;0,600;0,700;1,300;1,400;1,600;1,700&display=swap">
     <link rel="stylesheet" href="{{static('/css/generated.css')}}">
     <link rel="stylesheet" href="{{static('/css/additional.css')}}">


### PR DESCRIPTION
**Description**
In this PR we fix an issue where Edge would automatically translate English keywords to Dutch in some cases. This is undesirable as we want to decide in what language the keywords are shown and not our browser. We prevent this by manually adding the `class="notranslate"` to our layout template, which should work.

**Fixes**
This PR fixes #3208.

**How to test**
Make sure you are using Edge on a non-english language (for example Dutch). Verify that the browser no longer translates the keywords when they are set in English and therefore should be shown in English.
