### PR TITLE
Enables admin to view class overview

### DIFF
--- a/templates/admin/admin-classes.html
+++ b/templates/admin/admin-classes.html
@@ -9,7 +9,7 @@
 <div class="program w-full mx-auto border-solid border-2 border-orange-400 rounded p-4">
   <table class="table-auto w-full text-sm">
     <thead>
-      <tr class="font-bold text-left">
+      <tr class="font-bold">
           <td id="classname_header">Class name</td>
           <td id="teacher_header">Teacher</td>
           <td id="students_header">Students</td>
@@ -18,6 +18,7 @@
           <td id="runs_header">Total runs</td>
           <td id="error_percentage_header">Error percentage</td>
           <td id="statistics_header">Statistics</td>
+          <td id="overview_header">Class overview</td>
       </tr>
     </thead>
     <tbody>
@@ -31,6 +32,7 @@
             <td class="runs_cell">{{class.stats.total.runs}}</td>
             <td class="error_percentage_cell">{% if class.stats.total.runs > 0 %}{{(class.stats.total.fails / class.stats.total.runs * 100)|round(2)}}{% else %}0.00{% endif %}%</td>
             <td id="statistics_cell"><a href="/stats/class/{{class.id}}" target="_blank">Click here</a></td>
+            <td id="overview_cell"><a href="/for-teachers/class/{{class.id}}" target="_blank">Click here</a></td>
           </tr>
       {% endfor %}
     </tbody>

--- a/templates/class-overview.html
+++ b/templates/class-overview.html
@@ -43,8 +43,12 @@
       </div>
       <div class="flex flex-col gap-4">
         <div class="flex flex-wrap gap-2">
-            <button class="green-btn" onclick=$('#add_students_options').toggle();$(this).toggleClass('green-btn');$(this).toggleClass('blue-btn');>{{_('add_students')}}</button>
-            <button class="green-btn" onclick="window.location.href = '/for-teachers/customize-class/{{class_info.id}}'">{{_('customize_class')}}</button>
+            {% if is_admin and class_info.teacher != username %}
+                <button class="green-btn" onclick="window.location.href = '/for-teachers/customize-class/{{class_info.id}}'">View customizations</button>
+            {% else %}
+                <button class="green-btn" onclick=$('#add_students_options').toggle();$(this).toggleClass('green-btn');$(this).toggleClass('blue-btn');>{{_('add_students')}}</button>
+                <button class="green-btn" onclick="window.location.href = '/for-teachers/customize-class/{{class_info.id}}'">{{_('customize_class')}}</button>
+            {% endif %}
             <button class="green-btn" onclick="window.location.href = '/stats/class/{{class_info.id}}'">{{_('class_stats')}}</button>
             <button class="green-btn" onclick="window.location.href = '/logs/class/{{class_info.id}}'">{{_('class_logs')}}</button>
         </div>

--- a/templates/customize-class.html
+++ b/templates/customize-class.html
@@ -155,17 +155,19 @@
                     </table>
                 </div>
             </div>
-            <div class="flex flex-col gap-2">
-                <div class="flex flex-row ml-auto gap-2">
-                    <button class="yellow-btn text-white" onclick="hedyApp.modal.confirm('{{_('reset_adventure_prompt')}}', function(){$('.adventure_level_input').prop('checked', false);$('.teacher_adventures_checkbox').prop('checked', false);});">{{_('reset_adventures')}}</button>
-                    <button class="blue-btn" onclick="hedyApp.save_customizations('{{class_info.id}}')">{{_('save')}}</button>
+            {% if not (is_admin and class_info.teacher != username) %}
+                <div class="flex flex-col gap-2">
+                    <div class="flex flex-row ml-auto gap-2">
+                        <button class="yellow-btn text-white" onclick="hedyApp.modal.confirm('{{_('reset_adventure_prompt')}}', function(){$('.adventure_level_input').prop('checked', false);$('.teacher_adventures_checkbox').prop('checked', false);});">{{_('reset_adventures')}}</button>
+                        <button class="blue-btn" onclick="hedyApp.save_customizations('{{class_info.id}}')">{{_('save')}}</button>
+                    </div>
+                    <div class="flex flex-row ml-auto gap-2">
+                        <button class="red-btn {% if not customizations %}hidden{% endif %}" id="remove_customizations_button" onclick='hedyApp.remove_customizations("{{class_info.id}}", {{_('remove_customizations_prompt')|tojson}})'>
+                        {{_('remove_customization')}}</button>
+                        <button class="green-btn" onclick=validate_changes()>{{_('back_to_class')}}</button>
+                    </div>
                 </div>
-                <div class="flex flex-row ml-auto gap-2">
-                    <button class="red-btn {% if not customizations %}hidden{% endif %}" id="remove_customizations_button" onclick='hedyApp.remove_customizations("{{class_info.id}}", {{_('remove_customizations_prompt')|tojson}})'>
-                    {{_('remove_customization')}}</button>
-                    <button class="green-btn" onclick=validate_changes()>{{_('back_to_class')}}</button>
-                </div>
-            </div>
+            {% endif %}
         </div>
     </div>
 </div>

--- a/website/teacher.py
+++ b/website/teacher.py
@@ -64,10 +64,11 @@ def routes(app, database, achievements):
     @requires_login
     def get_class(user, class_id):
         app.logger.info('This is info output')
-        if not is_teacher(user):
+        if not is_teacher(user) and not is_admin(user):
             return utils.error_page_403(error=403, ui_message=gettext('retrieve_class_error'))
         Class = DATABASE.get_class(class_id)
-        if not Class or Class['teacher'] != user['username']:
+        print(Class)
+        if not Class or (Class['teacher'] != user['username'] and not is_admin(user)):
             return utils.error_page(error=404, ui_message=gettext('no_such_class'))
         students = []
 

--- a/website/teacher.py
+++ b/website/teacher.py
@@ -296,10 +296,10 @@ def routes(app, database, achievements):
     @app.route('/for-teachers/customize-class/<class_id>', methods=['GET'])
     @requires_login
     def get_class_info(user, class_id):
-        if not is_teacher(user):
+        if not is_teacher(user) and not is_admin(user):
             return utils.error_page(error=403, ui_message=gettext('retrieve_class_error'))
         Class = DATABASE.get_class(class_id)
-        if not Class or Class['teacher'] != user['username']:
+        if not Class or (Class['teacher'] != user['username'] and not is_admin(user)):
             return utils.error_page(error=404, ui_message=gettext('no_such_class'))
 
         if hedy_content.Adventures(g.lang).has_adventures():

--- a/website/teacher.py
+++ b/website/teacher.py
@@ -67,7 +67,6 @@ def routes(app, database, achievements):
         if not is_teacher(user) and not is_admin(user):
             return utils.error_page_403(error=403, ui_message=gettext('retrieve_class_error'))
         Class = DATABASE.get_class(class_id)
-        print(Class)
         if not Class or (Class['teacher'] != user['username'] and not is_admin(user)):
             return utils.error_page(error=404, ui_message=gettext('no_such_class'))
         students = []


### PR DESCRIPTION
**Description**
In this PR we enable the admin to view the class overview as well as the class customizations of each class. We change the UI a bit when the admin views these specific pages to make sure it is clear that no alterations can be made. These would still be caught by the server as the admin is not the teacher of the class, but still. 

**Fixes**
This PR fixes #3194.

**How to test**
Make sure you are admin and there are classes for which you are not the teacher. Verify that you can visit these as well as the customizations but the buttons are hidden.
