### PR TITLE
[BUG FIX] Able to create account with one programming experience again

### DIFF
--- a/website/auth.py
+++ b/website/auth.py
@@ -404,10 +404,12 @@ def routes(app, database):
         if 'prog_experience' in body and body['prog_experience'] not in ['yes', 'no']:
             return gettext('experience_invalid'), 400
         if 'experience_languages' in body:
+            if isinstance(body['experience_languages'], str):
+                body['experience_languages'] = [body['experience_languages']]
             if not isinstance(body['experience_languages'], list):
                 return gettext('experience_invalid'), 400
             for language in body['experience_languages']:
-                if language not in['scratch', 'other_block', 'python', 'other_text']:
+                if language not in ['scratch', 'other_block', 'python', 'other_text']:
                     return gettext('programming_invalid'), 400
 
         if DATABASE.user_by_username(body['username'].strip().lower()):


### PR DESCRIPTION
**Description**
In this PR we fix a specific bug where the signup flow would be broken when selecting one language of the programming experience options. This was due to one item automatically being sent to the back-end as a string where we expect a list. We now typecast if we find a string and keep the rest of the validation the same.

**Fixes**
This PR fixes #3320

**How to test**
Create an account and select programming experience 'yes' and select only one language. Verify that you can signup successfully.
