### PR TITLE
Setup black formatter on pre-commit for python formatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+repos:
+-   repo: https://github.com/ambv/black
+    rev: 22.8.0
+    hooks:
+    - id: black
+      language: python
+      types: [python]
+      args: ["--line-length=120"]

--- a/app.py
+++ b/app.py
@@ -11,19 +11,54 @@ from website import programs
 import utils
 from utils import timems, load_yaml_rt, dump_yaml_rt, version, is_debug_mode
 from website.log_fetcher import log_fetcher
-from website.auth import current_user, login_user_from_token_cookie, requires_login, is_admin, is_teacher, update_is_teacher
+from website.auth import (
+    current_user,
+    login_user_from_token_cookie,
+    requires_login,
+    is_admin,
+    is_teacher,
+    update_is_teacher,
+)
 from website.yaml_file import YamlFile
-from website import querylog, aws_helpers, jsonbin, translating, ab_proxying, cdn, database, achievements
+from website import (
+    querylog,
+    aws_helpers,
+    jsonbin,
+    translating,
+    ab_proxying,
+    cdn,
+    database,
+    achievements,
+)
 import hedy_translation
-from hedy_content import COUNTRIES, ALL_LANGUAGES, ALL_KEYWORD_LANGUAGES, NON_LATIN_LANGUAGES, NON_BABEL
+from hedy_content import (
+    COUNTRIES,
+    ALL_LANGUAGES,
+    ALL_KEYWORD_LANGUAGES,
+    NON_LATIN_LANGUAGES,
+    NON_BABEL,
+)
 import hedyweb
 import hedy_content
 from flask_babel import gettext
 from flask_babel import Babel
 from flask_compress import Compress
 from flask_helpers import render_template
-from flask import Flask, request, jsonify, session, abort, g, redirect, Response, make_response, Markup, send_file, \
-    after_this_request, send_from_directory
+from flask import (
+    Flask,
+    request,
+    jsonify,
+    session,
+    abort,
+    g,
+    redirect,
+    Response,
+    make_response,
+    Markup,
+    send_file,
+    after_this_request,
+    send_from_directory,
+)
 from config import config
 from werkzeug.urls import url_encode
 from babel import Locale
@@ -38,19 +73,27 @@ import sys
 import textwrap
 
 # Todo TB: This can introduce a possible app breaking bug when switching to Python 4 -> e.g. Python 4.0.1 is invalid
-if (sys.version_info.major < 3 or sys.version_info.minor < 7):
-    print('Hedy requires Python 3.7 or newer to run. However, your version of Python is',
-          '.'.join([str(sys.version_info.major), str(sys.version_info.minor), str(sys.version_info.micro)]))
+if sys.version_info.major < 3 or sys.version_info.minor < 7:
+    print(
+        "Hedy requires Python 3.7 or newer to run. However, your version of Python is",
+        ".".join(
+            [
+                str(sys.version_info.major),
+                str(sys.version_info.minor),
+                str(sys.version_info.micro),
+            ]
+        ),
+    )
     quit()
 
 # Set the current directory to the root Hedy folder
 import os
 from os import path
-os.chdir(os.path.join(os.getcwd(), __file__.replace(
-    os.path.basename(__file__), '')))
+
+os.chdir(os.path.join(os.getcwd(), __file__.replace(os.path.basename(__file__), "")))
 
 # Setting up Flask and babel (web and translations)
-app = Flask(__name__, static_url_path='')
+app = Flask(__name__, static_url_path="")
 app.url_map.strict_slashes = False  # Ignore trailing slashes in URLs
 babel = Babel(app)
 
@@ -86,72 +129,68 @@ PUBLIC_PROGRAMS = DATABASE.get_all_public_programs()
 def load_adventures_per_level(level, keyword_lang):
     loaded_programs = {}
     # If user is logged in, we iterate their programs that belong to the current level. Out of these, we keep the latest created program for both the level mode(no adventure) and for each of the adventures.
-    if current_user()['username']:
-        user_programs = DATABASE.level_programs_for_user(
-            current_user()['username'], level)
+    if current_user()["username"]:
+        user_programs = DATABASE.level_programs_for_user(current_user()["username"], level)
         for program in user_programs:
-            program_key = 'default' if not program.get(
-                'adventure_name') else program['adventure_name']
-            if program_key not in loaded_programs or loaded_programs[program_key]['date'] < program['date']:
+            program_key = "default" if not program.get("adventure_name") else program["adventure_name"]
+            if program_key not in loaded_programs or loaded_programs[program_key]["date"] < program["date"]:
                 loaded_programs[program_key] = program
 
     all_adventures = []
     adventures = ADVENTURES[g.lang].get_adventures(keyword_lang)
 
     for short_name, adventure in adventures.items():
-        if level not in adventure['levels']:
+        if level not in adventure["levels"]:
             continue
         # end adventure is the quiz
         # if quizzes are not enabled, do not load it
         # Todo TB -> Is this still relevant? Teachers can simply "disable" adventures in customizations!
-        if short_name == 'end' and not config['quiz-enabled']:
+        if short_name == "end" and not config["quiz-enabled"]:
             continue
         current_adventure = {
-            'short_name': short_name,
-            'name': adventure['name'],
-            'image': adventure.get('image', None),
-            'default_save_name': adventure.get('default_save_name', adventure['name']),
-            'text': adventure['levels'][level].get('story_text', ""),
-            'example_code': adventure['levels'][level].get('example_code', ""),
-            'start_code': adventure['levels'][level].get('start_code', ""),
-            'loaded_program': '' if not loaded_programs.get(short_name) else {
-                'name': loaded_programs.get(short_name)['name'],
-                'code': loaded_programs.get(short_name)['code']
-            }
+            "short_name": short_name,
+            "name": adventure["name"],
+            "image": adventure.get("image", None),
+            "default_save_name": adventure.get("default_save_name", adventure["name"]),
+            "text": adventure["levels"][level].get("story_text", ""),
+            "example_code": adventure["levels"][level].get("example_code", ""),
+            "start_code": adventure["levels"][level].get("start_code", ""),
+            "loaded_program": ""
+            if not loaded_programs.get(short_name)
+            else {
+                "name": loaded_programs.get(short_name)["name"],
+                "code": loaded_programs.get(short_name)["code"],
+            },
         }
         # Sometimes we have multiple text and example_code -> iterate these and add as well!
         extra_stories = []
         for i in range(2, 10):
             extra_story = {}
-            if adventure['levels'][level].get('story_text_' + str(i)):
-                extra_story['text'] = adventure['levels'][level].get(
-                    'story_text_' + str(i))
-                if adventure['levels'][level].get('example_code_' + str(i)):
-                    extra_story['example_code'] = adventure['levels'][level].get(
-                        'example_code_' + str(i))
+            if adventure["levels"][level].get("story_text_" + str(i)):
+                extra_story["text"] = adventure["levels"][level].get("story_text_" + str(i))
+                if adventure["levels"][level].get("example_code_" + str(i)):
+                    extra_story["example_code"] = adventure["levels"][level].get("example_code_" + str(i))
                 extra_stories.append(extra_story)
             else:
                 break
-        current_adventure['extra_stories'] = extra_stories
+        current_adventure["extra_stories"] = extra_stories
         all_adventures.append(current_adventure)
     return all_adventures
 
 
-logging.basicConfig(
-    level=logging.DEBUG,
-    format='[%(asctime)s] %(levelname)-8s: %(message)s')
+logging.basicConfig(level=logging.DEBUG, format="[%(asctime)s] %(levelname)-8s: %(message)s")
 
 # Return the session language, if not: return best match
 
 
 @babel.localeselector
 def get_locale():
-    if session.get("lang", request.accept_languages.best_match(ALL_LANGUAGES.keys(), 'en')) in NON_BABEL:
+    if session.get("lang", request.accept_languages.best_match(ALL_LANGUAGES.keys(), "en")) in NON_BABEL:
         return "en"
-    return session.get("lang", request.accept_languages.best_match(ALL_LANGUAGES.keys(), 'en'))
+    return session.get("lang", request.accept_languages.best_match(ALL_LANGUAGES.keys(), "en"))
 
 
-cdn.Cdn(app, os.getenv('CDN_PREFIX'), os.getenv('HEROKU_SLUG_COMMIT', 'dev'))
+cdn.Cdn(app, os.getenv("CDN_PREFIX"), os.getenv("HEROKU_SLUG_COMMIT", "dev"))
 
 
 @app.before_request
@@ -161,8 +200,7 @@ def before_request_begin_logging():
     This needs to happen as one of the first things, as the database calls
     etc. depend on it.
     """
-    path = (str(request.path) + '?' + str(request.query_string)
-            ) if request.query_string else str(request.path)
+    path = (str(request.path) + "?" + str(request.query_string)) if request.query_string else str(request.path)
     querylog.begin_global_log_record(path=path, method=request.method)
 
 
@@ -187,59 +225,58 @@ def initialize_session():
     login_user_from_token_cookie()
 
 
-if os.getenv('IS_PRODUCTION'):
+if os.getenv("IS_PRODUCTION"):
+
     @app.before_request
     def reject_e2e_requests():
         if utils.is_testing_request(request):
-            return 'No E2E tests are allowed in production', 400
+            return "No E2E tests are allowed in production", 400
 
 
 @app.before_request
 def before_request_proxy_testing():
-    if utils.is_testing_request(request) and os.getenv('IS_TEST_ENV'):
-        session['test_session'] = 'test'
+    if utils.is_testing_request(request) and os.getenv("IS_TEST_ENV"):
+        session["test_session"] = "test"
 
 
 # HTTP -> HTTPS redirect
 # https://stackoverflow.com/questions/32237379/python-flask-redirect-to-https-from-http/32238093
-if os.getenv('REDIRECT_HTTP_TO_HTTPS'):
+if os.getenv("REDIRECT_HTTP_TO_HTTPS"):
+
     @app.before_request
     def before_request_https():
-        if request.url.startswith('http://'):
-            url = request.url.replace('http://', 'https://', 1)
+        if request.url.startswith("http://"):
+            url = request.url.replace("http://", "https://", 1)
             # We use a 302 in case we need to revert the redirect.
             return redirect(url, code=302)
+
 
 # Unique random key for sessions.
 # For settings with multiple workers, an environment variable is required, otherwise cookies will be constantly removed and re-set by different workers.
 if utils.is_production():
-    if not os.getenv('SECRET_KEY'):
-        raise RuntimeError(
-            'The SECRET KEY must be provided for non-dev environments.')
+    if not os.getenv("SECRET_KEY"):
+        raise RuntimeError("The SECRET KEY must be provided for non-dev environments.")
 
-    app.config['SECRET_KEY'] = os.getenv('SECRET_KEY')
+    app.config["SECRET_KEY"] = os.getenv("SECRET_KEY")
 
 else:
     # The value doesn't matter for dev environments, but it needs to be a constant
     # so that our cookies don't get invalidated every time we restart the server.
-    app.config['SECRET_KEY'] = os.getenv('SECRET_KEY', 'WeAreDeveloping')
+    app.config["SECRET_KEY"] = os.getenv("SECRET_KEY", "WeAreDeveloping")
 
 if utils.is_heroku():
     app.config.update(
         SESSION_COOKIE_SECURE=True,
         SESSION_COOKIE_HTTPONLY=True,
-        SESSION_COOKIE_SAMESITE='Lax',
+        SESSION_COOKIE_SAMESITE="Lax",
     )
 
 # Set security attributes for cookies in a central place - but not when running locally, so that session cookies work well without HTTPS
 
 Compress(app)
 Commonmark(app)
-parse_logger = jsonbin.MultiParseLogger(
-    jsonbin.JsonBinLogger.from_env_vars(),
-    jsonbin.S3ParseLogger.from_env_vars())
-querylog.LOG_QUEUE.set_transmitter(
-    aws_helpers.s3_querylog_transmitter_from_env())
+parse_logger = jsonbin.MultiParseLogger(jsonbin.JsonBinLogger.from_env_vars(), jsonbin.S3ParseLogger.from_env_vars())
+querylog.LOG_QUEUE.set_transmitter(aws_helpers.s3_querylog_transmitter_from_env())
 
 
 @app.before_request
@@ -248,18 +285,17 @@ def setup_language():
     #
     # If not in the request parameters, use the browser's accept-languages
     # header to do language negotiation.
-    if 'lang' not in session:
-        session['lang'] = request.accept_languages.best_match(
-            ALL_LANGUAGES.keys(), 'en')
+    if "lang" not in session:
+        session["lang"] = request.accept_languages.best_match(ALL_LANGUAGES.keys(), "en")
 
-    g.lang = session['lang']
-    if 'keyword_lang' not in session:
+    g.lang = session["lang"]
+    if "keyword_lang" not in session:
         if g.lang in ALL_KEYWORD_LANGUAGES.keys() and g.lang in NON_LATIN_LANGUAGES:
             g.keyword_lang = g.lang
         else:
             g.keyword_lang = "en"
     else:
-        g.keyword_lang = session['keyword_lang']
+        g.keyword_lang = session["keyword_lang"]
 
     # Set the page direction -> automatically set it to "left-to-right"
     # Switch to "right-to-left" if one of the language is rtl according to Locale (from Babel) settings.
@@ -273,25 +309,29 @@ def setup_language():
         return "Language " + g.lang + " not supported", 404
 
 
-if utils.is_heroku() and not os.getenv('HEROKU_RELEASE_CREATED_AT'):
+if utils.is_heroku() and not os.getenv("HEROKU_RELEASE_CREATED_AT"):
     logging.warning(
-        'Cannot determine release; enable Dyno metadata by running "heroku labs:enable runtime-dyno-metadata -a <APP_NAME>"')
+        'Cannot determine release; enable Dyno metadata by running "heroku labs:enable runtime-dyno-metadata -a <APP_NAME>"'
+    )
 
 
 # A context processor injects variables in the context that are available to all templates.
 @app.context_processor
 def enrich_context_with_user_info():
     user = current_user()
-    data = {'username': user.get('username', ''),
-            'is_teacher': is_teacher(user), 'is_admin': is_admin(user)}
+    data = {
+        "username": user.get("username", ""),
+        "is_teacher": is_teacher(user),
+        "is_admin": is_admin(user),
+    }
     return data
 
 
 @app.after_request
 def set_security_headers(response):
     security_headers = {
-        'Strict-Transport-Security': 'max-age=31536000; includeSubDomains',
-        'X-XSS-Protection': '1; mode=block',
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-XSS-Protection": "1; mode=block",
     }
     # Not X-Frame-Options on purpose -- we are being embedded by Online Masters
     # and that's okay.
@@ -305,94 +345,100 @@ def teardown_request_finish_logging(exc):
 
 
 # If present, PROXY_TO_TEST_HOST should be the 'http[s]://hostname[:port]' of the target environment
-if os.getenv('PROXY_TO_TEST_HOST') and not os.getenv('IS_TEST_ENV'):
-    ab_proxying.ABProxying(app, os.getenv(
-        'PROXY_TO_TEST_HOST'), app.config['SECRET_KEY'])
+if os.getenv("PROXY_TO_TEST_HOST") and not os.getenv("IS_TEST_ENV"):
+    ab_proxying.ABProxying(app, os.getenv("PROXY_TO_TEST_HOST"), app.config["SECRET_KEY"])
 
 
-@app.route('/session_test', methods=['GET'])
+@app.route("/session_test", methods=["GET"])
 def echo_session_vars_test():
     if not utils.is_testing_request(request):
-        return 'This endpoint is only meant for E2E tests', 400
-    return jsonify({'session': dict(session)})
+        return "This endpoint is only meant for E2E tests", 400
+    return jsonify({"session": dict(session)})
 
 
-@app.route('/session_main', methods=['GET'])
+@app.route("/session_main", methods=["GET"])
 def echo_session_vars_main():
     if not utils.is_testing_request(request):
-        return 'This endpoint is only meant for E2E tests', 400
-    return jsonify({'session': dict(session), 'proxy_enabled': bool(os.getenv('PROXY_TO_TEST_HOST'))})
+        return "This endpoint is only meant for E2E tests", 400
+    return jsonify(
+        {
+            "session": dict(session),
+            "proxy_enabled": bool(os.getenv("PROXY_TO_TEST_HOST")),
+        }
+    )
 
 
-@app.route('/parse', methods=['POST'])
+@app.route("/parse", methods=["POST"])
 def parse():
     body = request.json
     if not body:
         return "body must be an object", 400
-    if 'code' not in body:
+    if "code" not in body:
         return "body.code must be a string", 400
-    if 'level' not in body:
+    if "level" not in body:
         return "body.level must be a string", 400
-    if 'adventure_name' in body and not isinstance(body['adventure_name'], str):
+    if "adventure_name" in body and not isinstance(body["adventure_name"], str):
         return "if present, body.adventure_name must be a string", 400
 
     error_check = False
-    if 'error_check' in body:
+    if "error_check" in body:
         error_check = True
 
-    code = body['code']
-    level = int(body['level'])
+    code = body["code"]
+    level = int(body["level"])
 
     # Language should come principally from the request body,
     # but we'll fall back to browser default if it's missing for whatever
     # reason.
-    lang = body.get('lang', g.lang)
+    lang = body.get("lang", g.lang)
 
     # true if kid enabled the read aloud option
-    read_aloud = body.get('read_aloud', False)
+    read_aloud = body.get("read_aloud", False)
 
     response = {}
-    username = current_user()['username'] or None
+    username = current_user()["username"] or None
     exception = None
 
-    querylog.log_value(level=level, lang=lang,
-                       session_id=utils.session_id(), username=username)
+    querylog.log_value(level=level, lang=lang, session_id=utils.session_id(), username=username)
 
     try:
-        with querylog.log_time('transpile'):
+        with querylog.log_time("transpile"):
             try:
                 transpile_result = transpile_add_stats(code, level, lang)
-                if username and not body.get('tutorial'):
+                if username and not body.get("tutorial"):
                     DATABASE.increase_user_run_count(username)
                     ACHIEVEMENTS.increase_count("run")
             except hedy.exceptions.FtfyException as ex:
                 translated_error = translate_error(ex.error_code, ex.arguments)
                 if type(ex) is hedy.exceptions.InvalidSpaceException:
-                    response['Warning'] = translated_error
+                    response["Warning"] = translated_error
                 else:
-                    response['Error'] = translated_error
-                response['Location'] = ex.error_location
-                response['FixedCode'] = ex.fixed_code
+                    response["Error"] = translated_error
+                response["Location"] = ex.error_location
+                response["FixedCode"] = ex.fixed_code
                 transpile_result = ex.fixed_result
                 exception = ex
             except hedy.exceptions.UnquotedEqualityCheck as ex:
-                response['Error'] = translate_error(
-                    ex.error_code, ex.arguments)
-                response['Location'] = ex.error_location
+                response["Error"] = translate_error(ex.error_code, ex.arguments)
+                response["Location"] = ex.error_location
                 exception = ex
         try:
-            response['Code'] = transpile_result.code
+            response["Code"] = transpile_result.code
             if transpile_result.has_turtle:
-                response['has_turtle'] = True
+                response["has_turtle"] = True
         except Exception as E:
             pass
         try:
-            response['has_sleep'] = 'sleep' in hedy.all_commands(code, level, lang)
+            response["has_sleep"] = "sleep" in hedy.all_commands(code, level, lang)
         except:
             pass
         try:
-            if username and not body.get('tutorial') and ACHIEVEMENTS.verify_run_achievements(username, code, level, response):
-                response['achievements'] = ACHIEVEMENTS.get_earned_achievements()
+            if (
+                username
+                and not body.get("tutorial")
+                and ACHIEVEMENTS.verify_run_achievements(username, code, level, response)
+            ):
+                response["achievements"] = ACHIEVEMENTS.get_earned_achievements()
         except Exception as E:
             print(f"error determining achievements for {code} with {E}")
     except hedy.exceptions.HedyException as ex:
@@ -406,63 +452,65 @@ def parse():
         response["Error"] = str(E)
         exception = E
 
-    querylog.log_value(server_error=response.get('Error'))
-    parse_logger.log({
-        'session': utils.session_id(),
-        'date': str(datetime.datetime.now()),
-        'level': level,
-        'lang': lang,
-        'code': code,
-        'server_error': response.get('Error'),
-        'exception': get_class_name(exception),
-        'version': version(),
-        'username': username,
-        'read_aloud': read_aloud,
-        'is_test': 1 if os.getenv('IS_TEST_ENV') else None,
-        'adventure_name': body.get('adventure_name', None)
-    })
+    querylog.log_value(server_error=response.get("Error"))
+    parse_logger.log(
+        {
+            "session": utils.session_id(),
+            "date": str(datetime.datetime.now()),
+            "level": level,
+            "lang": lang,
+            "code": code,
+            "server_error": response.get("Error"),
+            "exception": get_class_name(exception),
+            "version": version(),
+            "username": username,
+            "read_aloud": read_aloud,
+            "is_test": 1 if os.getenv("IS_TEST_ENV") else None,
+            "adventure_name": body.get("adventure_name", None),
+        }
+    )
 
     if "Error" in response and error_check:
-        response["message"] = gettext('program_contains_error')
+        response["message"] = gettext("program_contains_error")
     return jsonify(response)
 
 
-@app.route('/parse-by-id', methods=['POST'])
+@app.route("/parse-by-id", methods=["POST"])
 @requires_login
 def parse_by_id(user):
     body = request.json
     # Validations
     if not isinstance(body, dict):
-        return 'body must be an object', 400
-    if not isinstance(body.get('id'), str):
-        return 'class id must be a string', 400
+        return "body must be an object", 400
+    if not isinstance(body.get("id"), str):
+        return "class id must be a string", 400
 
-    program = DATABASE.program_by_id(body.get('id'))
-    if program and program.get('username') == user['username']:
+    program = DATABASE.program_by_id(body.get("id"))
+    if program and program.get("username") == user["username"]:
         try:
-            hedy.transpile(program.get('code'), program.get(
-                'level'), program.get('lang'))
+            hedy.transpile(program.get("code"), program.get("level"), program.get("lang"))
             return {}, 200
         except:
             return {"error": "parsing error"}, 200
     else:
-        return 'this is not your program!', 400
+        return "this is not your program!", 400
 
 
-@app.route('/parse_tutorial', methods=['POST'])
+@app.route("/parse_tutorial", methods=["POST"])
 @requires_login
 def parse_tutorial(user):
     body = request.json
 
-    code = body['code']
-    level = int(body['level'])
+    code = body["code"]
+    level = int(body["level"])
     try:
         result = hedy.transpile(code, level, "en")
-        jsonify({'code': result.code}), 200
+        jsonify({"code": result.code}), 200
     except:
         return "error", 400
 
-@app.route("/generate_dst", methods=['POST'])
+
+@app.route("/generate_dst", methods=["POST"])
 def prepare_dst_file():
     body = request.json
     # Prepare the file -> return the "secret" filename as response
@@ -471,25 +519,27 @@ def prepare_dst_file():
 
     # We have to turn the turtle 90 degrees to align with the user perspective app.ts#16
     # This is not a really nice solution, but as we store the prefix on the front-end it should be good for now
-    threader = textwrap.dedent("""
+    threader = textwrap.dedent(
+        """
         import time
         from turtlethread import Turtle
         t = Turtle()
         t.left(90)
         with t.running_stitch(stitch_length=20):
-        """)
+        """
+    )
     lines = transpiled_code.code.split("\n")
     threader += "  " + "\n  ".join(lines)
     threader += "\n" + 't.save("dst_files/' + filename + '.dst")'
-    if not os.path.isdir('dst_files'):
-        os.makedirs('dst_files')
+    if not os.path.isdir("dst_files"):
+        os.makedirs("dst_files")
     exec(threader)
 
-    return jsonify({'filename': filename}), 200
+    return jsonify({"filename": filename}), 200
 
 
 # this is a route for testing purposes
-@app.route("/download_dst/<filename>", methods=['GET'])
+@app.route("/download_dst/<filename>", methods=["GET"])
 def download_dst_file(filename):
     # https://stackoverflow.com/questions/24612366/delete-an-uploaded-file-after-downloading-it-from-flask
     @after_this_request
@@ -499,20 +549,22 @@ def download_dst_file(filename):
         except:
             print("Error removing the generated .dst file!")
         return response
+
     # Once the file is downloaded -> remove it
     return send_file("dst_files/" + filename + ".dst", as_attachment=True)
 
 
 def transpile_add_stats(code, level, lang_):
-    username = current_user()['username'] or None
+    username = current_user()["username"] or None
     try:
         result = hedy.transpile(code, level, lang_)
-        statistics.add(
-            username, lambda id_: DATABASE.add_program_stats(id_, level, None))
+        statistics.add(username, lambda id_: DATABASE.add_program_stats(id_, level, None))
         return result
     except Exception as ex:
-        statistics.add(username, lambda id_: DATABASE.add_program_stats(
-            id_, level, get_class_name(ex)))
+        statistics.add(
+            username,
+            lambda id_: DATABASE.add_program_stats(id_, level, get_class_name(ex)),
+        )
         raise
 
 
@@ -525,18 +577,30 @@ def get_class_name(i):
 def hedy_error_to_response(ex):
     return {
         "Error": translate_error(ex.error_code, ex.arguments),
-        "Location": ex.error_location
+        "Location": ex.error_location,
     }
 
 
 def translate_error(code, arguments):
-    arguments_that_require_translation = ['allowed_types', 'invalid_type', 'invalid_type_2', 'character_found',
-                                          'concept', 'tip']
-    arguments_that_require_highlighting = ['command', 'guessed_command', 'invalid_argument', 'invalid_argument_2',
-                                           'variable', 'invalid_value']
+    arguments_that_require_translation = [
+        "allowed_types",
+        "invalid_type",
+        "invalid_type_2",
+        "character_found",
+        "concept",
+        "tip",
+    ]
+    arguments_that_require_highlighting = [
+        "command",
+        "guessed_command",
+        "invalid_argument",
+        "invalid_argument_2",
+        "variable",
+        "invalid_value",
+    ]
 
     # Todo TB -> We have to find a more delicate way to fix this: returns some gettext() errors
-    error_template = gettext('' + str(code))
+    error_template = gettext("" + str(code))
 
     # some arguments like allowed types or characters need to be translated in the error message
     for k, v in arguments.items():
@@ -547,42 +611,42 @@ def translate_error(code, arguments):
             if isinstance(v, list):
                 arguments[k] = translate_list(v)
             else:
-                arguments[k] = gettext('' + str(v))
+                arguments[k] = gettext("" + str(v))
 
     return error_template.format(**arguments)
 
 
 def translate_list(args):
-    translated_args = [gettext('' + str(a)) for a in args]
+    translated_args = [gettext("" + str(a)) for a in args]
     # Deduplication is needed because diff values could be translated to the same value, e.g. int and float => a number
     translated_args = list(dict.fromkeys(translated_args))
 
     if len(translated_args) > 1:
-        return f"{', '.join(translated_args[0:-1])}" \
-               f" {gettext('or')} " \
-               f"{translated_args[-1]}"
-    return ''.join(translated_args)
+        return f"{', '.join(translated_args[0:-1])}" f" {gettext('or')} " f"{translated_args[-1]}"
+    return "".join(translated_args)
 
 
-@app.route('/report_error', methods=['POST'])
+@app.route("/report_error", methods=["POST"])
 def report_error():
     post_body = request.json
 
-    parse_logger.log({
-        'session': utils.session_id(),
-        'date': str(datetime.datetime.now()),
-        'level': post_body.get('level'),
-        'code': post_body.get('code'),
-        'client_error': post_body.get('client_error'),
-        'version': version(),
-        'username': current_user()['username'] or None,
-        'is_test': 1 if os.getenv('IS_TEST_ENV') else None
-    })
+    parse_logger.log(
+        {
+            "session": utils.session_id(),
+            "date": str(datetime.datetime.now()),
+            "level": post_body.get("level"),
+            "code": post_body.get("code"),
+            "client_error": post_body.get("client_error"),
+            "version": version(),
+            "username": current_user()["username"] or None,
+            "is_test": 1 if os.getenv("IS_TEST_ENV") else None,
+        }
+    )
 
-    return 'logged'
+    return "logged"
 
 
-@app.route('/client_exception', methods=['POST'])
+@app.route("/client_exception", methods=["POST"])
 def report_client_exception():
     post_body = request.json
 
@@ -591,80 +655,86 @@ def report_client_exception():
         date=str(datetime.datetime.now()),
         client_error=post_body,
         version=version(),
-        username=current_user()['username'] or None,
-        is_test=1 if os.getenv('IS_TEST_ENV') else None
+        username=current_user()["username"] or None,
+        is_test=1 if os.getenv("IS_TEST_ENV") else None,
     )
 
     # Return a 500 so the HTTP status codes will stand out in our monitoring/logging
-    return 'logged', 500
+    return "logged", 500
 
 
-@app.route('/version', methods=['GET'])
+@app.route("/version", methods=["GET"])
 def version_page():
     """
-    Generate a page with some diagnostic information and a useful GitHub URL on upcoming changes.
+     Generate a page with some diagnostic information and a useful GitHub URL on upcoming changes.
 
-    This is an admin-only page, it does not need to be linked.
-   (Also does not have any sensitive information so it's fine to be unauthenticated).
+     This is an admin-only page, it does not need to be linked.
+    (Also does not have any sensitive information so it's fine to be unauthenticated).
     """
-    app_name = os.getenv('HEROKU_APP_NAME')
+    app_name = os.getenv("HEROKU_APP_NAME")
 
-    vrz = os.getenv('HEROKU_RELEASE_CREATED_AT')
-    the_date = datetime.date.fromisoformat(
-        vrz[:10]) if vrz else datetime.date.today()
+    vrz = os.getenv("HEROKU_RELEASE_CREATED_AT")
+    the_date = datetime.date.fromisoformat(vrz[:10]) if vrz else datetime.date.today()
 
-    commit = os.getenv('HEROKU_SLUG_COMMIT', '????')[0:6]
+    commit = os.getenv("HEROKU_SLUG_COMMIT", "????")[0:6]
 
-    return render_template('version-page.html',
-                           app_name=app_name,
-                           heroku_release_time=the_date,
-                           commit=commit)
+    return render_template(
+        "version-page.html",
+        app_name=app_name,
+        heroku_release_time=the_date,
+        commit=commit,
+    )
 
 
 def achievements_page():
     user = current_user()
-    username = user['username']
+    username = user["username"]
     if not username:
         # redirect users to /login if they are not logged in
         # Todo: TB -> I wrote this once, but wouldn't it make more sense to simply throw a 302 error?
-        url = request.url.replace('/my-achievements', '/login')
+        url = request.url.replace("/my-achievements", "/login")
         return redirect(url, code=302)
 
-    user_achievements = DATABASE.achievements_by_username(user.get('username')) or []
-    achievements = ACHIEVEMENTS_TRANSLATIONS.get_translations(g.lang).get('achievements')
+    user_achievements = DATABASE.achievements_by_username(user.get("username")) or []
+    achievements = ACHIEVEMENTS_TRANSLATIONS.get_translations(g.lang).get("achievements")
 
-    return render_template('achievements.html', page_title=gettext('title_achievements'), translations=achievements,
-                           user_achievements=user_achievements, current_page='my-profile')
+    return render_template(
+        "achievements.html",
+        page_title=gettext("title_achievements"),
+        translations=achievements,
+        user_achievements=user_achievements,
+        current_page="my-profile",
+    )
 
 
-@app.route('/programs', methods=['GET'])
+@app.route("/programs", methods=["GET"])
 @requires_login
 def programs_page(user):
-    username = user['username']
+    username = user["username"]
     if not username:
         # redirect users to /login if they are not logged in
-        url = request.url.replace('/programs', '/login')
+        url = request.url.replace("/programs", "/login")
         return redirect(url, code=302)
 
-    from_user = request.args.get('user') or None
+    from_user = request.args.get("user") or None
     # If from_user -> A teacher is trying to view the user programs
     if from_user and not is_admin(user):
         if not is_teacher(user):
-            return utils.error_page(error=403, ui_message=gettext('not_teacher'))
+            return utils.error_page(error=403, ui_message=gettext("not_teacher"))
         students = DATABASE.get_teacher_students(username)
         if from_user not in students:
-            return utils.error_page(error=403, ui_message=gettext('not_enrolled'))
+            return utils.error_page(error=403, ui_message=gettext("not_enrolled"))
 
-    adventures_names = hedy_content.Adventures(session['lang']).get_adventure_names()
+    adventures_names = hedy_content.Adventures(session["lang"]).get_adventure_names()
 
     # We request our own page -> also get the public_profile settings
     public_profile = None
     if not from_user:
         public_profile = DATABASE.get_public_profile_settings(username)
 
-    level = request.args.get('level', default=None, type=str)
-    adventure = request.args.get('adventure', default=None, type=str)
-    filter = request.args.get('filter', default=None, type=str)
+    level = request.args.get("level", default=None, type=str)
+    adventure = request.args.get("adventure", default=None, type=str)
+    filter = request.args.get("filter", default=None, type=str)
 
     level = None if level == "null" else level
     adventure = None if adventure == "null" else adventure
@@ -677,186 +747,210 @@ def programs_page(user):
     programs = []
     for item in result:
         # If we filter on the submitted programs -> skip the onces that are not submitted
-        if filter == "submitted" and not item.get('submitted'):
+        if filter == "submitted" and not item.get("submitted"):
             continue
-        date = utils.delta_timestamp(item['date'])
+        date = utils.delta_timestamp(item["date"])
         # This way we only keep the first 4 lines to show as preview to the user
-        code = "\n".join(item['code'].split("\n")[:4])
+        code = "\n".join(item["code"].split("\n")[:4])
         programs.append(
-            {'id': item['id'],
-             'code': code,
-             'date': date,
-             'level': item['level'],
-             'name': item['name'],
-             'adventure_name': item.get('adventure_name'),
-             'submitted': item.get('submitted'),
-             'public': item.get('public')
-             }
+            {
+                "id": item["id"],
+                "code": code,
+                "date": date,
+                "level": item["level"],
+                "name": item["name"],
+                "adventure_name": item.get("adventure_name"),
+                "submitted": item.get("submitted"),
+                "public": item.get("public"),
+            }
         )
 
-    return render_template('programs.html', programs=programs, page_title=gettext('title_programs'),
-                           current_page='programs', from_user=from_user, adventure_names=adventures_names,
-                           public_profile=public_profile, max_level=hedy.HEDY_MAX_LEVEL)
+    return render_template(
+        "programs.html",
+        programs=programs,
+        page_title=gettext("title_programs"),
+        current_page="programs",
+        from_user=from_user,
+        adventure_names=adventures_names,
+        public_profile=public_profile,
+        max_level=hedy.HEDY_MAX_LEVEL,
+    )
 
 
-@app.route('/logs/query', methods=['POST'])
+@app.route("/logs/query", methods=["POST"])
 def query_logs():
     user = current_user()
     if not is_admin(user) and not is_teacher(user):
-        return utils.error_page(error=403, ui_message=gettext('unauthorized'))
+        return utils.error_page(error=403, ui_message=gettext("unauthorized"))
 
     body = request.json
     if body is not None and not isinstance(body, dict):
-        return 'body must be an object', 400
+        return "body must be an object", 400
 
-    class_id = body.get('class_id')
+    class_id = body.get("class_id")
     if not is_admin(user):
-        username_filter = body.get('username')
+        username_filter = body.get("username")
         if not class_id or not username_filter:
-            return utils.error_page(error=403, ui_message=gettext('unauthorized'))
+            return utils.error_page(error=403, ui_message=gettext("unauthorized"))
 
         class_ = DATABASE.get_class(class_id)
-        if not class_ or class_['teacher'] != user['username'] or username_filter not in class_.get('students', []):
-            return utils.error_page(error=403, ui_message=gettext('unauthorized'))
+        if not class_ or class_["teacher"] != user["username"] or username_filter not in class_.get("students", []):
+            return utils.error_page(error=403, ui_message=gettext("unauthorized"))
 
     (exec_id, status) = log_fetcher.query(body)
-    response = {'query_status': status, 'query_execution_id': exec_id}
+    response = {"query_status": status, "query_execution_id": exec_id}
     return jsonify(response)
 
 
-@app.route('/logs/results', methods=['GET'])
+@app.route("/logs/results", methods=["GET"])
 def get_log_results():
-    query_execution_id = request.args.get(
-        'query_execution_id', default=None, type=str)
-    next_token = request.args.get('next_token', default=None, type=str)
+    query_execution_id = request.args.get("query_execution_id", default=None, type=str)
+    next_token = request.args.get("next_token", default=None, type=str)
 
     user = current_user()
     if not is_admin(user) and not is_teacher(user):
-        return utils.error_page(error=403, ui_message=gettext('unauthorized'))
+        return utils.error_page(error=403, ui_message=gettext("unauthorized"))
 
-    data, next_token = log_fetcher.get_query_results(
-        query_execution_id, next_token)
-    response = {'data': data, 'next_token': next_token}
+    data, next_token = log_fetcher.get_query_results(query_execution_id, next_token)
+    response = {"data": data, "next_token": next_token}
     return jsonify(response)
 
 
-@app.route('/tutorial', methods=['GET'])
+@app.route("/tutorial", methods=["GET"])
 def tutorial_index():
-    if not current_user()['username']:
-        return redirect('/login')
+    if not current_user()["username"]:
+        return redirect("/login")
     level = 1
     cheatsheet = COMMANDS[g.lang].get_commands_for_level(level, g.keyword_lang)
     commands = hedy.commands_per_level.get(level)
     adventures = load_adventures_per_level(level, g.keyword_lang)
     parsons = len(PARSONS[g.lang].get_parsons_data_for_level(level))
 
-    return hedyweb.render_tutorial_mode(level=level, cheatsheet=cheatsheet, commands=commands,
-                                        adventures=adventures, parsons_exercises=parsons)
+    return hedyweb.render_tutorial_mode(
+        level=level,
+        cheatsheet=cheatsheet,
+        commands=commands,
+        adventures=adventures,
+        parsons_exercises=parsons,
+    )
 
 
-@app.route('/teacher-tutorial', methods=['GET'])
+@app.route("/teacher-tutorial", methods=["GET"])
 @requires_login
 def teacher_tutorial(user):
     if not is_teacher(user):
-        return utils.error_page(error=403, ui_message=gettext('not_teacher'))
+        return utils.error_page(error=403, ui_message=gettext("not_teacher"))
 
-    teacher_classes = DATABASE.get_teacher_classes(current_user()['username'], True)
+    teacher_classes = DATABASE.get_teacher_classes(current_user()["username"], True)
     adventures = []
-    for adventure in DATABASE.get_teacher_adventures(current_user()['username']):
+    for adventure in DATABASE.get_teacher_adventures(current_user()["username"]):
         adventures.append(
-            {'id': adventure.get('id'),
-             'name': adventure.get('name'),
-             'date': utils.localized_date_format(adventure.get('date')),
-             'level': adventure.get('level')
-             }
+            {
+                "id": adventure.get("id"),
+                "name": adventure.get("name"),
+                "date": utils.localized_date_format(adventure.get("date")),
+                "level": adventure.get("level"),
+            }
         )
 
-    return render_template('for-teachers.html', current_page='my-profile',
-                           page_title=gettext('title_for-teacher'), teacher_classes=teacher_classes,
-                           teacher_adventures=adventures, tutorial=True,
-                           content=hedyweb.PageTranslations('for-teachers').get_page_translations(g.lang))
+    return render_template(
+        "for-teachers.html",
+        current_page="my-profile",
+        page_title=gettext("title_for-teacher"),
+        teacher_classes=teacher_classes,
+        teacher_adventures=adventures,
+        tutorial=True,
+        content=hedyweb.PageTranslations("for-teachers").get_page_translations(g.lang),
+    )
 
 
 # routing to index.html
-@app.route('/ontrack', methods=['GET'], defaults={'level': '1', 'program_id': None})
-@app.route('/onlinemasters', methods=['GET'], defaults={'level': '1', 'program_id': None})
-@app.route('/onlinemasters/<int:level>', methods=['GET'], defaults={'program_id': None})
-@app.route('/space_eu', methods=['GET'], defaults={'level': '1', 'program_id': None})
-@app.route('/hedy', methods=['GET'], defaults={'level': '1', 'program_id': None})
-@app.route('/hedy/<level>', methods=['GET'], defaults={'program_id': None})
-@app.route('/hedy/<level>/<program_id>', methods=['GET'])
+@app.route("/ontrack", methods=["GET"], defaults={"level": "1", "program_id": None})
+@app.route("/onlinemasters", methods=["GET"], defaults={"level": "1", "program_id": None})
+@app.route("/onlinemasters/<int:level>", methods=["GET"], defaults={"program_id": None})
+@app.route("/space_eu", methods=["GET"], defaults={"level": "1", "program_id": None})
+@app.route("/hedy", methods=["GET"], defaults={"level": "1", "program_id": None})
+@app.route("/hedy/<level>", methods=["GET"], defaults={"program_id": None})
+@app.route("/hedy/<level>/<program_id>", methods=["GET"])
 def index(level, program_id):
     try:
         level = int(level)
         if level < 1 or level > hedy.HEDY_MAX_LEVEL:
-            return utils.error_page(error=404, ui_message=gettext('no_such_level'))
+            return utils.error_page(error=404, ui_message=gettext("no_such_level"))
     except:
-        return utils.error_page(error=404, ui_message=gettext('no_such_level'))
+        return utils.error_page(error=404, ui_message=gettext("no_such_level"))
 
-    loaded_program = ''
-    adventure_name = ''
+    loaded_program = ""
+    adventure_name = ""
 
     if program_id:
         result = DATABASE.program_by_id(program_id)
         if not result:
-            return utils.error_page(error=404, ui_message=gettext('no_such_program'))
+            return utils.error_page(error=404, ui_message=gettext("no_such_program"))
 
         user = current_user()
-        public_program = result.get('public')
+        public_program = result.get("public")
         # Verify that the program is either public, the current user is the creator, teacher or the user is admin
-        if not public_program and user['username'] != result['username'] and not is_admin(user):
-            if (not is_teacher(user)) or (is_teacher(user) and result['username'] not in DATABASE.get_teacher_students(user['username'])):
-                return utils.error_page(error=404, ui_message=gettext(u'no_such_program'))
+        if not public_program and user["username"] != result["username"] and not is_admin(user):
+            if (not is_teacher(user)) or (
+                is_teacher(user) and result["username"] not in DATABASE.get_teacher_students(user["username"])
+            ):
+                return utils.error_page(error=404, ui_message=gettext("no_such_program"))
 
-        loaded_program = {'code': result['code'], 'name': result['name'],
-                          'adventure_name': result.get('adventure_name')}
-        if 'adventure_name' in result:
-            adventure_name = result['adventure_name']
+        loaded_program = {
+            "code": result["code"],
+            "name": result["name"],
+            "adventure_name": result.get("adventure_name"),
+        }
+        if "adventure_name" in result:
+            adventure_name = result["adventure_name"]
 
     # In case of a "forced keyword language" -> load that one, otherwise: load the one stored in the g object
-    keyword_language = request.args.get('keyword_language', default=None, type=str)
+    keyword_language = request.args.get("keyword_language", default=None, type=str)
     if keyword_language:
         adventures = load_adventures_per_level(level, keyword_language)
     else:
         adventures = load_adventures_per_level(level, g.keyword_lang)
 
     customizations = {}
-    if current_user()['username']:
-        customizations = DATABASE.get_student_class_customizations(current_user()['username'])
+    if current_user()["username"]:
+        customizations = DATABASE.get_student_class_customizations(current_user()["username"])
 
-    if 'levels' in customizations:
-        available_levels = customizations['levels']
+    if "levels" in customizations:
+        available_levels = customizations["levels"]
         now = timems()
-        for current_level, timestamp in customizations.get('opening_dates', {}).items():
+        for current_level, timestamp in customizations.get("opening_dates", {}).items():
             if utils.datetotimeordate(timestamp) > utils.datetotimeordate(utils.mstoisostring(now)):
                 try:
                     available_levels.remove(int(current_level))
                 except:
                     print("Error: there is an openings date without a level")
 
-    if 'levels' in customizations and level not in available_levels:
-        return utils.error_page(error=403, ui_message=gettext('level_not_class'))
+    if "levels" in customizations and level not in available_levels:
+        return utils.error_page(error=403, ui_message=gettext("level_not_class"))
 
     cheatsheet = COMMANDS[g.lang].get_commands_for_level(level, g.keyword_lang)
 
     teacher_adventures = []
     # Todo: TB It would be nice to improve this by using level as a sort key
-    for adventure in customizations.get('teacher_adventures', []):
+    for adventure in customizations.get("teacher_adventures", []):
         current_adventure = DATABASE.get_adventure(adventure)
-        if current_adventure.get('level') == str(level):
+        if current_adventure.get("level") == str(level):
             try:
-                current_adventure['content'] = current_adventure['content'].format(**hedy_content.KEYWORDS.get(g.keyword_lang))
+                current_adventure["content"] = current_adventure["content"].format(
+                    **hedy_content.KEYWORDS.get(g.keyword_lang)
+                )
             except:
                 # We don't want teacher being able to break the student UI -> pass this adventure
                 pass
             teacher_adventures.append(current_adventure)
 
     enforce_developers_mode = False
-    if 'other_settings' in customizations and 'developers_mode' in customizations['other_settings']:
+    if "other_settings" in customizations and "developers_mode" in customizations["other_settings"]:
         enforce_developers_mode = True
 
     hide_cheatsheet = False
-    if 'other_settings' in customizations and 'hide_cheatsheet' in customizations['other_settings']:
+    if "other_settings" in customizations and "hide_cheatsheet" in customizations["other_settings"]:
         hide_cheatsheet = True
 
     parsons = True if PARSONS[g.lang].get_parsons_data_for_level(level) else False
@@ -869,9 +963,9 @@ def index(level, program_id):
     if parsons:
         parson_exercises = len(PARSONS[g.lang].get_parsons_data_for_level(level))
 
-    if 'other_settings' in customizations and 'hide_parsons' in customizations['other_settings']:
+    if "other_settings" in customizations and "hide_parsons" in customizations["other_settings"]:
         parsons = False
-    if 'other_settings' in customizations and 'hide_quiz' in customizations['other_settings']:
+    if "other_settings" in customizations and "hide_quiz" in customizations["other_settings"]:
         quiz = False
 
     commands = hedy.commands_per_level.get(level)
@@ -892,48 +986,60 @@ def index(level, program_id):
         enforce_developers_mode=enforce_developers_mode,
         teacher_adventures=teacher_adventures,
         loaded_program=loaded_program,
-        adventure_name=adventure_name)
+        adventure_name=adventure_name,
+    )
 
 
-@app.route('/hedy/<id>/view', methods=['GET'])
+@app.route("/hedy/<id>/view", methods=["GET"])
 @requires_login
 def view_program(user, id):
     result = DATABASE.program_by_id(id)
 
     if not result:
-        return utils.error_page(error=404, ui_message=gettext('no_such_program'))
+        return utils.error_page(error=404, ui_message=gettext("no_such_program"))
 
-    public_program = result.get('public')
+    public_program = result.get("public")
     # Verify that the program is either public, the current user is the creator, teacher or the user is admin
-    if not public_program and user['username'] != result['username'] and not is_admin(user):
-        if (not is_teacher(user)) or (is_teacher(user) and result['username'] not in DATABASE.get_teacher_students(user['username'])):
-            return utils.error_page(error=404, ui_message=gettext(u'no_such_program'))
+    if not public_program and user["username"] != result["username"] and not is_admin(user):
+        if (not is_teacher(user)) or (
+            is_teacher(user) and result["username"] not in DATABASE.get_teacher_students(user["username"])
+        ):
+            return utils.error_page(error=404, ui_message=gettext("no_such_program"))
 
     # The program is valid, verify if the creator also have a public profile
-    result['public_profile'] = True if DATABASE.get_public_profile_settings(
-        result['username']) else None
+    result["public_profile"] = True if DATABASE.get_public_profile_settings(result["username"]) else None
 
-    code = result['code']
+    code = result["code"]
     if result.get("lang") != "en" and result.get("lang") in ALL_KEYWORD_LANGUAGES.keys():
-        code = hedy_translation.translate_keywords(code, from_lang=result.get('lang'), to_lang="en", level=int(result.get('level', 1)))
+        code = hedy_translation.translate_keywords(
+            code,
+            from_lang=result.get("lang"),
+            to_lang="en",
+            level=int(result.get("level", 1)),
+        )
     # If the keyword language is non-English -> parse again to guarantee completely localized keywords
     if g.keyword_lang != "en":
-        code = hedy_translation.translate_keywords(code, from_lang="en", to_lang=g.keyword_lang, level=int(result.get('level', 1)))
+        code = hedy_translation.translate_keywords(
+            code,
+            from_lang="en",
+            to_lang=g.keyword_lang,
+            level=int(result.get("level", 1)),
+        )
 
-    result['code'] = code
+    result["code"] = code
 
     arguments_dict = {}
-    arguments_dict['program_id'] = id
-    arguments_dict['page_title'] = f'{result["name"]} – Hedy'
-    arguments_dict['level'] = result['level']  # Necessary for running
-    arguments_dict['loaded_program'] = result
-    arguments_dict['editor_readonly'] = True
+    arguments_dict["program_id"] = id
+    arguments_dict["page_title"] = f'{result["name"]} – Hedy'
+    arguments_dict["level"] = result["level"]  # Necessary for running
+    arguments_dict["loaded_program"] = result
+    arguments_dict["editor_readonly"] = True
 
-    if "submitted" in result and result['submitted']:
-        arguments_dict['show_edit_button'] = False
-        arguments_dict['program_timestamp'] = utils.localized_date_format(result['date'])
+    if "submitted" in result and result["submitted"]:
+        arguments_dict["show_edit_button"] = False
+        arguments_dict["program_timestamp"] = utils.localized_date_format(result["date"])
     else:
-        arguments_dict['show_edit_button'] = True
+        arguments_dict["show_edit_button"] = True
 
     # Everything below this line has nothing to do with this page and it's silly
     # that every page needs to put in so much effort to re-set it
@@ -941,37 +1047,47 @@ def view_program(user, id):
     return render_template("view-program-page.html", **arguments_dict)
 
 
-@app.route('/adventure/<name>', methods=['GET'], defaults={'level': 1})
-@app.route('/adventure/<name>/<level>', methods=['GET'])
+@app.route("/adventure/<name>", methods=["GET"], defaults={"level": 1})
+@app.route("/adventure/<name>/<level>", methods=["GET"])
 def get_specific_adventure(name, level):
     try:
         level = int(level)
     except:
-        return utils.error_page(error=404, ui_message=gettext('no_such_level'))
+        return utils.error_page(error=404, ui_message=gettext("no_such_level"))
 
-    adventure = [x for x in load_adventures_per_level(
-        level, g.keyword_lang) if x.get('short_name') == name]
+    adventure = [x for x in load_adventures_per_level(level, g.keyword_lang) if x.get("short_name") == name]
     if not adventure:
-        return utils.error_page(error=404, ui_message=gettext('no_such_adventure'))
+        return utils.error_page(error=404, ui_message=gettext("no_such_adventure"))
 
-    prev_level = level-1 if [x for x in load_adventures_per_level(
-        level-1, g.keyword_lang) if x.get('short_name') == name] else False
-    next_level = level+1 if [x for x in load_adventures_per_level(
-        level+1, g.keyword_lang) if x.get('short_name') == name] else False
+    prev_level = (
+        level - 1
+        if [x for x in load_adventures_per_level(level - 1, g.keyword_lang) if x.get("short_name") == name]
+        else False
+    )
+    next_level = (
+        level + 1
+        if [x for x in load_adventures_per_level(level + 1, g.keyword_lang) if x.get("short_name") == name]
+        else False
+    )
 
-    return hedyweb.render_specific_adventure(level_number=level, adventure=adventure, version=version(),
-                                             prev_level=prev_level, next_level=next_level)
+    return hedyweb.render_specific_adventure(
+        level_number=level,
+        adventure=adventure,
+        version=version(),
+        prev_level=prev_level,
+        next_level=next_level,
+    )
 
 
-@app.route('/cheatsheet/', methods=['GET'], defaults={'level': 1})
-@app.route('/cheatsheet/<level>', methods=['GET'])
+@app.route("/cheatsheet/", methods=["GET"], defaults={"level": 1})
+@app.route("/cheatsheet/<level>", methods=["GET"])
 def get_cheatsheet_page(level):
     try:
         level = int(level)
         if level < 1 or level > hedy.HEDY_MAX_LEVEL:
-            return utils.error_page(error=404, ui_message=gettext('no_such_level'))
+            return utils.error_page(error=404, ui_message=gettext("no_such_level"))
     except:
-        return utils.error_page(error=404, ui_message=gettext('no_such_level'))
+        return utils.error_page(error=404, ui_message=gettext("no_such_level"))
 
     commands = COMMANDS[g.lang].get_commands_for_level(level, g.keyword_lang)
 
@@ -980,119 +1096,144 @@ def get_cheatsheet_page(level):
 
 @app.errorhandler(404)
 def not_found(exception):
-    return utils.error_page(error=404, ui_message=gettext('page_not_found'))
+    return utils.error_page(error=404, ui_message=gettext("page_not_found"))
 
 
 @app.errorhandler(500)
 def internal_error(exception):
     import traceback
+
     print(traceback.format_exc())
     return utils.error_page(error=500)
 
 
-@app.route('/index.html')
-@app.route('/')
+@app.route("/index.html")
+@app.route("/")
 def default_landing_page():
-    return main_page('start')
+    return main_page("start")
 
 
-@app.route('/signup', methods=['GET'])
+@app.route("/signup", methods=["GET"])
 def signup_page():
-    if current_user()['username']:
-        return redirect('/my-profile')
-    return render_template('signup.html', page_title=gettext('title_signup'), current_page='login')
+    if current_user()["username"]:
+        return redirect("/my-profile")
+    return render_template("signup.html", page_title=gettext("title_signup"), current_page="login")
 
 
-@app.route('/login', methods=['GET'])
+@app.route("/login", methods=["GET"])
 def login_page():
-    if current_user()['username']:
-        return redirect('/my-profile')
-    return render_template('login.html', page_title=gettext('title_login'), current_page='login')
+    if current_user()["username"]:
+        return redirect("/my-profile")
+    return render_template("login.html", page_title=gettext("title_login"), current_page="login")
 
 
-@app.route('/recover', methods=['GET'])
+@app.route("/recover", methods=["GET"])
 def recover_page():
-    if current_user()['username']:
-        return redirect('/my-profile')
-    return render_template('recover.html', page_title=gettext('title_recover'), current_page='login')
+    if current_user()["username"]:
+        return redirect("/my-profile")
+    return render_template("recover.html", page_title=gettext("title_recover"), current_page="login")
 
 
-@app.route('/reset', methods=['GET'])
+@app.route("/reset", methods=["GET"])
 def reset_page():
     # If there is a user logged in -> don't allow password reset
-    if current_user()['username']:
-        return redirect('/my-profile')
+    if current_user()["username"]:
+        return redirect("/my-profile")
 
-    username = request.args.get('username', default=None, type=str)
-    token = request.args.get('token', default=None, type=str)
+    username = request.args.get("username", default=None, type=str)
+    token = request.args.get("token", default=None, type=str)
     username = None if username == "null" else username
     token = None if token == "null" else token
 
     if not username or not token:
-        return utils.error_page(error=403, ui_message=gettext('unauthorized'))
-    return render_template('reset.html', page_title=gettext('title_reset'), reset_username=username, reset_token=token, current_page='login')
+        return utils.error_page(error=403, ui_message=gettext("unauthorized"))
+    return render_template(
+        "reset.html",
+        page_title=gettext("title_reset"),
+        reset_username=username,
+        reset_token=token,
+        current_page="login",
+    )
 
 
-@app.route('/my-profile', methods=['GET'])
+@app.route("/my-profile", methods=["GET"])
 @requires_login
 def profile_page(user):
 
-    profile = DATABASE.user_by_username(user['username'])
-    programs = DATABASE.public_programs_for_user(user['username'])
-    public_profile_settings = DATABASE.get_public_profile_settings(current_user()['username'])
+    profile = DATABASE.user_by_username(user["username"])
+    programs = DATABASE.public_programs_for_user(user["username"])
+    public_profile_settings = DATABASE.get_public_profile_settings(current_user()["username"])
 
     classes = []
-    if profile.get('classes'):
-        for class_id in profile.get('classes'):
+    if profile.get("classes"):
+        for class_id in profile.get("classes"):
             classes.append(DATABASE.get_class(class_id))
 
-    invite = DATABASE.get_username_invite(user['username'])
+    invite = DATABASE.get_username_invite(user["username"])
     if invite:
         # We have to keep this in mind as well, can simply be set to 1 for now
         # But when adding more message structures we have to use a more sophisticated structure
-        session['messages'] = 1
+        session["messages"] = 1
         # If there is an invite: retrieve the class information
-        class_info = DATABASE.get_class(invite.get('class_id', None))
+        class_info = DATABASE.get_class(invite.get("class_id", None))
         if class_info:
-            invite['teacher'] = class_info.get('teacher')
-            invite['class_name'] = class_info.get('name')
-            invite['join_link'] = class_info.get('link')
+            invite["teacher"] = class_info.get("teacher")
+            invite["class_name"] = class_info.get("name")
+            invite["join_link"] = class_info.get("link")
     else:
-        session['messages'] = 0
+        session["messages"] = 0
 
-    return render_template('profile.html', page_title=gettext('title_my-profile'), programs=programs,
-                           user_data=profile, invite_data=invite, public_settings=public_profile_settings,
-                           user_classes=classes, current_page='my-profile')
+    return render_template(
+        "profile.html",
+        page_title=gettext("title_my-profile"),
+        programs=programs,
+        user_data=profile,
+        invite_data=invite,
+        public_settings=public_profile_settings,
+        user_classes=classes,
+        current_page="my-profile",
+    )
 
 
-@app.route('/research/<filename>', methods=['GET'])
+@app.route("/research/<filename>", methods=["GET"])
 def get_research(filename):
-    return send_from_directory('content/research/', filename)
+    return send_from_directory("content/research/", filename)
 
 
-@app.route('/<page>')
+@app.route("/<page>")
 def main_page(page):
-    if page == 'favicon.ico':
+    if page == "favicon.ico":
         abort(404)
 
     if page == "my-achievements":
         return achievements_page()
 
-    if page == 'learn-more':
+    if page == "learn-more":
         learn_more_translations = hedyweb.PageTranslations(page).get_page_translations(g.lang)
-        return render_template('learn-more.html', papers=hedy_content.RESEARCH, page_title=gettext('title_learn-more'),
-                               current_page='learn-more', content=learn_more_translations)
+        return render_template(
+            "learn-more.html",
+            papers=hedy_content.RESEARCH,
+            page_title=gettext("title_learn-more"),
+            current_page="learn-more",
+            content=learn_more_translations,
+        )
 
-    if page == 'join':
+    if page == "join":
         join_translations = hedyweb.PageTranslations(page).get_page_translations(g.lang)
-        return render_template('join.html', page_title=gettext('title_learn-more'),
-                               current_page='join', content=join_translations)
+        return render_template(
+            "join.html",
+            page_title=gettext("title_learn-more"),
+            current_page="join",
+            content=join_translations,
+        )
 
-    if page == 'privacy':
-        privacy_translations = hedyweb.PageTranslations(
-            page).get_page_translations(g.lang)
-        return render_template('privacy.html', page_title=gettext('title_privacy'),
-                               content=privacy_translations)
+    if page == "privacy":
+        privacy_translations = hedyweb.PageTranslations(page).get_page_translations(g.lang)
+        return render_template(
+            "privacy.html",
+            page_title=gettext("title_privacy"),
+            content=privacy_translations,
+        )
 
     user = current_user()
 
@@ -1101,15 +1242,19 @@ def main_page(page):
         abort(404)
 
     main_page_translations = requested_page.get_page_translations(g.lang)
-    return render_template('main-page.html', page_title=gettext('title_start'),
-                           current_page='start', content=main_page_translations)
+    return render_template(
+        "main-page.html",
+        page_title=gettext("title_start"),
+        current_page="start",
+        content=main_page_translations,
+    )
 
 
-@app.route('/landing-page/', methods=['GET'], defaults={'first': False})
-@app.route('/landing-page/<first>', methods=['GET'])
+@app.route("/landing-page/", methods=["GET"], defaults={"first": False})
+@app.route("/landing-page/<first>", methods=["GET"])
 @requires_login
 def landing_page(user, first):
-    username = user['username']
+    username = user["username"]
 
     user_info = DATABASE.get_public_profile_settings(username)
     user_programs = DATABASE.programs_for_user(username)
@@ -1118,19 +1263,25 @@ def landing_page(user, first):
         user_programs = user_programs[:1][0]
     user_achievements = DATABASE.progress_by_username(username)
 
-    return render_template('landing-page.html', first_time=True if first else False,
-                           page_title=gettext('title_landing-page'), user=user['username'],
-                           user_info=user_info, program=user_programs, achievements=user_achievements)
+    return render_template(
+        "landing-page.html",
+        first_time=True if first else False,
+        page_title=gettext("title_landing-page"),
+        user=user["username"],
+        user_info=user_info,
+        program=user_programs,
+        achievements=user_achievements,
+    )
 
 
-@app.route('/explore', methods=['GET'])
+@app.route("/explore", methods=["GET"])
 def explore():
-    if not current_user()['username']:
-        return redirect('/login')
+    if not current_user()["username"]:
+        return redirect("/login")
 
-    level = request.args.get('level', default=None, type=str)
-    adventure = request.args.get('adventure', default=None, type=str)
-    language = request.args.get('lang', default=None, type=str)
+    level = request.args.get("level", default=None, type=str)
+    adventure = request.args.get("adventure", default=None, type=str)
+    language = request.args.get("lang", default=None, type=str)
 
     level = None if level == "null" else level
     adventure = None if adventure == "null" else adventure
@@ -1140,192 +1291,222 @@ def explore():
     if level or adventure or language:
         programs = PUBLIC_PROGRAMS
         if level:
-            programs = [x for x in programs if x.get('level') == int(level)]
+            programs = [x for x in programs if x.get("level") == int(level)]
         if language:
-            programs = [x for x in programs if x.get('lang') == language]
+            programs = [x for x in programs if x.get("lang") == language]
         if adventure:
             # If the adventure we filter on is called 'default' -> return all programs WITHOUT an adventure
             if adventure == "default":
-                programs = [x for x in programs if x.get('adventure_name') == ""]
+                programs = [x for x in programs if x.get("adventure_name") == ""]
                 return programs[-48:]
-            programs = [x for x in programs if x.get('adventure_name') == adventure]
+            programs = [x for x in programs if x.get("adventure_name") == adventure]
         programs = programs[-48:]
-        achievement = ACHIEVEMENTS.add_single_achievement(current_user()['username'], "indiana_jones")
+        achievement = ACHIEVEMENTS.add_single_achievement(current_user()["username"], "indiana_jones")
     else:
         programs = PUBLIC_PROGRAMS[:48]
 
     filtered_programs = []
     for program in programs:
         # If program does not have an error value set -> parse it and set value
-        if 'error' not in program:
+        if "error" not in program:
             try:
-                hedy.transpile(program.get('code'), program.get('level'), program.get('lang'))
-                program['error'] = False
+                hedy.transpile(program.get("code"), program.get("level"), program.get("lang"))
+                program["error"] = False
             except:
-                program['error'] = True
+                program["error"] = True
             DATABASE.store_program(program)
-        public_profile = DATABASE.get_public_profile_settings(program['username'])
+        public_profile = DATABASE.get_public_profile_settings(program["username"])
 
         # If the language doesn't match the user -> parse the keywords
         # We perform a "double parse" to make sure english keywords are also always translated
-        code = program['code']
+        code = program["code"]
 
         # First, if the program language is not equal to english and the language supports keywords
         # It might contain non-english keywords -> parse all to english
         if program.get("lang") != "en" and program.get("lang") in ALL_KEYWORD_LANGUAGES.keys():
-            code = hedy_translation.translate_keywords(code, from_lang=program.get('lang'), to_lang="en", level=int(program.get('level', 1)))
+            code = hedy_translation.translate_keywords(
+                code,
+                from_lang=program.get("lang"),
+                to_lang="en",
+                level=int(program.get("level", 1)),
+            )
         # If the keyword language is non-English -> parse again to guarantee completely localized keywords
         if g.keyword_lang != "en":
-            code = hedy_translation.translate_keywords(code, from_lang="en", to_lang=g.keyword_lang, level=int(program.get('level', 1)))
+            code = hedy_translation.translate_keywords(
+                code,
+                from_lang="en",
+                to_lang=g.keyword_lang,
+                level=int(program.get("level", 1)),
+            )
 
-        filtered_programs.append({
-            'username': program['username'],
-            'name': program['name'],
-            'level': program['level'],
-            'id': program['id'],
-            'error': program['error'],
-            'hedy_choice': True if program.get('hedy_choice') == 1 else False,
-            'public_user': True if public_profile else None,
-            'code': "\n".join(code.split("\n")[:4])
-        })
+        filtered_programs.append(
+            {
+                "username": program["username"],
+                "name": program["name"],
+                "level": program["level"],
+                "id": program["id"],
+                "error": program["error"],
+                "hedy_choice": True if program.get("hedy_choice") == 1 else False,
+                "public_user": True if public_profile else None,
+                "code": "\n".join(code.split("\n")[:4]),
+            }
+        )
 
     favourite_programs = DATABASE.get_hedy_choices()
     hedy_choices = []
     for program in favourite_programs:
-        hedy_choices.append({
-            'username': program['username'],
-            'name': program['name'],
-            'level': program['level'],
-            'id': program['id'],
-            'hedy_choice': True,
-            'public_user': True if public_profile else None,
-            'code': "\n".join(program['code'].split("\n")[:4])
-        })
+        hedy_choices.append(
+            {
+                "username": program["username"],
+                "name": program["name"],
+                "level": program["level"],
+                "id": program["id"],
+                "hedy_choice": True,
+                "public_user": True if public_profile else None,
+                "code": "\n".join(program["code"].split("\n")[:4]),
+            }
+        )
 
-    adventures_names = hedy_content.Adventures(session['lang']).get_adventure_names()
+    adventures_names = hedy_content.Adventures(session["lang"]).get_adventure_names()
 
-    return render_template('explore.html', programs=filtered_programs, favourite_programs=hedy_choices,
-                           filtered_level=level,
-                           achievement=achievement,
-                           filtered_adventure=adventure,
-                           filtered_lang=language,
-                           max_level=hedy.HEDY_MAX_LEVEL,
-                           adventures_names=adventures_names,
-                           page_title=gettext('title_explore'),
-                           current_page='explore')
+    return render_template(
+        "explore.html",
+        programs=filtered_programs,
+        favourite_programs=hedy_choices,
+        filtered_level=level,
+        achievement=achievement,
+        filtered_adventure=adventure,
+        filtered_lang=language,
+        max_level=hedy.HEDY_MAX_LEVEL,
+        adventures_names=adventures_names,
+        page_title=gettext("title_explore"),
+        current_page="explore",
+    )
 
 
-@app.route('/highscores', methods=['GET'], defaults={'filter': 'global'})
-@app.route('/highscores/<filter>', methods=['GET'])
+@app.route("/highscores", methods=["GET"], defaults={"filter": "global"})
+@app.route("/highscores/<filter>", methods=["GET"])
 @requires_login
 def get_highscores_page(user, filter):
     if filter not in ["global", "country", "class"]:
-        return utils.error_page(error=404, ui_message=gettext('page_not_found'))
+        return utils.error_page(error=404, ui_message=gettext("page_not_found"))
 
-    user_data = DATABASE.user_by_username(user['username'])
-    public_profile = True if DATABASE.get_public_profile_settings(user['username']) else False
-    classes = list(user_data.get('classes', set()))
-    country = user_data.get('country')
+    user_data = DATABASE.user_by_username(user["username"])
+    public_profile = True if DATABASE.get_public_profile_settings(user["username"]) else False
+    classes = list(user_data.get("classes", set()))
+    country = user_data.get("country")
     user_country = COUNTRIES.get(country)
 
     if filter == "global":
-        highscores = DATABASE.get_highscores(user['username'], filter)
+        highscores = DATABASE.get_highscores(user["username"], filter)
     elif filter == "country":
         # Can't get a country highscore if you're not in a country!
         if not country:
-            return utils.error_page(error=403, ui_message=gettext('no_such_highscore'))
-        highscores = DATABASE.get_highscores(user['username'], filter, country)
+            return utils.error_page(error=403, ui_message=gettext("no_such_highscore"))
+        highscores = DATABASE.get_highscores(user["username"], filter, country)
     elif filter == "class":
         # Can't get a class highscore if you're not in a class!
         if not classes:
-            return utils.error_page(error=403, ui_message=gettext('no_such_highscore'))
-        highscores = DATABASE.get_highscores(user['username'], filter, classes[0])
+            return utils.error_page(error=403, ui_message=gettext("no_such_highscore"))
+        highscores = DATABASE.get_highscores(user["username"], filter, classes[0])
 
     # Make a deepcopy if working locally, otherwise the local database values are by-reference and overwritten
-    if not os.getenv('NO_DEBUG_MODE'):
+    if not os.getenv("NO_DEBUG_MODE"):
         highscores = copy.deepcopy(highscores)
     for highscore in highscores:
-        highscore['country'] = highscore.get('country') if highscore.get('country') else "-"
-        highscore['last_achievement'] = utils.delta_timestamp(highscore.get('last_achievement'))
-    return render_template('highscores.html', highscores=highscores, has_country=True if country else False,
-                           filter=filter, user_country=user_country, public_profile=public_profile,
-                           in_class=True if classes else False)
+        highscore["country"] = highscore.get("country") if highscore.get("country") else "-"
+        highscore["last_achievement"] = utils.delta_timestamp(highscore.get("last_achievement"))
+    return render_template(
+        "highscores.html",
+        highscores=highscores,
+        has_country=True if country else False,
+        filter=filter,
+        user_country=user_country,
+        public_profile=public_profile,
+        in_class=True if classes else False,
+    )
 
 
-@app.route('/change_language', methods=['POST'])
+@app.route("/change_language", methods=["POST"])
 def change_language():
     body = request.json
-    session['lang'] = body.get('lang')
-    return jsonify({'succes': 200})
+    session["lang"] = body.get("lang")
+    return jsonify({"succes": 200})
 
 
-@app.route('/translate_keywords', methods=['POST'])
+@app.route("/translate_keywords", methods=["POST"])
 def translate_keywords():
     body = request.json
     try:
-        translated_code = hedy_translation.translate_keywords(body.get('code'), body.get(
-            'start_lang'), body.get('goal_lang'), level=int(body.get('level', 1)))
+        translated_code = hedy_translation.translate_keywords(
+            body.get("code"),
+            body.get("start_lang"),
+            body.get("goal_lang"),
+            level=int(body.get("level", 1)),
+        )
         if translated_code:
-            return jsonify({'success': 200, 'code': translated_code})
+            return jsonify({"success": 200, "code": translated_code})
         else:
-            return gettext('translate_error'), 400
+            return gettext("translate_error"), 400
     except:
-        return gettext('translate_error'), 400
+        return gettext("translate_error"), 400
 
 
 # TODO TB: Think about changing this to sending all steps to the front-end at once
-@app.route('/get_tutorial_step/<level>/<step>', methods=['GET'])
+@app.route("/get_tutorial_step/<level>/<step>", methods=["GET"])
 def get_tutorial_translation(level, step):
     # Keep this structure temporary until we decide on a nice code / parse structure
     if step == "code_snippet":
-        return jsonify({'code': gettext('tutorial_code_snippet')}), 200
+        return jsonify({"code": gettext("tutorial_code_snippet")}), 200
     try:
         step = int(step)
     except ValueError:
-        return gettext('invalid_tutorial_step'), 400
+        return gettext("invalid_tutorial_step"), 400
 
     data = TUTORIALS[g.lang].get_tutorial_for_level_step(level, step, g.keyword_lang)
     if not data:
-        data = {'title': gettext('tutorial_title_not_found'), 'text': gettext('tutorial_message_not_found')}
+        data = {
+            "title": gettext("tutorial_title_not_found"),
+            "text": gettext("tutorial_message_not_found"),
+        }
     return jsonify(data), 200
 
 
-@app.route('/store_parsons_order', methods=['POST'])
+@app.route("/store_parsons_order", methods=["POST"])
 def store_parsons_order():
     body = request.json
     # Validations
     if not isinstance(body, dict):
-        return 'body must be an object', 400
-    if not isinstance(body.get('level'), str):
-        return 'level must be a string', 400
-    if not isinstance(body.get('exercise'), str):
-        return 'exercise must be a string', 400
-    if not isinstance(body.get('order'), list):
-        return 'order must be a list', 400
+        return "body must be an object", 400
+    if not isinstance(body.get("level"), str):
+        return "level must be a string", 400
+    if not isinstance(body.get("exercise"), str):
+        return "exercise must be a string", 400
+    if not isinstance(body.get("order"), list):
+        return "order must be a list", 400
 
     attempt = {
-        'id': utils.random_id_generator(12),
-        'username': current_user()['username'] or f'anonymous:{utils.session_id()}',
-        'level': int(body['level']),
-        'exercise': int(body['exercise']),
-        'order': body['order'],
-        'correct': 1 if body['correct'] else 0,
-        'timestamp': utils.timems()
+        "id": utils.random_id_generator(12),
+        "username": current_user()["username"] or f"anonymous:{utils.session_id()}",
+        "level": int(body["level"]),
+        "exercise": int(body["exercise"]),
+        "order": body["order"],
+        "correct": 1 if body["correct"] else 0,
+        "timestamp": utils.timems(),
     }
 
     DATABASE.store_parsons(attempt)
     return jsonify({}), 200
 
-@app.route('/client_messages.js', methods=['GET'])
+
+@app.route("/client_messages.js", methods=["GET"])
 def client_messages():
     # Not really nice, but we don't call this often as it is cached
-    d = collections.defaultdict(lambda: 'Unknown Exception')
-    d.update(YamlFile.for_file('content/client-messages/en.yaml').to_dict())
-    d.update(YamlFile.for_file(
-        f'content/client-messages/{g.lang}.yaml').to_dict())
+    d = collections.defaultdict(lambda: "Unknown Exception")
+    d.update(YamlFile.for_file("content/client-messages/en.yaml").to_dict())
+    d.update(YamlFile.for_file(f"content/client-messages/{g.lang}.yaml").to_dict())
 
-    response = make_response(render_template(
-        "client_messages.js", error_messages=json.dumps(d)))
+    response = make_response(render_template("client_messages.js", error_messages=json.dumps(d)))
 
     if not is_debug_mode():
         # Cache for longer when not developing
@@ -1347,9 +1528,10 @@ def current_keyword_language():
 def other_keyword_language():
     # If the current keyword language isn't English: we are sure the other option is English
     # But, only if the user has an existing keyword language -> on the session
-    if session.get('keyword_lang') and session['keyword_lang'] != "en":
+    if session.get("keyword_lang") and session["keyword_lang"] != "en":
         return make_keyword_lang_obj("en")
     return None
+
 
 @app.template_global()
 def translate_command(command):
@@ -1367,19 +1549,19 @@ def nl2br(x):
     # In case of a Markup object, make sure to tell it the <br> we're adding is safe
     if not isinstance(x, Markup):
         x = Markup.escape(x)
-    return x.replace('\n', Markup('<br />'))
+    return x.replace("\n", Markup("<br />"))
 
 
 @app.template_global()
 def hedy_link(level_nr, assignment_nr, subpage=None):
     """Make a link to a Hedy page."""
-    parts = ['/hedy']
-    parts.append('/' + str(level_nr))
-    if str(assignment_nr) != '1' or subpage:
-        parts.append('/' + str(assignment_nr if assignment_nr else '1'))
-    if subpage and subpage != 'code':
-        parts.append('/' + subpage)
-    return ''.join(parts)
+    parts = ["/hedy"]
+    parts.append("/" + str(level_nr))
+    if str(assignment_nr) != "1" or subpage:
+        parts.append("/" + str(assignment_nr if assignment_nr else "1"))
+    if subpage and subpage != "code":
+        parts.append("/" + subpage)
+    return "".join(parts)
 
 
 @app.template_global()
@@ -1430,18 +1612,12 @@ def parse_keyword(keyword):
 
 def make_lang_obj(lang):
     """Make a language object for a given language."""
-    return {
-        'sym': ALL_LANGUAGES[lang],
-        'lang': lang
-    }
+    return {"sym": ALL_LANGUAGES[lang], "lang": lang}
 
 
 def make_keyword_lang_obj(lang):
     """Make a language object for a given language."""
-    return {
-        'sym': ALL_KEYWORD_LANGUAGES[lang],
-        'lang': lang
-    }
+    return {"sym": ALL_KEYWORD_LANGUAGES[lang], "lang": lang}
 
 
 @app.template_global()
@@ -1451,130 +1627,138 @@ def modify_query(**new_values):
     for key, value in new_values.items():
         args[key] = value
 
-    return '{}?{}'.format(request.path, url_encode(args))
+    return "{}?{}".format(request.path, url_encode(args))
+
 
 @app.template_global()
 def get_user_messages():
-    if not session.get('messages'):
+    if not session.get("messages"):
         # Todo TB: In the future this should contain the class invites + other messages
         # As the class invites are binary (you either have one or you have none, we can possibly simplify this)
         # Simply set it to 1 if we have an invite, otherwise keep at 0
-        invite = DATABASE.get_username_invite(current_user()['username'])
-        session['messages'] = 1 if invite else 0
-    if session.get('messages') > 0:
-        return session.get('messages')
+        invite = DATABASE.get_username_invite(current_user()["username"])
+        session["messages"] = 1 if invite else 0
+    if session.get("messages") > 0:
+        return session.get("messages")
     return None
+
 
 # Todo TB: Re-write this somewhere sometimes following the line below
 # We only store this @app.route here to enable the use of achievements -> might want to re-write this in the future
-@app.route('/auth/public_profile', methods=['POST'])
+@app.route("/auth/public_profile", methods=["POST"])
 @requires_login
 def update_public_profile(user):
     body = request.json
 
     # Validations
     if not isinstance(body, dict):
-        return gettext('ajax_error'), 400
+        return gettext("ajax_error"), 400
     # The images are given as a "picture id" from 1 till 12
-    if not isinstance(body.get('image'), str) or int(body.get('image'), 0) not in [*range(1, 13)]:
-        return gettext('image_invalid'), 400
-    if not isinstance(body.get('personal_text'), str):
-        return gettext('personal_text_invalid'), 400
-    if 'favourite_program' in body and not isinstance(body.get('favourite_program'), str):
-        return gettext('favourite_program_invalid'), 400
+    if not isinstance(body.get("image"), str) or int(body.get("image"), 0) not in [*range(1, 13)]:
+        return gettext("image_invalid"), 400
+    if not isinstance(body.get("personal_text"), str):
+        return gettext("personal_text_invalid"), 400
+    if "favourite_program" in body and not isinstance(body.get("favourite_program"), str):
+        return gettext("favourite_program_invalid"), 400
 
     # Verify that the set favourite program is actually from the user (and public)!
-    if 'favourite_program' in body:
-        program = DATABASE.program_by_id(body.get('favourite_program'))
-        if not program or program.get('username') != user['username'] or not program.get('public'):
-            return gettext('favourite_program_invalid'), 400
+    if "favourite_program" in body:
+        program = DATABASE.program_by_id(body.get("favourite_program"))
+        if not program or program.get("username") != user["username"] or not program.get("public"):
+            return gettext("favourite_program_invalid"), 400
 
     achievement = None
-    current_profile = DATABASE.get_public_profile_settings(user['username'])
+    current_profile = DATABASE.get_public_profile_settings(user["username"])
     if current_profile:
-        if current_profile.get('image') != body.get('image'):
-            achievement = ACHIEVEMENTS.add_single_achievement(current_user()['username'], "fresh_look")
+        if current_profile.get("image") != body.get("image"):
+            achievement = ACHIEVEMENTS.add_single_achievement(current_user()["username"], "fresh_look")
     else:
-        achievement = ACHIEVEMENTS.add_single_achievement(current_user()['username'], "go_live")
+        achievement = ACHIEVEMENTS.add_single_achievement(current_user()["username"], "go_live")
 
     # Make sure the session value for the profile image is up-to-date
-    session['profile_image'] = body.get('image')
+    session["profile_image"] = body.get("image")
 
     # If there is no current profile or if it doesn't have the tags list -> check if the user is a teacher / admin
-    if not current_profile or not current_profile.get('tags'):
-        body['tags'] = []
+    if not current_profile or not current_profile.get("tags"):
+        body["tags"] = []
         if is_teacher(user):
-            body['tags'].append('teacher')
+            body["tags"].append("teacher")
         if is_admin(user):
-            body['tags'].append('admin')
+            body["tags"].append("admin")
 
-    DATABASE.update_public_profile(user['username'], body)
+    DATABASE.update_public_profile(user["username"], body)
     if achievement:
         # Todo TB -> Check if we require message or success on front-end
-        return {'message': gettext('public_profile_updated'), 'achievement': achievement}, 200
-    return {'message': gettext('public_profile_updated')}, 200
+        return {
+            "message": gettext("public_profile_updated"),
+            "achievement": achievement,
+        }, 200
+    return {"message": gettext("public_profile_updated")}, 200
 
 
-@app.route('/translating')
+@app.route("/translating")
 def translating_page():
-    return render_template('translating.html')
+    return render_template("translating.html")
 
 
-@app.route('/update_yaml', methods=['POST'])
+@app.route("/update_yaml", methods=["POST"])
 def update_yaml():
-    filename = path.join('coursedata', request.form['file'])
+    filename = path.join("coursedata", request.form["file"])
     # The file MUST point to something inside our 'coursedata' directory
     filepath = path.abspath(filename)
-    expected_path = path.abspath('coursedata')
+    expected_path = path.abspath("coursedata")
     if not filepath.startswith(expected_path):
-        raise RuntimeError('Invalid path given')
+        raise RuntimeError("Invalid path given")
 
     data = load_yaml_rt(filepath)
     for key, value in request.form.items():
-        if key.startswith('c:'):
-            translating.apply_form_change(
-                data, key[2:], translating.normalize_newlines(value))
+        if key.startswith("c:"):
+            translating.apply_form_change(data, key[2:], translating.normalize_newlines(value))
 
     data = translating.normalize_yaml_blocks(data)
 
-    return Response(dump_yaml_rt(data),
-                    mimetype='application/x-yaml',
-                    headers={'Content-disposition': 'attachment; filename=' + request.form['file'].replace('/', '-')})
+    return Response(
+        dump_yaml_rt(data),
+        mimetype="application/x-yaml",
+        headers={"Content-disposition": "attachment; filename=" + request.form["file"].replace("/", "-")},
+    )
 
 
-@app.route('/user/<username>')
+@app.route("/user/<username>")
 def public_user_page(username):
-    if not current_user()['username']:
-        return utils.error_page(error=403, ui_message=gettext('unauthorized'))
+    if not current_user()["username"]:
+        return utils.error_page(error=403, ui_message=gettext("unauthorized"))
     username = username.lower()
     user = DATABASE.user_by_username(username)
     if not user:
-        return utils.error_page(error=404, ui_message=gettext('user_not_private'))
+        return utils.error_page(error=404, ui_message=gettext("user_not_private"))
     user_public_info = DATABASE.get_public_profile_settings(username)
     if user_public_info:
         user_programs = DATABASE.public_programs_for_user(username)
         user_achievements = DATABASE.progress_by_username(username) or {}
 
         favourite_program = None
-        if 'favourite_program' in user_public_info and user_public_info['favourite_program']:
-            favourite_program = DATABASE.program_by_id(
-                user_public_info['favourite_program'])
+        if "favourite_program" in user_public_info and user_public_info["favourite_program"]:
+            favourite_program = DATABASE.program_by_id(user_public_info["favourite_program"])
         if len(user_programs) >= 5:
             user_programs = user_programs[:5]
 
         last_achieved = None
-        if user_achievements.get('achieved'):
-            last_achieved = user_achievements['achieved'][-1]
+        if user_achievements.get("achieved"):
+            last_achieved = user_achievements["achieved"][-1]
 
         # Todo: TB -> In the near future: add achievement for user visiting their own profile
 
-        return render_template('public-page.html', user_info=user_public_info,
-                               achievements=ACHIEVEMENTS_TRANSLATIONS.get_translations(g.lang).get('achievements'),
-                               favourite_program=favourite_program,
-                               programs=user_programs,
-                               last_achieved=last_achieved,
-                               user_achievements=user_achievements)
-    return utils.error_page(error=404, ui_message=gettext('user_not_private'))
+        return render_template(
+            "public-page.html",
+            user_info=user_public_info,
+            achievements=ACHIEVEMENTS_TRANSLATIONS.get_translations(g.lang).get("achievements"),
+            favourite_program=favourite_program,
+            programs=user_programs,
+            last_achieved=last_achieved,
+            user_achievements=user_achievements,
+        )
+    return utils.error_page(error=404, ui_message=gettext("user_not_private"))
 
 
 def valid_invite_code(code):
@@ -1583,30 +1767,32 @@ def valid_invite_code(code):
 
     # Get the value from the environment, use literal_eval to convert from string list to an actual list
     valid_codes = []
-    if os.getenv('TEACHER_INVITE_CODE'):
-        valid_codes.append(os.getenv('TEACHER_INVITE_CODE'))
-    if os.getenv('TEACHER_INVITE_CODES'):
-        valid_codes.extend(os.getenv('TEACHER_INVITE_CODES').split(','))
+    if os.getenv("TEACHER_INVITE_CODE"):
+        valid_codes.append(os.getenv("TEACHER_INVITE_CODE"))
+    if os.getenv("TEACHER_INVITE_CODES"):
+        valid_codes.extend(os.getenv("TEACHER_INVITE_CODES").split(","))
 
     return code in valid_codes
 
-@app.route('/invite/<code>', methods=['GET'])
+
+@app.route("/invite/<code>", methods=["GET"])
 def teacher_invitation(code):
     user = current_user()
 
     if not valid_invite_code(code):
-        return utils.error_page(error=404, ui_message=gettext('invalid_teacher_invitation_code'))
+        return utils.error_page(error=404, ui_message=gettext("invalid_teacher_invitation_code"))
 
-    if not user['username']:
-        return render_template('teacher-invitation.html')
+    if not user["username"]:
+        return render_template("teacher-invitation.html")
 
     update_is_teacher(user)
     # When visiting this link we update the current user to a teacher -> also update user in session
-    session.get('user')['is_teacher'] = True
+    session.get("user")["is_teacher"] = True
 
-    session['welcome-teacher'] = True
-    url = request.url.replace(f'/invite/{code}', '/for-teachers')
+    session["welcome-teacher"] = True
+    url = request.url.replace(f"/invite/{code}", "/for-teachers")
     return redirect(url)
+
 
 # *** AUTH ***
 
@@ -1653,11 +1839,11 @@ def on_server_start():
     pass
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     # Start the server on a developer machine. Flask is initialized in DEBUG mode, so it
     # hot-reloads files. We also flip our own internal "debug mode" flag to True, so our
     # own file loading routines also hot-reload.
-    utils.set_debug_mode(not os.getenv('NO_DEBUG_MODE'))
+    utils.set_debug_mode(not os.getenv("NO_DEBUG_MODE"))
 
     # If we are running in a Python debugger, don't use flasks reload mode. It creates
     # subprocesses which make debugging harder.
@@ -1666,7 +1852,6 @@ if __name__ == '__main__':
     on_server_start()
 
     # Threaded option enables multiple instances for multiple user access support
-    app.run(threaded=True, debug=not is_in_debugger,
-            port=config['port'], host="0.0.0.0")
+    app.run(threaded=True, debug=not is_in_debugger, port=config["port"], host="0.0.0.0")
 
     # See `Procfile` for how the server is started on Heroku.

--- a/archive/is_an_isis_tests.py
+++ b/archive/is_an_isis_tests.py
@@ -2,136 +2,139 @@ import hedy
 import textwrap
 from tests_level_01 import HedyTester
 
+
 class TestsLevel21(HedyTester):
     level = 21
 
     def test_sum_in_if(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
     if 5+3 == 8:
         print('5+3 is inderdaad 8')
     else:
-        print('Dit wordt niet geprint want 5+3 is 8!')""")
-        expected = textwrap.dedent("""\
+        print('Dit wordt niet geprint want 5+3 is 8!')"""
+        )
+        expected = textwrap.dedent(
+            """\
     if int(5) + int(3) == int(8):
       print(f'5+3 is inderdaad 8')
     else:
-      print(f'Dit wordt niet geprint want 5+3 is 8!')""")
+      print(f'Dit wordt niet geprint want 5+3 is 8!')"""
+        )
 
         self.multi_level_tester(
-          
-          code=code,
-          expected=expected,
-          extra_check_function=self.is_not_turtle(),
-          test_name=self.name()
+            code=code, expected=expected, extra_check_function=self.is_not_turtle(), test_name=self.name()
         )
+
     def test_sum_in_right_side_if(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
     if 8 == 5+3:
         print('5+3 is inderdaad 8')
     else:
-        print('Dit wordt niet geprint want 5+3 is 8!')""")
-        expected = textwrap.dedent("""\
+        print('Dit wordt niet geprint want 5+3 is 8!')"""
+        )
+        expected = textwrap.dedent(
+            """\
     if int(8) == int(5) + int(3):
       print(f'5+3 is inderdaad 8')
     else:
-      print(f'Dit wordt niet geprint want 5+3 is 8!')""")
+      print(f'Dit wordt niet geprint want 5+3 is 8!')"""
+        )
 
         self.multi_level_tester(
-          
-          code=code,
-          expected=expected,
-          extra_check_function=self.is_not_turtle(),
-          test_name=self.name()
+            code=code, expected=expected, extra_check_function=self.is_not_turtle(), test_name=self.name()
         )
+
     def test_min_in_if(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
     if 5-3 == 2:
         print('5-3 is inderdaad 2')
     else:
-        print('Dit wordt niet geprint want 5+3 is 8!')""")
-        expected = textwrap.dedent("""\
+        print('Dit wordt niet geprint want 5+3 is 8!')"""
+        )
+        expected = textwrap.dedent(
+            """\
     if int(5) - int(3) == int(2):
       print(f'5-3 is inderdaad 2')
     else:
-      print(f'Dit wordt niet geprint want 5+3 is 8!')""")
+      print(f'Dit wordt niet geprint want 5+3 is 8!')"""
+        )
 
         self.multi_level_tester(
-          
-          code=code,
-          expected=expected,
-          extra_check_function=self.is_not_turtle(),
-          test_name=self.name()
+            code=code, expected=expected, extra_check_function=self.is_not_turtle(), test_name=self.name()
         )
+
     def test_multiply_in_if(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
     if 5*3 == 15:
         print('5*3 is inderdaad 15')
     else:
-        print('Dit wordt niet geprint want 5+3 is 8!')""")
-        expected = textwrap.dedent("""\
+        print('Dit wordt niet geprint want 5+3 is 8!')"""
+        )
+        expected = textwrap.dedent(
+            """\
     if int(5) * int(3) == int(15):
       print(f'5*3 is inderdaad 15')
     else:
-      print(f'Dit wordt niet geprint want 5+3 is 8!')""")
+      print(f'Dit wordt niet geprint want 5+3 is 8!')"""
+        )
 
         self.multi_level_tester(
-          
-          code=code,
-          expected=expected,
-          extra_check_function=self.is_not_turtle(),
-          test_name=self.name()
+            code=code, expected=expected, extra_check_function=self.is_not_turtle(), test_name=self.name()
         )
+
     def test_print_brackets(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         leeftijd = input('Hoe oud ben jij?')
         print('Dus jij hebt zo veel verjaardagen gehad:')
         for i in range(0,leeftijd):
-            print(i)""")
-        expected = textwrap.dedent("""\
+            print(i)"""
+        )
+        expected = textwrap.dedent(
+            """\
         leeftijd = input('Hoe oud ben jij?')
         print(f'Dus jij hebt zo veel verjaardagen gehad:')
         step = 1 if int(0) < int(leeftijd) else -1
         for i in range(int(0), int(leeftijd) + step, step):
-          print(f'{i}')""")
+          print(f'{i}')"""
+        )
 
         self.multi_level_tester(
-          
-          code=code,
-          expected=expected,
-          extra_check_function=self.is_not_turtle(),
-          test_name=self.name()
+            code=code, expected=expected, extra_check_function=self.is_not_turtle(), test_name=self.name()
         )
+
     def test_print_var_brackets(self):
         code = "naam = Hedy\nprint('ik heet' naam)"
         expected = "naam = 'Hedy'\nprint(f'ik heet{naam}')"
 
         self.multi_level_tester(
-          max_level=18,
-          code=code,
-          expected=expected,
-          extra_check_function=self.is_not_turtle(),
-          test_name=self.name()
+            max_level=18, code=code, expected=expected, extra_check_function=self.is_not_turtle(), test_name=self.name()
         )
+
     def test_if_nesting(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         kleur = blauw
         kleurtwee = geel
         if kleur == blauw:
           if kleurtwee == geel:
-            print('Samen is dit groen!')""")
-        expected = textwrap.dedent("""\
+            print('Samen is dit groen!')"""
+        )
+        expected = textwrap.dedent(
+            """\
         kleur = 'blauw'
         kleurtwee = 'geel'
         if str(kleur) == str('blauw'):
           if str(kleurtwee) == str('geel'):
-            print(f'Samen is dit groen!')""")
+            print(f'Samen is dit groen!')"""
+        )
 
         self.multi_level_tester(
-          
-          code=code,
-          expected=expected,
-          extra_check_function=self.is_not_turtle(),
-          test_name=self.name()
+            code=code, expected=expected, extra_check_function=self.is_not_turtle(), test_name=self.name()
         )
 
     def test_assign_parses_periods(self):
@@ -139,36 +142,30 @@ class TestsLevel21(HedyTester):
         expected = "period = '.'"
 
         self.multi_level_tester(
-            code=code,
-            expected=expected,
-            extra_check_function=self.is_not_turtle(),
-            test_name=self.name()
+            code=code, expected=expected, extra_check_function=self.is_not_turtle(), test_name=self.name()
         )
 
     def test_input_disallows_lists(self):
-        code = textwrap.dedent("""
+        code = textwrap.dedent(
+            """
         color = ['green', 'blue']
-        choice = input('Is your favorite color one of ' color)""")
-
-        self.multi_level_tester(
-            code=code,
-            exception=hedy.InvalidArgumentTypeException,
-            test_name=self.name()
+        choice = input('Is your favorite color one of ' color)"""
         )
+
+        self.multi_level_tester(code=code, exception=hedy.InvalidArgumentTypeException, test_name=self.name())
 
     # negative tests
     def test_var_undefined_error_message(self):
-      code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         naam = Hedy
-        print('ik heet ' name)""")
+        print('ik heet ' name)"""
+        )
 
-      self.multi_level_tester(
-        code=code,
-        exception=hedy.UndefinedVarException,
-        max_level=self.max_Hedy_level,
-        test_name=self.name()
-      )
+        self.multi_level_tester(
+            code=code, exception=hedy.UndefinedVarException, max_level=self.max_Hedy_level, test_name=self.name()
+        )
 
-      # deze extra check functie kan nu niet mee omdat die altijd op result werkt
-      # evt toch splitsen in 2 (pos en neg?)
-      # self.assertEqual('name', context.exception.arguments['name'])
+        # deze extra check functie kan nu niet mee omdat die altijd op result werkt
+        # evt toch splitsen in 2 (pos en neg?)
+        # self.assertEqual('name', context.exception.arguments['name'])

--- a/archive/rect_bracket_tests.py
+++ b/archive/rect_bracket_tests.py
@@ -5,81 +5,84 @@ import hedy
 import textwrap
 from tests_level_01 import HedyTester
 
+
 class TestsLevel13(HedyTester):
-  level = 13
+    level = 13
 
-
-  def test_list(self):
-    code = textwrap.dedent("""\
+    def test_list(self):
+        code = textwrap.dedent(
+            """\
     fruit is ['appel', 'banaan', 'kers']
-    print(fruit)""")
-    expected = textwrap.dedent("""\
+    print(fruit)"""
+        )
+        expected = textwrap.dedent(
+            """\
     fruit = ['appel', 'banaan', 'kers']
-    print(f'{fruit}')""")
+    print(f'{fruit}')"""
+        )
 
-    self.multi_level_tester(
-      max_level=20,
-      code=code,
-      expected=expected,
-      extra_check_function=self.is_not_turtle(),
-      test_name=self.name()
-    )
-      
-  def test_random(self):
-    code = textwrap.dedent("""\
+        self.multi_level_tester(
+            max_level=20, code=code, expected=expected, extra_check_function=self.is_not_turtle(), test_name=self.name()
+        )
+
+    def test_random(self):
+        code = textwrap.dedent(
+            """\
     dieren is ['Hond', 'Kat', 'Kangoeroe']
-    print(dieren[random])""")
+    print(dieren[random])"""
+        )
 
-    expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
     dieren = ['Hond', 'Kat', 'Kangoeroe']
-    print(f'{random.choice(dieren)}')""")
+    print(f'{random.choice(dieren)}')"""
+        )
 
-    # check if result is in the expected list
-    check_in_list = (lambda x: self.run_code(x) in ['Hond', 'Kat', 'Kangoeroe'])
+        # check if result is in the expected list
+        check_in_list = lambda x: self.run_code(x) in ["Hond", "Kat", "Kangoeroe"]
 
-    self.multi_level_tester(
-      max_level=19,
-      code=code,
-      expected=expected,
-      test_name=self.name(),
-      extra_check_function=check_in_list
-    )
-  def test_list_multiple_spaces(self):
-    code = textwrap.dedent("""\
+        self.multi_level_tester(
+            max_level=19, code=code, expected=expected, test_name=self.name(), extra_check_function=check_in_list
+        )
+
+    def test_list_multiple_spaces(self):
+        code = textwrap.dedent(
+            """\
     fruit is ['appel',  'banaan',    'kers']
-    print(fruit)""")
-    expected = textwrap.dedent("""\
+    print(fruit)"""
+        )
+        expected = textwrap.dedent(
+            """\
     fruit = ['appel', 'banaan', 'kers']
-    print(f'{fruit}')""")
+    print(f'{fruit}')"""
+        )
 
-    self.multi_level_tester(
-      max_level=20,
-      code=code,
-      expected=expected,
-      extra_check_function=self.is_not_turtle(),
-      test_name=self.name()
-    )
-  def test_specific_access(self):
-    code = textwrap.dedent("""\
+        self.multi_level_tester(
+            max_level=20, code=code, expected=expected, extra_check_function=self.is_not_turtle(), test_name=self.name()
+        )
+
+    def test_specific_access(self):
+        code = textwrap.dedent(
+            """\
     fruit is ['banaan', 'appel', 'kers']
     eerstefruit is fruit[1]
-    print(eerstefruit)""")
-    expected = textwrap.dedent("""\
+    print(eerstefruit)"""
+        )
+        expected = textwrap.dedent(
+            """\
     fruit = ['banaan', 'appel', 'kers']
     eerstefruit=fruit[1-1]
-    print(f'{eerstefruit}')""")
+    print(f'{eerstefruit}')"""
+        )
 
-    self.multi_level_tester(
-      max_level=20,
-      code=code,
-      expected=expected,
-      extra_check_function=self.is_not_turtle(),
-      test_name=self.name()
-    )
+        self.multi_level_tester(
+            max_level=20, code=code, expected=expected, extra_check_function=self.is_not_turtle(), test_name=self.name()
+        )
 
-#note that print(str(highscore)) will not print as it will compare 'score[i]' as str to a variable
-  def test_everything_combined(self):
-    code = textwrap.dedent("""\
+    # note that print(str(highscore)) will not print as it will compare 'score[i]' as str to a variable
+    def test_everything_combined(self):
+        code = textwrap.dedent(
+            """\
     score is ['100', '300', '500']
     highscore is score[random]
     print('De highscore is: ' highscore)
@@ -87,8 +90,10 @@ class TestsLevel13(HedyTester):
         scorenu is score[i]
         print('Score is nu ' scorenu)
         if highscore is score[i]:
-            print(highscore)""")
-    expected = textwrap.dedent("""\
+            print(highscore)"""
+        )
+        expected = textwrap.dedent(
+            """\
     score = ['100', '300', '500']
     highscore=random.choice(score)
     print(f'De highscore is: {highscore}')
@@ -97,24 +102,20 @@ class TestsLevel13(HedyTester):
       scorenu=score[i-1]
       print(f'Score is nu {scorenu}')
       if str(highscore) == str('score[i]'):
-        print(f'{highscore}')""")
+        print(f'{highscore}')"""
+        )
 
-    self.multi_level_tester(
-      max_level=20,
-      code=code,
-      expected=expected,
-      extra_check_function=self.is_not_turtle(),
-      test_name=self.name()
-    )
+        self.multi_level_tester(
+            max_level=20, code=code, expected=expected, extra_check_function=self.is_not_turtle(), test_name=self.name()
+        )
 
-  def test_input_disallows_lists(self):
-    code = textwrap.dedent("""
+    def test_input_disallows_lists(self):
+        code = textwrap.dedent(
+            """
       color is ['green', 'blue']
-      choice is input('Is your favorite color one of ' color)""")
+      choice is input('Is your favorite color one of ' color)"""
+        )
 
-    self.multi_level_tester(
-      code=code,
-      exception=hedy.InvalidArgumentTypeException,
-      max_level=20,
-      test_name=self.name()
-    )
+        self.multi_level_tester(
+            code=code, exception=hedy.InvalidArgumentTypeException, max_level=20, test_name=self.name()
+        )

--- a/archive/tests_level_21.py
+++ b/archive/tests_level_21.py
@@ -2,63 +2,64 @@ import hedy
 import textwrap
 from tests_level_01 import HedyTester
 
+
 class TestsLevel20(HedyTester):
     level = 20
 
     def test_length(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         fruit is ['appel', 'banaan', 'kers']
         hoi is length(fruit)
-        print(hoi)""")
-        expected = textwrap.dedent("""\
+        print(hoi)"""
+        )
+        expected = textwrap.dedent(
+            """\
         fruit = ['appel', 'banaan', 'kers']
         hoi = len(fruit)
-        print(f'{hoi}')""")
+        print(f'{hoi}')"""
+        )
 
         self.multi_level_tester(
-          max_level=20,
-          code=code,
-          expected=expected,
-          extra_check_function=self.is_not_turtle(),
-          test_name=self.name()
+            max_level=20, code=code, expected=expected, extra_check_function=self.is_not_turtle(), test_name=self.name()
         )
+
     def test_length2(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         fruit is ['appel', 'banaan', 'kers']
         for i in range(1, length(fruit)):
-            print(fruit[i])""")
-        expected = textwrap.dedent("""\
+            print(fruit[i])"""
+        )
+        expected = textwrap.dedent(
+            """\
         fruit = ['appel', 'banaan', 'kers']
         step = 1 if int(1) < int(len(fruit)) else -1
         for i in range(int(1), int(len(fruit)) + step, step):
-          print(f'{fruit[i-1]}')""")
+          print(f'{fruit[i-1]}')"""
+        )
 
         self.multi_level_tester(
-          max_level=20,
-          code=code,
-          expected=expected,
-          extra_check_function=self.is_not_turtle(),
-          test_name=self.name()
+            max_level=20, code=code, expected=expected, extra_check_function=self.is_not_turtle(), test_name=self.name()
         )
+
     def test_print_length(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         fruit is ['appel', 'banaan', 'kers']
         print('lengte van de lijst is' length(fruit))
         for i in range(1, 3):
-            print(fruit[i])""")
-        expected = textwrap.dedent("""\
+            print(fruit[i])"""
+        )
+        expected = textwrap.dedent(
+            """\
         fruit = ['appel', 'banaan', 'kers']
         print(f'lengte van de lijst is{len(fruit)}')
         step = 1 if int(1) < int(3) else -1
         for i in range(int(1), int(3) + step, step):
-          print(f'{fruit[i-1]}')""")
-
-        self.multi_level_tester(
-          max_level=20,
-          code=code,
-          expected=expected,
-          extra_check_function=self.is_not_turtle(),
-          test_name=self.name()
+          print(f'{fruit[i-1]}')"""
         )
 
-
+        self.multi_level_tester(
+            max_level=20, code=code, expected=expected, extra_check_function=self.is_not_turtle(), test_name=self.name()
+        )

--- a/batchhedy/batchhedy.py
+++ b/batchhedy/batchhedy.py
@@ -14,104 +14,107 @@ from pydantic import BaseModel, FilePath
 from lark.exceptions import GrammarError, UnexpectedEOF
 from lazy.lazy import lazy
 
-def run(filenames, report, top, check = None, ):
-        jobs = create_jobs(filenames)
-        #skip empty programs
-        jobs = [j for j in jobs if not is_empty(j.code)]
 
-        number_of_error_programs = 0
+def run(
+    filenames,
+    report,
+    top,
+    check=None,
+):
+    jobs = create_jobs(filenames)
+    # skip empty programs
+    jobs = [j for j in jobs if not is_empty(j.code)]
 
-        for job in jobs:
-            job.transpile()
-            if job.error_msg != '':
-                number_of_error_programs += 1
+    number_of_error_programs = 0
 
-            checkdata = create_checkdata(check)
-            if checkdata is not None:
-                # Compare with previous run
-                try:
-                    chkjob = checkdata[job.filename]
-                    chktime = float(chkjob["transpile time"])
-                    diff = 0 if chktime == 0 else 100 * job.transpile_time / chktime
+    for job in jobs:
+        job.transpile()
+        if job.error_msg != "":
+            number_of_error_programs += 1
 
-                    if (job.error is True) and (chkjob["error"] == "False"):
-                        job.error_change = f"{'no error->error':15}"
-                    elif (job.error is True) and (chkjob["error"] == "True"):
-                        # only check the first line, args position change
-                        if (job.error_msg.splitlines()[0] !=
-                                chkjob["error message"].splitlines()[0]):
-                            job.error_change = f"{'error diff.':15}"
-                    elif (job.error is False) and (chkjob["error"] == "True"):
-                        job.error_change = f"{'error->no error':15}"
-                except Exception as e:
-                    print('checking failed')
+        checkdata = create_checkdata(check)
+        if checkdata is not None:
+            # Compare with previous run
+            try:
+                chkjob = checkdata[job.filename]
+                chktime = float(chkjob["transpile time"])
+                diff = 0 if chktime == 0 else 100 * job.transpile_time / chktime
 
-        if report is not None:
-            _save_report(jobs, report)
+                if (job.error is True) and (chkjob["error"] == "False"):
+                    job.error_change = f"{'no error->error':15}"
+                elif (job.error is True) and (chkjob["error"] == "True"):
+                    # only check the first line, args position change
+                    if job.error_msg.splitlines()[0] != chkjob["error message"].splitlines()[0]:
+                        job.error_change = f"{'error diff.':15}"
+                elif (job.error is False) and (chkjob["error"] == "True"):
+                    job.error_change = f"{'error->no error':15}"
+            except Exception as e:
+                print("checking failed")
 
-        # print run informations
-        runtimes_and_files = [(r.filename, r.transpile_time) for r in jobs]
-        ordered_runtimes = sorted(runtimes_and_files, key=lambda x: x[1], reverse = True)
-        slowest_top_x = [x[0] for x in ordered_runtimes[:top]]
+    if report is not None:
+        _save_report(jobs, report)
 
-        runtimes = [x[1] for x in runtimes_and_files]
+    # print run informations
+    runtimes_and_files = [(r.filename, r.transpile_time) for r in jobs]
+    ordered_runtimes = sorted(runtimes_and_files, key=lambda x: x[1], reverse=True)
+    slowest_top_x = [x[0] for x in ordered_runtimes[:top]]
 
-        maxvalue = max(runtimes)
-        minvalue = min(runtimes)
-        name_of_slowest_file = jobs[runtimes.index(maxvalue)].filename
+    runtimes = [x[1] for x in runtimes_and_files]
 
-        if checkdata is None:
-            # Simple run
-            print(f"Total transpile time: {sum(runtimes):10f}s ")
-            print(f"Average transpile time: {sum(runtimes)/len(runtimes):10f}s ")
-        else:
-            # Compare with previous data
-            previous_total_time = sum(float(
-                checkdata[job.filename]["transpile time"]
-                ) for job in jobs)
-            diff = 100 * sum(runtimes) / previous_total_time
-            print(f"Total transpile time: {sum(runtimes):10f}s ({diff:6.2f}%)")
+    maxvalue = max(runtimes)
+    minvalue = min(runtimes)
+    name_of_slowest_file = jobs[runtimes.index(maxvalue)].filename
 
-        print(f"Number of files:  {len(jobs)}")
-        print(f"Max transpile time:   {maxvalue:10f}s (files: {name_of_slowest_file})")
-        print(f"Slowest files: {slowest_top_x})")
-        print(f"Min transpile time:   {minvalue:10f}s")
-        print(f"Number of error files:  {number_of_error_programs} ({100*number_of_error_programs/len(jobs):3f}) ")
+    if checkdata is None:
+        # Simple run
+        print(f"Total transpile time: {sum(runtimes):10f}s ")
+        print(f"Average transpile time: {sum(runtimes)/len(runtimes):10f}s ")
+    else:
+        # Compare with previous data
+        previous_total_time = sum(float(checkdata[job.filename]["transpile time"]) for job in jobs)
+        diff = 100 * sum(runtimes) / previous_total_time
+        print(f"Total transpile time: {sum(runtimes):10f}s ({diff:6.2f}%)")
+
+    print(f"Number of files:  {len(jobs)}")
+    print(f"Max transpile time:   {maxvalue:10f}s (files: {name_of_slowest_file})")
+    print(f"Slowest files: {slowest_top_x})")
+    print(f"Min transpile time:   {minvalue:10f}s")
+    print(f"Number of error files:  {number_of_error_programs} ({100*number_of_error_programs/len(jobs):3f}) ")
+
 
 def create_jobs(filenames):
-    """ The list of jobs to be run """
+    """The list of jobs to be run"""
     # Create object list
     jobs = [TranspileJob(f) for f in filenames]
 
     # Remove files with invalid level
     invalidjob = [j for j in jobs if j.level > hedy.HEDY_MAX_LEVEL]
     if len(invalidjob) > 0:
-        print(f"WARNING: There are {len(invalidjob)} files with"
-              f" invalid Hedy level (> {hedy.HEDY_MAX_LEVEL})")
+        print(f"WARNING: There are {len(invalidjob)} files with" f" invalid Hedy level (> {hedy.HEDY_MAX_LEVEL})")
         jobs = [j for j in jobs if j.level <= hedy.HEDY_MAX_LEVEL]
 
     return jobs
 
+
 def create_checkdata(check):
-    """ Data of a previous run. Return None is self.check is not set."""
+    """Data of a previous run. Return None is self.check is not set."""
     if check is None:
         return None
 
     comparedata = {}
-    with open(check, newline="", encoding='utf-8') as csvfile:
+    with open(check, newline="", encoding="utf-8") as csvfile:
         reader = csv.reader(csvfile)
         fields = None
         for row in reader:
             if fields is None:
                 fields = row
             else:
-                comparedata[row[0]] = ({k: v for k, v in zip(fields, row)})
+                comparedata[row[0]] = {k: v for k, v in zip(fields, row)}
     return comparedata
 
 
-
 class TranspileJob:
-    """ Load an Hedy file and do a timed transpiling.
+    """Load an Hedy file and do a timed transpiling.
 
     Attributes:
         code: The Hedy code
@@ -127,7 +130,7 @@ class TranspileJob:
     """
 
     def __init__(self, filename: FilePath):
-        """ Create a new transpiling job of the file `filename`.
+        """Create a new transpiling job of the file `filename`.
 
         The transpiling job is not run immediately, only when a call
         to transpile() or pycode is made.
@@ -141,13 +144,13 @@ class TranspileJob:
 
         # Get the level and code position
         try:
-            with open(filename, encoding='utf-8') as f:
+            with open(filename, encoding="utf-8") as f:
                 all_lines = f.readlines()
                 # remove header info
                 firstline = all_lines[0]
                 self.date = all_lines[1]
-                non_empty_lines = [a for a in all_lines[4:] if a != '']
-                self.code = ''.join(non_empty_lines) + '\n'
+                non_empty_lines = [a for a in all_lines[4:] if a != ""]
+                self.code = "".join(non_empty_lines) + "\n"
 
             self.level = 0
 
@@ -163,7 +166,6 @@ class TranspileJob:
         except ValueError as e:
             self.error = True
             self.error_msg = str(e)
-
 
     def transpile(self) -> str:
         if self.error:
@@ -195,7 +197,7 @@ class TranspileJob:
 
     @lazy
     def code(self) -> str:
-        """ The hedy code"""
+        """The hedy code"""
         code = self.code
 
         # Make sure that the last line is "\n".
@@ -205,34 +207,35 @@ class TranspileJob:
             return ""
 
 
-
-
-
 def extract_level_from_code(code: str) -> Tuple[int, str]:
-    """ Return a (level, code) tuple of the level and the code without the
-    level line. Return None for the level if it not found. """
+    """Return a (level, code) tuple of the level and the code without the
+    level line. Return None for the level if it not found."""
     newline = code.find("\n")
     firstline = code[0:newline].strip().lower()
-    if firstline[0] == "#":   # expecting level X or level = X
+    if firstline[0] == "#":  # expecting level X or level = X
         idx = firstline.find("level")
         if idx > -1:  # string found
             try:
                 if firstline.find("=") > -1:
                     level = int(firstline.split("=")[-1])
                 else:
-                    level = int(firstline[idx+5:])
-                return level, code[newline+1:]
+                    level = int(firstline[idx + 5 :])
+                return level, code[newline + 1 :]
             except ValueError:
                 pass
     return None, code
 
+
 def is_empty(program):
-    all_lines = program.split('\n')
-    return all(line == '' for line in all_lines)
+    all_lines = program.split("\n")
+    return all(line == "" for line in all_lines)
+
 
 def _save_report(jobs, report):
-        with open(report, "w", newline="", encoding='utf-8') as csvfile:
-            writer = csv.DictWriter(csvfile, fieldnames=[
+    with open(report, "w", newline="", encoding="utf-8") as csvfile:
+        writer = csv.DictWriter(
+            csvfile,
+            fieldnames=[
                 "filename",
                 "date",
                 "level",
@@ -240,32 +243,35 @@ def _save_report(jobs, report):
                 "transpile time",
                 "error",
                 "error message",
-                "error_change"
-            ])
+                "error_change",
+            ],
+        )
 
-
-            writer.writeheader()
-            for job in jobs:
-                code = job.code.replace("\\n", "")
-                writer.writerow({
+        writer.writeheader()
+        for job in jobs:
+            code = job.code.replace("\\n", "")
+            writer.writerow(
+                {
                     "filename": job.filename,
                     "date": job.date,
                     "level": job.level,
-                    "code": f'{code}',
+                    "code": f"{code}",
                     "transpile time": job.transpile_time,
                     "error": job.error,
                     "error message": job.error_msg,
                     "error_change": job.error_change,
-                })
+                }
+            )
+
 
 os.chdir(path.dirname(path.abspath(__file__)))
-filenames_list = glob.glob('../../input_small/*.hedy')
+filenames_list = glob.glob("../../input_small/*.hedy")
 
-#report determines if we are generating a fresh report
-#check determines if we are comparing against an existing report
+# report determines if we are generating a fresh report
+# check determines if we are comparing against an existing report
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     if len(filenames_list) == 0:
         print("no files found!")
     else:
-        run(filenames=filenames_list, check = 'output_report_small.csv', report = 'output_report_small.csv', top=10)
+        run(filenames=filenames_list, check="output_report_small.csv", report="output_report_small.csv", top=10)

--- a/build-tools/github/validate-python
+++ b/build-tools/github/validate-python
@@ -10,4 +10,4 @@ echo "------> Linting Python code"
 # Let's just check for definite errors.
 pylint -j 0 \
     --errors-only \
-    *.py tests
+    *.py website highlighting tests

--- a/config.py
+++ b/config.py
@@ -1,49 +1,47 @@
 import os
 import socket
 
-app_name = os.getenv('HEROKU_APP_NAME', socket.gethostname())
-dyno = os.getenv('DYNO')
-athena_query = os.getenv('AWS_ATHENA_PREPARE_STATEMENT')
+app_name = os.getenv("HEROKU_APP_NAME", socket.gethostname())
+dyno = os.getenv("DYNO")
+athena_query = os.getenv("AWS_ATHENA_PREPARE_STATEMENT")
 
 config = {
-    'port': os.getenv ('PORT') or 8080,
-    'session': {
-        'cookie_name': 'hedy',
+    "port": os.getenv("PORT") or 8080,
+    "session": {
+        "cookie_name": "hedy",
         # in minutes
-        'session_length': 60 * 24 * 14,
-        'reset_length': 60 * 4,
-        'invite_length': 60 * 24 * 7
+        "session_length": 60 * 24 * 14,
+        "reset_length": 60 * 4,
+        "invite_length": 60 * 24 * 7,
     },
-    'email': {
-        'sender': 'Hedy <hello@hedy.org>',
-        'region': 'eu-central-1',
+    "email": {
+        "sender": "Hedy <hello@hedy.org>",
+        "region": "eu-central-1",
     },
     # The bcrypt library's default is 12
-    'bcrypt_rounds': 9,
-    'dynamodb': {
-        'region': 'eu-west-1'
-    },
-    's3-query-logs': {
-        'bucket': 'hedy-query-logs',
-        'prefix': app_name + '/',
+    "bcrypt_rounds": 9,
+    "dynamodb": {"region": "eu-west-1"},
+    "s3-query-logs": {
+        "bucket": "hedy-query-logs",
+        "prefix": app_name + "/",
         # Make logs from different instances/processes unique
-        'postfix': ('-' + dyno if dyno else '') + '-' + str(os.getpid()),
-        'region': 'eu-west-1'
+        "postfix": ("-" + dyno if dyno else "") + "-" + str(os.getpid()),
+        "region": "eu-west-1",
     },
-    's3-parse-logs': {
-        'bucket': 'hedy-parse-logs',
-        'prefix': app_name + '/',
+    "s3-parse-logs": {
+        "bucket": "hedy-parse-logs",
+        "prefix": app_name + "/",
         # Make logs from different instances/processes unique
-        'postfix': ('-' + dyno if dyno else '') + '-' + str(os.getpid()),
-        'region': 'eu-west-1'
+        "postfix": ("-" + dyno if dyno else "") + "-" + str(os.getpid()),
+        "region": "eu-west-1",
     },
-    'athena': {
-        'region': 'eu-west-1',
-        'database': 'hedy-logs',
-        'prepare_statement': athena_query,
-        's3_output': 's3://hedy-query-outputs/',
-        'max_results': 50
+    "athena": {
+        "region": "eu-west-1",
+        "database": "hedy-logs",
+        "prepare_statement": athena_query,
+        "s3_output": "s3://hedy-query-outputs/",
+        "max_results": 50,
     },
-    #enables the quiz environment by setting the config variable on True
-    'quiz-enabled': True,
+    # enables the quiz environment by setting the config variable on True
+    "quiz-enabled": True,
 }

--- a/content/yaml_to_lark_utils.py
+++ b/content/yaml_to_lark_utils.py
@@ -4,6 +4,7 @@ import copy
 import os
 import yaml
 
+
 def extract_Lark_grammar_from_yaml():
     """Creates a lark file in ../grammars/ for  all yaml files located in ../content/keywords/.
     If a keyword is not yet translated, it will use the English translation of the keyword
@@ -12,24 +13,27 @@ def extract_Lark_grammar_from_yaml():
         only_new_lang (bool, optional): Specifies if only a lark file should be created for a new keyword language or for all languages. Defaults to True.
     """
     dirname = os.path.dirname(__file__)
-    input_path = os.path.join(dirname, 'keywords')
-    current_grammar_path = os.path.join(dirname, '../grammars')
+    input_path = os.path.join(dirname, "keywords")
+    current_grammar_path = os.path.join(dirname, "../grammars")
 
-    yaml_languages = [f.replace('.yaml', '') for f in os.listdir(input_path) if
-                      os.path.isfile(os.path.join(input_path, f)) and f.endswith('.yaml')]
+    yaml_languages = [
+        f.replace(".yaml", "")
+        for f in os.listdir(input_path)
+        if os.path.isfile(os.path.join(input_path, f)) and f.endswith(".yaml")
+    ]
 
-    template_lark = os.path.join(current_grammar_path, 'keywords-template.lark')
-    with open(template_lark, 'r', encoding='utf-8') as f:
+    template_lark = os.path.join(current_grammar_path, "keywords-template.lark")
+    with open(template_lark, "r", encoding="utf-8") as f:
         template = f.read()
 
     for yaml_lang in yaml_languages:
-        yaml_filesname_with_path = os.path.join(input_path, yaml_lang + '.yaml')
-        default_yaml_with_path = os.path.join(input_path, 'en' + '.yaml')
+        yaml_filesname_with_path = os.path.join(input_path, yaml_lang + ".yaml")
+        default_yaml_with_path = os.path.join(input_path, "en" + ".yaml")
 
-        with open(default_yaml_with_path, 'r', encoding='utf-8') as stream:
+        with open(default_yaml_with_path, "r", encoding="utf-8") as stream:
             en_command_combinations = yaml.safe_load(stream)
 
-        with open(yaml_filesname_with_path, 'r', encoding='utf-8') as stream:
+        with open(yaml_filesname_with_path, "r", encoding="utf-8") as stream:
             command_combinations = yaml.safe_load(stream)
 
         # We don't want to create the grammar if there are no translations
@@ -37,33 +41,32 @@ def extract_Lark_grammar_from_yaml():
             continue
 
         # Create an empty dictionary -> fill with english keywords and then overwrite all translated keywords
-        translations = collections.defaultdict(lambda: 'Unknown Exception')
+        translations = collections.defaultdict(lambda: "Unknown Exception")
         translations.update(en_command_combinations)
         translations.update(command_combinations)
 
         translation_copy = copy.deepcopy(translations)
         for k, v in translation_copy.items():
             if yaml_lang == "ar":
-              mixed_tatweel_in = ''.join([' "ـ"* ' + '"'+l+'"' for l in v]) + ' "ـ"* '
-              translations[k] = mixed_tatweel_in
+                mixed_tatweel_in = "".join([' "ـ"* ' + '"' + l + '"' for l in v]) + ' "ـ"* '
+                translations[k] = mixed_tatweel_in
             else:
-              # other languages need their translations surrounded by "'s
-              translations[k] = '"' + v + '"'
+                # other languages need their translations surrounded by "'s
+                translations[k] = '"' + v + '"'
 
             # we use | if we have multiple options, such as repete and repète
             if "|" in v:
                 valid_translation = ""
                 options = v.split("|")
-                valid_translation = ' | '.join(['"' + option + '"' for option in options])
+                valid_translation = " | ".join(['"' + option + '"' for option in options])
                 translations[k] = valid_translation
 
         translated_template = template.format(**translations)
 
-        lark_filesname_with_path = os.path.join(current_grammar_path, 'keywords-' + yaml_lang + '.lark')
+        lark_filesname_with_path = os.path.join(current_grammar_path, "keywords-" + yaml_lang + ".lark")
 
-        with open(lark_filesname_with_path, 'w', encoding='utf-8') as f:
+        with open(lark_filesname_with_path, "w", encoding="utf-8") as f:
             f.write(translated_template)
 
+
 extract_Lark_grammar_from_yaml()
-
-

--- a/docs.py
+++ b/docs.py
@@ -3,68 +3,70 @@ import glob
 import re
 import unicodedata
 
+
 def slugify(s):
-  if s is None:
-    return None
-  return re.sub('[^a-zA-Z0-9]', '-', strip_accents(s)).lower()
+    if s is None:
+        return None
+    return re.sub("[^a-zA-Z0-9]", "-", strip_accents(s)).lower()
 
 
 def strip_accents(s):
-  return ''.join(c for c in unicodedata.normalize('NFD', s)
-                 if unicodedata.category(c) != 'Mn')
+    return "".join(c for c in unicodedata.normalize("NFD", s) if unicodedata.category(c) != "Mn")
+
 
 class DocCollection:
-  def __init__(self, keys=[], synth={}):
-    self.docs = []
-    self.index = {}
-    self.keys = keys
-    self.synth = synth
+    def __init__(self, keys=[], synth={}):
+        self.docs = []
+        self.index = {}
+        self.keys = keys
+        self.synth = synth
 
-  def get(self, *keys):
-    v = self.index
-    for key in keys:
-      v = v.get(key)
-      if not v:
-        return {} if len(keys) < len(self.keys) else None
-    return v
+    def get(self, *keys):
+        v = self.index
+        for key in keys:
+            v = v.get(key)
+            if not v:
+                return {} if len(keys) < len(self.keys) else None
+        return v
 
-  def load_dir(self, rootdir):
-    files = glob.glob(f'{rootdir}/**/*.md', recursive=True)
-    for file in sorted(files):
-      doc = MarkdownDoc.from_file(file)
+    def load_dir(self, rootdir):
+        files = glob.glob(f"{rootdir}/**/*.md", recursive=True)
+        for file in sorted(files):
+            doc = MarkdownDoc.from_file(file)
 
-      for k, v in self.synth.items():
-        doc.front_matter[k] = v(doc)
+            for k, v in self.synth.items():
+                doc.front_matter[k] = v(doc)
 
-      self.docs.append(doc)
-      self.add_to_index(doc)
+            self.docs.append(doc)
+            self.add_to_index(doc)
 
-  def add_to_index(self, doc):
-    if not self.keys:
-      return
+    def add_to_index(self, doc):
+        if not self.keys:
+            return
 
-    d = self.index
-    for key in self.keys[:-1]:
-      value = doc.front_matter.get(key, None)
-      if not value:
-        return
-      d = d.setdefault(value, {})
+        d = self.index
+        for key in self.keys[:-1]:
+            value = doc.front_matter.get(key, None)
+            if not value:
+                return
+            d = d.setdefault(value, {})
 
-    key = self.keys[-1]
-    value = doc.front_matter.get(key, None)
-    if value:
-      d[value] = doc
+        key = self.keys[-1]
+        value = doc.front_matter.get(key, None)
+        if value:
+            d[value] = doc
+
 
 class MarkdownDoc:
-  @staticmethod
-  def from_file(filename):
-    with open(filename, 'r', encoding='utf-8') as f:
-      contents = f.read()
-    parts = re.split('^---+$', contents, maxsplit=1, flags=re.M)
-    if len(parts) == 1:
-      return MarkdownDoc({}, parts[0])
-    return MarkdownDoc(yaml.safe_load(parts[0]), parts[1])
+    @staticmethod
+    def from_file(filename):
+        with open(filename, "r", encoding="utf-8") as f:
+            contents = f.read()
+        parts = re.split("^---+$", contents, maxsplit=1, flags=re.M)
+        if len(parts) == 1:
+            return MarkdownDoc({}, parts[0])
+        return MarkdownDoc(yaml.safe_load(parts[0]), parts[1])
 
-  def __init__(self, front_matter, doc):
-    self.front_matter = front_matter
-    self.markdown = doc
+    def __init__(self, front_matter, doc):
+        self.front_matter = front_matter
+        self.markdown = doc

--- a/exceptions.py
+++ b/exceptions.py
@@ -24,11 +24,12 @@ class HedyException(Exception):
         If 'location' is part of the keyword arguments, return that.
         Otherwise, if 'line_number' is part of the keyword arguments, return that instead.
         """
-        if 'location' in self.arguments:
-            return self.arguments['location']
-        if 'line_number' in self.arguments:
-            return [self.arguments['line_number']]
+        if "location" in self.arguments:
+            return self.arguments["location"]
+        if "line_number" in self.arguments:
+            return [self.arguments["line_number"]]
         return None
+
 
 class FtfyException(HedyException):
     """Fixed That For You warning/exception.
@@ -39,173 +40,185 @@ class FtfyException(HedyException):
     'fixed_code' and 'fixed_result' will contain the repaired
     code, and the result of compiling that repaired code.
     """
+
     def __init__(self, error_code, fixed_code, fixed_result, **arguments):
         super().__init__(error_code, **arguments)
         self.fixed_code = fixed_code
         self.fixed_result = fixed_result
 
+
 class InvalidSpaceException(FtfyException):
     def __init__(self, level, line_number, fixed_code, fixed_result):
-        super().__init__('Invalid Space',
-            level=level,
-            line_number=line_number,
-            fixed_code=fixed_code,
-            fixed_result=fixed_result)
+        super().__init__(
+            "Invalid Space", level=level, line_number=line_number, fixed_code=fixed_code, fixed_result=fixed_result
+        )
+
 
 class ParseException(HedyException):
     def __init__(self, level, location, found, fixed_code=None):
-        super().__init__('Parse',
+        super().__init__(
+            "Parse",
             level=level,
             location=location,
             found=found,
             # 'character_found' for backwards compatibility
-            character_found=found)
+            character_found=found,
+        )
 
-        #TODO (FH, 8 dec 21) many exceptions now support fixed code maybe we should move it to hedyexception?
+        # TODO (FH, 8 dec 21) many exceptions now support fixed code maybe we should move it to hedyexception?
         self.fixed_code = fixed_code
+
 
 class UnquotedEqualityCheck(HedyException):
     def __init__(self, line_number):
-        super().__init__('Unquoted Equality Check',
-             line_number=line_number)
+        super().__init__("Unquoted Equality Check", line_number=line_number)
         self.location = [line_number]
+
 
 class AccessBeforeAssign(HedyException):
     def __init__(self, name, access_line_number, definition_line_number):
-        super().__init__('Access Before Assign',
-                         name=name,
-                         access_line_number=access_line_number,
-                         definition_line_number=definition_line_number)
+        super().__init__(
+            "Access Before Assign",
+            name=name,
+            access_line_number=access_line_number,
+            definition_line_number=definition_line_number,
+        )
+
 
 class UndefinedVarException(HedyException):
     def __init__(self, name):
-        super().__init__('Var Undefined',
-            name=name)
+        super().__init__("Var Undefined", name=name)
+
 
 class CyclicVariableDefinitionException(HedyException):
     def __init__(self, variable):
-        super().__init__('Cyclic Var Definition',
-                         variable=variable)
+        super().__init__("Cyclic Var Definition", variable=variable)
+
 
 class InvalidArgumentTypeException(HedyException):
     def __init__(self, command, invalid_type, allowed_types, invalid_argument):
-        super().__init__('Invalid Argument Type',
+        super().__init__(
+            "Invalid Argument Type",
             command=command,
             invalid_type=invalid_type,
             allowed_types=allowed_types,
-            invalid_argument=invalid_argument)
+            invalid_argument=invalid_argument,
+        )
+
 
 class InvalidTypeCombinationException(HedyException):
     def __init__(self, command, arg1, arg2, type1, type2):
-        super().__init__('Invalid Type Combination',
+        super().__init__(
+            "Invalid Type Combination",
             command=command,
             invalid_argument=arg1,
             invalid_argument_2=arg2,
             invalid_type=type1,
-            invalid_type_2=type2)
+            invalid_type_2=type2,
+        )
+
 
 class InvalidArgumentException(HedyException):
     def __init__(self, command, allowed_types, invalid_argument):
-        super().__init__('Invalid Argument',
-            command=command,
-            allowed_types=allowed_types,
-            invalid_argument=invalid_argument)
+        super().__init__(
+            "Invalid Argument", command=command, allowed_types=allowed_types, invalid_argument=invalid_argument
+        )
+
 
 class WrongLevelException(HedyException):
     def __init__(self, working_level, offending_keyword, tip):
-        super().__init__('Wrong Level',
-            working_level=working_level,
-            offending_keyword=offending_keyword,
-            tip=tip)
+        super().__init__("Wrong Level", working_level=working_level, offending_keyword=offending_keyword, tip=tip)
+
 
 class InputTooBigException(HedyException):
     def __init__(self, lines_of_code, max_lines):
-        super().__init__('Too Big',
-            lines_of_code=lines_of_code,
-            max_lines=max_lines)
+        super().__init__("Too Big", lines_of_code=lines_of_code, max_lines=max_lines)
+
 
 class InvalidCommandException(FtfyException):
     def __init__(self, level, invalid_command, guessed_command, line_number, fixed_code, fixed_result):
-        super().__init__('Invalid',
+        super().__init__(
+            "Invalid",
             invalid_command=invalid_command,
             level=level,
             guessed_command=guessed_command,
             line_number=line_number,
             fixed_code=fixed_code,
-            fixed_result=fixed_result)
+            fixed_result=fixed_result,
+        )
         self.location = [line_number]
+
 
 class MissingCommandException(HedyException):
     def __init__(self, level, line_number):
-        super().__init__('Missing Command',
-            level=level,
-            line_number=line_number)
+        super().__init__("Missing Command", level=level, line_number=line_number)
+
 
 class MissingInnerCommandException(HedyException):
     def __init__(self, command, level, line_number):
-        super().__init__('Missing Inner Command',
-            command=command,
-            level=level,
-            line_number=line_number)
+        super().__init__("Missing Inner Command", command=command, level=level, line_number=line_number)
+
 
 class IncompleteRepeatException(HedyException):
     def __init__(self, command, level, line_number):
-        super().__init__('Incomplete Repeat',
-            command=command,
-            level=level,
-            line_number=line_number)
+        super().__init__("Incomplete Repeat", command=command, level=level, line_number=line_number)
+
 
 class IncompleteCommandException(HedyException):
     def __init__(self, incomplete_command, level, line_number):
-        super().__init__('Incomplete',
-            incomplete_command=incomplete_command,
-            level=level,
-            line_number=line_number)
+        super().__init__("Incomplete", incomplete_command=incomplete_command, level=level, line_number=line_number)
 
         # Location is copied here so that 'hedy_error_to_response' will find it
         # Location can be either [row, col] or just [row]
         self.location = [line_number]
 
+
 class UnquotedTextException(HedyException):
     def __init__(self, level, unquotedtext=None):
-        super().__init__('Unquoted Text', level=level, unquotedtext=unquotedtext)
+        super().__init__("Unquoted Text", level=level, unquotedtext=unquotedtext)
+
 
 class UnquotedAssignTextException(HedyException):
     def __init__(self, text):
-        super().__init__('Unquoted Assignment', text=text)
+        super().__init__("Unquoted Assignment", text=text)
+
 
 class LonelyEchoException(HedyException):
     def __init__(self):
-        super().__init__('Lonely Echo')
+        super().__init__("Lonely Echo")
+
 
 class CodePlaceholdersPresentException(HedyException):
     def __init__(self):
-        super().__init__('Has Blanks')
+        super().__init__("Has Blanks")
+
 
 class NoIndentationException(HedyException):
     def __init__(self, line_number, leading_spaces, indent_size, fixed_code=None):
-        super().__init__('No Indentation',
-            line_number=line_number,
-            leading_spaces=leading_spaces,
-            indent_size=indent_size)
+        super().__init__(
+            "No Indentation", line_number=line_number, leading_spaces=leading_spaces, indent_size=indent_size
+        )
         self.fixed_code = fixed_code
+
 
 class IndentationException(HedyException):
     def __init__(self, line_number, leading_spaces, indent_size, fixed_code=None):
-        super().__init__('Unexpected Indentation',
-            line_number=line_number,
-            leading_spaces=leading_spaces,
-            indent_size=indent_size)
+        super().__init__(
+            "Unexpected Indentation", line_number=line_number, leading_spaces=leading_spaces, indent_size=indent_size
+        )
         self.fixed_code = fixed_code
+
 
 class UnsupportedFloatException(HedyException):
     def __init__(self, value):
-        super().__init__('Unsupported Float', value=value)
+        super().__init__("Unsupported Float", value=value)
+
 
 class LockedLanguageFeatureException(HedyException):
     def __init__(self, concept):
-        super().__init__('Locked Language Feature', concept=concept)
+        super().__init__("Locked Language Feature", concept=concept)
+
 
 class UnsupportedStringValue(HedyException):
     def __init__(self, invalid_value):
-        super().__init__('Unsupported String Value', invalid_value=invalid_value)
+        super().__init__("Unsupported String Value", invalid_value=invalid_value)

--- a/flask_helpers.py
+++ b/flask_helpers.py
@@ -1,6 +1,7 @@
 import flask
 from website import querylog
 
+
 @querylog.timed
 def render_template(filename, **kwargs):
     """A copy of Flask's render_template that is timed."""

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -1,14 +1,18 @@
 # This file is used to configure gunicorn,
 # used on Heroku.
 
+
 def worker_exit(server, worker):
     # When the worker is being exited (perhaps because of a timeout),
     # give the query_log handler a chance to flush to disk.
     from website import querylog, jsonbin
+
     querylog.emergency_shutdown()
     jsonbin.emergency_shutdown()
+
 
 def post_fork(server, worker):
     """When the worker has started."""
     import app
+
     app.on_server_start()

--- a/hedy.py
+++ b/hedy.py
@@ -34,80 +34,117 @@ local_keywords_enabled = True
 TRANSPILER_LOOKUP = {}
 
 # Python keywords need hashing when used as var names
-reserved_words = ['and', 'except', 'lambda', 'with', 'as', 'finally', 'nonlocal', 'while', 'assert', 'False', 'None', 'yield', 'break', 'for', 'not', 'class', 'from', 'or', 'continue', 'global', 'pass', 'def', 'if', 'raise', 'del', 'import', 'return', 'elif', 'in', 'True', 'else', 'is', 'try']
+reserved_words = [
+    "and",
+    "except",
+    "lambda",
+    "with",
+    "as",
+    "finally",
+    "nonlocal",
+    "while",
+    "assert",
+    "False",
+    "None",
+    "yield",
+    "break",
+    "for",
+    "not",
+    "class",
+    "from",
+    "or",
+    "continue",
+    "global",
+    "pass",
+    "def",
+    "if",
+    "raise",
+    "del",
+    "import",
+    "return",
+    "elif",
+    "in",
+    "True",
+    "else",
+    "is",
+    "try",
+]
 
 # Let's retrieve all keywords dynamically from the cached KEYWORDS dictionary
 indent_keywords = []
 for lang, keywords in KEYWORDS.items():
-    for keyword in ['if', 'for', 'repeat', 'while', 'else']:
+    for keyword in ["if", "for", "repeat", "while", "else"]:
         indent_keywords.append(keywords.get(keyword))
 
 # These are the preprocessor rules that we use to specify changes in the rules that
 # are expected to work across several rules
-# Example 
+# Example
 # for<needs_colon> instead of defining the whole rule again.
 
-def needs_colon(rule):
-  pos = rule.find('_EOL (_SPACE command)')
-  return f'{rule[0:pos]} _COLON {rule[pos:]}'
 
-PREPROCESS_RULES = {
-    'needs_colon': needs_colon
-}
+def needs_colon(rule):
+    pos = rule.find("_EOL (_SPACE command)")
+    return f"{rule[0:pos]} _COLON {rule[pos:]}"
+
+
+PREPROCESS_RULES = {"needs_colon": needs_colon}
+
 
 class Command:
-    print = 'print'
-    ask = 'ask'
-    echo = 'echo'
-    turn = 'turn'
-    forward = 'forward'
-    sleep = 'sleep'
-    color = 'color'
-    add_to_list = 'add to list'
-    remove_from_list = 'remove from list'
-    list_access = 'at random'
-    in_list = 'in list'
-    equality = 'is (equality)'
-    repeat = 'repeat'
-    for_list = 'for in'
-    for_loop = 'for in range'
-    addition = '+'
-    subtraction = '-'
-    multiplication = '*'
-    division = '/'
-    smaller = '<'
-    smaller_equal = '<='
-    bigger = '>'
-    bigger_equal = '>='
-    not_equal = '!='
+    print = "print"
+    ask = "ask"
+    echo = "echo"
+    turn = "turn"
+    forward = "forward"
+    sleep = "sleep"
+    color = "color"
+    add_to_list = "add to list"
+    remove_from_list = "remove from list"
+    list_access = "at random"
+    in_list = "in list"
+    equality = "is (equality)"
+    repeat = "repeat"
+    for_list = "for in"
+    for_loop = "for in range"
+    addition = "+"
+    subtraction = "-"
+    multiplication = "*"
+    division = "/"
+    smaller = "<"
+    smaller_equal = "<="
+    bigger = ">"
+    bigger_equal = ">="
+    not_equal = "!="
 
 
-translatable_commands = {Command.print: ['print'],
-                         Command.ask: ['ask'],
-                         Command.echo: ['echo'],
-                         Command.turn: ['turn'],
-                         Command.sleep: ['sleep'],
-                         Command.color: ['color'],
-                         Command.forward: ['forward'],
-                         Command.add_to_list: ['add', 'to_list'],
-                         Command.remove_from_list: ['remove', 'from'],
-                         Command.list_access: ['at', 'random'],
-                         Command.in_list: ['in'],
-                         Command.equality: ['is', '=', '=='],
-                         Command.repeat: ['repeat', 'times'],
-                         Command.for_list: ['for', 'in'],
-                         Command.for_loop: ['in', 'range', 'to']}
+translatable_commands = {
+    Command.print: ["print"],
+    Command.ask: ["ask"],
+    Command.echo: ["echo"],
+    Command.turn: ["turn"],
+    Command.sleep: ["sleep"],
+    Command.color: ["color"],
+    Command.forward: ["forward"],
+    Command.add_to_list: ["add", "to_list"],
+    Command.remove_from_list: ["remove", "from"],
+    Command.list_access: ["at", "random"],
+    Command.in_list: ["in"],
+    Command.equality: ["is", "=", "=="],
+    Command.repeat: ["repeat", "times"],
+    Command.for_list: ["for", "in"],
+    Command.for_loop: ["in", "range", "to"],
+}
 
 
 class HedyType:
-    any = 'any'
-    none = 'none'
-    string = 'string'
-    integer = 'integer'
-    list = 'list'
-    float = 'float'
-    boolean = 'boolean'
-    input = 'input'
+    any = "any"
+    none = "none"
+    string = "string"
+    integer = "integer"
+    list = "list"
+    float = "float"
+    boolean = "boolean"
+    input = "input"
 
 
 # Type promotion rules are used to implicitly convert one type to another, e.g. integer should be auto converted
@@ -129,56 +166,321 @@ def promote_types(types, rules):
 
 # Commands per Hedy level which are used to suggest the closest command when kids make a mistake
 commands_per_level = {
-    1 :['print', 'ask', 'echo', 'turn', 'forward', 'color'],
-    2 :['print', 'ask', 'is', 'turn', 'forward', 'color', 'sleep'],
-    3 :['ask', 'is', 'print', 'forward', 'turn', 'color', 'sleep', 'at', 'random', 'add', 'to', 'remove', 'from'],
-    4 :['ask', 'is', 'print', 'forward', 'turn', 'color', 'sleep', 'at', 'random', 'add', 'to', 'remove', 'from'],
-    5 :['ask', 'is', 'print', 'forward', 'turn', 'color', 'sleep', 'at', 'random', 'add', 'to', 'remove', 'from', 'in', 'if', 'else'],
-    6 :['ask', 'is', 'print', 'forward', 'turn', 'color', 'sleep', 'at', 'random', 'add', 'to', 'remove', 'from', 'in', 'if', 'else'],
-    7 :['ask', 'is', 'print', 'forward', 'turn', 'color', 'sleep', 'at', 'random', 'add', 'to', 'remove', 'from', 'in', 'if', 'else', 'repeat', 'times'],
-    8 :['ask', 'is', 'print', 'forward', 'turn', 'color', 'sleep', 'at', 'random', 'add', 'to', 'remove', 'from', 'in', 'if', 'else', 'repeat', 'times'],
-    9 :['ask', 'is', 'print', 'forward', 'turn', 'color', 'sleep', 'at', 'random', 'add', 'to', 'remove', 'from', 'in', 'if', 'else', 'repeat', 'times'],
-    10 :['ask', 'is', 'print', 'forward', 'turn', 'color', 'sleep', 'at', 'random', 'add', 'to', 'remove', 'from', 'in', 'if', 'else', 'repeat', 'times', 'for'],
-    11 :['ask', 'is', 'print', 'sleep', 'at', 'random', 'add', 'to', 'remove', 'from', 'in', 'if', 'else', 'for', 'range', 'repeat'],
-    12 :['ask', 'is', 'print', 'sleep', 'at', 'random', 'add', 'to', 'remove', 'from', 'in', 'if', 'else', 'for', 'range', 'repeat'],
-    13 :['ask', 'is', 'print', 'sleep', 'at', 'random', 'add', 'to', 'remove', 'from', 'in', 'if', 'else', 'for', 'range', 'repeat', 'and', 'or'],
-    14 :['ask', 'is', 'print', 'sleep', 'at', 'random', 'add', 'to', 'remove', 'from', 'in', 'if', 'else', 'for', 'range', 'repeat', 'and', 'or'],
-    15 :['ask', 'is', 'print', 'sleep', 'at', 'random', 'add', 'to', 'remove', 'from', 'in', 'if', 'else', 'for', 'range', 'repeat', 'and', 'or', 'while'],
-    16 :['ask', 'is', 'print', 'sleep', 'at', 'random', 'add', 'to', 'remove', 'from', 'in', 'if', 'else', 'for', 'range', 'repeat', 'and', 'or', 'while'],
-    17 :['ask', 'is', 'print', 'sleep', 'at', 'random', 'add', 'to', 'remove', 'from', 'in', 'if', 'else', 'for', 'range', 'repeat', 'and', 'or', 'while', 'elif'],
-    18 :['is', 'print', 'sleep', 'at', 'random', 'add', 'to', 'remove', 'from', 'in', 'if', 'else', 'for', 'range', 'repeat', 'and', 'or', 'while', 'elif', 'input'],
+    1: ["print", "ask", "echo", "turn", "forward", "color"],
+    2: ["print", "ask", "is", "turn", "forward", "color", "sleep"],
+    3: ["ask", "is", "print", "forward", "turn", "color", "sleep", "at", "random", "add", "to", "remove", "from"],
+    4: ["ask", "is", "print", "forward", "turn", "color", "sleep", "at", "random", "add", "to", "remove", "from"],
+    5: [
+        "ask",
+        "is",
+        "print",
+        "forward",
+        "turn",
+        "color",
+        "sleep",
+        "at",
+        "random",
+        "add",
+        "to",
+        "remove",
+        "from",
+        "in",
+        "if",
+        "else",
+    ],
+    6: [
+        "ask",
+        "is",
+        "print",
+        "forward",
+        "turn",
+        "color",
+        "sleep",
+        "at",
+        "random",
+        "add",
+        "to",
+        "remove",
+        "from",
+        "in",
+        "if",
+        "else",
+    ],
+    7: [
+        "ask",
+        "is",
+        "print",
+        "forward",
+        "turn",
+        "color",
+        "sleep",
+        "at",
+        "random",
+        "add",
+        "to",
+        "remove",
+        "from",
+        "in",
+        "if",
+        "else",
+        "repeat",
+        "times",
+    ],
+    8: [
+        "ask",
+        "is",
+        "print",
+        "forward",
+        "turn",
+        "color",
+        "sleep",
+        "at",
+        "random",
+        "add",
+        "to",
+        "remove",
+        "from",
+        "in",
+        "if",
+        "else",
+        "repeat",
+        "times",
+    ],
+    9: [
+        "ask",
+        "is",
+        "print",
+        "forward",
+        "turn",
+        "color",
+        "sleep",
+        "at",
+        "random",
+        "add",
+        "to",
+        "remove",
+        "from",
+        "in",
+        "if",
+        "else",
+        "repeat",
+        "times",
+    ],
+    10: [
+        "ask",
+        "is",
+        "print",
+        "forward",
+        "turn",
+        "color",
+        "sleep",
+        "at",
+        "random",
+        "add",
+        "to",
+        "remove",
+        "from",
+        "in",
+        "if",
+        "else",
+        "repeat",
+        "times",
+        "for",
+    ],
+    11: [
+        "ask",
+        "is",
+        "print",
+        "sleep",
+        "at",
+        "random",
+        "add",
+        "to",
+        "remove",
+        "from",
+        "in",
+        "if",
+        "else",
+        "for",
+        "range",
+        "repeat",
+    ],
+    12: [
+        "ask",
+        "is",
+        "print",
+        "sleep",
+        "at",
+        "random",
+        "add",
+        "to",
+        "remove",
+        "from",
+        "in",
+        "if",
+        "else",
+        "for",
+        "range",
+        "repeat",
+    ],
+    13: [
+        "ask",
+        "is",
+        "print",
+        "sleep",
+        "at",
+        "random",
+        "add",
+        "to",
+        "remove",
+        "from",
+        "in",
+        "if",
+        "else",
+        "for",
+        "range",
+        "repeat",
+        "and",
+        "or",
+    ],
+    14: [
+        "ask",
+        "is",
+        "print",
+        "sleep",
+        "at",
+        "random",
+        "add",
+        "to",
+        "remove",
+        "from",
+        "in",
+        "if",
+        "else",
+        "for",
+        "range",
+        "repeat",
+        "and",
+        "or",
+    ],
+    15: [
+        "ask",
+        "is",
+        "print",
+        "sleep",
+        "at",
+        "random",
+        "add",
+        "to",
+        "remove",
+        "from",
+        "in",
+        "if",
+        "else",
+        "for",
+        "range",
+        "repeat",
+        "and",
+        "or",
+        "while",
+    ],
+    16: [
+        "ask",
+        "is",
+        "print",
+        "sleep",
+        "at",
+        "random",
+        "add",
+        "to",
+        "remove",
+        "from",
+        "in",
+        "if",
+        "else",
+        "for",
+        "range",
+        "repeat",
+        "and",
+        "or",
+        "while",
+    ],
+    17: [
+        "ask",
+        "is",
+        "print",
+        "sleep",
+        "at",
+        "random",
+        "add",
+        "to",
+        "remove",
+        "from",
+        "in",
+        "if",
+        "else",
+        "for",
+        "range",
+        "repeat",
+        "and",
+        "or",
+        "while",
+        "elif",
+    ],
+    18: [
+        "is",
+        "print",
+        "sleep",
+        "at",
+        "random",
+        "add",
+        "to",
+        "remove",
+        "from",
+        "in",
+        "if",
+        "else",
+        "for",
+        "range",
+        "repeat",
+        "and",
+        "or",
+        "while",
+        "elif",
+        "input",
+    ],
 }
 
-command_turn_literals = ['right', 'left']
-command_make_color = ['black', 'blue', 'brown', 'gray', 'green', 'orange', 'pink', 'purple', 'red', 'white', 'yellow']
+command_turn_literals = ["right", "left"]
+command_make_color = ["black", "blue", "brown", "gray", "green", "orange", "pink", "purple", "red", "white", "yellow"]
 
 # Commands and their types per level (only partially filled!)
 commands_and_types_per_level = {
     Command.print: {
         1: [HedyType.string, HedyType.integer, HedyType.input],
         12: [HedyType.string, HedyType.integer, HedyType.input, HedyType.float],
-        16: [HedyType.string, HedyType.integer, HedyType.input, HedyType.float, HedyType.list]
+        16: [HedyType.string, HedyType.integer, HedyType.input, HedyType.float, HedyType.list],
     },
     Command.ask: {
         1: [HedyType.string, HedyType.integer, HedyType.input],
         12: [HedyType.string, HedyType.integer, HedyType.input, HedyType.float],
-        16: [HedyType.string, HedyType.integer, HedyType.input, HedyType.float, HedyType.list]
+        16: [HedyType.string, HedyType.integer, HedyType.input, HedyType.float, HedyType.list],
     },
-    Command.turn: {1: command_turn_literals,
-                   2: [HedyType.integer, HedyType.input]},
-    Command.color: {1: command_make_color,
-                    2: [command_make_color, HedyType.string, HedyType.input]},
+    Command.turn: {1: command_turn_literals, 2: [HedyType.integer, HedyType.input]},
+    Command.color: {1: command_make_color, 2: [command_make_color, HedyType.string, HedyType.input]},
     Command.forward: {1: [HedyType.integer, HedyType.input]},
     Command.sleep: {1: [HedyType.integer, HedyType.input]},
     Command.list_access: {1: [HedyType.list]},
     Command.in_list: {1: [HedyType.list]},
     Command.add_to_list: {1: [HedyType.list]},
     Command.remove_from_list: {1: [HedyType.list]},
-    Command.equality: {1: [HedyType.string, HedyType.integer, HedyType.input, HedyType.float],
-                       14: [HedyType.string, HedyType.integer, HedyType.input, HedyType.float, HedyType.list]},
+    Command.equality: {
+        1: [HedyType.string, HedyType.integer, HedyType.input, HedyType.float],
+        14: [HedyType.string, HedyType.integer, HedyType.input, HedyType.float, HedyType.list],
+    },
     Command.addition: {
         6: [HedyType.integer, HedyType.input],
-        12: [HedyType.string, HedyType.integer, HedyType.input, HedyType.float]
+        12: [HedyType.string, HedyType.integer, HedyType.input, HedyType.float],
     },
     Command.subtraction: {
         1: [HedyType.integer, HedyType.input],
@@ -199,32 +501,31 @@ commands_and_types_per_level = {
     Command.smaller_equal: {14: [HedyType.integer, HedyType.float, HedyType.input]},
     Command.bigger: {14: [HedyType.integer, HedyType.float, HedyType.input]},
     Command.bigger_equal: {14: [HedyType.integer, HedyType.float, HedyType.input]},
-    Command.not_equal: {14: [HedyType.integer, HedyType.float, HedyType.string, HedyType.input, HedyType.list]}
+    Command.not_equal: {14: [HedyType.integer, HedyType.float, HedyType.string, HedyType.input, HedyType.list]},
 }
 
 # we generate Python strings with ' always, so ' needs to be escaped but " works fine
 # \ also needs to be escaped because it eats the next character
 characters_that_need_escaping = ["\\", "'"]
 
-character_skulpt_cannot_parse = re.compile('[^a-zA-Z0-9_]')
+character_skulpt_cannot_parse = re.compile("[^a-zA-Z0-9_]")
 
 
 def get_list_keywords(commands, to_lang):
-    """ Returns a list with the local keywords of the argument 'commands'
-    """
+    """Returns a list with the local keywords of the argument 'commands'"""
 
     translation_commands = []
     dir = path.abspath(path.dirname(__file__))
     path_keywords = dir + "/content/keywords"
 
-    to_yaml_filesname_with_path = path.join(path_keywords, to_lang + '.yaml')
-    en_yaml_filesname_with_path = path.join(path_keywords, 'en' + '.yaml')
+    to_yaml_filesname_with_path = path.join(path_keywords, to_lang + ".yaml")
+    en_yaml_filesname_with_path = path.join(path_keywords, "en" + ".yaml")
 
-    with open(en_yaml_filesname_with_path, 'r', encoding='utf-8') as stream:
+    with open(en_yaml_filesname_with_path, "r", encoding="utf-8") as stream:
         en_yaml_dict = yaml.safe_load(stream)
 
     try:
-        with open(to_yaml_filesname_with_path, 'r', encoding='utf-8') as stream:
+        with open(to_yaml_filesname_with_path, "r", encoding="utf-8") as stream:
             to_yaml_dict = yaml.safe_load(stream)
         for command in commands:
             try:
@@ -240,19 +541,21 @@ def get_list_keywords(commands, to_lang):
 
 def get_suggestions_for_language(lang, level):
     if not local_keywords_enabled:
-        lang = 'en'
+        lang = "en"
 
     lang_commands = get_list_keywords(commands_per_level[level], lang)
 
     # if we allow multiple keyword languages:
-    en_commands = get_list_keywords(commands_per_level[level], 'en')
+    en_commands = get_list_keywords(commands_per_level[level], "en")
     en_lang_commands = list(set(en_commands + lang_commands))
 
     return en_lang_commands
 
+
 def escape_var(var):
     var_name = var.name if type(var) is LookupEntry else var
     return "_" + var_name if var_name in reserved_words else var_name
+
 
 def closest_command(invalid_command, known_commands, threshold=2):
     # closest_command() searches for a similar command (distance smaller than threshold)
@@ -267,12 +570,13 @@ def closest_command(invalid_command, known_commands, threshold=2):
     # This is to prevent "print is not a command in Hedy level 3, did you mean print?" error message
 
     if min_command == invalid_command:
-        return 'keyword'
+        return "keyword"
     return min_command
 
 
 def style_closest_command(command):
     return f'<span class="command-highlighted">{command}</span>'
+
 
 def closest_command_with_min_distance(invalid_command, commands, threshold):
     # FH, early 2020: simple string distance, could be more sophisticated MACHINE LEARNING!
@@ -286,6 +590,7 @@ def closest_command_with_min_distance(invalid_command, commands, threshold):
             closest_command = command
 
     return closest_command
+
 
 def calculate_minimum_distance(s1, s2):
     """Return string distance between 2 strings."""
@@ -306,7 +611,7 @@ def calculate_minimum_distance(s1, s2):
 @dataclass
 class InvalidInfo:
     error_type: str
-    command: str = ''
+    command: str = ""
     arguments: list = field(default_factory=list)
     line: int = 0
     column: int = 0
@@ -333,48 +638,49 @@ class TypedTree(Tree):
 class ExtractAST(Transformer):
     # simplifies the tree: f.e. flattens arguments of text, var and punctuation for further processing
     def text(self, meta, args):
-        return Tree('text', [' '.join([str(c) for c in args])], meta)
+        return Tree("text", [" ".join([str(c) for c in args])], meta)
 
     def INT(self, args):
-        return Tree('integer', [str(args)])
+        return Tree("integer", [str(args)])
 
     def NUMBER(self, args):
-        return Tree('number', [str(args)])
+        return Tree("number", [str(args)])
 
     def POSITIVE_NUMBER(self, args):
-        return Tree('number', [str(args)])
+        return Tree("number", [str(args)])
 
     def NEGATIVE_NUMBER(self, args):
-        return Tree('number', [str(args)])
+        return Tree("number", [str(args)])
 
-    #level 2
+    # level 2
     def var(self, meta, args):
-        return Tree('var', [''.join([str(c) for c in args])], meta)
+        return Tree("var", ["".join([str(c) for c in args])], meta)
 
     def list_access(self, meta, args):
         # FH, may 2022 I don't fully understand why we remove INT here and just plemp
         # the number in the tree. should be improved but that requires rewriting the further processing code too (TODO)
         if type(args[1]) == Tree:
             if "random" in args[1].data:
-                return Tree('list_access', [args[0], 'random'], meta)
+                return Tree("list_access", [args[0], "random"], meta)
             elif args[1].data == "var_access":
-                return Tree('list_access', [args[0], args[1].children[0]], meta)
+                return Tree("list_access", [args[0], args[1].children[0]], meta)
             else:
                 # convert to latin int
                 latin_int_index = str(int(args[1].children[0]))
-                return Tree('list_access', [args[0], latin_int_index], meta)
+                return Tree("list_access", [args[0], latin_int_index], meta)
         else:
-            return Tree('list_access', [args[0], args[1]], meta)
+            return Tree("list_access", [args[0], args[1]], meta)
 
-    #level 5
+    # level 5
     def error_unsupported_number(self, meta, args):
-        return Tree('unsupported_number', [''.join([str(c) for c in args])], meta)
+        return Tree("unsupported_number", ["".join([str(c) for c in args])], meta)
 
 
 # This visitor collects all entries that should be part of the lookup table. It only stores the name of the entry
 # (e.g. 'animal') and its value as a tree node (e.g. Tree['text', ['cat']]) which is later used to infer the type
 # of the entry. This preliminary traversal is needed to avoid issues with loops in which an iterator variable is
 # used in the inner commands which are visited before the iterator variable is added to the lookup.
+
 
 class LookupEntryCollector(visitors.Visitor):
     def __init__(self, level):
@@ -402,21 +708,21 @@ class LookupEntryCollector(visitors.Visitor):
         var_name = tree.children[0].children[0]
         self.add_to_lookup(var_name, tree, tree.meta.line)
 
-
     # list access is added to the lookup table not because it must be escaped
     # for example we print(dieren[1]) not print('dieren[1]')
     def list_access(self, tree):
         list_name = escape_var(tree.children[0].children[0])
         position_name = escape_var(tree.children[1])
-        if position_name == 'random':
-            name = f'random.choice({list_name})'
+        if position_name == "random":
+            name = f"random.choice({list_name})"
         else:
             # We want list access to be 1-based instead of 0-based, hence the -1
-            name = f'{list_name}[{position_name}-1]'
+            name = f"{list_name}[{position_name}-1]"
         self.add_to_lookup(name, tree, tree.meta.line, True)
 
     def list_access_var(self, tree):
         self.add_to_lookup(tree.children[0].children[0], tree, tree.meta.line)
+
     def change_list_item(self, tree):
         self.add_to_lookup(tree.children[0].children[0], tree, tree.meta.line, True)
 
@@ -455,9 +761,7 @@ class TypeValidator(Transformer):
     def print(self, tree):
         self.validate_args_type_allowed(Command.print, tree.children, tree.meta)
 
-
         return self.to_typed_tree(tree)
-
 
     def ask(self, tree):
         if self.level > 1:
@@ -497,7 +801,7 @@ class TypeValidator(Transformer):
             self.save_type_to_lookup(tree.children[0].children[0], type_)
         except hedy.exceptions.UndefinedVarException as ex:
             if self.level >= 12:
-                raise hedy.exceptions.UnquotedAssignTextException(text=ex.arguments['name'])
+                raise hedy.exceptions.UnquotedAssignTextException(text=ex.arguments["name"])
             else:
                 raise
 
@@ -511,11 +815,11 @@ class TypeValidator(Transformer):
         self.validate_args_type_allowed(Command.list_access, tree.children[0], tree.meta)
 
         list_name = escape_var(tree.children[0].children[0])
-        if tree.children[1] == 'random':
-            name = f'random.choice({list_name})'
+        if tree.children[1] == "random":
+            name = f"random.choice({list_name})"
         else:
             # We want list access to be 1-based instead of 0-based, hence the -1
-            name = f'{list_name}[{tree.children[1]}-1]'
+            name = f"{list_name}[{tree.children[1]}-1]"
         self.save_type_to_lookup(name, HedyType.any)
 
         return self.to_typed_tree(tree, HedyType.any)
@@ -599,7 +903,7 @@ class TypeValidator(Transformer):
         if ConvertToPython.is_float(number):
             return self.to_typed_tree(tree, HedyType.float)
         # We managed to parse a number that cannot be parsed by python
-        raise exceptions.ParseException(level=self.level, location='', found=number)
+        raise exceptions.ParseException(level=self.level, location="", found=number)
 
     def subtraction(self, tree):
         return self.to_sum_typed_tree(tree, Command.subtraction)
@@ -671,18 +975,27 @@ class TypeValidator(Transformer):
 
             if command in translatable_commands:
                 keywords = translatable_commands[command]
-                result = hedy_translation.find_command_keywords(self.input_string, self.lang, self.level, keywords,
-                                                                meta.line, meta.end_line, meta.column-1, meta.end_column-2)
+                result = hedy_translation.find_command_keywords(
+                    self.input_string,
+                    self.lang,
+                    self.level,
+                    keywords,
+                    meta.line,
+                    meta.end_line,
+                    meta.column - 1,
+                    meta.end_column - 2,
+                )
                 result = {k: v for k, v in result.items()}
-                command = ' '.join([v.strip() for v in result.values() if v is not None])
-            raise exceptions.InvalidArgumentTypeException(command=command, invalid_type=arg_type,
-                                                          invalid_argument=variable, allowed_types=allowed_types)
+                command = " ".join([v.strip() for v in result.values() if v is not None])
+            raise exceptions.InvalidArgumentTypeException(
+                command=command, invalid_type=arg_type, invalid_argument=variable, allowed_types=allowed_types
+            )
         return arg_type
 
     def get_type(self, tree):
         # The rule var_access is used in the grammars definitions only in places where a variable needs to be accessed.
         # So, if it cannot be found in the lookup table, then it is an undefined variable for sure.
-        if tree.data == 'var_access':
+        if tree.data == "var_access":
             var_name = tree.children[0]
             in_lookup, type_in_lookup = self.try_get_type_from_lookup(var_name)
             if in_lookup:
@@ -690,7 +1003,7 @@ class TypeValidator(Transformer):
             else:
                 raise hedy.exceptions.UndefinedVarException(name=var_name)
 
-        if tree.data == 'var_access_print':
+        if tree.data == "var_access_print":
             var_name = tree.children[0]
             in_lookup, type_in_lookup = self.try_get_type_from_lookup(var_name)
             if in_lookup:
@@ -712,7 +1025,6 @@ class TypeValidator(Transformer):
 
                     # nothing found? fall back to UnquotedTextException
                     raise hedy.exceptions.UnquotedTextException(level=self.level, unquotedtext=var_name)
-
 
         # TypedTree with type 'None' and 'string' could be in the lookup because of the grammar definitions
         # If the tree has more than 1 child, then it is not a leaf node, so do not search in the lookup
@@ -772,13 +1084,16 @@ class TypeValidator(Transformer):
 def flatten_list_of_lists_to_list(args):
     flat_list = []
     for element in args:
-        if isinstance(element, str): #str needs a special case before list because a str is also a list and we don't want to split all letters out
+        if isinstance(
+            element, str
+        ):  # str needs a special case before list because a str is also a list and we don't want to split all letters out
             flat_list.append(element)
         elif isinstance(element, list):
             flat_list += flatten_list_of_lists_to_list(element)
         else:
             flat_list.append(element)
     return flat_list
+
 
 def are_all_arguments_true(args):
     bool_arguments = [x[0] for x in args]
@@ -797,27 +1112,27 @@ class Filter(Transformer):
     def program(self, meta, args):
         bool_arguments = [x[0] for x in args]
         if all(bool_arguments):
-            return [True] #all complete
+            return [True]  # all complete
         else:
             for a in args:
                 if not a[0]:
                     return False, a[1]
 
-    #leafs are treated differently, they are True + their arguments flattened
+    # leafs are treated differently, they are True + their arguments flattened
     def var(self, meta, args):
-        return True, ''.join([str(c) for c in args]), meta
+        return True, "".join([str(c) for c in args]), meta
 
     def random(self, meta, args):
-        return True, 'random', meta
+        return True, "random", meta
 
     def number(self, meta, args):
-        return True, ''.join([c for c in args]), meta
+        return True, "".join([c for c in args]), meta
 
     def NEGATIVE_NUMBER(self, args):
-        return True, ''.join([c for c in args]), None
+        return True, "".join([c for c in args]), None
 
     def text(self, meta, args):
-        return all(args), ''.join([c for c in args]), meta
+        return all(args), "".join([c for c in args]), meta
 
 
 class UsesTurtle(Transformer):
@@ -827,9 +1142,9 @@ class UsesTurtle(Transformer):
             return False
         else:
             if all(type(c) == bool for c in children):
-                return any(children) # children? if any is true there is a Turtle leaf
+                return any(children)  # children? if any is true there is a Turtle leaf
             else:
-                return False # some nodes like text and punctuation have text children (their letters) these are not turtles
+                return False  # some nodes like text and punctuation have text children (their letters) these are not turtles
 
     def forward(self, args):
         return True
@@ -849,12 +1164,13 @@ class UsesTurtle(Transformer):
 
     def NUMBER(self, args):
         return False
-    
+
     def POSITIVE_NUMBER(self, args):
         return False
 
     def NEGATIVE_NUMBER(self, args):
         return False
+
 
 class AllCommands(Transformer):
     def __init__(self, level):
@@ -864,45 +1180,49 @@ class AllCommands(Transformer):
         # some keywords have names that are not a valid name for a command
         # that's why we call them differently in the grammar
         # we have to translate them to the regular names here for further communciation
-        if keyword in ['assign', 'assign_list']:
-            return 'is'
-        if keyword == 'ifelse':
-            return 'else'
-        if keyword == 'ifs':
-            return 'if'
-        if keyword == 'elifs':
-            return 'elif'
-        if keyword == 'for_loop':
-            return 'for'
-        if keyword == 'for_list':
-            return 'for'
-        if keyword == 'or_condition':
-            return 'or'
-        if keyword == 'and_condition':
-            return 'and'
-        if keyword == 'while_loop':
-            return 'while'
-        if keyword == 'in_list_check':
-            return 'in'
-        if keyword == 'input_empty_brackets':
-            return 'input'
-        if keyword == 'print_empty_brackets':
-            return 'print'
+        if keyword in ["assign", "assign_list"]:
+            return "is"
+        if keyword == "ifelse":
+            return "else"
+        if keyword == "ifs":
+            return "if"
+        if keyword == "elifs":
+            return "elif"
+        if keyword == "for_loop":
+            return "for"
+        if keyword == "for_list":
+            return "for"
+        if keyword == "or_condition":
+            return "or"
+        if keyword == "and_condition":
+            return "and"
+        if keyword == "while_loop":
+            return "while"
+        if keyword == "in_list_check":
+            return "in"
+        if keyword == "input_empty_brackets":
+            return "input"
+        if keyword == "print_empty_brackets":
+            return "print"
         return str(keyword)
 
     def __default__(self, args, children, meta):
         # if we are matching a rule that is a command
         production_rule_name = self.translate_keyword(args)
         leaves = flatten_list_of_lists_to_list(children)
-        operators = ['addition', 'subtraction', 'multiplication', 'division'] # for the achievements we want to be able to also detct which operators were used by a kid
+        operators = [
+            "addition",
+            "subtraction",
+            "multiplication",
+            "division",
+        ]  # for the achievements we want to be able to also detct which operators were used by a kid
 
         if production_rule_name in commands_per_level[self.level] or production_rule_name in operators:
-            if production_rule_name == 'else': # use of else also has an if
-                return ['if', 'else'] + leaves
+            if production_rule_name == "else":  # use of else also has an if
+                return ["if", "else"] + leaves
             return [production_rule_name] + leaves
         else:
-            return leaves # 'pop up' the children
-
+            return leaves  # 'pop up' the children
 
     def command(self, args):
         return args
@@ -919,7 +1239,7 @@ class AllCommands(Transformer):
 
     def NUMBER(self, args):
         return []
-    
+
     def POSITIVE_NUMBER(self, args):
         return []
 
@@ -930,11 +1250,12 @@ class AllCommands(Transformer):
         return []
 
 
-def all_commands(input_string, level, lang='en'):
+def all_commands(input_string, level, lang="en"):
     input_string = process_input_string(input_string, level)
     program_root = parse_input(input_string, level, lang)
 
     return AllCommands(level).transform(program_root)
+
 
 class AllPrintArguments(Transformer):
     def __init__(self, level):
@@ -943,10 +1264,10 @@ class AllPrintArguments(Transformer):
     def __default__(self, args, children, meta):
         leaves = flatten_list_of_lists_to_list(children)
 
-        if args == 'print':
+        if args == "print":
             return children
         else:
-            return leaves # 'pop up' the children
+            return leaves  # 'pop up' the children
 
     def program(self, args):
         return flatten_list_of_lists_to_list(args)
@@ -960,7 +1281,7 @@ class AllPrintArguments(Transformer):
 
     def NUMBER(self, args):
         return []
-    
+
     def POSITIVE_NUMBER(self, args):
         return []
 
@@ -968,11 +1289,10 @@ class AllPrintArguments(Transformer):
         return []
 
     def text(self, args):
-        return ''.join(args)
+        return "".join(args)
 
 
-
-def all_print_arguments(input_string, level, lang='en'):
+def all_print_arguments(input_string, level, lang="en"):
     input_string = process_input_string(input_string, level)
     program_root = parse_input(input_string, level, lang)
 
@@ -995,82 +1315,103 @@ class IsValid(Filter):
             text = args[1][1]
         else:
             text = args[0][1]
-        return False, InvalidInfo("print without quotes", arguments=[text], line=args[0][2].line, column=args[0][2].column), meta
+        return (
+            False,
+            InvalidInfo("print without quotes", arguments=[text], line=args[0][2].line, column=args[0][2].column),
+            meta,
+        )
 
     def error_invalid(self, meta, args):
         # TODO: this will not work for misspelling 'at', needs to be improved!
 
-        error = InvalidInfo('invalid command', command=args[0][1], arguments=[[a[1] for a in args[1:]]], line=meta.line, column=meta.column)
+        error = InvalidInfo(
+            "invalid command",
+            command=args[0][1],
+            arguments=[[a[1] for a in args[1:]]],
+            line=meta.line,
+            column=meta.column,
+        )
         return False, error, meta
 
     def error_unsupported_number(self, meta, args):
-        error = InvalidInfo('unsupported number', arguments=[str(args[0])], line=meta.line, column=meta.column)
+        error = InvalidInfo("unsupported number", arguments=[str(args[0])], line=meta.line, column=meta.column)
         return False, error, meta
 
     def error_condition(self, meta, args):
-        error = InvalidInfo('invalid condition', arguments=[str(args[0])], line=meta.line, column=meta.column)
+        error = InvalidInfo("invalid condition", arguments=[str(args[0])], line=meta.line, column=meta.column)
         return False, error, meta
 
     def error_repeat_no_command(self, meta, args):
-        error = InvalidInfo('invalid repeat', arguments=[str(args[0])], line=meta.line, column=meta.column)
+        error = InvalidInfo("invalid repeat", arguments=[str(args[0])], line=meta.line, column=meta.column)
         return False, error, meta
 
     def error_repeat_no_print(self, meta, args):
-        error = InvalidInfo('repeat missing print', arguments=[str(args[0])], line=meta.line, column=meta.column)
+        error = InvalidInfo("repeat missing print", arguments=[str(args[0])], line=meta.line, column=meta.column)
         return False, error, meta
 
     def error_repeat_no_times(self, meta, args):
-        error = InvalidInfo('repeat missing times', arguments=[str(args[0])], line=meta.line, column=meta.column)
+        error = InvalidInfo("repeat missing times", arguments=[str(args[0])], line=meta.line, column=meta.column)
         return False, error, meta
-    #other rules are inherited from Filter
+
+    # other rules are inherited from Filter
+
 
 def valid_echo(ast):
     commands = ast.children
     command_names = [x.children[0].data for x in commands]
-    no_echo = not 'echo' in command_names
+    no_echo = not "echo" in command_names
 
-    #no echo is always ok!
+    # no echo is always ok!
 
-    #otherwise, both have to be in the list and echo shold come after
-    return no_echo or ('echo' in command_names and 'ask' in command_names) and command_names.index('echo') > command_names.index('ask')
+    # otherwise, both have to be in the list and echo shold come after
+    return (
+        no_echo
+        or ("echo" in command_names and "ask" in command_names)
+        and command_names.index("echo") > command_names.index("ask")
+    )
+
 
 @v_args(meta=True)
 class IsComplete(Filter):
     def __init__(self, level):
         self.level = level
+
     # print, ask and echo can miss arguments and then are not complete
     # used to generate more informative error messages
     # tree is transformed to a node of [True] or [False, args, line_number]
-
 
     def ask(self, meta, args):
         # in level 1 ask without arguments means args == []
         # in level 2 and up, ask without arguments is a list of 1, namely the var name
         incomplete = (args == [] and self.level == 1) or (len(args) == 1 and self.level >= 2)
         if meta is not None:
-            return not incomplete, ('ask', meta.line)
+            return not incomplete, ("ask", meta.line)
         else:
-            return not incomplete, ('ask', 1)
+            return not incomplete, ("ask", 1)
 
     def print(self, meta, args):
-        return args != [], ('print', meta.line)
+        return args != [], ("print", meta.line)
+
     def input(self, meta, args):
-        return len(args) > 1, ('input', meta.line)
+        return len(args) > 1, ("input", meta.line)
 
     def length(self, meta, args):
-        return args != [], ('len', meta.line)
-    def error_print_nq(self, meta, args):
-        return args != [], ('print level 2', meta.line)
-    def echo(self, meta, args):
-        #echo may miss an argument
-        return True, ('echo', meta.line)
+        return args != [], ("len", meta.line)
 
-    #other rules are inherited from Filter
+    def error_print_nq(self, meta, args):
+        return args != [], ("print level 2", meta.line)
+
+    def echo(self, meta, args):
+        # echo may miss an argument
+        return True, ("echo", meta.line)
+
+    # other rules are inherited from Filter
+
 
 def process_characters_needing_escape(value):
     # defines what happens if a kids uses ' or \ in in a string
     for c in characters_that_need_escaping:
-        value = value.replace(c, f'\\{c}')
+        value = value.replace(c, f"\\{c}")
     return value
 
 
@@ -1087,7 +1428,9 @@ def hedy_transpiler(level):
         TRANSPILER_LOOKUP[level] = c
         c.level = level
         return c
+
     return decorator
+
 
 @v_args(meta=True)
 class ConvertToPython(Transformer):
@@ -1104,7 +1447,9 @@ class ConvertToPython(Transformer):
         if variable_name in all_names and not variable_name in all_names_before_access_line:
             # referenced before assignment!
             definition_line_number = [a.linenumber for a in self.lookup if a.name == variable_name][0]
-            raise hedy.exceptions.AccessBeforeAssign(name=variable_name, access_line_number=access_line_number, definition_line_number=definition_line_number)
+            raise hedy.exceptions.AccessBeforeAssign(
+                name=variable_name, access_line_number=access_line_number, definition_line_number=definition_line_number
+            )
 
         return escape_var(variable_name) in all_names_before_access_line
 
@@ -1132,7 +1477,7 @@ class ConvertToPython(Transformer):
             return f"{name}.zfill(100)"
 
     def make_f_string(self, args):
-        argument_string = ''
+        argument_string = ""
         for argument in args:
             if self.is_variable(argument):
                 # variables are placed in {} in the f string
@@ -1141,25 +1486,23 @@ class ConvertToPython(Transformer):
                 # strings are written regularly
                 # however we no longer need the enclosing quotes in the f-string
                 # the quotes are only left on the argument to check if they are there.
-                argument_string += argument.replace("'", '')
+                argument_string += argument.replace("'", "")
 
         return f"print(f'{argument_string}')"
 
     def get_fresh_var(self, name):
         while self.is_variable(name):
-            name = '_' + name
+            name = "_" + name
         return name
 
-    def check_var_usage(self, args, var_access_linenumber = 100):
+    def check_var_usage(self, args, var_access_linenumber=100):
         # this function checks whether arguments are valid
         # we can proceed if all arguments are either quoted OR all variables
 
         def is_var_candidate(arg) -> bool:
-            return not isinstance(arg, Tree) and \
-                    not ConvertToPython.is_int(arg) and \
-                    not ConvertToPython.is_float(arg)
+            return not isinstance(arg, Tree) and not ConvertToPython.is_int(arg) and not ConvertToPython.is_float(arg)
 
-        args_to_process = [a for a in args if is_var_candidate(a)] #we do not check trees (calcs) they are always ok
+        args_to_process = [a for a in args if is_var_candidate(a)]  # we do not check trees (calcs) they are always ok
 
         unquoted_args = [a for a in args_to_process if not ConvertToPython.is_quoted(a)]
         unquoted_in_lookup = [self.is_variable(a, var_access_linenumber) for a in unquoted_args]
@@ -1196,34 +1539,34 @@ class ConvertToPython(Transformer):
 
     @staticmethod
     def is_random(s):
-        return 'random.choice' in s
+        return "random.choice" in s
 
     @staticmethod
     def indent(s):
-        lines = s.split('\n')
-        return '\n'.join(['  ' + l for l in lines])
+        lines = s.split("\n")
+        return "\n".join(["  " + l for l in lines])
 
 
 @v_args(meta=True)
 @hedy_transpiler(level=1)
 class ConvertToPython_1(ConvertToPython):
-
     def __init__(self, lookup, numerals_language):
         self.numerals_language = numerals_language
         self.lookup = lookup
         __class__.level = 1
 
     def program(self, meta, args):
-        return '\n'.join([str(c) for c in args])
+        return "\n".join([str(c) for c in args])
+
     def command(self, meta, args):
         return args[0]
 
     def text(self, meta, args):
-        return ''.join([str(c) for c in args])
+        return "".join([str(c) for c in args])
 
     def integer(self, meta, args):
-        # remove whitespaces        
-        return str(int(args[0].replace(' ', '')))
+        # remove whitespaces
+        return str(int(args[0].replace(" ", "")))
 
     def number(self, meta, args):
         return str(int(args[0]))
@@ -1242,7 +1585,7 @@ class ConvertToPython_1(ConvertToPython):
 
     def echo(self, meta, args):
         if len(args) == 0:
-            return "print(answer)" #no arguments, just print answer
+            return "print(answer)"  # no arguments, just print answer
 
         argument = process_characters_needing_escape(args[0])
         return "print('" + argument + " '+answer)"
@@ -1252,7 +1595,7 @@ class ConvertToPython_1(ConvertToPython):
 
     def forward(self, meta, args):
         if len(args) == 0:
-            return sleep_after('t.forward(50)', False)
+            return sleep_after("t.forward(50)", False)
         return self.make_forward(int(args[0]))
 
     def color(self, meta, args):
@@ -1264,65 +1607,78 @@ class ConvertToPython_1(ConvertToPython):
             return f"t.pencolor('{arg}')"
         else:
             # the TypeValidator should protect against reaching this line:
-            raise exceptions.InvalidArgumentTypeException(command=Command.color, invalid_type='', invalid_argument=arg,
-                                                          allowed_types=get_allowed_types(Command.color, self.level))
+            raise exceptions.InvalidArgumentTypeException(
+                command=Command.color,
+                invalid_type="",
+                invalid_argument=arg,
+                allowed_types=get_allowed_types(Command.color, self.level),
+            )
 
     def turn(self, meta, args):
         if len(args) == 0:
             return "t.right(90)"  # no arguments defaults to a right turn
 
         arg = args[0].data
-        if arg == 'left':
+        if arg == "left":
             return "t.left(90)"
-        elif arg == 'right':
+        elif arg == "right":
             return "t.right(90)"
         else:
             # the TypeValidator should protect against reaching this line:
-            raise exceptions.InvalidArgumentTypeException(command=Command.turn, invalid_type='', invalid_argument=arg,
-                                                          allowed_types=get_allowed_types(Command.turn, self.level))
+            raise exceptions.InvalidArgumentTypeException(
+                command=Command.turn,
+                invalid_type="",
+                invalid_argument=arg,
+                allowed_types=get_allowed_types(Command.turn, self.level),
+            )
 
     def make_turn(self, parameter):
-        return self.make_turtle_command(parameter, Command.turn, 'right', False)
+        return self.make_turtle_command(parameter, Command.turn, "right", False)
 
     def make_forward(self, parameter):
-        return self.make_turtle_command(parameter, Command.forward, 'forward', True)
+        return self.make_turtle_command(parameter, Command.forward, "forward", True)
 
     def make_color(self, parameter):
-        return self.make_turtle_color_command(parameter, Command.color, 'pencolor')
+        return self.make_turtle_color_command(parameter, Command.color, "pencolor")
 
     def make_turtle_command(self, parameter, command, command_text, add_sleep):
-        variable = self.get_fresh_var('trtl')
-        transpiled = textwrap.dedent(f"""\
+        variable = self.get_fresh_var("trtl")
+        transpiled = textwrap.dedent(
+            f"""\
             {variable} = {parameter}
             try:
               {variable} = int({variable})
             except ValueError:
               raise Exception(f'While running your program the command {style_closest_command(command)} received the value {style_closest_command('{'+variable+'}')} which is not allowed. Try changing the value to a number.')
-            t.{command_text}(min(600, {variable}) if {variable} > 0 else max(-600, {variable}))""")
+            t.{command_text}(min(600, {variable}) if {variable} > 0 else max(-600, {variable}))"""
+        )
         if add_sleep:
             return sleep_after(transpiled, False)
         return transpiled
 
     def make_turtle_color_command(self, parameter, command, command_text):
-        variable = self.get_fresh_var('trtl')
-        return textwrap.dedent(f"""\
+        variable = self.get_fresh_var("trtl")
+        return textwrap.dedent(
+            f"""\
             {variable} = f'{parameter}'
             if {variable} not in {command_make_color}:
               raise Exception(f'While running your program the command {style_closest_command(command)} received the value {style_closest_command('{' + variable + '}')} which is not allowed. Try using another color.')
-            t.{command_text}({variable})""")
+            t.{command_text}({variable})"""
+        )
+
 
 @v_args(meta=True)
 @hedy_transpiler(level=2)
 class ConvertToPython_2(ConvertToPython_1):
-
     def error_ask_dep_2(self, meta, args):
         # ask is no longer usable this way, raise!
         # ask_needs_var is an entry in lang.yaml in texts where we can add extra info on this error
-        raise hedy.exceptions.WrongLevelException(1, 'ask', "ask_needs_var")
+        raise hedy.exceptions.WrongLevelException(1, "ask", "ask_needs_var")
+
     def error_echo_dep_2(self, meta, args):
         # echo is no longer usable this way, raise!
         # ask_needs_var is an entry in lang.yaml in texts where we can add extra info on this error
-        raise hedy.exceptions.WrongLevelException(1,  'echo', "echo_out")
+        raise hedy.exceptions.WrongLevelException(1, "echo", "echo_out")
 
     def color(self, meta, args):
         if len(args) == 0:
@@ -1353,7 +1709,6 @@ class ConvertToPython_2(ConvertToPython_1):
         self.check_var_usage(args, meta.line)
         return escape_var(name)
 
-
     def var_access_print(self, meta, args):
         return self.var_access(meta, args)
 
@@ -1369,21 +1724,24 @@ class ConvertToPython_2(ConvertToPython_1):
             if "random.choice" in a or "[" in a:
                 args_new.append(self.process_variable_for_fstring(a, meta.line))
             else:
-                res = regex.findall(r"[\p{Lu}\p{Ll}\p{Lt}\p{Lm}\p{Lo}\p{Nl}\p{Mn}\p{Mc}\p{Nd}\p{Pc}]+|[^\p{Lu}\p{Ll}\p{Lt}\p{Lm}\p{Lo}\p{Nl}]+", a)
-                args_new.append(''.join([self.process_variable_for_fstring(x, meta.line) for x in res]))
+                res = regex.findall(
+                    r"[\p{Lu}\p{Ll}\p{Lt}\p{Lm}\p{Lo}\p{Nl}\p{Mn}\p{Mc}\p{Nd}\p{Pc}]+|[^\p{Lu}\p{Ll}\p{Lt}\p{Lm}\p{Lo}\p{Nl}]+",
+                    a,
+                )
+                args_new.append("".join([self.process_variable_for_fstring(x, meta.line) for x in res]))
 
-        argument_string = ' '.join(args_new)
+        argument_string = " ".join(args_new)
 
         return f"print(f'{argument_string}')"
 
     def ask(self, meta, args):
         var = args[0]
         all_parameters = ["'" + process_characters_needing_escape(a) + "'" for a in args[1:]]
-        return f'{var} = input(' + '+'.join(all_parameters) + ")"
+        return f"{var} = input(" + "+".join(all_parameters) + ")"
 
     def forward(self, meta, args):
         if len(args) == 0:
-            return sleep_after('t.forward(50)', False)
+            return sleep_after("t.forward(50)", False)
 
         if ConvertToPython.is_int(args[0]):
             parameter = int(args[0])
@@ -1412,11 +1770,13 @@ class ConvertToPython_2(ConvertToPython_1):
             return "time.sleep(1)"
         else:
             value = f'"{args[0]}"' if self.is_int(args[0]) else args[0]
-            return textwrap.dedent(f"""\
+            return textwrap.dedent(
+                f"""\
                 try:
                   time.sleep(int({value}))
                 except ValueError:
-                  raise Exception(f'While running your program the command {style_closest_command(Command.sleep)} received the value {style_closest_command('{' + value + '}')} which is not allowed. Try changing the value to a number.')""")
+                  raise Exception(f'While running your program the command {style_closest_command(Command.sleep)} received the value {style_closest_command('{' + value + '}')} which is not allowed. Try changing the value to a number.')"""
+            )
 
 
 @v_args(meta=True)
@@ -1431,12 +1791,12 @@ class ConvertToPython_3(ConvertToPython_2):
         args = [escape_var(a) for a in args]
 
         # check the arguments (except when they are random or numbers, that is not quoted nor a var but is allowed)
-        self.check_var_usage([a for a in args if a != 'random' and not a.isnumeric()], meta.line)
+        self.check_var_usage([a for a in args if a != "random" and not a.isnumeric()], meta.line)
 
-        if args[1] == 'random':
-            return 'random.choice(' + args[0] + ')'
+        if args[1] == "random":
+            return "random.choice(" + args[0] + ")"
         else:
-            return args[0] + '[' + args[1] + '-1]'
+            return args[0] + "[" + args[1] + "-1]"
 
     def add(self, meta, args):
         value = self.process_variable(args[0], meta.line)
@@ -1446,17 +1806,18 @@ class ConvertToPython_3(ConvertToPython_2):
     def remove(self, meta, args):
         value = self.process_variable(args[0], meta.line)
         list_var = args[1]
-        return textwrap.dedent(f"""\
+        return textwrap.dedent(
+            f"""\
         try:
           {list_var}.remove({value})
         except:
-          pass""")
+          pass"""
+        )
 
 
 @v_args(meta=True)
 @hedy_transpiler(level=4)
 class ConvertToPython_4(ConvertToPython_3):
-
     def process_variable_for_fstring(self, name):
         if self.is_variable(name):
             if self.numerals_language == "Latin":
@@ -1479,7 +1840,7 @@ class ConvertToPython_4(ConvertToPython_3):
 
     def print_ask_args(self, meta, args):
         args = self.check_var_usage(args, meta.line)
-        result = ''
+        result = ""
         for argument in args:
             argument = self.process_variable_for_fstring(argument)
             result += argument
@@ -1504,9 +1865,9 @@ class ConvertToPython_5(ConvertToPython_4):
     def list_access_var(self, meta, args):
         var = escape_var(args[0])
         if isinstance(args[2], Tree):
-            return var + ' = random.choice(' + args[1] + ')'
+            return var + " = random.choice(" + args[1] + ")"
         else:
-            return var + ' = ' + args[1] + '[' + args[2] + '-1]'
+            return var + " = " + args[1] + "[" + args[2] + "-1]"
 
     def ifs(self, meta, args):
         return f"""if {args[0]}:
@@ -1519,33 +1880,33 @@ else:
 {ConvertToPython.indent(args[2])}"""
 
     def condition(self, meta, args):
-        return ' and '.join(args)
+        return " and ".join(args)
 
     def condition_spaces(self, meta, args):
         arg0 = self.process_variable(args[0], meta.line)
-        arg1 = self.process_variable(' '.join(args[1:]))
+        arg1 = self.process_variable(" ".join(args[1:]))
         return f"{arg0} == {arg1}"
 
     def equality_check(self, meta, args):
         arg0 = self.process_variable(args[0], meta.line)
-        arg1 = ' '.join([self.process_variable(a) for a in args[1:]])
+        arg1 = " ".join([self.process_variable(a) for a in args[1:]])
         return f"{arg0} == {arg1}"
-        #TODO, FH 2021: zelfde change moet ik ook nog ff maken voor equal. check in hogere levels
+        # TODO, FH 2021: zelfde change moet ik ook nog ff maken voor equal. check in hogere levels
 
     def in_list_check(self, meta, args):
         arg0 = self.process_variable(args[0], meta.line)
         arg1 = self.process_variable(args[1], meta.line)
         return f"{arg0} in {arg1}"
 
+
 @v_args(meta=True)
 @hedy_transpiler(level=6)
 class ConvertToPython_6(ConvertToPython_5):
-
     def print_ask_args(self, meta, args):
         # we only check non-Tree (= non calculation) arguments
         self.check_var_usage(args, meta.line)
 
-        #force all to be printed as strings (since there can not be int arguments)
+        # force all to be printed as strings (since there can not be int arguments)
         args_new = []
         for a in args:
             if isinstance(a, Tree):
@@ -1557,11 +1918,11 @@ class ConvertToPython_6(ConvertToPython_5):
             else:
                 args_new.append(self.process_variable_for_fstring(a))
 
-        return ''.join(args_new)
+        return "".join(args_new)
 
     def equality_check(self, meta, args):
         arg0 = self.process_variable(args[0], meta.line)
-        remaining_text = ' '.join(args[1:])
+        remaining_text = " ".join(args[1:])
         arg1 = self.process_variable(remaining_text, meta.line)
 
         # FH, 2022 this used to be str but convert_numerals in needed to accept non-latin numbers
@@ -1584,11 +1945,11 @@ class ConvertToPython_6(ConvertToPython_5):
 
     def process_token_or_tree(self, argument):
         if type(argument) is Tree:
-            return f'{str(argument.children[0])}'
+            return f"{str(argument.children[0])}"
         if argument.isnumeric():
             latin_numeral = int(argument)
-            return f'int({latin_numeral})'
-        return f'int({argument})'
+            return f"int({latin_numeral})"
+        return f"int({argument})"
 
     def process_calculation(self, args, operator):
         # arguments of a sum are either a token or a
@@ -1597,33 +1958,35 @@ class ConvertToPython_6(ConvertToPython_5):
         # for tokens we add int around them
 
         args = [self.process_token_or_tree(a) for a in args]
-        return Tree('sum', [f'{args[0]} {operator} {args[1]}'])
+        return Tree("sum", [f"{args[0]} {operator} {args[1]}"])
 
     def addition(self, meta, args):
-        return self.process_calculation(args, '+')
+        return self.process_calculation(args, "+")
 
     def subtraction(self, meta, args):
-        return self.process_calculation(args, '-')
+        return self.process_calculation(args, "-")
 
     def multiplication(self, meta, args):
-        return self.process_calculation(args, '*')
+        return self.process_calculation(args, "*")
 
     def division(self, meta, args):
-        return self.process_calculation(args, '//')
+        return self.process_calculation(args, "//")
+
 
 def sleep_after(commands, indent=True):
     lines = commands.split()
-    if lines[-1] == "time.sleep(0.1)": #we don't sleep double so skip if final line is a sleep already
+    if lines[-1] == "time.sleep(0.1)":  # we don't sleep double so skip if final line is a sleep already
         return commands
 
     sleep_command = "time.sleep(0.1)" if indent is False else "  time.sleep(0.1)"
     return commands + "\n" + sleep_command
 
+
 @v_args(meta=True)
 @hedy_transpiler(level=7)
 class ConvertToPython_7(ConvertToPython_6):
     def repeat(self, meta, args):
-        var_name = self.get_fresh_var('i')
+        var_name = self.get_fresh_var("i")
         times = self.process_variable(args[0], meta.line)
         command = args[1]
         # in level 7, repeats can only have 1 line as their arguments
@@ -1631,12 +1994,12 @@ class ConvertToPython_7(ConvertToPython_6):
         return f"""for {var_name} in range(int({str(times)})):
 {ConvertToPython.indent(command)}"""
 
+
 @v_args(meta=True)
 @hedy_transpiler(level=8)
 @v_args(meta=True)
 @hedy_transpiler(level=9)
 class ConvertToPython_8_9(ConvertToPython_7):
-
     def command(self, meta, args):
         return "".join(args)
 
@@ -1644,7 +2007,7 @@ class ConvertToPython_8_9(ConvertToPython_7):
         # todo fh, may 2022, could be merged with 7 if we make
         # indent a boolean parameter?
 
-        var_name = self.get_fresh_var('i')
+        var_name = self.get_fresh_var("i")
         times = self.process_variable(args[0], meta.line)
 
         all_lines = [ConvertToPython.indent(x) for x in args[1:]]
@@ -1654,41 +2017,47 @@ class ConvertToPython_8_9(ConvertToPython_7):
         return f"for {var_name} in range(int({times})):\n{body}"
 
     def ifs(self, meta, args):
-        args = [a for a in args if a != ""] # filter out in|dedent tokens
+        args = [a for a in args if a != ""]  # filter out in|dedent tokens
 
         all_lines = [ConvertToPython.indent(x) for x in args[1:]]
 
         return "if " + args[0] + ":\n" + "\n".join(all_lines)
 
     def elses(self, meta, args):
-        args = [a for a in args if a != ""] # filter out in|dedent tokens
+        args = [a for a in args if a != ""]  # filter out in|dedent tokens
 
         all_lines = [ConvertToPython.indent(x) for x in args]
 
         return "\nelse:\n" + "\n".join(all_lines)
 
     def var_access(self, meta, args):
-        if len(args) == 1: #accessing a var
+        if len(args) == 1:  # accessing a var
             return escape_var(args[0])
         else:
-        # this is list_access
-            return escape_var(args[0]) + "[" + str(escape_var(args[1])) + "]" if type(args[1]) is not Tree else "random.choice(" + str(escape_var(args[0])) + ")"
+            # this is list_access
+            return (
+                escape_var(args[0]) + "[" + str(escape_var(args[1])) + "]"
+                if type(args[1]) is not Tree
+                else "random.choice(" + str(escape_var(args[0])) + ")"
+            )
 
     def var_access_print(self, meta, args):
         return self.var_access(meta, args)
+
 
 @v_args(meta=True)
 @hedy_transpiler(level=10)
 class ConvertToPython_10(ConvertToPython_8_9):
     def for_list(self, meta, args):
-      args = [a for a in args if a != ""]  # filter out in|dedent tokens
-      times = self.process_variable(args[0], meta.line)
+        args = [a for a in args if a != ""]  # filter out in|dedent tokens
+        times = self.process_variable(args[0], meta.line)
 
-      body = "\n".join([ConvertToPython.indent(x) for x in args[2:]])
+        body = "\n".join([ConvertToPython.indent(x) for x in args[2:]])
 
-      body = sleep_after(body, True)
+        body = sleep_after(body, True)
 
-      return f"for {times} in {args[1]}:\n{body}"
+        return f"for {times} in {args[1]}:\n{body}"
+
 
 @v_args(meta=True)
 @hedy_transpiler(level=11)
@@ -1698,14 +2067,12 @@ class ConvertToPython_11(ConvertToPython_10):
         iterator = escape_var(args[0])
         body = "\n".join([ConvertToPython.indent(x) for x in args[3:]])
         body = sleep_after(body)
-        stepvar_name = self.get_fresh_var('step')
+        stepvar_name = self.get_fresh_var("step")
         begin = self.process_token_or_tree(args[1])
         end = self.process_token_or_tree(args[2])
         return f"""{stepvar_name} = 1 if {begin} < {end} else -1
 for {iterator} in range({begin}, {end} + {stepvar_name}, {stepvar_name}):
 {body}"""
-
-
 
 
 @v_args(meta=True)
@@ -1716,19 +2083,19 @@ class ConvertToPython_12(ConvertToPython_11):
         try:
             all_int = [str(int(x)) == x for x in args]
             if all(all_int):
-                return ''.join(args)
+                return "".join(args)
             else:
                 # int succeeds but does nto return the same? these are non-latin numbers
                 # and need to be casted
-                return ''.join([str(int(x)) for x in args])
+                return "".join([str(int(x)) for x in args])
         except Exception as E:
             # if not? make into all floats
             numbers = [str(float(x)) for x in args]
-            return ''.join(numbers)
+            return "".join(numbers)
 
     def NEGATIVE_NUMBER(self, meta, args):
         numbers = [str(float(x)) for x in args]
-        return ''.join(numbers)
+        return "".join(numbers)
 
     def text_in_quotes(self, meta, args):
         # We need to re-add the quotes, so that the Python code becomes name = 'Jan' or "Jan's"
@@ -1739,7 +2106,7 @@ class ConvertToPython_12(ConvertToPython_11):
 
     def process_token_or_tree(self, argument):
         if isinstance(argument, Tree):
-            return f'{str(argument.children[0])}'
+            return f"{str(argument.children[0])}"
         else:
             return argument
 
@@ -1758,7 +2125,8 @@ class ConvertToPython_12(ConvertToPython_11):
         argument_string = self.print_ask_args(meta, args[1:])
         assign = f"{var} = input(f'''{argument_string}''')"
 
-        return textwrap.dedent(f"""\
+        return textwrap.dedent(
+            f"""\
         {assign}
         try:
           {var} = int({var})
@@ -1766,7 +2134,8 @@ class ConvertToPython_12(ConvertToPython_11):
           try:
             {var} = float({var})
           except ValueError:
-            pass""")  # no number? leave as string
+            pass"""
+        )  # no number? leave as string
 
     def assign_list(self, meta, args):
         parameter = args[0]
@@ -1781,12 +2150,18 @@ class ConvertToPython_12(ConvertToPython_11):
         # either a var or quoted, if it is not (and undefined var is raised)
         # the real issue is probably that the kid forgot quotes
         try:
-            self.check_var_usage([right_hand_side], meta.line) #check_var_usage expects a list of arguments so place this one in a list.
+            self.check_var_usage(
+                [right_hand_side], meta.line
+            )  # check_var_usage expects a list of arguments so place this one in a list.
         except exceptions.UndefinedVarException as E:
             # is the text a number? then no quotes are fine. if not, raise maar!
 
-            if not (ConvertToPython.is_int(right_hand_side) or ConvertToPython.is_float(right_hand_side) or ConvertToPython.is_random(right_hand_side)):
-                raise exceptions.UnquotedAssignTextException(text = args[1])
+            if not (
+                ConvertToPython.is_int(right_hand_side)
+                or ConvertToPython.is_float(right_hand_side)
+                or ConvertToPython.is_random(right_hand_side)
+            ):
+                raise exceptions.UnquotedAssignTextException(text=args[1])
 
         if isinstance(right_hand_side, Tree):
             return left_hand_side + " = " + right_hand_side.children[0]
@@ -1799,13 +2174,16 @@ class ConvertToPython_12(ConvertToPython_11):
         self.check_var_usage(args, meta.line)
         return escape_var(name)
 
+
 @v_args(meta=True)
 @hedy_transpiler(level=13)
 class ConvertToPython_13(ConvertToPython_12):
     def and_condition(self, meta, args):
-        return ' and '.join(args)
+        return " and ".join(args)
+
     def or_condition(self, meta, args):
-        return ' or '.join(args)
+        return " or ".join(args)
+
 
 @v_args(meta=True)
 @hedy_transpiler(level=14)
@@ -1847,6 +2225,7 @@ class ConvertToPython_14(ConvertToPython_13):
     def not_equal(self, meta, args):
         return self.process_comparison(meta, args, "!=")
 
+
 @v_args(meta=True)
 @hedy_transpiler(level=15)
 class ConvertToPython_15(ConvertToPython_14):
@@ -1857,6 +2236,7 @@ class ConvertToPython_15(ConvertToPython_14):
         body = sleep_after(body)
         return "while " + args[0] + ":\n" + body
 
+
 @v_args(meta=True)
 @hedy_transpiler(level=16)
 class ConvertToPython_16(ConvertToPython_15):
@@ -1866,7 +2246,8 @@ class ConvertToPython_16(ConvertToPython_15):
         return parameter + " = [" + ", ".join(values) + "]"
 
     def change_list_item(self, meta, args):
-        return args[0] + '[' + args[1] + '-1] = ' + args[2]
+        return args[0] + "[" + args[1] + "-1] = " + args[2]
+
 
 @v_args(meta=True)
 @hedy_transpiler(level=17)
@@ -1875,6 +2256,7 @@ class ConvertToPython_17(ConvertToPython_16):
         args = [a for a in args if a != ""]  # filter out in|dedent tokens
         all_lines = [ConvertToPython.indent(x) for x in args[1:]]
         return "\nelif " + args[0] + ":\n" + "\n".join(all_lines)
+
 
 @v_args(meta=True)
 @hedy_transpiler(level=18)
@@ -1892,7 +2274,8 @@ class ConvertToPython_18(ConvertToPython_17):
         return self.input(meta, args)
 
     def print_empty_brackets(self, meta, args):
-        return self.print(meta,args)
+        return self.print(meta, args)
+
 
 def merge_grammars(grammar_text_1, grammar_text_2, level):
     # this function takes two grammar files and merges them into one
@@ -1901,33 +2284,35 @@ def merge_grammars(grammar_text_1, grammar_text_2, level):
 
     merged_grammar = []
 
-    rules_grammar_1 = grammar_text_1.split('\n')
-    remaining_rules_grammar_2 = grammar_text_2.split('\n')
+    rules_grammar_1 = grammar_text_1.split("\n")
+    remaining_rules_grammar_2 = grammar_text_2.split("\n")
     for line_1 in rules_grammar_1:
-        if line_1 == '' or line_1[0] == '/': #skip comments and empty lines:
+        if line_1 == "" or line_1[0] == "/":  # skip comments and empty lines:
             continue
-        parts = line_1.split(':')
-        name_1, definition_1 = parts[0], ''.join(parts[1:]) #get part before are after : (this is a join because there can be : in the rule)
+        parts = line_1.split(":")
+        name_1, definition_1 = parts[0], "".join(
+            parts[1:]
+        )  # get part before are after : (this is a join because there can be : in the rule)
 
-        rules_grammar_2 = grammar_text_2.split('\n')
+        rules_grammar_2 = grammar_text_2.split("\n")
         override_found = False
         for line_2 in rules_grammar_2:
-            if line_2 == '' or line_2[0] == '/':  # skip comments and empty lines:
-                continue            
-            
-            needs_preprocessing = re.match(r'((\w|_)+)<((\w|_)+)>', line_2)
-            if needs_preprocessing:                
-                name_2 = f'{needs_preprocessing.group(1)}'                
+            if line_2 == "" or line_2[0] == "/":  # skip comments and empty lines:
+                continue
+
+            needs_preprocessing = re.match(r"((\w|_)+)<((\w|_)+)>", line_2)
+            if needs_preprocessing:
+                name_2 = f"{needs_preprocessing.group(1)}"
                 processor = needs_preprocessing.group(3)
-            else:                
-                parts = line_2.split(':')
-                name_2, definition_2 = parts[0], ''.join(parts[1]) #get part before are after :
+            else:
+                parts = line_2.split(":")
+                name_2, definition_2 = parts[0], "".join(parts[1])  # get part before are after :
 
             if name_1 == name_2:
                 override_found = True
                 if needs_preprocessing:
                     definition_2 = PREPROCESS_RULES[processor](definition_1)
-                    line_2_processed = f'{name_2}: {definition_2}'
+                    line_2_processed = f"{name_2}: {definition_2}"
                 else:
                     line_2_processed = line_2
                 if definition_1.strip() == definition_2.strip():
@@ -1936,7 +2321,7 @@ def merge_grammars(grammar_text_1, grammar_text_2, level):
                 # Used to compute the rules that use the merge operators in the grammar
                 # namely +=, -= and >
                 new_rule = merge_rules_operator(definition_1, definition_2, name_1, line_2_processed)
-                #Already procesed so remove it
+                # Already procesed so remove it
                 remaining_rules_grammar_2.remove(line_2)
                 break
         # new rule found? print that. nothing found? print org rule
@@ -1945,33 +2330,34 @@ def merge_grammars(grammar_text_1, grammar_text_2, level):
         else:
             merged_grammar.append(line_1)
 
-    #all rules that were not overlapping are new in the grammar, add these too
+    # all rules that were not overlapping are new in the grammar, add these too
     for rule in remaining_rules_grammar_2:
-        if not(rule == '' or rule[0] == '/'):
+        if not (rule == "" or rule[0] == "/"):
             merged_grammar.append(rule)
 
     merged_grammar = sorted(merged_grammar)
-    return '\n'.join(merged_grammar)
+    return "\n".join(merged_grammar)
+
 
 def merge_rules_operator(prev_definition, new_definition, name, complete_line):
-    # Check if the rule is adding or substracting new rules                
-    has_add_op = new_definition.startswith('+=')
-    has_sub_op = has_add_op and '-=' in new_definition
-    has_last_op = has_add_op and '>' in new_definition
+    # Check if the rule is adding or substracting new rules
+    has_add_op = new_definition.startswith("+=")
+    has_sub_op = has_add_op and "-=" in new_definition
+    has_last_op = has_add_op and ">" in new_definition
     if has_sub_op:
         # Get the rules we need to substract
-        part_list = new_definition.split('-=')
-        add_list, sub_list =  (part_list[0], part_list[1]) if has_sub_op else (part_list[0], '')
-        add_list = add_list[3:]  
+        part_list = new_definition.split("-=")
+        add_list, sub_list = (part_list[0], part_list[1]) if has_sub_op else (part_list[0], "")
+        add_list = add_list[3:]
         # Get the rules that need to be last
-        sub_list = sub_list.split('>')  
-        sub_list, last_list = (sub_list[0], sub_list[1]) if has_last_op  else (sub_list[0], '')
-        sub_list = sub_list + '|' + last_list
+        sub_list = sub_list.split(">")
+        sub_list, last_list = (sub_list[0], sub_list[1]) if has_last_op else (sub_list[0], "")
+        sub_list = sub_list + "|" + last_list
         result_cmd_list = get_remaining_rules(prev_definition, sub_list)
     elif has_add_op:
-            # Get the rules that need to be last
-        part_list = new_definition.split('>')
-        add_list, sub_list =  (part_list[0], part_list[1]) if has_last_op else (part_list[0], '')
+        # Get the rules that need to be last
+        part_list = new_definition.split(">")
+        add_list, sub_list = (part_list[0], part_list[1]) if has_last_op else (part_list[0], "")
         add_list = add_list[3:]
         last_list = sub_list
         result_cmd_list = get_remaining_rules(prev_definition, sub_list)
@@ -1986,11 +2372,12 @@ def merge_rules_operator(prev_definition, new_definition, name, complete_line):
         new_rule = complete_line
     return new_rule
 
+
 def get_remaining_rules(orig_def, sub_def):
-    orig_cmd_list     = [command.strip() for command in orig_def.split('|')]
-    unwanted_cmd_list = [command.strip() for command in sub_def.split('|')]
-    result_cmd_list   = [cmd for cmd in orig_cmd_list if cmd not in unwanted_cmd_list]
-    result_cmd_list   = ' | '.join(result_cmd_list) # turn the result list into a string
+    orig_cmd_list = [command.strip() for command in orig_def.split("|")]
+    unwanted_cmd_list = [command.strip() for command in sub_def.split("|")]
+    result_cmd_list = [cmd for cmd in orig_cmd_list if cmd not in unwanted_cmd_list]
+    result_cmd_list = " | ".join(result_cmd_list)  # turn the result list into a string
     return result_cmd_list
 
 
@@ -2001,7 +2388,7 @@ def create_grammar(level, lang="en"):
 
     result = merge_grammars(result, keywords, 1)
     # then keep merging new grammars in
-    for i in range(2, level+1):
+    for i in range(2, level + 1):
         grammar_text_i = get_additional_rules_for_level(i)
         result = merge_grammars(result, grammar_text_i, i)
 
@@ -2010,6 +2397,7 @@ def create_grammar(level, lang="en"):
     save_total_grammar_file(level, result, lang)
 
     return result
+
 
 def save_total_grammar_file(level, grammar, lang):
     # Load Lark grammars relative to directory of current file
@@ -2020,7 +2408,8 @@ def save_total_grammar_file(level, grammar, lang):
     file.write(grammar)
     file.close()
 
-def get_additional_rules_for_level(level, sub = 0):
+
+def get_additional_rules_for_level(level, sub=0):
     script_dir = path.abspath(path.dirname(__file__))
     if sub:
         filename = "level" + str(level) + "-" + str(sub) + "-Additions.lark"
@@ -2030,12 +2419,14 @@ def get_additional_rules_for_level(level, sub = 0):
         grammar_text = file.read()
     return grammar_text
 
+
 def get_full_grammar_for_level(level):
     script_dir = path.abspath(path.dirname(__file__))
     filename = "level" + str(level) + ".lark"
     with open(path.join(script_dir, "grammars", filename), "r", encoding="utf-8") as file:
         grammar_text = file.read()
     return grammar_text
+
 
 # TODO FH, May 2022. I feel there are other places in the code where we also do this
 # opportunity to combine?
@@ -2053,6 +2444,7 @@ def get_keywords_for_language(language):
             keywords = file.read()
     return keywords
 
+
 PARSER_CACHE = {}
 
 
@@ -2061,48 +2453,51 @@ def get_parser(level, lang="en", keep_all_tokens=False):
 
     Uses caching if Hedy is NOT running in development mode.
     """
-    key = str(level) + "." + lang + '.' + str(keep_all_tokens)
+    key = str(level) + "." + lang + "." + str(keep_all_tokens)
     existing = PARSER_CACHE.get(key)
     if existing and not utils.is_debug_mode():
         return existing
     grammar = create_grammar(level, lang)
-    ret = Lark(grammar, regex=True, propagate_positions=True, keep_all_tokens=keep_all_tokens) #ambiguity='explicit'
+    ret = Lark(grammar, regex=True, propagate_positions=True, keep_all_tokens=keep_all_tokens)  # ambiguity='explicit'
     PARSER_CACHE[key] = ret
     return ret
 
-ParseResult = namedtuple('ParseResult', ['code', 'has_turtle'])
+
+ParseResult = namedtuple("ParseResult", ["code", "has_turtle"])
+
 
 def transpile(input_string, level, lang="en"):
     transpile_result = transpile_inner(input_string, level, lang)
     return transpile_result
 
+
 def translate_characters(s):
-# this method is used to make it more clear to kids what is meant in error messages
-# for example ' ' is hard to read, space is easier
-# this could (should?) be localized so we can call a ' "Hoge komma" for example (Felienne, dd Feb 25, 2021)
-    if s == ' ':
-        return 'space'
-    elif s == ',':
-        return 'comma'
-    elif s == '?':
-        return 'question mark'
-    elif s == '\n':
-        return 'newline'
-    elif s == '.':
-        return 'period'
-    elif s == '!':
-        return 'exclamation mark'
-    elif s == '*':
-        return 'star'
+    # this method is used to make it more clear to kids what is meant in error messages
+    # for example ' ' is hard to read, space is easier
+    # this could (should?) be localized so we can call a ' "Hoge komma" for example (Felienne, dd Feb 25, 2021)
+    if s == " ":
+        return "space"
+    elif s == ",":
+        return "comma"
+    elif s == "?":
+        return "question mark"
+    elif s == "\n":
+        return "newline"
+    elif s == ".":
+        return "period"
+    elif s == "!":
+        return "exclamation mark"
+    elif s == "*":
+        return "star"
     elif s == "'":
-        return 'single quotes'
+        return "single quotes"
     elif s == '"':
-        return 'double quotes'
-    elif s == '/':
-        return 'slash'
-    elif s == '-':
-        return 'dash'
-    elif s >= 'a' and s <= 'z' or s >= 'A' and s <= 'Z':
+        return "double quotes"
+    elif s == "/":
+        return "slash"
+    elif s == "-":
+        return "dash"
+    elif s >= "a" and s <= "z" or s >= "A" and s <= "Z":
         return s
     else:
         return s
@@ -2112,14 +2507,16 @@ def beautify_parse_error(character_found):
     character_found = translate_characters(character_found)
     return character_found
 
+
 def find_indent_length(line):
     number_of_spaces = 0
     for x in line:
-        if x == ' ':
+        if x == " ":
             number_of_spaces += 1
         else:
             break
     return number_of_spaces
+
 
 def needs_indentation(code):
     # this is done a bit half-assed, clearly *parsing* the one line would be superior
@@ -2133,13 +2530,12 @@ def needs_indentation(code):
     return first_keyword in indent_keywords
 
 
-
 def preprocess_blocks(code, level):
     processed_code = []
     lines = code.split("\n")
     current_number_of_indents = 0
     previous_number_of_indents = 0
-    indent_size = 4 # set at 4 for now
+    indent_size = 4  # set at 4 for now
     indent_size_adapted = False
     line_number = 0
     next_line_needs_indentation = False
@@ -2157,18 +2553,26 @@ def preprocess_blocks(code, level):
         if leading_spaces == len(line):
             continue
 
-        #calculate nuber of indents if possible
+        # calculate nuber of indents if possible
         if indent_size != None:
             if (leading_spaces % indent_size) != 0:
                 # there is inconsistent indentation, not sure if that is too much or too little!
                 if leading_spaces < current_number_of_indents * indent_size:
                     fixed_code = program_repair.fix_indent(code, line_number, leading_spaces, indent_size)
-                    raise hedy.exceptions.NoIndentationException(line_number=line_number, leading_spaces=leading_spaces,
-                                                                 indent_size=indent_size, fixed_code=fixed_code)
+                    raise hedy.exceptions.NoIndentationException(
+                        line_number=line_number,
+                        leading_spaces=leading_spaces,
+                        indent_size=indent_size,
+                        fixed_code=fixed_code,
+                    )
                 else:
                     fixed_code = program_repair.fix_indent(code, line_number, leading_spaces, indent_size)
-                    raise hedy.exceptions.IndentationException(line_number=line_number, leading_spaces=leading_spaces,
-                                                                 indent_size=indent_size, fixed_code=fixed_code)
+                    raise hedy.exceptions.IndentationException(
+                        line_number=line_number,
+                        leading_spaces=leading_spaces,
+                        indent_size=indent_size,
+                        fixed_code=fixed_code,
+                    )
 
             current_number_of_indents = leading_spaces // indent_size
             if current_number_of_indents > 1 and level == hedy.LEVEL_STARTING_INDENTATION:
@@ -2176,8 +2580,9 @@ def preprocess_blocks(code, level):
 
         if next_line_needs_indentation and current_number_of_indents <= previous_number_of_indents:
             fixed_code = program_repair.fix_indent(code, line_number, leading_spaces, indent_size)
-            raise hedy.exceptions.NoIndentationException(line_number=line_number, leading_spaces=leading_spaces,
-                                                         indent_size=indent_size, fixed_code=fixed_code)
+            raise hedy.exceptions.NoIndentationException(
+                line_number=line_number, leading_spaces=leading_spaces, indent_size=indent_size, fixed_code=fixed_code
+            )
 
         if needs_indentation(line):
             next_line_needs_indentation = True
@@ -2186,44 +2591,44 @@ def preprocess_blocks(code, level):
 
         if current_number_of_indents - previous_number_of_indents > 1:
             fixed_code = program_repair.fix_indent(code, line_number, leading_spaces, indent_size)
-            raise hedy.exceptions.IndentationException(line_number=line_number, leading_spaces=leading_spaces,
-                                            indent_size=indent_size, fixed_code=fixed_code)
-
-
+            raise hedy.exceptions.IndentationException(
+                line_number=line_number, leading_spaces=leading_spaces, indent_size=indent_size, fixed_code=fixed_code
+            )
 
         if current_number_of_indents < previous_number_of_indents:
             # we springen 'terug' dus er moeten end-blocken in
             # bij meerdere terugsprongen sluiten we ook meerdere blokken
 
-            difference_in_indents = (previous_number_of_indents - current_number_of_indents)
+            difference_in_indents = previous_number_of_indents - current_number_of_indents
             for i in range(difference_in_indents):
-                processed_code.append('end-block')
+                processed_code.append("end-block")
 
-        #save to compare for next line
+        # save to compare for next line
         previous_number_of_indents = current_number_of_indents
 
-        #if indent remains the same, do nothing, just add line
+        # if indent remains the same, do nothing, just add line
         processed_code.append(line)
 
     # if the last line is indented, the end of the program is also the end of all indents
     # so close all blocks
     for i in range(current_number_of_indents):
-        processed_code.append('end-block')
+        processed_code.append("end-block")
     return "\n".join(processed_code)
+
 
 def contains_blanks(code):
     return (" _ " in code) or (" _\n" in code)
 
 
 def check_program_size_is_valid(input_string):
-    number_of_lines = input_string.count('\n')
+    number_of_lines = input_string.count("\n")
     # parser is not made for huge programs!
     if number_of_lines > MAX_LINES:
         raise exceptions.InputTooBigException(lines_of_code=number_of_lines, max_lines=MAX_LINES)
 
 
 def process_input_string(input_string, level, escape_backslashes=True):
-    result = input_string.replace('\r\n', '\n')
+    result = input_string.replace("\r\n", "\n")
 
     if contains_blanks(result):
         raise exceptions.CodePlaceholdersPresentException()
@@ -2241,21 +2646,25 @@ def process_input_string(input_string, level, escape_backslashes=True):
 def parse_input(input_string, level, lang):
     parser = get_parser(level, lang)
     try:
-        parse_result = parser.parse(input_string + '\n')
+        parse_result = parser.parse(input_string + "\n")
         return parse_result.children[0]  # getting rid of the root could also be done in the transformer would be nicer
     except lark.UnexpectedEOF as e:
-        lines = input_string.split('\n')
+        lines = input_string.split("\n")
         last_line = len(lines)
         raise exceptions.UnquotedEqualityCheck(line_number=last_line)
     except UnexpectedCharacters as e:
         try:
             location = e.line, e.column
-            characters_expected = str(e.allowed) #not yet in use, could be used in the future (when our parser rules are better organize, now it says ANON*__12 etc way too often!)
+            characters_expected = str(
+                e.allowed
+            )  # not yet in use, could be used in the future (when our parser rules are better organize, now it says ANON*__12 etc way too often!)
             character_found = beautify_parse_error(e.char)
             # print(e.args[0])
             # print(location, character_found, characters_expected)
             fixed_code = program_repair.remove_unexpected_char(input_string, location[0], location[1])
-            raise exceptions.ParseException(level=level, location=location, found=character_found, fixed_code=fixed_code) from e
+            raise exceptions.ParseException(
+                level=level, location=location, found=character_found, fixed_code=fixed_code
+            ) from e
         except UnexpectedEOF:
             # this one can't be beautified (for now), so give up :)
             raise e
@@ -2264,7 +2673,7 @@ def parse_input(input_string, level, lang):
 def is_program_valid(program_root, input_string, level, lang):
     # IsValid returns (True,) or (False, args)
     instance = IsValid()
-    instance.level = level # TODO: could be done in a constructor once we are sure we will go this way
+    instance.level = level  # TODO: could be done in a constructor once we are sure we will go this way
     is_valid = instance.transform(program_root)
 
     if not is_valid[0]:
@@ -2278,45 +2687,51 @@ def is_program_valid(program_root, input_string, level, lang):
 
         line = invalid_info.line
         column = invalid_info.column
-        if invalid_info.error_type == ' ':
+        if invalid_info.error_type == " ":
 
             # the error here is a space at the beginning of a line, we can fix that!
             fixed_code = program_repair.remove_leading_spaces(input_string)
-            if fixed_code != input_string: #only if we have made a successful fix
+            if fixed_code != input_string:  # only if we have made a successful fix
                 try:
                     fixed_result = transpile_inner(fixed_code, level, lang)
                     result = fixed_result
-                    raise exceptions.InvalidSpaceException(level=level, line_number=line, fixed_code=fixed_code, fixed_result=result)
+                    raise exceptions.InvalidSpaceException(
+                        level=level, line_number=line, fixed_code=fixed_code, fixed_result=result
+                    )
                 except exceptions.HedyException:
                     invalid_info.error_type = None
                     transpile_inner(fixed_code, level)
                     # The fixed code contains another error. Only report the original error for now.
                     pass
-            raise exceptions.InvalidSpaceException(level=level, line_number=line, fixed_code=fixed_code, fixed_result=result)
-        elif invalid_info.error_type == 'invalid condition':
+            raise exceptions.InvalidSpaceException(
+                level=level, line_number=line, fixed_code=fixed_code, fixed_result=result
+            )
+        elif invalid_info.error_type == "invalid condition":
             raise exceptions.UnquotedEqualityCheck(line_number=line)
-        elif invalid_info.error_type == 'invalid repeat':
-            raise exceptions.MissingInnerCommandException(command='repeat', level=level, line_number=line)
-        elif invalid_info.error_type == 'repeat missing print':
-            raise exceptions.IncompleteRepeatException(command='print', level=level, line_number=line)
-        elif invalid_info.error_type == 'repeat missing times':
-            raise exceptions.IncompleteRepeatException(command='times', level=level, line_number=line)    
-        elif invalid_info.error_type == 'print without quotes':
+        elif invalid_info.error_type == "invalid repeat":
+            raise exceptions.MissingInnerCommandException(command="repeat", level=level, line_number=line)
+        elif invalid_info.error_type == "repeat missing print":
+            raise exceptions.IncompleteRepeatException(command="print", level=level, line_number=line)
+        elif invalid_info.error_type == "repeat missing times":
+            raise exceptions.IncompleteRepeatException(command="times", level=level, line_number=line)
+        elif invalid_info.error_type == "print without quotes":
             unquotedtext = invalid_info.arguments[0]
             # grammar rule is agnostic of line number so we can't easily return that here
             raise exceptions.UnquotedTextException(level=level, unquotedtext=unquotedtext)
-        elif invalid_info.error_type == 'unsupported number':
-            raise exceptions.UnsupportedFloatException(value=''.join(invalid_info.arguments))
+        elif invalid_info.error_type == "unsupported number":
+            raise exceptions.UnsupportedFloatException(value="".join(invalid_info.arguments))
         else:
             invalid_command = invalid_info.command
             closest = closest_command(invalid_command, get_suggestions_for_language(lang, level))
 
-            if closest == 'keyword':  # we couldn't find a suggestion
+            if closest == "keyword":  # we couldn't find a suggestion
                 if invalid_command == Command.turn:
                     arg = invalid_info.arguments[0][0]
-                    raise hedy.exceptions.InvalidArgumentException(command=invalid_info.command,
-                                                                   allowed_types=get_allowed_types(Command.turn, level),
-                                                                   invalid_argument=arg)
+                    raise hedy.exceptions.InvalidArgumentException(
+                        command=invalid_info.command,
+                        allowed_types=get_allowed_types(Command.turn, level),
+                        invalid_argument=arg,
+                    )
                 # clearly the error message here should be better or it should be a different one!
                 raise exceptions.ParseException(level=level, location=[line, column], found=invalid_command)
             elif closest is None:
@@ -2335,9 +2750,14 @@ def is_program_valid(program_root, input_string, level, lang):
                         # The fixed code contains another error. Only report the original error for now.
                         pass
 
-            raise exceptions.InvalidCommandException(invalid_command=invalid_command, level=level,
-                                                     guessed_command=closest, line_number=line,
-                                                     fixed_code=fixed_code, fixed_result=result)
+            raise exceptions.InvalidCommandException(
+                invalid_command=invalid_command,
+                level=level,
+                guessed_command=closest,
+                line_number=line,
+                fixed_code=fixed_code,
+                fixed_result=result,
+            )
 
 
 def is_program_complete(abstract_syntax_tree, level):
@@ -2346,8 +2766,9 @@ def is_program_complete(abstract_syntax_tree, level):
         incomplete_command_and_line = is_complete[1][0]
         incomplete_command = incomplete_command_and_line[0]
         line = incomplete_command_and_line[1]
-        raise exceptions.IncompleteCommandException(incomplete_command=incomplete_command, level=level,
-                                                    line_number=line)
+        raise exceptions.IncompleteCommandException(
+            incomplete_command=incomplete_command, level=level, line_number=line
+        )
 
 
 def create_lookup_table(abstract_syntax_tree, level, lang, input_string):
@@ -2365,7 +2786,7 @@ def transpile_inner(input_string, level, lang="en"):
 
     level = int(level)
     if level > HEDY_MAX_LEVEL:
-        raise Exception(f'Levels over {HEDY_MAX_LEVEL} not implemented yet')
+        raise Exception(f"Levels over {HEDY_MAX_LEVEL} not implemented yet")
 
     input_string = process_input_string(input_string, level)
 
@@ -2373,7 +2794,6 @@ def transpile_inner(input_string, level, lang="en"):
 
     # checks whether any error production nodes are present in the parse tree
     is_program_valid(program_root, input_string, level, lang)
-
 
     try:
         abstract_syntax_tree = ExtractAST().transform(program_root)
@@ -2396,7 +2816,6 @@ def transpile_inner(input_string, level, lang="en"):
         # grab the right transpiler from the lookup
         convertToPython = TRANSPILER_LOOKUP[level]
         python = convertToPython(lookup_table, numerals_language).transform(abstract_syntax_tree)
-
 
         has_turtle = UsesTurtle().transform(abstract_syntax_tree)
         return ParseResult(python, has_turtle)

--- a/hedy_content.py
+++ b/hedy_content.py
@@ -33,36 +33,36 @@ ALL_LANGUAGES = {}
 ALL_KEYWORD_LANGUAGES = {}
 
 # Todo TB -> We create this list manually, but it would be nice if we find a way to automate this as well
-NON_LATIN_LANGUAGES = ['ar', 'bg', 'bn', 'el', 'fa', 'hi', 'he', 'ru', 'zh_Hans']
+NON_LATIN_LANGUAGES = ["ar", "bg", "bn", "el", "fa", "hi", "he", "ru", "zh_Hans"]
 
 # It would be nice if we created this list manually but couldn't find a way to retrieve this from Babel
-NON_BABEL = ['tn']
+NON_BABEL = ["tn"]
 
 ADVENTURE_ORDER = [
-    'default',
-    'story',
-    'parrot',
-    'songs',
-    'turtle',
-    'dishes',
-    'dice',
-    'rock',
-    'calculator',
-    'fortune',
-    'restaurant',
-    'haunted',
-    'piggybank',
-    'quizmaster',
-    'language',
-    'secret',
-    'tic',
-    'blackjack',
-    'next',
-    'end'
+    "default",
+    "story",
+    "parrot",
+    "songs",
+    "turtle",
+    "dishes",
+    "dice",
+    "rock",
+    "calculator",
+    "fortune",
+    "restaurant",
+    "haunted",
+    "piggybank",
+    "quizmaster",
+    "language",
+    "secret",
+    "tic",
+    "blackjack",
+    "next",
+    "end",
 ]
 
 RESEARCH = {}
-for paper in os.listdir('content/research'):
+for paper in os.listdir("content/research"):
     # An_approach_to_describing_the_semantics_of_Hedy_2022.pdf -> An approach to describing the semantics of Hedy
     name = paper.replace("_", " ").split(".")[0]
     RESEARCH[name] = paper
@@ -70,39 +70,37 @@ for paper in os.listdir('content/research'):
 # load all available languages in dict
 # list_translations of babel does about the same, but without territories.
 languages = {}
-if not os.path.isdir('translations'):
+if not os.path.isdir("translations"):
     # should not be possible, but if it's moved someday, EN would still be working.
-    ALL_LANGUAGES['en'] = 'English'
-    ALL_KEYWORD_LANGUAGES['en'] = 'EN'
+    ALL_LANGUAGES["en"] = "English"
+    ALL_KEYWORD_LANGUAGES["en"] = "EN"
 
-for folder in os.listdir('translations'):
+for folder in os.listdir("translations"):
     # we cant properly open non-supported langs like Tswana (tn)
     # so we have to load en for those until Babel adds support
     if folder in NON_BABEL:
-        folder = 'en'
-    locale_dir = os.path.join('translations', folder, 'LC_MESSAGES')
+        folder = "en"
+    locale_dir = os.path.join("translations", folder, "LC_MESSAGES")
     if not os.path.isdir(locale_dir):
         continue
 
-    if filter(lambda x: x.endswith('.mo'), os.listdir(locale_dir)):
+    if filter(lambda x: x.endswith(".mo"), os.listdir(locale_dir)):
         locale = Locale.parse(folder)
         languages[folder] = locale.display_name.title()
 
 for l in sorted(languages):
     ALL_LANGUAGES[l] = languages[l]
-    if os.path.exists('./grammars/keywords-' + l + '.lark'):
+    if os.path.exists("./grammars/keywords-" + l + ".lark"):
         ALL_KEYWORD_LANGUAGES[l] = l[0:2].upper()  # first two characters
 
 # Load and cache all keyword yamls
 KEYWORDS = {}
 for lang in ALL_KEYWORD_LANGUAGES.keys():
-    KEYWORDS[lang] = dict(YamlFile.for_file(f'content/keywords/{lang}.yaml'))
+    KEYWORDS[lang] = dict(YamlFile.for_file(f"content/keywords/{lang}.yaml"))
     for k, v in KEYWORDS[lang].items():
         if type(v) == str and "|" in v:
             # when we have several options, pick the first one as default
-            KEYWORDS[lang][k] = v.split('|')[0]
-
-
+            KEYWORDS[lang][k] = v.split("|")[0]
 
 
 class Commands:
@@ -110,13 +108,13 @@ class Commands:
     def __init__(self, language):
         self.language = language
         # We can keep these cached, even in debug_mode: files are small and don't influence start-up time much
-        self.file = YamlFile.for_file(f'content/commands/{self.language}.yaml')
+        self.file = YamlFile.for_file(f"content/commands/{self.language}.yaml")
         self.data = {}
 
         # For some reason the is_debug_mode() function is not (yet) ready when we call this code
         # So we call the NO_DEBUG_MODE directly from the environment
         # Todo TB -> Fix that the is_debug_mode() function is ready before server start
-        self.debug_mode = not os.getenv('NO_DEBUG_MODE')
+        self.debug_mode = not os.getenv("NO_DEBUG_MODE")
 
         if not self.debug_mode:
             # We always create one with english keywords
@@ -155,6 +153,7 @@ class NoSuchCommand:
     def get_commands_for_level(self, level, keyword_lang):
         return {}
 
+
 class Adventures:
     def __init__(self, language):
         self.language = language
@@ -164,11 +163,10 @@ class Adventures:
         # For some reason the is_debug_mode() function is not (yet) ready when we call this code
         # So we call the NO_DEBUG_MODE directly from the environment
         # Todo TB -> Fix that the is_debug_mode() function is ready before server start
-        self.debug_mode = not os.getenv('NO_DEBUG_MODE')
+        self.debug_mode = not os.getenv("NO_DEBUG_MODE")
 
         if not self.debug_mode:
-            self.file = YamlFile.for_file(
-                f'content/adventures/{self.language}.yaml').get('adventures')
+            self.file = YamlFile.for_file(f"content/adventures/{self.language}.yaml").get("adventures")
             # We always create one with english keywords
             self.data["en"] = self.cache_adventure_keywords("en")
             if language in ALL_KEYWORD_LANGUAGES.keys():
@@ -179,15 +177,15 @@ class Adventures:
         sorted_adventures = {}
         for adventure_index in ADVENTURE_ORDER:
             if self.file.get(adventure_index, None):
-                sorted_adventures[adventure_index] = (self.file.get(adventure_index))
+                sorted_adventures[adventure_index] = self.file.get(adventure_index)
         self.file = sorted_adventures
         keyword_data = {}
         for short_name, adventure in self.file.items():
             parsed_adventure = copy.deepcopy(adventure)
-            for level in adventure.get('levels'):
-                for k, v in adventure.get('levels').get(level).items():
+            for level in adventure.get("levels"):
+                for k, v in adventure.get("levels").get(level).items():
                     try:
-                        parsed_adventure.get('levels').get(level)[k] = v.format(**KEYWORDS.get(language))
+                        parsed_adventure.get("levels").get(level)[k] = v.format(**KEYWORDS.get(language))
                     except IndexError:
                         print("There is an issue due to an empty placeholder in the following line:")
                         print(v)
@@ -202,12 +200,11 @@ class Adventures:
     def get_adventure_keyname_name_levels(self):
         if self.debug_mode and not self.data.get("en", None):
             if not self.file:
-                self.file = YamlFile.for_file(
-                    f'content/adventures/{self.language}.yaml').get('adventures')
+                self.file = YamlFile.for_file(f"content/adventures/{self.language}.yaml").get("adventures")
             self.data["en"] = self.cache_adventure_keywords("en")
         adventures_dict = {}
         for adventure in self.data["en"].items():
-            adventures_dict[adventure[0]] = {adventure[1]['name']: list(adventure[1]['levels'].keys())}
+            adventures_dict[adventure[0]] = {adventure[1]["name"]: list(adventure[1]["levels"].keys())}
         return adventures_dict
 
     # Todo TB -> We can also cache this; why not?
@@ -215,36 +212,33 @@ class Adventures:
     def get_adventure_names(self):
         if self.debug_mode and not self.data.get("en", None):
             if not self.file:
-                self.file = YamlFile.for_file(
-                    f'content/adventures/{self.language}.yaml').get('adventures')
+                self.file = YamlFile.for_file(f"content/adventures/{self.language}.yaml").get("adventures")
             self.data["en"] = self.cache_adventure_keywords("en")
         adventures_dict = {}
         for adventure in self.data["en"].items():
-            adventures_dict[adventure[0]] = adventure[1]['name']
+            adventures_dict[adventure[0]] = adventure[1]["name"]
         return adventures_dict
 
     def get_adventures(self, keyword_lang="en"):
         if self.debug_mode and not self.data.get(keyword_lang, None):
             if not self.file:
-                self.file = YamlFile.for_file(
-                    f'content/adventures/{self.language}.yaml').get('adventures')
-            self.data[keyword_lang] = self.cache_adventure_keywords(
-                keyword_lang)
+                self.file = YamlFile.for_file(f"content/adventures/{self.language}.yaml").get("adventures")
+            self.data[keyword_lang] = self.cache_adventure_keywords(keyword_lang)
         return self.data.get(keyword_lang)
 
     def has_adventures(self):
         if self.debug_mode and not self.data.get("en", None):
             if not self.file:
-                self.file = YamlFile.for_file(
-                    f'content/adventures/{self.language}.yaml').get('adventures')
+                self.file = YamlFile.for_file(f"content/adventures/{self.language}.yaml").get("adventures")
             self.data["en"] = self.cache_adventure_keywords("en")
-        return True if self.data.get("en") else False     
-      
+        return True if self.data.get("en") else False
+
+
 # Todo TB -> We don't need these anymore as we guarantee with Weblate that each language file is there
 class NoSuchAdventure:
-  def get_adventure(self):
-    return {}
-  
+    def get_adventure(self):
+        return {}
+
 
 class ParsonsProblem:
     def __init__(self, language):
@@ -252,10 +246,10 @@ class ParsonsProblem:
         self.file = {}
         self.data = {}
 
-        self.debug_mode = not os.getenv('NO_DEBUG_MODE')
+        self.debug_mode = not os.getenv("NO_DEBUG_MODE")
 
         if not self.debug_mode:
-            self.file = YamlFile.for_file(f'content/parsons/{self.language}.yaml').get('levels')
+            self.file = YamlFile.for_file(f"content/parsons/{self.language}.yaml").get("levels")
             # We always create one with english keywords
             self.data["en"] = self.cache_parsons_keywords("en")
             if language in ALL_KEYWORD_LANGUAGES.keys():
@@ -266,9 +260,9 @@ class ParsonsProblem:
         for level in copy.deepcopy(self.file):
             exercises = copy.deepcopy(self.file.get(level))
             for number, exercise in exercises.items():
-                for k, v in exercise.get('code_lines').items():
+                for k, v in exercise.get("code_lines").items():
                     try:
-                        exercises.get(number).get('code_lines')[k] = v.format(**KEYWORDS.get(language))
+                        exercises.get(number).get("code_lines")[k] = v.format(**KEYWORDS.get(language))
                     except IndexError:
                         print("There is an issue due to an empty placeholder in the following line:")
                         print(v)
@@ -281,21 +275,21 @@ class ParsonsProblem:
     def get_highest_exercise_level(self, level):
         if self.debug_mode and not self.data.get("en", None):
             if not self.file:
-                self.file = YamlFile.for_file(f'content/parsons/{self.language}.yaml').get('levels')
+                self.file = YamlFile.for_file(f"content/parsons/{self.language}.yaml").get("levels")
             self.data["en"] = self.cache_parsons_keywords("en")
         return len(self.data["en"].get(level, {}))
 
     def get_parsons_data_for_level(self, level, keyword_lang="en"):
         if self.debug_mode and not self.data.get(keyword_lang, None):
             if not self.file:
-                self.file = YamlFile.for_file(f'content/parsons/{self.language}.yaml').get('levels')
+                self.file = YamlFile.for_file(f"content/parsons/{self.language}.yaml").get("levels")
             self.data[keyword_lang] = self.cache_parsons_keywords(keyword_lang)
         return self.data.get(keyword_lang, {}).get(level, None)
 
     def get_parsons_data_for_level_exercise(self, level, excercise, keyword_lang="en"):
         if self.debug_mode and not self.data.get(keyword_lang, None):
             if not self.file:
-                self.file = YamlFile.for_file(f'content/parsons/{self.language}.yaml').get('levels')
+                self.file = YamlFile.for_file(f"content/parsons/{self.language}.yaml").get("levels")
             self.data[keyword_lang] = self.cache_parsons_keywords(keyword_lang)
         return self.data.get(keyword_lang, {}).get(level, {}).get(excercise, None)
 
@@ -309,10 +303,10 @@ class Quizzes:
         # For some reason the is_debug_mode() function is not (yet) ready when we call this code
         # So we call the NO_DEBUG_MODE directly from the environment
         # Todo TB -> Fix that the is_debug_mode() function is ready before server start
-        self.debug_mode = not os.getenv('NO_DEBUG_MODE')
+        self.debug_mode = not os.getenv("NO_DEBUG_MODE")
 
         if not self.debug_mode:
-            self.file = YamlFile.for_file(f'content/quizzes/{self.language}.yaml').to_dict()
+            self.file = YamlFile.for_file(f"content/quizzes/{self.language}.yaml").to_dict()
             self.data["en"] = self.cache_quiz_keywords("en")
             if language in ALL_KEYWORD_LANGUAGES.keys():
                 self.data[language] = self.cache_quiz_keywords(language)
@@ -340,7 +334,7 @@ class Quizzes:
     def get_highest_question_level(self, level):
         if self.debug_mode and not self.data.get("en", None):
             if not self.file:
-                self.file = YamlFile.for_file(f'content/quizzes/{self.language}.yaml').get('levels')
+                self.file = YamlFile.for_file(f"content/quizzes/{self.language}.yaml").get("levels")
             self.data["en"] = self.cache_quiz_keywords("en")
         return len(self.data["en"].get(level, {}))
 
@@ -350,7 +344,7 @@ class Quizzes:
 
         if self.debug_mode and not self.data.get(keyword_lang, None):
             if not self.file:
-                self.file = YamlFile.for_file(f'content/quizzes/{self.language}.yaml').get('levels')
+                self.file = YamlFile.for_file(f"content/quizzes/{self.language}.yaml").get("levels")
             self.data[keyword_lang] = self.cache_quiz_keywords(keyword_lang)
         return self.data.get(keyword_lang, {}).get(level, None)
 
@@ -360,7 +354,7 @@ class Quizzes:
 
         if self.debug_mode and not self.data.get(keyword_lang, None):
             if not self.file:
-                self.file = YamlFile.for_file(f'content/quizzes/{self.language}.yaml').get('levels')
+                self.file = YamlFile.for_file(f"content/quizzes/{self.language}.yaml").get("levels")
             self.data[keyword_lang] = self.cache_quiz_keywords(keyword_lang)
         return self.data.get(keyword_lang, {}).get(level, {}).get(question, None)
 
@@ -375,10 +369,10 @@ class Tutorials:
     def __init__(self, language):
         self.language = language
         # We can keep these cached, even in debug_mode: files are small and don't influence start-up time much
-        self.file = YamlFile.for_file(f'content/tutorials/{self.language}.yaml')
+        self.file = YamlFile.for_file(f"content/tutorials/{self.language}.yaml")
         self.data = {}
 
-        self.debug_mode = not os.getenv('NO_DEBUG_MODE')
+        self.debug_mode = not os.getenv("NO_DEBUG_MODE")
 
         if not self.debug_mode:
             self.data["en"] = self.cache_tutorials("en")
@@ -388,9 +382,9 @@ class Tutorials:
     def cache_tutorials(self, language):
         tutorial_data = {}
         for level in copy.deepcopy(self.file):
-            steps = copy.deepcopy(self.file).get(level).get('steps')
+            steps = copy.deepcopy(self.file).get(level).get("steps")
             for index, data in steps.items():
-                steps[index]['text'] = data['text'].format(**KEYWORDS.get(language))
+                steps[index]["text"] = data["text"].format(**KEYWORDS.get(language))
             tutorial_data[level] = steps
         return tutorial_data
 
@@ -403,6 +397,7 @@ class Tutorials:
         if self.debug_mode and not self.data.get(keyword_lang, None):
             self.data[keyword_lang] = self.cache_tutorials(keyword_lang)
         return self.data.get(keyword_lang, {}).get(level, {}).get(step, None)
+
 
 class NoSuchTutorial:
     def get_tutorial_data_for_level(self, level, keyword_lang):

--- a/hedy_translation.py
+++ b/hedy_translation.py
@@ -11,21 +11,19 @@ Rule = namedtuple("Rule", "keyword line start end value")
 
 
 def keywords_to_dict(lang="nl"):
-    """"Return a dictionary of keywords from language of choice. Key is english value is lang of choice"""
+    """ "Return a dictionary of keywords from language of choice. Key is english value is lang of choice"""
     base = path.abspath(path.dirname(__file__))
 
-    keywords_path = 'content/keywords/'
-    yaml_filesname_with_path = path.join(
-        base, keywords_path, lang + '.yaml')
+    keywords_path = "content/keywords/"
+    yaml_filesname_with_path = path.join(base, keywords_path, lang + ".yaml")
 
-    with open(yaml_filesname_with_path, 'r', encoding='UTF-8') as stream:
+    with open(yaml_filesname_with_path, "r", encoding="UTF-8") as stream:
         command_combinations = yaml.safe_load(stream)
 
     for k, v in command_combinations.items():
         if type(v) == str and "|" in v:
             # when we have several options, pick the first one as default
-            command_combinations[k] = v.split('|')[0]
-
+            command_combinations[k] = v.split("|")[0]
 
     return command_combinations
 
@@ -37,12 +35,12 @@ def all_keywords_to_dict():
         commands = keywords_to_dict(lang)
         keyword_dict[lang] = commands
 
-    all_translations = {k: [v.get(k,k) for v in keyword_dict.values()] for k in keyword_dict['en']}
+    all_translations = {k: [v.get(k, k) for v in keyword_dict.values()] for k in keyword_dict["en"]}
     return all_translations
 
 
 def translate_keywords(input_string_, from_lang="en", to_lang="nl", level=1):
-    """"Return code with keywords translated to language of choice in level of choice"""
+    """ "Return code with keywords translated to language of choice in level of choice"""
     try:
         processed_input = hedy.process_input_string(input_string_, level, escape_backslashes=False)
 
@@ -50,12 +48,11 @@ def translate_keywords(input_string_, from_lang="en", to_lang="nl", level=1):
         keyword_dict_from = keywords_to_dict(from_lang)
         keyword_dict_to = keywords_to_dict(to_lang)
 
-        program_root = parser.parse(processed_input + '\n').children[0]
+        program_root = parser.parse(processed_input + "\n").children[0]
 
         translator = Translator(processed_input)
         translator.visit(program_root)
-        ordered_rules = reversed(
-            sorted(translator.rules, key=operator.attrgetter("line", "start")))
+        ordered_rules = reversed(sorted(translator.rules, key=operator.attrgetter("line", "start")))
 
         # FH Feb 2022 TODO trees containing invalid nodes are happily translated, should be stopped here!
 
@@ -63,14 +60,14 @@ def translate_keywords(input_string_, from_lang="en", to_lang="nl", level=1):
         for rule in ordered_rules:
             if rule.keyword in keyword_dict_from and rule.keyword in keyword_dict_to:
                 lines = result.splitlines()
-                line = lines[rule.line-1]
+                line = lines[rule.line - 1]
                 replaced_line = replace_token_in_line(
-                    line, rule, keyword_dict_from[rule.keyword], keyword_dict_to[rule.keyword])
-                result = replace_line(lines, rule.line-1, replaced_line)
+                    line, rule, keyword_dict_from[rule.keyword], keyword_dict_to[rule.keyword]
+                )
+                result = replace_line(lines, rule.line - 1, replaced_line)
 
         # For now the needed post processing is only removing the 'end-block's added during pre-processing
-        result = '\n'.join([line for line in result.splitlines()
-                           if not line.startswith('end-block')])
+        result = "\n".join([line for line in result.splitlines() if not line.startswith("end-block")])
 
         return result
     except:
@@ -78,19 +75,19 @@ def translate_keywords(input_string_, from_lang="en", to_lang="nl", level=1):
 
 
 def replace_line(lines, index, line):
-    before = '\n'.join(lines[0:index])
-    after = '\n'.join(lines[index+1:])
+    before = "\n".join(lines[0:index])
+    after = "\n".join(lines[index + 1 :])
     if len(before) > 0:
-        before = before + '\n'
+        before = before + "\n"
     if len(after) > 0:
-        after = '\n' + after
-    return ''.join([before, line, after])
+        after = "\n" + after
+    return "".join([before, line, after])
 
 
 def replace_token_in_line(line, rule, original, target):
     """Replaces a token in a line from the user input with its translated equivalent"""
-    before = '' if rule.start == 0 else line[0:rule.start]
-    after = '' if rule.end == len(line)-1 else line[rule.end+1:]
+    before = "" if rule.start == 0 else line[0 : rule.start]
+    after = "" if rule.end == len(line) - 1 else line[rule.end + 1 :]
     # Note that we need to replace the target value in the original value because some
     # grammar rules have ambiguous length and value, e.g. _COMMA: _SPACES* (latin_comma | arabic_comma) _SPACES*
     return before + rule.value.replace(original, target) + after
@@ -103,7 +100,9 @@ def find_command_keywords(input_string, lang, level, keywords, start_line, end_l
     translator = Translator(input_string)
     translator.visit(program_root)
 
-    return {k: find_keyword_in_rules(translator.rules, k, start_line, end_line, start_column, end_column) for k in keywords}
+    return {
+        k: find_keyword_in_rules(translator.rules, k, start_line, end_line, start_column, end_column) for k in keywords
+    }
 
 
 def find_keyword_in_rules(rules, keyword, start_line, end_line, start_column, end_column):
@@ -116,145 +115,140 @@ def find_keyword_in_rules(rules, keyword, start_line, end_line, start_column, en
 
 class Translator(Visitor):
     """The visitor finds tokens that must be translated and stores information about their exact position
-       in the user input string and original value. The information is later used to replace the token in
-       the original user input with the translated token value."""
+    in the user input string and original value. The information is later used to replace the token in
+    the original user input with the translated token value."""
 
     def __init__(self, input_string):
         self.input_string = input_string
         self.rules = []
 
     def print(self, tree):
-        self.add_rule('_PRINT', 'print', tree)
+        self.add_rule("_PRINT", "print", tree)
 
     def print_empty_brackets(self, tree):
         self.print(tree)
 
     def ask(self, tree):
-        self.add_rule('_IS', 'is', tree)
-        self.add_rule('_ASK', 'ask', tree)
+        self.add_rule("_IS", "is", tree)
+        self.add_rule("_ASK", "ask", tree)
 
     def echo(self, tree):
-        self.add_rule('_ECHO', 'echo', tree)
+        self.add_rule("_ECHO", "echo", tree)
 
     def color(self, tree):
-        self.add_rule('_COLOR', 'color', tree)
+        self.add_rule("_COLOR", "color", tree)
 
     def forward(self, tree):
-        self.add_rule('_FORWARD', 'forward', tree)
+        self.add_rule("_FORWARD", "forward", tree)
 
     def turn(self, tree):
-        self.add_rule('_TURN', 'turn', tree)
+        self.add_rule("_TURN", "turn", tree)
 
     def left(self, tree):
         token = tree.children[0]
-        rule = Rule('left', token.line, token.column -
-                    1, token.end_column - 2, token.value)
+        rule = Rule("left", token.line, token.column - 1, token.end_column - 2, token.value)
         self.rules.append(rule)
 
     def right(self, tree):
         token = tree.children[0]
-        rule = Rule('right', token.line, token.column -
-                    1, token.end_column - 2, token.value)
+        rule = Rule("right", token.line, token.column - 1, token.end_column - 2, token.value)
         self.rules.append(rule)
 
     def assign_list(self, tree):
-        self.add_rule('_IS', 'is', tree)
-        commas = self.get_keyword_tokens('_COMMA', tree)
+        self.add_rule("_IS", "is", tree)
+        commas = self.get_keyword_tokens("_COMMA", tree)
         for comma in commas:
-            rule = Rule('comma', comma.line, comma.column -
-                        1, comma.end_column - 2, comma.value)
+            rule = Rule("comma", comma.line, comma.column - 1, comma.end_column - 2, comma.value)
             self.rules.append(rule)
 
     def assign(self, tree):
-        self.add_rule('_IS', 'is', tree)
+        self.add_rule("_IS", "is", tree)
 
     def sleep(self, tree):
-        self.add_rule('_SLEEP', 'sleep', tree)
+        self.add_rule("_SLEEP", "sleep", tree)
 
     def add(self, tree):
-        self.add_rule('_ADD_LIST', 'add', tree)
-        self.add_rule('_TO_LIST', 'to_list', tree)
+        self.add_rule("_ADD_LIST", "add", tree)
+        self.add_rule("_TO_LIST", "to_list", tree)
 
     def remove(self, tree):
-        self.add_rule('_REMOVE', 'remove', tree)
-        self.add_rule('_FROM', 'from', tree)
+        self.add_rule("_REMOVE", "remove", tree)
+        self.add_rule("_FROM", "from", tree)
 
     def random(self, tree):
         token = tree.children[0]
-        rule = Rule('random', token.line, token.column -
-                    1, token.end_column - 2, token.value)
+        rule = Rule("random", token.line, token.column - 1, token.end_column - 2, token.value)
         self.rules.append(rule)
 
     def ifs(self, tree):
-        self.add_rule('_IF', 'if', tree)
+        self.add_rule("_IF", "if", tree)
 
     def ifelse(self, tree):
-        self.add_rule('_IF', 'if', tree)
-        self.add_rule('_ELSE', 'else', tree)
+        self.add_rule("_IF", "if", tree)
+        self.add_rule("_ELSE", "else", tree)
 
     def elifs(self, tree):
-        self.add_rule('_ELIF', 'elif', tree)
+        self.add_rule("_ELIF", "elif", tree)
 
     def elses(self, tree):
-        self.add_rule('_ELSE', 'else', tree)
+        self.add_rule("_ELSE", "else", tree)
 
     def condition_spaces(self, tree):
-        self.add_rule('_IS', 'is', tree)
+        self.add_rule("_IS", "is", tree)
 
     def equality_check_is(self, tree):
         self.equality_check(tree)
 
     def equality_check(self, tree):
-        self.add_rule('_IS', 'is', tree)
-        self.add_rule('_EQUALS', '=', tree)
-        self.add_rule('_DOUBLE_EQUALS', '==', tree)
+        self.add_rule("_IS", "is", tree)
+        self.add_rule("_EQUALS", "=", tree)
+        self.add_rule("_DOUBLE_EQUALS", "==", tree)
 
     def in_list_check(self, tree):
-        self.add_rule('_IN', 'in', tree)
+        self.add_rule("_IN", "in", tree)
 
     def list_access(self, tree):
-        self.add_rule('_AT', 'at', tree)
+        self.add_rule("_AT", "at", tree)
 
     def list_access_var(self, tree):
-        self.add_rule('_IS', 'is', tree)
-        self.add_rule('_AT', 'at', tree)
+        self.add_rule("_IS", "is", tree)
+        self.add_rule("_AT", "at", tree)
 
     def repeat(self, tree):
-        self.add_rule('_REPEAT', 'repeat', tree)
-        self.add_rule('_TIMES', 'times', tree)
+        self.add_rule("_REPEAT", "repeat", tree)
+        self.add_rule("_TIMES", "times", tree)
 
     def for_list(self, tree):
-        self.add_rule('_FOR', 'for', tree)
-        self.add_rule('_IN', 'in', tree)
+        self.add_rule("_FOR", "for", tree)
+        self.add_rule("_IN", "in", tree)
 
     def for_loop(self, tree):
-        self.add_rule('_FOR', 'for', tree)
-        self.add_rule('_IN', 'in', tree)
-        self.add_rule('_RANGE', 'range', tree)
-        self.add_rule('_TO', 'to', tree)
+        self.add_rule("_FOR", "for", tree)
+        self.add_rule("_IN", "in", tree)
+        self.add_rule("_RANGE", "range", tree)
+        self.add_rule("_TO", "to", tree)
 
     def while_loop(self, tree):
-        self.add_rule('_WHILE', 'while', tree)
+        self.add_rule("_WHILE", "while", tree)
 
     def and_condition(self, tree):
-        self.add_rule('_AND', 'and', tree)
+        self.add_rule("_AND", "and", tree)
 
     def or_condition(self, tree):
-        self.add_rule('_OR', 'or', tree)
+        self.add_rule("_OR", "or", tree)
 
     def input(self, tree):
-        self.add_rule('_IS', 'is', tree)
-        self.add_rule('_INPUT', 'input', tree)
+        self.add_rule("_IS", "is", tree)
+        self.add_rule("_INPUT", "input", tree)
 
     def input_empty_brackets(self, tree):
-        self.add_rule('_IS', 'is', tree)
-        self.add_rule('_INPUT', 'input', tree)
+        self.add_rule("_IS", "is", tree)
+        self.add_rule("_INPUT", "input", tree)
 
     def add_rule(self, token_name, token_keyword, tree):
         token = self.get_keyword_token(token_name, tree)
         if token:
-            rule = Rule(token_keyword, token.line, token.column -
-                        1, token.end_column - 2, token.value)
+            rule = Rule(token_keyword, token.line, token.column - 1, token.end_column - 2, token.value)
             self.rules.append(rule)
 
     def get_keyword_token(self, token_type, node):

--- a/hedyweb.py
+++ b/hedyweb.py
@@ -15,14 +15,14 @@ class AchievementTranslations:
     def __init__(self):
         self.data = {}
 
-        translations = glob.glob('content/achievements/*.yaml')
+        translations = glob.glob("content/achievements/*.yaml")
         for trans_file in translations:
             lang = path.splitext(path.basename(trans_file))[0]
             self.data[lang] = YamlFile.for_file(trans_file)
 
     def get_translations(self, language):
-        d = collections.defaultdict(lambda: 'Unknown Exception')
-        d.update(**self.data.get('en', {}))
+        d = collections.defaultdict(lambda: "Unknown Exception")
+        d.update(**self.data.get("en", {}))
         d.update(**self.data.get(language, {}))
         return d
 
@@ -30,10 +30,10 @@ class AchievementTranslations:
 class PageTranslations:
     def __init__(self, page):
         self.data = {}
-        if page in ['start', 'join', 'learn-more', 'for-teachers']:
-            translations = glob.glob('content/pages/*.yaml')
+        if page in ["start", "join", "learn-more", "for-teachers"]:
+            translations = glob.glob("content/pages/*.yaml")
         else:
-            translations = glob.glob('content/pages/' + page + '/*.yaml')
+            translations = glob.glob("content/pages/" + page + "/*.yaml")
         for file in translations:
             lang = path.splitext(path.basename(file))[0]
             self.data[lang] = YamlFile.for_file(file)
@@ -43,34 +43,51 @@ class PageTranslations:
         return len(self.data) > 0
 
     def get_page_translations(self, language):
-        d = collections.defaultdict(lambda: '')
-        d.update(**self.data.get('en', {}))
+        d = collections.defaultdict(lambda: "")
+        d.update(**self.data.get("en", {}))
         d.update(**self.data.get(language, {}))
         return d
 
 
-def render_code_editor_with_tabs(cheatsheet, commands, max_level, level_number, version, quiz, quiz_questions, loaded_program, adventures, parsons, parsons_exercises, customizations, hide_cheatsheet, enforce_developers_mode, teacher_adventures, adventure_name):
+def render_code_editor_with_tabs(
+    cheatsheet,
+    commands,
+    max_level,
+    level_number,
+    version,
+    quiz,
+    quiz_questions,
+    loaded_program,
+    adventures,
+    parsons,
+    parsons_exercises,
+    customizations,
+    hide_cheatsheet,
+    enforce_developers_mode,
+    teacher_adventures,
+    adventure_name,
+):
     arguments_dict = {}
 
     # Meta stuff
-    arguments_dict['level_nr'] = str(level_number)
-    arguments_dict['level'] = level_number
-    arguments_dict['current_page'] = 'hedy'
-    arguments_dict['prev_level'] = int(level_number) - 1 if int(level_number) > 1 else None
-    arguments_dict['next_level'] = int(level_number) + 1 if int(level_number) < max_level else None
-    arguments_dict['customizations'] = customizations
-    arguments_dict['hide_cheatsheet'] = hide_cheatsheet
-    arguments_dict['enforce_developers_mode'] = enforce_developers_mode
-    arguments_dict['teacher_adventures'] = teacher_adventures
-    arguments_dict['loaded_program'] = loaded_program
-    arguments_dict['adventures'] = adventures
-    arguments_dict['commands'] = commands
-    arguments_dict['parsons'] = parsons
-    arguments_dict['parsons_exercises'] = parsons_exercises
-    arguments_dict['adventure_name'] = adventure_name
-    arguments_dict['latest'] = version
-    arguments_dict['quiz'] = quiz
-    arguments_dict['quiz_questions'] = quiz_questions
+    arguments_dict["level_nr"] = str(level_number)
+    arguments_dict["level"] = level_number
+    arguments_dict["current_page"] = "hedy"
+    arguments_dict["prev_level"] = int(level_number) - 1 if int(level_number) > 1 else None
+    arguments_dict["next_level"] = int(level_number) + 1 if int(level_number) < max_level else None
+    arguments_dict["customizations"] = customizations
+    arguments_dict["hide_cheatsheet"] = hide_cheatsheet
+    arguments_dict["enforce_developers_mode"] = enforce_developers_mode
+    arguments_dict["teacher_adventures"] = teacher_adventures
+    arguments_dict["loaded_program"] = loaded_program
+    arguments_dict["adventures"] = adventures
+    arguments_dict["commands"] = commands
+    arguments_dict["parsons"] = parsons
+    arguments_dict["parsons_exercises"] = parsons_exercises
+    arguments_dict["adventure_name"] = adventure_name
+    arguments_dict["latest"] = version
+    arguments_dict["quiz"] = quiz
+    arguments_dict["quiz_questions"] = quiz_questions
 
     return render_template("code-page.html", **arguments_dict, cheatsheet=cheatsheet)
 
@@ -78,32 +95,33 @@ def render_code_editor_with_tabs(cheatsheet, commands, max_level, level_number, 
 def render_tutorial_mode(level, cheatsheet, commands, adventures, parsons_exercises):
     arguments_dict = {}
 
-    arguments_dict['tutorial'] = True
-    arguments_dict['next_level'] = 2
-    arguments_dict['level_nr'] = str(level)
-    arguments_dict['level'] = str(level)
-    arguments_dict['adventures'] = adventures
-    arguments_dict['commands'] = commands
-    arguments_dict['quiz'] = True
-    arguments_dict['parsons'] = True if parsons_exercises else False
-    arguments_dict['parsons_exercises'] = parsons_exercises
+    arguments_dict["tutorial"] = True
+    arguments_dict["next_level"] = 2
+    arguments_dict["level_nr"] = str(level)
+    arguments_dict["level"] = str(level)
+    arguments_dict["adventures"] = adventures
+    arguments_dict["commands"] = commands
+    arguments_dict["quiz"] = True
+    arguments_dict["parsons"] = True if parsons_exercises else False
+    arguments_dict["parsons_exercises"] = parsons_exercises
 
     return render_template("code-page.html", **arguments_dict, cheatsheet=cheatsheet)
+
 
 def render_specific_adventure(level_number, adventure, version, prev_level, next_level):
     arguments_dict = {}
 
     # Meta stuff
-    arguments_dict['specific_adventure'] = True
-    arguments_dict['level_nr'] = str(level_number)
-    arguments_dict['level'] = level_number
-    arguments_dict['prev_level'] = prev_level
-    arguments_dict['next_level'] = next_level
-    arguments_dict['customizations'] = []
-    arguments_dict['hide_cheatsheet'] = None
-    arguments_dict['enforce_developers_mode'] = None
-    arguments_dict['teacher_adventures'] = []
-    arguments_dict['adventures'] = adventure
-    arguments_dict['latest'] = version
+    arguments_dict["specific_adventure"] = True
+    arguments_dict["level_nr"] = str(level_number)
+    arguments_dict["level"] = level_number
+    arguments_dict["prev_level"] = prev_level
+    arguments_dict["next_level"] = next_level
+    arguments_dict["customizations"] = []
+    arguments_dict["hide_cheatsheet"] = None
+    arguments_dict["enforce_developers_mode"] = None
+    arguments_dict["teacher_adventures"] = []
+    arguments_dict["adventures"] = adventure
+    arguments_dict["latest"] = version
 
     return render_template("code-page.html", **arguments_dict)

--- a/highlighting/definition.py
+++ b/highlighting/definition.py
@@ -1,86 +1,86 @@
 # This file defines the special regexes
 
 # list of symbols recognized as characters (with non-Latin characters)
-CHARACTER = '0-9_A-Za-zÀ-ÿء-ي'
+CHARACTER = "0-9_A-Za-zÀ-ÿء-ي"
 
 # definition of word
-WORD      = '([' + CHARACTER + "]+)"
+WORD = "([" + CHARACTER + "]+)"
 # space
-SPACE     = "( +)"
+SPACE = "( +)"
 
-# beginning and end of one line, including space 
-START_LINE = '(^ *)'
-END_LINE = '( *$)'
+# beginning and end of one line, including space
+START_LINE = "(^ *)"
+END_LINE = "( *$)"
 
 # beginning and end of words
-START_WORD = '(^| )'
-END_WORD   = '(?![' + CHARACTER + '])'
+START_WORD = "(^| )"
+END_WORD = "(?![" + CHARACTER + "])"
 
-DIGIT = '[__DIGIT__]'
+DIGIT = "[__DIGIT__]"
 
 TRANSLATE_WORDS = [
-	"print",
-	"ask",
-	"echo",
-	"forward",
-	"turn",
-	"color",
-	"black",
-	"blue",
-	"brown",
-	"gray",
-	"green",
-	"orange",
-	"pink",
-	"purple",
-	"red",
-	"white",
-	"yellow",
-	"right",
-	"left",
-	"is",
-	"sleep",
-	"add",
-	"to_list",
-	"remove",
-	"from",
-	"at",
-	"random",
-	"in",
-	"if",
-	"else",
-	"and",
-	"repeat",
-	"times",
-	"for",
-	"range",
-	"to",
-	"step",
-	"elif",
-	"input",
-	"or",
-	"while",
-	"length",
-	"comma"
+    "print",
+    "ask",
+    "echo",
+    "forward",
+    "turn",
+    "color",
+    "black",
+    "blue",
+    "brown",
+    "gray",
+    "green",
+    "orange",
+    "pink",
+    "purple",
+    "red",
+    "white",
+    "yellow",
+    "right",
+    "left",
+    "is",
+    "sleep",
+    "add",
+    "to_list",
+    "remove",
+    "from",
+    "at",
+    "random",
+    "in",
+    "if",
+    "else",
+    "and",
+    "repeat",
+    "times",
+    "for",
+    "range",
+    "to",
+    "step",
+    "elif",
+    "input",
+    "or",
+    "while",
+    "length",
+    "comma",
 ]
 
 
 TOKEN_CONSTANT = "text"
 
 
-def get_translated_keyword(word, withoutGroup = False):
-	""" Function that allows to add double underscores around the keywords to be translated.
-		The "__" are added before and after only if the keyword belongs to the list.
+def get_translated_keyword(word, withoutGroup=False):
+    """Function that allows to add double underscores around the keywords to be translated.
+    The "__" are added before and after only if the keyword belongs to the list.
 
-		- withoutGroup : bool, Add parentheses for make a group or not
-	"""
-	if withoutGroup:
-		if word in TRANSLATE_WORDS:
-			return "__"+word+"__"
-		else:
-			return word
-	else:
-		if word in TRANSLATE_WORDS:
-			return "(__"+word+"__)"
-		else:
-			return "(" + word + ")"
+    - withoutGroup : bool, Add parentheses for make a group or not
+    """
+    if withoutGroup:
+        if word in TRANSLATE_WORDS:
+            return "__" + word + "__"
+        else:
+            return word
+    else:
+        if word in TRANSLATE_WORDS:
+            return "(__" + word + "__)"
+        else:
+            return "(" + word + ")"

--- a/highlighting/generate-rules-highlighting.py
+++ b/highlighting/generate-rules-highlighting.py
@@ -9,63 +9,68 @@ from rules_list import rule_all
 from definition import TRANSLATE_WORDS
 
 # destinations of files containing syntax highlighting rules
-OUTPUT_PATH_HIGHLIGHT  = "highlighting/highlighting.json"
+OUTPUT_PATH_HIGHLIGHT = "highlighting/highlighting.json"
 OUTPUT_PATH_TRANSLATION = "highlighting/highlighting-trad.json"
 
 # Files containing translations of keywords
-KEYWORDS_PATH = 'content/keywords/'
-KEYWORDS_PATTERN = '(\w+).yaml'
+KEYWORDS_PATH = "content/keywords/"
+KEYWORDS_PATTERN = "(\w+).yaml"
 
 # Functions that collect all the rules, for all levels, of a given language
 def generate_rules():
     return [
-        { 'name': 'level1' , 'rules': rule_level1() },
-        { 'name': 'level2' , 'rules': rule_level2() },
-        { 'name': 'level3' , 'rules': rule_level3() },
-        { 'name': 'level4' , 'rules': rule_level4() },
-        { 'name': 'level5' , 'rules': rule_all(5) },
-        { 'name': 'level6' , 'rules': rule_all(6) },
-        { 'name': 'level7' , 'rules': rule_all(7) },
-        { 'name': 'level8' , 'rules': rule_all(8) },
-        { 'name': 'level9' , 'rules': rule_all(9) },
-        { 'name': 'level10', 'rules': rule_all(10) },
-        { 'name': 'level11', 'rules': rule_all(11) },
-        { 'name': 'level12', 'rules': rule_all(12) },
-        { 'name': 'level13', 'rules': rule_all(13) },
-        { 'name': 'level14', 'rules': rule_all(14) },
-        { 'name': 'level15', 'rules': rule_all(15) },
-        { 'name': 'level16', 'rules': rule_all(16) },
-        { 'name': 'level17', 'rules': rule_all(17) },
-        { 'name': 'level18', 'rules': rule_all(18) },
+        {"name": "level1", "rules": rule_level1()},
+        {"name": "level2", "rules": rule_level2()},
+        {"name": "level3", "rules": rule_level3()},
+        {"name": "level4", "rules": rule_level4()},
+        {"name": "level5", "rules": rule_all(5)},
+        {"name": "level6", "rules": rule_all(6)},
+        {"name": "level7", "rules": rule_all(7)},
+        {"name": "level8", "rules": rule_all(8)},
+        {"name": "level9", "rules": rule_all(9)},
+        {"name": "level10", "rules": rule_all(10)},
+        {"name": "level11", "rules": rule_all(11)},
+        {"name": "level12", "rules": rule_all(12)},
+        {"name": "level13", "rules": rule_all(13)},
+        {"name": "level14", "rules": rule_all(14)},
+        {"name": "level15", "rules": rule_all(15)},
+        {"name": "level16", "rules": rule_all(16)},
+        {"name": "level17", "rules": rule_all(17)},
+        {"name": "level18", "rules": rule_all(18)},
     ]
 
 
 def validate_ruleset(levels):
-  """Confirm that the generated syntax highlighting rules are valid, throw an error if not."""
-  errors = 0
-  for level in levels:
-    for state, rules in level['rules'].items():
-      for rule in rules:
-        r = re.compile(rule['regex'])
+    """Confirm that the generated syntax highlighting rules are valid, throw an error if not."""
+    errors = 0
+    for level in levels:
+        for state, rules in level["rules"].items():
+            for rule in rules:
+                r = re.compile(rule["regex"])
 
-        if r.groups == 0:
-            if type(rule["token"]) != str:
-                raise ValueError(f"In {level['name']}, state \'{state}\': if regex has no groups, token must be a string. In this rule.\n{rule}")
-                errors += 1
+                if r.groups == 0:
+                    if type(rule["token"]) != str:
+                        raise ValueError(
+                            f"In {level['name']}, state '{state}': if regex has no groups, token must be a string. In this rule.\n{rule}"
+                        )
+                        errors += 1
 
-        else:
-            if type(rule["token"]) != list :
-                raise ValueError(f"In {level['name']}, state \'{state}\': if regex has groups, token must be a list. In this rule.\n{rule}")
-                errors += 1
+                else:
+                    if type(rule["token"]) != list:
+                        raise ValueError(
+                            f"In {level['name']}, state '{state}': if regex has groups, token must be a list. In this rule.\n{rule}"
+                        )
+                        errors += 1
 
-            else:
-                if r.groups != len(rule["token"]):
-                    raise ValueError(f"In {level['name']}, state \'{state}\': number of groups in the regex is different from the number of tokens. In this rule.\n{rule}")
-                    errors += 1
+                    else:
+                        if r.groups != len(rule["token"]):
+                            raise ValueError(
+                                f"In {level['name']}, state '{state}': number of groups in the regex is different from the number of tokens. In this rule.\n{rule}"
+                            )
+                            errors += 1
 
-
-  if errors > 0:
-    raise RuntimeError(f'{errors} rules are invalid')
+    if errors > 0:
+        raise RuntimeError(f"{errors} rules are invalid")
 
 
 def get_yaml_content(file_name):
@@ -81,7 +86,7 @@ def get_yaml_content(file_name):
     Returns a dict.
     """
 
-    keywords_file = open(file_name, newline="", encoding='utf-8')
+    keywords_file = open(file_name, newline="", encoding="utf-8")
     yaml_file = yaml.safe_load(keywords_file)
     commandes = {}
     for k in yaml_file:
@@ -98,13 +103,13 @@ def get_commands(language_code, keywords, keywords_ref, translate_words):
     Arguments :
         - language_code : str, Language code (for execption creation)
         - keywords : str, The yaml content of the language you want to translate
-        - keywords_ref : str, The content of the reference language yaml 
+        - keywords_ref : str, The content of the reference language yaml
         - translate_words : str, List of keywords to be translated
 
     Returns a dict.
     """
     R = {}
-    for keyword in sorted(keywords.keys()) :
+    for keyword in sorted(keywords.keys()):
         word = keywords[keyword]
 
         if keyword in translate_words:
@@ -113,9 +118,9 @@ def get_commands(language_code, keywords, keywords_ref, translate_words):
             if language_code == "ar":
                 ch = "\u0640*"
                 word = ch + ch.join(list(word)) + ch
-            
+
             # if the keyword is identical to the reference, we keep only one of the 2
-            if word == keywords_ref[keyword] :
+            if word == keywords_ref[keyword]:
                 R[keyword] = "{}".format(keywords_ref[keyword])
             else:
                 R[keyword] = "{}|{}".format(word, keywords_ref[keyword])
@@ -131,13 +136,13 @@ def get_digits(keywords, keywords_ref):
 
     Arguments :
         - keywords : str, The yaml content of the language you want to translate
-        - keywords_ref : str, The content of the reference language yaml 
+        - keywords_ref : str, The content of the reference language yaml
 
     Returns a dict.
     """
     digits = []
 
-    for d in '0123456789':
+    for d in "0123456789":
         if keywords_ref[d] not in digits:
             digits.append(keywords_ref[d])
         if keywords[d] not in digits:
@@ -154,7 +159,7 @@ def get_translations(KEYWORDS_PATH, KEYWORDS_PATTERN):
 
     # get content
     for language_file in list_language_file:
-        language_code = re.search(KEYWORDS_PATTERN,language_file).group(1)
+        language_code = re.search(KEYWORDS_PATTERN, language_file).group(1)
         tmp[language_code] = get_yaml_content(os.path.join(KEYWORDS_PATH, language_file))
 
     # english is ref
@@ -163,7 +168,7 @@ def get_translations(KEYWORDS_PATH, KEYWORDS_PATTERN):
     result = {}
     for language_code in sorted(tmp.keys()):
 
-        # KEYWORDS 
+        # KEYWORDS
         result[language_code] = get_commands(language_code, tmp[language_code], reference, TRANSLATE_WORDS)
 
         # DIGITS
@@ -172,19 +177,16 @@ def get_translations(KEYWORDS_PATH, KEYWORDS_PATTERN):
     return result
 
 
-
-os.chdir(os.path.dirname(__file__) +"/..")
-
+os.chdir(os.path.dirname(__file__) + "/..")
 
 
 print("Generation of translations.....................", end="")
 language_keywords = get_translations(KEYWORDS_PATH, KEYWORDS_PATTERN)
 # Saving the rules in the corresponding file
-file_lang = open(OUTPUT_PATH_TRANSLATION, "w",encoding='utf8')
-file_lang.write(json.dumps(language_keywords, indent=4,ensure_ascii=False))
+file_lang = open(OUTPUT_PATH_TRANSLATION, "w", encoding="utf8")
+file_lang.write(json.dumps(language_keywords, indent=4, ensure_ascii=False))
 file_lang.close()
 print(" Done !")
-
 
 
 print("Generation of syntax highlighting rules........", end="")
@@ -195,9 +197,8 @@ levels = generate_rules()
 validate_ruleset(levels)
 
 # Saving the rules in the corresponding file
-file_syntax = open(OUTPUT_PATH_HIGHLIGHT,"w",encoding='utf8')
-file_syntax.write(json.dumps(levels,indent=4,ensure_ascii=False))
+file_syntax = open(OUTPUT_PATH_HIGHLIGHT, "w", encoding="utf8")
+file_syntax.write(json.dumps(levels, indent=4, ensure_ascii=False))
 file_syntax.close()
 
 print(" Done !")
-

--- a/highlighting/list_keywords.py
+++ b/highlighting/list_keywords.py
@@ -1,32 +1,28 @@
 from definition import *
 
-#extra rules for ask
+# extra rules for ask
 ask_after_is = {
     "regex": START_WORD + get_translated_keyword("is") + SPACE + get_translated_keyword("ask"),
-    "token": ["text","keyword","text","keyword"]
+    "token": ["text", "keyword", "text", "keyword"],
 }
 
-ask_after_equal = {
-    "regex": "(=)" + SPACE + get_translated_keyword("ask"),
-    "token": ["keyword","text","keyword"]
-}
-
+ask_after_equal = {"regex": "(=)" + SPACE + get_translated_keyword("ask"), "token": ["keyword", "text", "keyword"]}
 
 
 # This variable lists all the keywords in each level, i.e. everything that should be displayed in red (of type `keyword`)
-# 
-# There are several categories of keywords: 
+#
+# There are several categories of keywords:
 # - space_before_and_after
-#   These are the keywords that must be "alone" so neither preceded nor followed directly by a word 
-# 
+#   These are the keywords that must be "alone" so neither preceded nor followed directly by a word
+#
 # - no_space
 #   These are the keywords that are independent of the context (formerly the symbols).
 #   In particular, even if they are between 2 words, the syntax highlighting will select them
-# 
+#
 # - space_before
 #   This category of keywords allows you to have keywords that are not preceded
 #   by another word, but that can be followed immediately by another word. (see the PR #2413)
-# 
+#
 # - space_after
 #   This category of keywords allows you to have keywords that can be preceded immediately
 #   by another word, but that are not followed by another word.
@@ -41,154 +37,304 @@ ask_after_equal = {
 #   Some additional rules that will be added to reduce over highlighting
 
 LEVELS = {
-    4 :{ # not used
-        "space_before_and_after" : ["is","at","add","to_list","remove","from","color"],
-        "no_space"               : ["comma"],
-        "space_before"           : ["print","sleep","forward","turn","random"],
-        "space_after"            : [],
+    4: {  # not used
+        "space_before_and_after": ["is", "at", "add", "to_list", "remove", "from", "color"],
+        "no_space": ["comma"],
+        "space_before": ["print", "sleep", "forward", "turn", "random"],
+        "space_after": [],
         "constant": ["black", "blue", "brown", "gray", "green", "orange", "pink", "purple", "red", "white", "yellow"],
-        "number"  : False,
+        "number": False,
         "number_with_decimal": False,
-        "extra_rules" : [ask_after_is]
+        "extra_rules": [ask_after_is],
     },
-    5 :{
-        "space_before_and_after" : ["is","at","add","to_list","remove","from","in","if","else","color"],
-        "no_space"               : ["comma"],
-        "space_before"           : ["print","sleep","forward","turn","random"],
-        "space_after"            : [],
+    5: {
+        "space_before_and_after": ["is", "at", "add", "to_list", "remove", "from", "in", "if", "else", "color"],
+        "no_space": ["comma"],
+        "space_before": ["print", "sleep", "forward", "turn", "random"],
+        "space_after": [],
         "constant": ["black", "blue", "brown", "gray", "green", "orange", "pink", "purple", "red", "white", "yellow"],
-        "number"  : False,
+        "number": False,
         "number_with_decimal": False,
-        "extra_rules" : [ask_after_is]
+        "extra_rules": [ask_after_is],
     },
-    6 :{
-        "space_before_and_after" : ["is","at","add","to_list","remove","from","in","if","else","color"],
-        "no_space"               : ["comma","-","=","/","\\*","\\+"],
-        "space_before"           : ["print","sleep","forward","turn","random"],
-        "space_after"            : [],
+    6: {
+        "space_before_and_after": ["is", "at", "add", "to_list", "remove", "from", "in", "if", "else", "color"],
+        "no_space": ["comma", "-", "=", "/", "\\*", "\\+"],
+        "space_before": ["print", "sleep", "forward", "turn", "random"],
+        "space_after": [],
         "constant": ["black", "blue", "brown", "gray", "green", "orange", "pink", "purple", "red", "white", "yellow"],
-        "number"  : True,
+        "number": True,
         "number_with_decimal": False,
-        "extra_rules" : [ask_after_is,ask_after_equal]
+        "extra_rules": [ask_after_is, ask_after_equal],
     },
-    7 :{
-        "space_before_and_after" : ["is","at","add","to_list","remove","from","in","if","else","repeat","times","color"],
-        "no_space"               : ["comma","-","=","/","\\*","\\+"],
-        "space_before"           : ["print","sleep","forward","turn","random"],
-        "space_after"            : [],
+    7: {
+        "space_before_and_after": [
+            "is",
+            "at",
+            "add",
+            "to_list",
+            "remove",
+            "from",
+            "in",
+            "if",
+            "else",
+            "repeat",
+            "times",
+            "color",
+        ],
+        "no_space": ["comma", "-", "=", "/", "\\*", "\\+"],
+        "space_before": ["print", "sleep", "forward", "turn", "random"],
+        "space_after": [],
         "constant": ["black", "blue", "brown", "gray", "green", "orange", "pink", "purple", "red", "white", "yellow"],
-        "number"  : True,
+        "number": True,
         "number_with_decimal": False,
-        "extra_rules" : [ask_after_is,ask_after_equal]
+        "extra_rules": [ask_after_is, ask_after_equal],
     },
-    8 :{
-        "space_before_and_after" : ["is","at","add","to_list","remove","from","in","if","repeat","color"],
-        "no_space"               : ["comma","-","=","/","\\*","\\+"],
-        "space_before"           : ["print","sleep","forward","turn","random","else","times"],
-        "space_after"            : [],
+    8: {
+        "space_before_and_after": ["is", "at", "add", "to_list", "remove", "from", "in", "if", "repeat", "color"],
+        "no_space": ["comma", "-", "=", "/", "\\*", "\\+"],
+        "space_before": ["print", "sleep", "forward", "turn", "random", "else", "times"],
+        "space_after": [],
         "constant": ["black", "blue", "brown", "gray", "green", "orange", "pink", "purple", "red", "white", "yellow"],
-        "number"  : True,
+        "number": True,
         "number_with_decimal": False,
-        "extra_rules" : [ask_after_is,ask_after_equal]
+        "extra_rules": [ask_after_is, ask_after_equal],
     },
-    9 :{
-        "space_before_and_after" : ["is","at","add","to_list","remove","from","in","if","repeat","color"],
-        "no_space"               : ["comma","-","=","/","\\*","\\+"],
-        "space_before"           : ["print","sleep","forward","turn","random","else","times"],
-        "space_after"            : [],
+    9: {
+        "space_before_and_after": ["is", "at", "add", "to_list", "remove", "from", "in", "if", "repeat", "color"],
+        "no_space": ["comma", "-", "=", "/", "\\*", "\\+"],
+        "space_before": ["print", "sleep", "forward", "turn", "random", "else", "times"],
+        "space_after": [],
         "constant": ["black", "blue", "brown", "gray", "green", "orange", "pink", "purple", "red", "white", "yellow"],
-        "number"  : True,
+        "number": True,
         "number_with_decimal": False,
-        "extra_rules" : [ask_after_is,ask_after_equal]
+        "extra_rules": [ask_after_is, ask_after_equal],
     },
-    10 :{
-        "space_before_and_after" : ["is","at","add","to_list","remove","from","in","if","repeat","for","color"],
-        "no_space"               : ["comma","-","=","/","\\*","\\+"],
-        "space_before"           : ["print","sleep","forward","turn","random","else","times"],
-        "space_after"            : [],
+    10: {
+        "space_before_and_after": [
+            "is",
+            "at",
+            "add",
+            "to_list",
+            "remove",
+            "from",
+            "in",
+            "if",
+            "repeat",
+            "for",
+            "color",
+        ],
+        "no_space": ["comma", "-", "=", "/", "\\*", "\\+"],
+        "space_before": ["print", "sleep", "forward", "turn", "random", "else", "times"],
+        "space_after": [],
         "constant": ["black", "blue", "brown", "gray", "green", "orange", "pink", "purple", "red", "white", "yellow"],
-        "number"  : True,
+        "number": True,
         "number_with_decimal": False,
-        "extra_rules" : [ask_after_is,ask_after_equal]
+        "extra_rules": [ask_after_is, ask_after_equal],
     },
-    11 :{
-        "space_before_and_after" : ["is","at","add","to_list","remove","from","in","if","for","range","to","repeat"],
-        "no_space"               : ["comma","-","=","/","\\*","\\+"],
-        "space_before"           : ["print","sleep","random","else","times"],
-        "space_after"            : [],
+    11: {
+        "space_before_and_after": [
+            "is",
+            "at",
+            "add",
+            "to_list",
+            "remove",
+            "from",
+            "in",
+            "if",
+            "for",
+            "range",
+            "to",
+            "repeat",
+        ],
+        "no_space": ["comma", "-", "=", "/", "\\*", "\\+"],
+        "space_before": ["print", "sleep", "random", "else", "times"],
+        "space_after": [],
         "constant": [],
-        "number"  : True,
+        "number": True,
         "number_with_decimal": False,
-        "extra_rules" : [ask_after_is,ask_after_equal]
+        "extra_rules": [ask_after_is, ask_after_equal],
     },
-    12 :{
-        "space_before_and_after" : ["is","at","add","to_list","remove","from","in","if","for","range","to","repeat"],
-        "no_space"               : ["comma","-","=","/","\\*","\\+"],
-        "space_before"           : ["print","sleep","random","else","times"],
-        "space_after"            : [],
+    12: {
+        "space_before_and_after": [
+            "is",
+            "at",
+            "add",
+            "to_list",
+            "remove",
+            "from",
+            "in",
+            "if",
+            "for",
+            "range",
+            "to",
+            "repeat",
+        ],
+        "no_space": ["comma", "-", "=", "/", "\\*", "\\+"],
+        "space_before": ["print", "sleep", "random", "else", "times"],
+        "space_after": [],
         "constant": [],
-        "number"  : True,
-        "number_with_decimal": True ,
-        "extra_rules" : [ask_after_is,ask_after_equal]
-    },
-    13 :{
-        "space_before_and_after" : ["is","at","add","to_list","remove","from","in","if","for","range","to","and","or","repeat"],
-        "no_space"               : ["comma","-","=","/","\\*","\\+"],
-        "space_before"           : ["print","sleep","random","else","times"],
-        "space_after"            : [],
-        "constant": [],
-        "number"  : True,
-        "number_with_decimal": True ,
-        "extra_rules" : [ask_after_is,ask_after_equal]
-    },
-    14 :{
-        "space_before_and_after" : ["is","at","add","to_list","remove","from","in","if","for","range","to","and","or","else","repeat"],
-        "no_space"               : ["comma","-","=","/","\\*","\\+","<",">","!"],
-        "space_before"           : ["print","sleep","random","times"],
-        "space_after"            : [],
-        "constant": [],
-        "number"  : True,
-        "number_with_decimal": True ,
-        "extra_rules" : [ask_after_is,ask_after_equal]
-    },
-    15 :{
-        "space_before_and_after" : ["is","at","add","to_list","remove","from","in","if","for","range","to","and","or","while","repeat"],
-        "no_space"               : ["comma","-","=","/","\\*","\\+","<",">","!"],
-        "space_before"           : ["print","sleep","random","else","times"],
-        "space_after"            : [],
-        "constant": [],
-        "number"  : True,
-        "number_with_decimal": True ,
-        "extra_rules" : [ask_after_is,ask_after_equal]
-    },
-    16 :{
-        "space_before_and_after" : ["is","at","add","to_list","remove","from","in","if","else","for","range","to","and","or","while","repeat"],
-        "no_space"               : ["comma","-","=","/","\\*","\\+","<",">","!","\\[","\\]"],
-        "space_before"           : ["print","sleep","random","times"],
-        "space_after"            : [],
-        "constant": [],
-        "number"  : True,
-        "number_with_decimal": True ,
-        "extra_rules" : [ask_after_is,ask_after_equal]
-    },
-    17 :{
-        "space_before_and_after" : ["is","at","add","to_list","remove","from","in","if","else","for","range","to","and","or","while","repeat"],
-        "no_space"               : ["comma","-","=","/","\\*","\\+","<",">","!","\\[","\\]",":"],
-        "space_before"           : ["print","sleep","random","times"],
-        "space_after"            : ["elif"],
-        "constant": [],
-        "number"  : True,
-        "number_with_decimal": True ,
-        "extra_rules" : [ask_after_is,ask_after_equal]
-    },
-    18 :{
-        "space_before_and_after" : ["is","at","add","to_list","remove","from","in","if","else","for","range","to","and","or","while","input","repeat"],
-        "no_space"               : ["comma","-","=","/","\\*","\\+","<",">","!","\\[","\\]",":","\\(","\\)"],
-        "space_before"           : ["print","sleep","random","times"],
-        "space_after"            : ["elif"],
-        "constant": [],
-        "number"  : True,
+        "number": True,
         "number_with_decimal": True,
-        "extra_rules" : [ask_after_is,ask_after_equal]
+        "extra_rules": [ask_after_is, ask_after_equal],
+    },
+    13: {
+        "space_before_and_after": [
+            "is",
+            "at",
+            "add",
+            "to_list",
+            "remove",
+            "from",
+            "in",
+            "if",
+            "for",
+            "range",
+            "to",
+            "and",
+            "or",
+            "repeat",
+        ],
+        "no_space": ["comma", "-", "=", "/", "\\*", "\\+"],
+        "space_before": ["print", "sleep", "random", "else", "times"],
+        "space_after": [],
+        "constant": [],
+        "number": True,
+        "number_with_decimal": True,
+        "extra_rules": [ask_after_is, ask_after_equal],
+    },
+    14: {
+        "space_before_and_after": [
+            "is",
+            "at",
+            "add",
+            "to_list",
+            "remove",
+            "from",
+            "in",
+            "if",
+            "for",
+            "range",
+            "to",
+            "and",
+            "or",
+            "else",
+            "repeat",
+        ],
+        "no_space": ["comma", "-", "=", "/", "\\*", "\\+", "<", ">", "!"],
+        "space_before": ["print", "sleep", "random", "times"],
+        "space_after": [],
+        "constant": [],
+        "number": True,
+        "number_with_decimal": True,
+        "extra_rules": [ask_after_is, ask_after_equal],
+    },
+    15: {
+        "space_before_and_after": [
+            "is",
+            "at",
+            "add",
+            "to_list",
+            "remove",
+            "from",
+            "in",
+            "if",
+            "for",
+            "range",
+            "to",
+            "and",
+            "or",
+            "while",
+            "repeat",
+        ],
+        "no_space": ["comma", "-", "=", "/", "\\*", "\\+", "<", ">", "!"],
+        "space_before": ["print", "sleep", "random", "else", "times"],
+        "space_after": [],
+        "constant": [],
+        "number": True,
+        "number_with_decimal": True,
+        "extra_rules": [ask_after_is, ask_after_equal],
+    },
+    16: {
+        "space_before_and_after": [
+            "is",
+            "at",
+            "add",
+            "to_list",
+            "remove",
+            "from",
+            "in",
+            "if",
+            "else",
+            "for",
+            "range",
+            "to",
+            "and",
+            "or",
+            "while",
+            "repeat",
+        ],
+        "no_space": ["comma", "-", "=", "/", "\\*", "\\+", "<", ">", "!", "\\[", "\\]"],
+        "space_before": ["print", "sleep", "random", "times"],
+        "space_after": [],
+        "constant": [],
+        "number": True,
+        "number_with_decimal": True,
+        "extra_rules": [ask_after_is, ask_after_equal],
+    },
+    17: {
+        "space_before_and_after": [
+            "is",
+            "at",
+            "add",
+            "to_list",
+            "remove",
+            "from",
+            "in",
+            "if",
+            "else",
+            "for",
+            "range",
+            "to",
+            "and",
+            "or",
+            "while",
+            "repeat",
+        ],
+        "no_space": ["comma", "-", "=", "/", "\\*", "\\+", "<", ">", "!", "\\[", "\\]", ":"],
+        "space_before": ["print", "sleep", "random", "times"],
+        "space_after": ["elif"],
+        "constant": [],
+        "number": True,
+        "number_with_decimal": True,
+        "extra_rules": [ask_after_is, ask_after_equal],
+    },
+    18: {
+        "space_before_and_after": [
+            "is",
+            "at",
+            "add",
+            "to_list",
+            "remove",
+            "from",
+            "in",
+            "if",
+            "else",
+            "for",
+            "range",
+            "to",
+            "and",
+            "or",
+            "while",
+            "input",
+            "repeat",
+        ],
+        "no_space": ["comma", "-", "=", "/", "\\*", "\\+", "<", ">", "!", "\\[", "\\]", ":", "\\(", "\\)"],
+        "space_before": ["print", "sleep", "random", "times"],
+        "space_after": ["elif"],
+        "constant": [],
+        "number": True,
+        "number_with_decimal": True,
+        "extra_rules": [ask_after_is, ask_after_equal],
     },
 }

--- a/highlighting/rules_automaton.py
+++ b/highlighting/rules_automaton.py
@@ -4,393 +4,593 @@ from definition import *
 # so we have to color them with respect to what is around,
 # so we use particular functions
 def rule_level1():
-    return add_extra_rule({
-    "start" : [{
-            'regex': START_LINE + get_translated_keyword("ask"),
-            'token': ["text",'keyword'],
-            'next': 'value',
-        },{
-            'regex': START_LINE + get_translated_keyword("print"),
-            'token': ["text",'keyword'],
-            'next': 'value',
-        },{
-            'regex': START_LINE + get_translated_keyword("echo"),
-            'token': ["text",'keyword'], 
-            'next': 'value',
-        },{
-            'regex': START_LINE + get_translated_keyword("forward"),
-            'token': ["text",'keyword'],
-            'next': 'value',
-        },{
-            'regex': START_LINE + get_translated_keyword("turn"),
-            'token': ["text",'keyword'],
-            'next': 'direction',
-        },{
-            'regex': START_LINE + get_translated_keyword("color"),
-            'token': ["text",'keyword'],
-            'next': 'color',
-        }],
-    "value" : [],
-    "color" : [{
-            'regex': "(" + \
-                    get_translated_keyword("black",True)  + "|" +\
-                    get_translated_keyword("gray",True)   + "|" +\
-                    get_translated_keyword("white",True)  + "|" +\
-                    get_translated_keyword("green",True)  + "|" +\
-                    get_translated_keyword("blue",True)   + "|" +\
-                    get_translated_keyword("purple",True) + "|" +\
-                    get_translated_keyword("brown",True)  + "|" +\
-                    get_translated_keyword("pink",True)   + "|" +\
-                    get_translated_keyword("red",True)    + "|" +\
-                    get_translated_keyword("orange",True) + "|" +\
-                    get_translated_keyword("yellow",True) + \
-                ")",
-            'token': [TOKEN_CONSTANT],
-        }],
-    "direction" : [{
-            'regex': "(" +\
-                    get_translated_keyword("right",True) + "|" +\
-                    get_translated_keyword("left",True) +\
-                ")",
-            'token': [TOKEN_CONSTANT],
-        }]
-    })
+    return add_extra_rule(
+        {
+            "start": [
+                {
+                    "regex": START_LINE + get_translated_keyword("ask"),
+                    "token": ["text", "keyword"],
+                    "next": "value",
+                },
+                {
+                    "regex": START_LINE + get_translated_keyword("print"),
+                    "token": ["text", "keyword"],
+                    "next": "value",
+                },
+                {
+                    "regex": START_LINE + get_translated_keyword("echo"),
+                    "token": ["text", "keyword"],
+                    "next": "value",
+                },
+                {
+                    "regex": START_LINE + get_translated_keyword("forward"),
+                    "token": ["text", "keyword"],
+                    "next": "value",
+                },
+                {
+                    "regex": START_LINE + get_translated_keyword("turn"),
+                    "token": ["text", "keyword"],
+                    "next": "direction",
+                },
+                {
+                    "regex": START_LINE + get_translated_keyword("color"),
+                    "token": ["text", "keyword"],
+                    "next": "color",
+                },
+            ],
+            "value": [],
+            "color": [
+                {
+                    "regex": "("
+                    + get_translated_keyword("black", True)
+                    + "|"
+                    + get_translated_keyword("gray", True)
+                    + "|"
+                    + get_translated_keyword("white", True)
+                    + "|"
+                    + get_translated_keyword("green", True)
+                    + "|"
+                    + get_translated_keyword("blue", True)
+                    + "|"
+                    + get_translated_keyword("purple", True)
+                    + "|"
+                    + get_translated_keyword("brown", True)
+                    + "|"
+                    + get_translated_keyword("pink", True)
+                    + "|"
+                    + get_translated_keyword("red", True)
+                    + "|"
+                    + get_translated_keyword("orange", True)
+                    + "|"
+                    + get_translated_keyword("yellow", True)
+                    + ")",
+                    "token": [TOKEN_CONSTANT],
+                }
+            ],
+            "direction": [
+                {
+                    "regex": "("
+                    + get_translated_keyword("right", True)
+                    + "|"
+                    + get_translated_keyword("left", True)
+                    + ")",
+                    "token": [TOKEN_CONSTANT],
+                }
+            ],
+        }
+    )
 
-def rule_level2() :
-    return add_extra_rule({
-    "start" : [{
-            'regex': START_LINE + get_translated_keyword("print"),
-            'token': ["text",'keyword'],
-            'next': 'value',
-        },{
-            'regex': START_LINE + WORD + SPACE + get_translated_keyword("is") + SPACE + get_translated_keyword("ask"),
-            'token': ["text","text","text",'keyword',"text","keyword"],
-            'next': 'value',
-        },{
-            'regex': START_LINE + WORD + SPACE + get_translated_keyword("is"),
-            'token': ["text","text","text",'keyword'],
-            'next': 'value',
-        },{
-            'regex': START_LINE + get_translated_keyword("sleep"),
-            'token': ["text",'keyword'],
-            'next': 'value',
-        },{
-            'regex': START_LINE + get_translated_keyword("forward"),
-            'token': ["text",'keyword'],
-            'next': 'value',
-        },{
-            'regex': START_LINE + get_translated_keyword("turn"),
-            'token': ["text",'keyword'],
-            'next': 'value',
-        },{
-            'regex': START_LINE + get_translated_keyword("color"),
-            'token': ["text",'keyword'],
-            'next': 'value',
-        }],
-    "value" : [{
-            'regex': "(" +\
-                    get_translated_keyword("black",True) + "|" +\
-                    get_translated_keyword("blue",True) + "|" +\
-                    get_translated_keyword("brown",True) + "|" +\
-                    get_translated_keyword("gray",True) + "|" +\
-                    get_translated_keyword("green",True) + "|" +\
-                    get_translated_keyword("orange",True) + "|" +\
-                    get_translated_keyword("pink",True) + "|" +\
-                    get_translated_keyword("purple",True) + "|" +\
-                    get_translated_keyword("red",True) + "|" +\
-                    get_translated_keyword("white",True) + "|" +\
-                    get_translated_keyword("yellow",True) +\
-                ")",
-            'token': [TOKEN_CONSTANT],
-        }]
-    })
+
+def rule_level2():
+    return add_extra_rule(
+        {
+            "start": [
+                {
+                    "regex": START_LINE + get_translated_keyword("print"),
+                    "token": ["text", "keyword"],
+                    "next": "value",
+                },
+                {
+                    "regex": START_LINE
+                    + WORD
+                    + SPACE
+                    + get_translated_keyword("is")
+                    + SPACE
+                    + get_translated_keyword("ask"),
+                    "token": ["text", "text", "text", "keyword", "text", "keyword"],
+                    "next": "value",
+                },
+                {
+                    "regex": START_LINE + WORD + SPACE + get_translated_keyword("is"),
+                    "token": ["text", "text", "text", "keyword"],
+                    "next": "value",
+                },
+                {
+                    "regex": START_LINE + get_translated_keyword("sleep"),
+                    "token": ["text", "keyword"],
+                    "next": "value",
+                },
+                {
+                    "regex": START_LINE + get_translated_keyword("forward"),
+                    "token": ["text", "keyword"],
+                    "next": "value",
+                },
+                {
+                    "regex": START_LINE + get_translated_keyword("turn"),
+                    "token": ["text", "keyword"],
+                    "next": "value",
+                },
+                {
+                    "regex": START_LINE + get_translated_keyword("color"),
+                    "token": ["text", "keyword"],
+                    "next": "value",
+                },
+            ],
+            "value": [
+                {
+                    "regex": "("
+                    + get_translated_keyword("black", True)
+                    + "|"
+                    + get_translated_keyword("blue", True)
+                    + "|"
+                    + get_translated_keyword("brown", True)
+                    + "|"
+                    + get_translated_keyword("gray", True)
+                    + "|"
+                    + get_translated_keyword("green", True)
+                    + "|"
+                    + get_translated_keyword("orange", True)
+                    + "|"
+                    + get_translated_keyword("pink", True)
+                    + "|"
+                    + get_translated_keyword("purple", True)
+                    + "|"
+                    + get_translated_keyword("red", True)
+                    + "|"
+                    + get_translated_keyword("white", True)
+                    + "|"
+                    + get_translated_keyword("yellow", True)
+                    + ")",
+                    "token": [TOKEN_CONSTANT],
+                }
+            ],
+        }
+    )
+
 
 def rule_level3():
-    return add_extra_rule({"start" : [{
-        'regex': START_LINE + WORD + SPACE + get_translated_keyword("is") + "( *)" + get_translated_keyword("ask"),
-        'token': ["text",'text','text','keyword','text','keyword'],
-        'next': 'valueExpr',
-    },{
-        'regex': START_LINE + WORD + SPACE + get_translated_keyword("is"),
-        'token': ["text",'text','text','keyword'],
-        'next': 'value',
-    },{
-        'regex': START_LINE + get_translated_keyword("print") ,
-        'token': ['text','keyword'],
-        'next': 'valueExpr',
-    },{
-        'regex': START_LINE + get_translated_keyword("turn") ,
-        'token': ['text','keyword'],
-        'next': 'valueExpr',
-    },{
-        'regex': START_LINE + get_translated_keyword("sleep") ,
-        'token': ['text','keyword'],
-        'next': 'valueExpr',
-    },{
-        'regex': START_LINE + get_translated_keyword("forward") ,
-        'token': ['text','keyword'],
-        'next': 'valueExpr',
-    },{
-        'regex': START_LINE + get_translated_keyword("add"),
-        'token': ["text",'keyword'],
-        'next': 'valAdd',
-    },{
-        'regex': START_LINE + get_translated_keyword("remove"),
-        'token': ["text",'keyword'],
-        'next': 'valRemove',
-    },{
-        'regex': START_LINE + get_translated_keyword("color"),
-        'token': ["text",'keyword'],
-        'next': 'value',
-    }],
-    "value" : [{
-        'regex': START_WORD + get_translated_keyword("at") + SPACE + get_translated_keyword("random") ,
-        'token': ['text','keyword','keyword','keyword'],
-    },{
-        'regex': START_WORD + get_translated_keyword("at") + END_WORD,
-        'token': ['text','keyword'],
-    },{
-        'regex': get_translated_keyword("comma") ,
-        'token': ['keyword'],
-    },{
-        'regex': "(" +\
-                get_translated_keyword("black",True) + "|" +\
-                get_translated_keyword("blue",True) + "|" +\
-                get_translated_keyword("brown",True) + "|" +\
-                get_translated_keyword("gray",True) + "|" +\
-                get_translated_keyword("green",True) + "|" +\
-                get_translated_keyword("orange",True) + "|" +\
-                get_translated_keyword("pink",True) + "|" +\
-                get_translated_keyword("purple",True) + "|" +\
-                get_translated_keyword("red",True) + "|" +\
-                get_translated_keyword("white",True) + "|" +\
-                get_translated_keyword("yellow",True) +\
-            ")",
-        'token': [TOKEN_CONSTANT],
-    }],
-    "valueExpr" : [{
-        'regex': START_WORD + get_translated_keyword("at") + SPACE + get_translated_keyword("random") ,
-        'token': ['text','keyword','keyword','keyword'],
-    },{
-        'regex': START_WORD + get_translated_keyword("at") + END_WORD,
-        'token': ['text','keyword'],
-    }],
-    "valAdd"    : [{
-        'regex': START_WORD + get_translated_keyword("to_list") + END_WORD ,
-        'token': ['text','keyword'],
-        'next': 'valueTo',
-    },{
-        'regex': "(" +\
-                get_translated_keyword("black",True) + "|" +\
-                get_translated_keyword("blue",True) + "|" +\
-                get_translated_keyword("brown",True) + "|" +\
-                get_translated_keyword("gray",True) + "|" +\
-                get_translated_keyword("green",True) + "|" +\
-                get_translated_keyword("orange",True) + "|" +\
-                get_translated_keyword("pink",True) + "|" +\
-                get_translated_keyword("purple",True) + "|" +\
-                get_translated_keyword("red",True) + "|" +\
-                get_translated_keyword("white",True) + "|" +\
-                get_translated_keyword("yellow",True) +\
-            ")",
-        'token': [TOKEN_CONSTANT],
-    }],
-    "valueTo" : [],
-    "valRemove" : [{
-        'regex': START_WORD + get_translated_keyword("from") + END_WORD ,
-        'token': ['text','keyword'],
-        'next': 'valueFrom',
-    },{
-        'regex': "(" +\
-                get_translated_keyword("black",True) + "|" +\
-                get_translated_keyword("blue",True) + "|" +\
-                get_translated_keyword("brown",True) + "|" +\
-                get_translated_keyword("gray",True) + "|" +\
-                get_translated_keyword("green",True) + "|" +\
-                get_translated_keyword("orange",True) + "|" +\
-                get_translated_keyword("pink",True) + "|" +\
-                get_translated_keyword("purple",True) + "|" +\
-                get_translated_keyword("red",True) + "|" +\
-                get_translated_keyword("white",True) + "|" +\
-                get_translated_keyword("yellow",True) +\
-            ")",
-        'token': [TOKEN_CONSTANT],
-    }],
-    "valueFrom" : [],
-    })
+    return add_extra_rule(
+        {
+            "start": [
+                {
+                    "regex": START_LINE
+                    + WORD
+                    + SPACE
+                    + get_translated_keyword("is")
+                    + "( *)"
+                    + get_translated_keyword("ask"),
+                    "token": ["text", "text", "text", "keyword", "text", "keyword"],
+                    "next": "valueExpr",
+                },
+                {
+                    "regex": START_LINE + WORD + SPACE + get_translated_keyword("is"),
+                    "token": ["text", "text", "text", "keyword"],
+                    "next": "value",
+                },
+                {
+                    "regex": START_LINE + get_translated_keyword("print"),
+                    "token": ["text", "keyword"],
+                    "next": "valueExpr",
+                },
+                {
+                    "regex": START_LINE + get_translated_keyword("turn"),
+                    "token": ["text", "keyword"],
+                    "next": "valueExpr",
+                },
+                {
+                    "regex": START_LINE + get_translated_keyword("sleep"),
+                    "token": ["text", "keyword"],
+                    "next": "valueExpr",
+                },
+                {
+                    "regex": START_LINE + get_translated_keyword("forward"),
+                    "token": ["text", "keyword"],
+                    "next": "valueExpr",
+                },
+                {
+                    "regex": START_LINE + get_translated_keyword("add"),
+                    "token": ["text", "keyword"],
+                    "next": "valAdd",
+                },
+                {
+                    "regex": START_LINE + get_translated_keyword("remove"),
+                    "token": ["text", "keyword"],
+                    "next": "valRemove",
+                },
+                {
+                    "regex": START_LINE + get_translated_keyword("color"),
+                    "token": ["text", "keyword"],
+                    "next": "value",
+                },
+            ],
+            "value": [
+                {
+                    "regex": START_WORD + get_translated_keyword("at") + SPACE + get_translated_keyword("random"),
+                    "token": ["text", "keyword", "keyword", "keyword"],
+                },
+                {
+                    "regex": START_WORD + get_translated_keyword("at") + END_WORD,
+                    "token": ["text", "keyword"],
+                },
+                {
+                    "regex": get_translated_keyword("comma"),
+                    "token": ["keyword"],
+                },
+                {
+                    "regex": "("
+                    + get_translated_keyword("black", True)
+                    + "|"
+                    + get_translated_keyword("blue", True)
+                    + "|"
+                    + get_translated_keyword("brown", True)
+                    + "|"
+                    + get_translated_keyword("gray", True)
+                    + "|"
+                    + get_translated_keyword("green", True)
+                    + "|"
+                    + get_translated_keyword("orange", True)
+                    + "|"
+                    + get_translated_keyword("pink", True)
+                    + "|"
+                    + get_translated_keyword("purple", True)
+                    + "|"
+                    + get_translated_keyword("red", True)
+                    + "|"
+                    + get_translated_keyword("white", True)
+                    + "|"
+                    + get_translated_keyword("yellow", True)
+                    + ")",
+                    "token": [TOKEN_CONSTANT],
+                },
+            ],
+            "valueExpr": [
+                {
+                    "regex": START_WORD + get_translated_keyword("at") + SPACE + get_translated_keyword("random"),
+                    "token": ["text", "keyword", "keyword", "keyword"],
+                },
+                {
+                    "regex": START_WORD + get_translated_keyword("at") + END_WORD,
+                    "token": ["text", "keyword"],
+                },
+            ],
+            "valAdd": [
+                {
+                    "regex": START_WORD + get_translated_keyword("to_list") + END_WORD,
+                    "token": ["text", "keyword"],
+                    "next": "valueTo",
+                },
+                {
+                    "regex": "("
+                    + get_translated_keyword("black", True)
+                    + "|"
+                    + get_translated_keyword("blue", True)
+                    + "|"
+                    + get_translated_keyword("brown", True)
+                    + "|"
+                    + get_translated_keyword("gray", True)
+                    + "|"
+                    + get_translated_keyword("green", True)
+                    + "|"
+                    + get_translated_keyword("orange", True)
+                    + "|"
+                    + get_translated_keyword("pink", True)
+                    + "|"
+                    + get_translated_keyword("purple", True)
+                    + "|"
+                    + get_translated_keyword("red", True)
+                    + "|"
+                    + get_translated_keyword("white", True)
+                    + "|"
+                    + get_translated_keyword("yellow", True)
+                    + ")",
+                    "token": [TOKEN_CONSTANT],
+                },
+            ],
+            "valueTo": [],
+            "valRemove": [
+                {
+                    "regex": START_WORD + get_translated_keyword("from") + END_WORD,
+                    "token": ["text", "keyword"],
+                    "next": "valueFrom",
+                },
+                {
+                    "regex": "("
+                    + get_translated_keyword("black", True)
+                    + "|"
+                    + get_translated_keyword("blue", True)
+                    + "|"
+                    + get_translated_keyword("brown", True)
+                    + "|"
+                    + get_translated_keyword("gray", True)
+                    + "|"
+                    + get_translated_keyword("green", True)
+                    + "|"
+                    + get_translated_keyword("orange", True)
+                    + "|"
+                    + get_translated_keyword("pink", True)
+                    + "|"
+                    + get_translated_keyword("purple", True)
+                    + "|"
+                    + get_translated_keyword("red", True)
+                    + "|"
+                    + get_translated_keyword("white", True)
+                    + "|"
+                    + get_translated_keyword("yellow", True)
+                    + ")",
+                    "token": [TOKEN_CONSTANT],
+                },
+            ],
+            "valueFrom": [],
+        }
+    )
 
 
 def rule_level4():
-    return add_extra_rule({"start" : [{
-        'regex': START_LINE + WORD + SPACE + get_translated_keyword("is") + "( *)" + get_translated_keyword("ask"),
-        'token': ["text",'text','text','keyword','text','keyword'],
-        'next': 'valueExpr',
-    },{
-        'regex': START_LINE + WORD + SPACE + get_translated_keyword("is"),
-        'token': ["text",'text','text','keyword'],
-        'next': 'value',
-    },{
-        'regex': START_LINE + get_translated_keyword("print") ,
-        'token': ['text','keyword'],
-        'next': 'valueExpr',
-    },{
-        'regex': START_LINE + get_translated_keyword("turn") ,
-        'token': ['text','keyword'],
-        'next': 'valueSimple',
-    },{
-        'regex': START_LINE + get_translated_keyword("sleep") ,
-        'token': ['text','keyword'],
-        'next': 'valueSimple',
-    },{
-        'regex': START_LINE + get_translated_keyword("forward") ,
-        'token': ['text','keyword'],
-        'next': 'valueSimple',
-    },{
-        'regex': START_LINE + get_translated_keyword("color"),
-        'token': ["text",'keyword'],
-        'next': 'valueSimple',
-    },{
-        'regex': START_LINE + get_translated_keyword("add"),
-        'token': ["text",'keyword'],
-        'next': 'valAdd',
-    },{
-        'regex': START_LINE + get_translated_keyword("remove"),
-        'token': ["text",'keyword'],
-        'next': 'valRemove',
-    }],
-    "value" : [{
-        'regex': START_WORD + get_translated_keyword("at") + SPACE + get_translated_keyword("random") ,
-        'token': ['text','keyword','keyword','keyword'],
-    },{
-        'regex': START_WORD + get_translated_keyword("at") + END_WORD,
-        'token': ['text','keyword'],
-    },{
-        'regex': get_translated_keyword("comma") ,
-        'token': ['keyword'],
-    },{
-        'regex': "(" +\
-                get_translated_keyword("black",True) + "|" +\
-                get_translated_keyword("blue",True) + "|" +\
-                get_translated_keyword("brown",True) + "|" +\
-                get_translated_keyword("gray",True) + "|" +\
-                get_translated_keyword("green",True) + "|" +\
-                get_translated_keyword("orange",True) + "|" +\
-                get_translated_keyword("pink",True) + "|" +\
-                get_translated_keyword("purple",True) + "|" +\
-                get_translated_keyword("red",True) + "|" +\
-                get_translated_keyword("white",True) + "|" +\
-                get_translated_keyword("yellow",True) +\
-            ")",
-        'token': [TOKEN_CONSTANT],
-    }],
-    "valueExpr" : [{
-        'regex': START_WORD + get_translated_keyword("at") + SPACE + get_translated_keyword("random") ,
-        'token': ['text','keyword','keyword','keyword'],
-    },{
-        'regex': START_WORD + get_translated_keyword("at") + END_WORD,
-        'token': ['text','keyword'],
-    },{
-        'regex': '\"[^\"]*\"',
-        'token': 'constant.character',
-    },{
-        'regex': "\'[^\']*\'",
-        'token': 'constant.character',
-    },{
-        'regex': '\"[^\"]*$',
-        'token': 'constant.character',
-        'next' : 'start'
-    },{
-        'regex': "\'[^\']*$",
-        'token': 'constant.character',
-        'next' : 'start'
-    }],
-    "valueSimple":[{
-        'regex': START_WORD + get_translated_keyword("at") + SPACE + get_translated_keyword("random") ,
-        'token': ['text','keyword','keyword','keyword'],
-    },{
-        'regex': START_WORD + get_translated_keyword("at") + END_WORD,
-        'token': ['text','keyword'],
-    },{
-        'regex': "(" +\
-                get_translated_keyword("black",True) + "|" +\
-                get_translated_keyword("blue",True) + "|" +\
-                get_translated_keyword("brown",True) + "|" +\
-                get_translated_keyword("gray",True) + "|" +\
-                get_translated_keyword("green",True) + "|" +\
-                get_translated_keyword("orange",True) + "|" +\
-                get_translated_keyword("pink",True) + "|" +\
-                get_translated_keyword("purple",True) + "|" +\
-                get_translated_keyword("red",True) + "|" +\
-                get_translated_keyword("white",True) + "|" +\
-                get_translated_keyword("yellow",True) +\
-            ")",
-        'token': [TOKEN_CONSTANT],
-    }],
-    "valAdd"    : [{
-        'regex': START_WORD + get_translated_keyword("to_list") + END_WORD ,
-        'token': ['text','keyword'],
-        'next': 'valueTo',
-    },{
-        'regex': "(" +\
-                get_translated_keyword("black",True) + "|" +\
-                get_translated_keyword("blue",True) + "|" +\
-                get_translated_keyword("brown",True) + "|" +\
-                get_translated_keyword("gray",True) + "|" +\
-                get_translated_keyword("green",True) + "|" +\
-                get_translated_keyword("orange",True) + "|" +\
-                get_translated_keyword("pink",True) + "|" +\
-                get_translated_keyword("purple",True) + "|" +\
-                get_translated_keyword("red",True) + "|" +\
-                get_translated_keyword("white",True) + "|" +\
-                get_translated_keyword("yellow",True) +\
-            ")",
-        'token': [TOKEN_CONSTANT],
-    }],
-    "valueTo" : [],
-    "valRemove" : [{
-        'regex': START_WORD + get_translated_keyword("from") + END_WORD ,
-        'token': ['text','keyword'],
-        'next': 'valueFrom',
-    },{
-        'regex': "(" +\
-                get_translated_keyword("black",True) + "|" +\
-                get_translated_keyword("blue",True) + "|" +\
-                get_translated_keyword("brown",True) + "|" +\
-                get_translated_keyword("gray",True) + "|" +\
-                get_translated_keyword("green",True) + "|" +\
-                get_translated_keyword("orange",True) + "|" +\
-                get_translated_keyword("pink",True) + "|" +\
-                get_translated_keyword("purple",True) + "|" +\
-                get_translated_keyword("red",True) + "|" +\
-                get_translated_keyword("white",True) + "|" +\
-                get_translated_keyword("yellow",True) +\
-            ")",
-        'token': [TOKEN_CONSTANT],
-    }],
-    "valueFrom" : [],
-    })
+    return add_extra_rule(
+        {
+            "start": [
+                {
+                    "regex": START_LINE
+                    + WORD
+                    + SPACE
+                    + get_translated_keyword("is")
+                    + "( *)"
+                    + get_translated_keyword("ask"),
+                    "token": ["text", "text", "text", "keyword", "text", "keyword"],
+                    "next": "valueExpr",
+                },
+                {
+                    "regex": START_LINE + WORD + SPACE + get_translated_keyword("is"),
+                    "token": ["text", "text", "text", "keyword"],
+                    "next": "value",
+                },
+                {
+                    "regex": START_LINE + get_translated_keyword("print"),
+                    "token": ["text", "keyword"],
+                    "next": "valueExpr",
+                },
+                {
+                    "regex": START_LINE + get_translated_keyword("turn"),
+                    "token": ["text", "keyword"],
+                    "next": "valueSimple",
+                },
+                {
+                    "regex": START_LINE + get_translated_keyword("sleep"),
+                    "token": ["text", "keyword"],
+                    "next": "valueSimple",
+                },
+                {
+                    "regex": START_LINE + get_translated_keyword("forward"),
+                    "token": ["text", "keyword"],
+                    "next": "valueSimple",
+                },
+                {
+                    "regex": START_LINE + get_translated_keyword("color"),
+                    "token": ["text", "keyword"],
+                    "next": "valueSimple",
+                },
+                {
+                    "regex": START_LINE + get_translated_keyword("add"),
+                    "token": ["text", "keyword"],
+                    "next": "valAdd",
+                },
+                {
+                    "regex": START_LINE + get_translated_keyword("remove"),
+                    "token": ["text", "keyword"],
+                    "next": "valRemove",
+                },
+            ],
+            "value": [
+                {
+                    "regex": START_WORD + get_translated_keyword("at") + SPACE + get_translated_keyword("random"),
+                    "token": ["text", "keyword", "keyword", "keyword"],
+                },
+                {
+                    "regex": START_WORD + get_translated_keyword("at") + END_WORD,
+                    "token": ["text", "keyword"],
+                },
+                {
+                    "regex": get_translated_keyword("comma"),
+                    "token": ["keyword"],
+                },
+                {
+                    "regex": "("
+                    + get_translated_keyword("black", True)
+                    + "|"
+                    + get_translated_keyword("blue", True)
+                    + "|"
+                    + get_translated_keyword("brown", True)
+                    + "|"
+                    + get_translated_keyword("gray", True)
+                    + "|"
+                    + get_translated_keyword("green", True)
+                    + "|"
+                    + get_translated_keyword("orange", True)
+                    + "|"
+                    + get_translated_keyword("pink", True)
+                    + "|"
+                    + get_translated_keyword("purple", True)
+                    + "|"
+                    + get_translated_keyword("red", True)
+                    + "|"
+                    + get_translated_keyword("white", True)
+                    + "|"
+                    + get_translated_keyword("yellow", True)
+                    + ")",
+                    "token": [TOKEN_CONSTANT],
+                },
+            ],
+            "valueExpr": [
+                {
+                    "regex": START_WORD + get_translated_keyword("at") + SPACE + get_translated_keyword("random"),
+                    "token": ["text", "keyword", "keyword", "keyword"],
+                },
+                {
+                    "regex": START_WORD + get_translated_keyword("at") + END_WORD,
+                    "token": ["text", "keyword"],
+                },
+                {
+                    "regex": '"[^"]*"',
+                    "token": "constant.character",
+                },
+                {
+                    "regex": "'[^']*'",
+                    "token": "constant.character",
+                },
+                {"regex": '"[^"]*$', "token": "constant.character", "next": "start"},
+                {"regex": "'[^']*$", "token": "constant.character", "next": "start"},
+            ],
+            "valueSimple": [
+                {
+                    "regex": START_WORD + get_translated_keyword("at") + SPACE + get_translated_keyword("random"),
+                    "token": ["text", "keyword", "keyword", "keyword"],
+                },
+                {
+                    "regex": START_WORD + get_translated_keyword("at") + END_WORD,
+                    "token": ["text", "keyword"],
+                },
+                {
+                    "regex": "("
+                    + get_translated_keyword("black", True)
+                    + "|"
+                    + get_translated_keyword("blue", True)
+                    + "|"
+                    + get_translated_keyword("brown", True)
+                    + "|"
+                    + get_translated_keyword("gray", True)
+                    + "|"
+                    + get_translated_keyword("green", True)
+                    + "|"
+                    + get_translated_keyword("orange", True)
+                    + "|"
+                    + get_translated_keyword("pink", True)
+                    + "|"
+                    + get_translated_keyword("purple", True)
+                    + "|"
+                    + get_translated_keyword("red", True)
+                    + "|"
+                    + get_translated_keyword("white", True)
+                    + "|"
+                    + get_translated_keyword("yellow", True)
+                    + ")",
+                    "token": [TOKEN_CONSTANT],
+                },
+            ],
+            "valAdd": [
+                {
+                    "regex": START_WORD + get_translated_keyword("to_list") + END_WORD,
+                    "token": ["text", "keyword"],
+                    "next": "valueTo",
+                },
+                {
+                    "regex": "("
+                    + get_translated_keyword("black", True)
+                    + "|"
+                    + get_translated_keyword("blue", True)
+                    + "|"
+                    + get_translated_keyword("brown", True)
+                    + "|"
+                    + get_translated_keyword("gray", True)
+                    + "|"
+                    + get_translated_keyword("green", True)
+                    + "|"
+                    + get_translated_keyword("orange", True)
+                    + "|"
+                    + get_translated_keyword("pink", True)
+                    + "|"
+                    + get_translated_keyword("purple", True)
+                    + "|"
+                    + get_translated_keyword("red", True)
+                    + "|"
+                    + get_translated_keyword("white", True)
+                    + "|"
+                    + get_translated_keyword("yellow", True)
+                    + ")",
+                    "token": [TOKEN_CONSTANT],
+                },
+            ],
+            "valueTo": [],
+            "valRemove": [
+                {
+                    "regex": START_WORD + get_translated_keyword("from") + END_WORD,
+                    "token": ["text", "keyword"],
+                    "next": "valueFrom",
+                },
+                {
+                    "regex": "("
+                    + get_translated_keyword("black", True)
+                    + "|"
+                    + get_translated_keyword("blue", True)
+                    + "|"
+                    + get_translated_keyword("brown", True)
+                    + "|"
+                    + get_translated_keyword("gray", True)
+                    + "|"
+                    + get_translated_keyword("green", True)
+                    + "|"
+                    + get_translated_keyword("orange", True)
+                    + "|"
+                    + get_translated_keyword("pink", True)
+                    + "|"
+                    + get_translated_keyword("purple", True)
+                    + "|"
+                    + get_translated_keyword("red", True)
+                    + "|"
+                    + get_translated_keyword("white", True)
+                    + "|"
+                    + get_translated_keyword("yellow", True)
+                    + ")",
+                    "token": [TOKEN_CONSTANT],
+                },
+            ],
+            "valueFrom": [],
+        }
+    )
+
 
 def add_extra_rule(automaton):
     for state in automaton:
         if state != "start":
-            automaton[state].insert(0,{
-                'regex': "(^|$)",
-                'token': ["text"],
-                'next': 'start',
-            })
-        automaton[state].insert(0,{
-            'regex': "#.*$",
-            'token': "comment",
-            'next': 'start',
-        })
-        automaton[state].insert(0,{
-            'regex': "_\\?_",
-            'token': "invalid",
-            'next': state,
-        })
-        automaton[state].insert(0,{
-            'regex': '(^| )(_)(?= |$)',
-            'token': ['text','invalid'],
-            'next': state,
-        })
+            automaton[state].insert(
+                0,
+                {
+                    "regex": "(^|$)",
+                    "token": ["text"],
+                    "next": "start",
+                },
+            )
+        automaton[state].insert(
+            0,
+            {
+                "regex": "#.*$",
+                "token": "comment",
+                "next": "start",
+            },
+        )
+        automaton[state].insert(
+            0,
+            {
+                "regex": "_\\?_",
+                "token": "invalid",
+                "next": state,
+            },
+        )
+        automaton[state].insert(
+            0,
+            {
+                "regex": "(^| )(_)(?= |$)",
+                "token": ["text", "invalid"],
+                "next": state,
+            },
+        )
     return automaton

--- a/highlighting/rules_list.py
+++ b/highlighting/rules_list.py
@@ -9,8 +9,8 @@ import re
 # of what is around it, so we use a general function
 # This general function uses LEVELS
 
-def rule_all(level):
 
+def rule_all(level):
 
     # get keyword by level
     data_level = LEVELS[level]
@@ -19,94 +19,106 @@ def rule_all(level):
     list_rules = data_level["extra_rules"]
 
     # Rule for comments :
-    list_rules.append( { 'regex': '#.*$', 'token': 'comment', 'next': 'start' } )
+    list_rules.append({"regex": "#.*$", "token": "comment", "next": "start"})
 
     ## Rule for quoted string :
     # complete
-    list_rules.append( { 'regex': '\"[^\"]*\"', 'token': 'constant.character', 'next': 'start' } )
-    list_rules.append( { 'regex': "\'[^\']*\'", 'token': 'constant.character', 'next': 'start' } )
+    list_rules.append({"regex": '"[^"]*"', "token": "constant.character", "next": "start"})
+    list_rules.append({"regex": "'[^']*'", "token": "constant.character", "next": "start"})
 
     # incomplete
-    list_rules.append( { 'regex': '\"[^\"]*$', 'token': 'constant.character', 'next': 'start' } )
-    list_rules.append( { 'regex': "\'[^\']*$", 'token': 'constant.character', 'next': 'start' } )
+    list_rules.append({"regex": '"[^"]*$', "token": "constant.character", "next": "start"})
+    list_rules.append({"regex": "'[^']*$", "token": "constant.character", "next": "start"})
 
     # Rule for blanks marks :
-    list_rules.append( { 'regex': '_\\?_', 'token': 'invalid', 'next': 'start' })
-    list_rules.append( { 'regex': '(^| )(_)(?= |$)', 'token': ['text','invalid'], 'next': 'start' } )
-
+    list_rules.append({"regex": "_\\?_", "token": "invalid", "next": "start"})
+    list_rules.append({"regex": "(^| )(_)(?= |$)", "token": ["text", "invalid"], "next": "start"})
 
     # Rules for numbers
-    if (data_level["number"]) :
-        if (data_level["number_with_decimal"]) :
-            number_regex = '(' + DIGIT + '*\\.?' + DIGIT + '+)'
+    if data_level["number"]:
+        if data_level["number_with_decimal"]:
+            number_regex = "(" + DIGIT + "*\\.?" + DIGIT + "+)"
         else:
-            number_regex = '(' + DIGIT + '+)'
+            number_regex = "(" + DIGIT + "+)"
 
-        list_rules.append({'regex': START_WORD + number_regex + END_WORD, 'token': ['text','variable'], 'next':'start'} )
+        list_rules.append(
+            {"regex": START_WORD + number_regex + END_WORD, "token": ["text", "variable"], "next": "start"}
+        )
 
-        # Special case of an number directly followed by a number 
-        for command in data_level["space_before"]: 
-            list_rules.append({
-                'regex': START_WORD + get_translated_keyword(command) + number_regex + END_WORD,
-                'token': ['text','keyword','variable'],
-                'next': 'start',
-            })
+        # Special case of an number directly followed by a number
+        for command in data_level["space_before"]:
+            list_rules.append(
+                {
+                    "regex": START_WORD + get_translated_keyword(command) + number_regex + END_WORD,
+                    "token": ["text", "keyword", "variable"],
+                    "next": "start",
+                }
+            )
 
         for command in data_level["no_space"]:
-            list_rules.append({
-                'regex': get_translated_keyword(command) + number_regex + END_WORD,
-                'token': ['keyword','variable'],
-                'next': 'start',
-            })
+            list_rules.append(
+                {
+                    "regex": get_translated_keyword(command) + number_regex + END_WORD,
+                    "token": ["keyword", "variable"],
+                    "next": "start",
+                }
+            )
 
-
-    # Rules for commands of space_before_and_after 
-    # These are the keywords that must be "alone" so neither preceded nor followed directly by a word 
+    # Rules for commands of space_before_and_after
+    # These are the keywords that must be "alone" so neither preceded nor followed directly by a word
     for command in data_level["space_before_and_after"]:
-        list_rules.append({
-            'regex': START_WORD + get_translated_keyword(command) + END_WORD,
-            'token': ["text","keyword"],
-            'next': "start", 
-        })
-    
+        list_rules.append(
+            {
+                "regex": START_WORD + get_translated_keyword(command) + END_WORD,
+                "token": ["text", "keyword"],
+                "next": "start",
+            }
+        )
 
-    # Rules for commands of no_space 
+    # Rules for commands of no_space
     #  These are the keywords that are independent of the context (formerly the symbols
     # In particular, even if they are between 2 words, the syntax highlighting will select them
     for command in data_level["no_space"]:
-        list_rules.append({
-            'regex': get_translated_keyword(command),
-            'token': ["keyword"],
-            'next': "start", 
-        })
+        list_rules.append(
+            {
+                "regex": get_translated_keyword(command),
+                "token": ["keyword"],
+                "next": "start",
+            }
+        )
 
-    # Rules for commands of space_before 
+    # Rules for commands of space_before
     #  This category of keywords allows you to have keywords that are not preced
     # by another word, but that can be followed immediately by another word. (see the PR #2413)*/
     for command in data_level["space_before"]:
-        list_rules.append({
-            'regex': START_WORD + get_translated_keyword(command),
-            'token': ["text","keyword"],
-            'next': "start", 
-        })
+        list_rules.append(
+            {
+                "regex": START_WORD + get_translated_keyword(command),
+                "token": ["text", "keyword"],
+                "next": "start",
+            }
+        )
 
-    # Rules for commands of space_after 
+    # Rules for commands of space_after
     #  This category of keywords allows you to have keywords that can be preceded immediate
     # by another word, but that are not followed by another word.*/
     for command in data_level["space_after"]:
-        list_rules.append({
-            'regex': get_translated_keyword(command) + END_WORD,
-            'token': ["keyword"],
-            'next': "start", 
-        })
+        list_rules.append(
+            {
+                "regex": get_translated_keyword(command) + END_WORD,
+                "token": ["keyword"],
+                "next": "start",
+            }
+        )
 
     # Rules for constants (colors, directions)
-    for command in data_level['constant']:
-        list_rules.append({
-            'regex': START_WORD + get_translated_keyword(command) + END_WORD,
-            'token': ["text",TOKEN_CONSTANT],
-            'next': "start", 
-        })
+    for command in data_level["constant"]:
+        list_rules.append(
+            {
+                "regex": START_WORD + get_translated_keyword(command) + END_WORD,
+                "token": ["text", TOKEN_CONSTANT],
+                "next": "start",
+            }
+        )
 
-    return {"start" :list_rules}
-
+    return {"start": list_rules}

--- a/program_repair.py
+++ b/program_repair.py
@@ -1,21 +1,21 @@
 def insert(input_string, line, column, new_string):
-    """"insert new_string at (line, column)"""
+    """ "insert new_string at (line, column)"""
     rows = input_string.splitlines()
     rows[line] = rows[line][:column] + new_string + rows[line][column:]
 
-    return '\n'.join(rows)
+    return "\n".join(rows)
 
 
 def delete(input_string, line, column, length):
-    """"delete length chars starting at (line, column)"""
+    """ "delete length chars starting at (line, column)"""
     rows = input_string.splitlines()
-    rows[line] = rows[line][:column] + rows[line][column + length:]
+    rows[line] = rows[line][:column] + rows[line][column + length :]
 
-    return '\n'.join(rows)
+    return "\n".join(rows)
 
 
 def replace(input_string, line, column, length, new_string):
-    """"replace at (line, column) length chars with new_string"""
+    """ "replace at (line, column) length chars with new_string"""
     result = delete(input_string, line, column, length)
     result = insert(result, line, column, new_string)
 
@@ -24,7 +24,7 @@ def replace(input_string, line, column, length, new_string):
 
 def remove_leading_spaces(input_string):
     # the only repair we can do now is remove leading spaces, more can be added!
-    return '\n'.join([x.lstrip() for x in input_string.split('\n')])
+    return "\n".join([x.lstrip() for x in input_string.split("\n")])
 
 
 def remove_unexpected_char(input_string, line, column):
@@ -34,7 +34,7 @@ def remove_unexpected_char(input_string, line, column):
 def fix_indent(input_string, line, leading_spaces, indent_size):
     if leading_spaces < indent_size:
         # not enough spaces, add spaces
-        return insert(input_string, line - 1, 0, ' ' * (indent_size - leading_spaces))
+        return insert(input_string, line - 1, 0, " " * (indent_size - leading_spaces))
     else:
         # too many spaces, remove spaces
         return delete(input_string, line - 1, 0, leading_spaces - indent_size)

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,4 @@ parameterized==0.8.1
 Flask-Babel==2.0.0
 iso3166~=2.0.2
 turtlethread>=0.0.6
+pre-commit==2.20.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ ruamel.yaml==0.17.4
 docopt==0.6.2
 pydantic==1.8.2
 lazy==1.4
-pylint==2.8.2
+pylint==2.15.3
 awscli>=1.19.88
 PySumTypes==0.0.1
 beautifulsoup4==4.9.3

--- a/testddb.py
+++ b/testddb.py
@@ -1,12 +1,11 @@
-
 import pprint
 from website import dynamo, database
 
 storage = dynamo.AwsDynamoStorage.from_env()
 if not storage:
-  raise RuntimeError('DDB not configure quickly')
+    raise RuntimeError("DDB not configure quickly")
 
-Q = dynamo.Table(storage, 'preferences', partition_key='id', sort_key='level')
+Q = dynamo.Table(storage, "preferences", partition_key="id", sort_key="level")
 
-recs = database.USERS.get({ 'username': 'rix0rrr' })
+recs = database.USERS.get({"username": "rix0rrr"})
 pprint.pprint(recs)

--- a/tests/Highlighter.py
+++ b/tests/Highlighter.py
@@ -4,57 +4,53 @@ import json
 import os
 
 
-
 # Transcription of the used tokens into a symbol (a letter) in order to apply a coloring
 TOKEN_CODE = {
-    "text" :               'T', # normal
-    "keyword" :            'K', # 
-    "comment" :            'C',
-    "variable" :           'N',
-    "constant.character" : 'S',
-    "invalid" :            'I',
+    "text": "T",  # normal
+    "keyword": "K",  #
+    "comment": "C",
+    "variable": "N",
+    "constant.character": "S",
+    "invalid": "I",
 }
 
 # for the caractere SPACE, all this highlights are equals
-SAME_COLOR_FOR_SPACE = ['T','K','C','N','S']
+SAME_COLOR_FOR_SPACE = ["T", "K", "C", "N", "S"]
 
 ABBREVIATION = {
-    "text"                : "T",
-    "uncolor"             : "T",
-    "txt"                 : "T",
-    "white"               : "T",
-    "T"                   : "T",
-
-    "keyword"             : "K",
-    "kw"                  : "K",
-    "red"                 : "K",
-    "K"                   : "K",
-
-    "comment"             : "C",
-    "cmt"                 : "C",
-    "grey"                : "C",
-    "C"                   : "C",
-
-    "variable"            : "N",
-    "number"              : "N",
-    "green"               : "N",
-    "N"                   : "N",
-
-    "constant.character"  : "S",
-    "string"              : "S",
-    "str"                 : "S",
-    "blue"                : "S",
-    "S"                   : "S",
-
-    "invalid"             : "I",
-    "inv"                 : "I",
-    "pink"                : "I",
-    "I"                   : "I",
+    "text": "T",
+    "uncolor": "T",
+    "txt": "T",
+    "white": "T",
+    "T": "T",
+    "keyword": "K",
+    "kw": "K",
+    "red": "K",
+    "K": "K",
+    "comment": "C",
+    "cmt": "C",
+    "grey": "C",
+    "C": "C",
+    "variable": "N",
+    "number": "N",
+    "green": "N",
+    "N": "N",
+    "constant.character": "S",
+    "string": "S",
+    "str": "S",
+    "blue": "S",
+    "S": "S",
+    "invalid": "I",
+    "inv": "I",
+    "pink": "I",
+    "I": "I",
 }
 
-class HighlightTester(unittest.TestCase):
 
-    def assert_highlighted_chr(self, code, expected, level, lang="en", start_token="start", last_state="start", intermediate_tests=True):
+class HighlightTester(unittest.TestCase):
+    def assert_highlighted_chr(
+        self, code, expected, level, lang="en", start_token="start", last_state="start", intermediate_tests=True
+    ):
         """Test if the code has the expected coloring on one line
 
         Arguments :
@@ -69,12 +65,13 @@ class HighlightTester(unittest.TestCase):
                                             of the input word by word or not
         """
         state_machine = self.get_state_machine(level, lang)
-        self.check(code+"\n", expected+"\n", state_machine, start_token, last_state)
+        self.check(code + "\n", expected + "\n", state_machine, start_token, last_state)
         if intermediate_tests:
             self.checkInter(code, expected, state_machine, start_token)
 
-
-    def assert_highlighted_chr_multi_line(self, *args, level, lang="en", start_token="start", last_state="start", intermediate_tests=True):
+    def assert_highlighted_chr_multi_line(
+        self, *args, level, lang="en", start_token="start", last_state="start", intermediate_tests=True
+    ):
         """Test if the code has the expected coloring on several lines
 
         Arguments :
@@ -91,16 +88,19 @@ class HighlightTester(unittest.TestCase):
             - intermediate_tests : boolean, execution of tests on the consistency
                                             of the input word by word or not
         """
-        if len(args)%2 != 0:
-            raise RuntimeError(f'Pass an even number of strings to assert_highlighted_chr_multi_line (alternatingly code and highlighting). Got: {args}')
+        if len(args) % 2 != 0:
+            raise RuntimeError(
+                f"Pass an even number of strings to assert_highlighted_chr_multi_line (alternatingly code and highlighting). Got: {args}"
+            )
 
-        code = '\n'.join(line for i, line in enumerate(args) if i%2 == 0)
-        expected = '\n'.join(line for i, line in enumerate(args) if i%2 != 0)
+        code = "\n".join(line for i, line in enumerate(args) if i % 2 == 0)
+        expected = "\n".join(line for i, line in enumerate(args) if i % 2 != 0)
 
         self.assert_highlighted_chr(code, expected, level, lang, start_token, last_state, intermediate_tests)
 
-
-    def assert_highlighted(self, code_coloration, level, lang="en", start_token="start", last_state="start", intermediate_tests=True):
+    def assert_highlighted(
+        self, code_coloration, level, lang="en", start_token="start", last_state="start", intermediate_tests=True
+    ):
         """Test if the code has the expected coloring on one line
 
         Arguments :
@@ -116,8 +116,9 @@ class HighlightTester(unittest.TestCase):
         code, expected = self.convert(code_coloration)
         self.assert_highlighted_chr(code, expected, level, lang, start_token, last_state, intermediate_tests)
 
-
-    def assert_highlighted_multi_line(self, *args, level, lang="en", start_token="start", last_state="start", intermediate_tests=True):
+    def assert_highlighted_multi_line(
+        self, *args, level, lang="en", start_token="start", last_state="start", intermediate_tests=True
+    ):
         """Test if the code has the expected coloring on several lines
 
         Arguments :
@@ -153,7 +154,7 @@ class HighlightTester(unittest.TestCase):
         for n in range(len(listCode)):
             self.check(listCode[n], listExpected[n], state_machine, start_token, None)
 
-    def check(self, code, expected, state_machine, start_token="start", last_state='start'):
+    def check(self, code, expected, state_machine, start_token="start", last_state="start"):
         """Apply state_machine on code and check if the result is valid
 
         Arguments :
@@ -175,7 +176,7 @@ class HighlightTester(unittest.TestCase):
         expected = list(expected)
 
         # check if they are same length
-        self.assertEqual(len(result),len(expected))
+        self.assertEqual(len(result), len(expected))
 
         # replacement of space by result coloration
         for i in range(len(result)):
@@ -188,12 +189,11 @@ class HighlightTester(unittest.TestCase):
         expected = "".join(expected)
 
         # test between two coloration
-        self.assertEqual(result ,expected)
+        self.assertEqual(result, expected)
 
         # test for last state
         if last_state != None:
             self.assertEqual(last_state, last_state_result)
-
 
     def get_state_machine(self, level, lang="en"):
         """Recovery of syntax coloring rules.
@@ -207,19 +207,19 @@ class HighlightTester(unittest.TestCase):
 
         Returns a state machine.
         """
-        root_dir = os.path.dirname(__file__) +"/.."
-        
+        root_dir = os.path.dirname(__file__) + "/.."
+
         # get traduction
-        with open(f'{root_dir}/highlighting/highlighting-trad.json') as file_regex_trad:
+        with open(f"{root_dir}/highlighting/highlighting-trad.json") as file_regex_trad:
             data_regex_trad = json.load(file_regex_trad)
-    
+
         if lang not in data_regex_trad.keys():
-            lang = 'en'
+            lang = "en"
 
         regex_trad = data_regex_trad[lang]
 
         # get state_machine
-        with open(f'{root_dir}/highlighting/highlighting.json') as file_regex:
+        with open(f"{root_dir}/highlighting/highlighting.json") as file_regex:
             data_regex = json.load(file_regex)
 
         # apply translation of keywords
@@ -227,17 +227,15 @@ class HighlightTester(unittest.TestCase):
             for state in lvl_rules["rules"]:
                 for rule in lvl_rules["rules"][state]:
                     for key in regex_trad:
-                        rule['regex'] = rule['regex'].replace("__" + key + "__", regex_trad[key])
+                        rule["regex"] = rule["regex"].replace("__" + key + "__", regex_trad[key])
 
         # get state_machine for the level
-        state_machine = [item for item in data_regex if item['name']==level]
-        if len(state_machine) != 1 :
-              raise RuntimeError(f'Expected exactly 1 rule with {level}, got {len(state_machine)}')
-        else :
-            state_machine = state_machine[0]['rules']
+        state_machine = [item for item in data_regex if item["name"] == level]
+        if len(state_machine) != 1:
+            raise RuntimeError(f"Expected exactly 1 rule with {level}, got {len(state_machine)}")
+        else:
+            state_machine = state_machine[0]["rules"]
         return state_machine
-
-
 
     def convert(self, code_coloration):
         """Conversion of the test specification format.
@@ -252,35 +250,34 @@ class HighlightTester(unittest.TestCase):
             - coloration : str, Ex : "KKKKK TTTTTTTTTTTTTTTT",
         """
 
-        code     = []
+        code = []
         coloring = []
-        TEXT, CODE, KEYWORD = range(3)   
+        TEXT, CODE, KEYWORD = range(3)
         state = TEXT
         for ch in code_coloration:
-            if ch == "{" :
+            if ch == "{":
                 state = CODE
 
-                tmp_code     = []
+                tmp_code = []
                 tmp_coloring = []
-            elif ch == "}" :
+            elif ch == "}":
                 state = TEXT
 
                 code.append("".join(tmp_code))
                 coloring.append(ABBREVIATION["".join(tmp_coloring)] * len(tmp_code))
 
-            elif ch == "|" and state == CODE :
+            elif ch == "|" and state == CODE:
                 state = KEYWORD
 
-
-            else: # not a special symbol
+            else:  # not a special symbol
 
                 if state == CODE:
                     tmp_code.append(ch)
                 elif state == KEYWORD:
                     tmp_coloring.append(ch)
 
-                else : # state == TEXT
-                    if ch == "\n" :
+                else:  # state == TEXT
+                    if ch == "\n":
                         code.append("\n")
                         coloring.append("\n")
                     else:
@@ -290,14 +287,12 @@ class HighlightTester(unittest.TestCase):
         return "".join(code), "".join(coloring)
 
 
-
 def genInterTest(code, expected):
     """generates intermediate tests, word by word,
     to check that the highlighting when
     typing the code will be consistent."""
-    C, E = [],[]
-    codes = [k.split(' ') for k in code.split("\n")]
-
+    C, E = [], []
+    codes = [k.split(" ") for k in code.split("\n")]
 
     currentCode = []
 
@@ -307,14 +302,15 @@ def genInterTest(code, expected):
         for nbMot in range(len(codes[nbLine])):
             currentLine.append(codes[nbLine][nbMot])
 
-            # add 
+            # add
             current = "\n".join([" ".join(k) for k in currentCode + [currentLine]])
             C.append(current)
-            E.append(expected[:len(current)])
+            E.append(expected[: len(current)])
 
         currentCode.append(currentLine)
 
     return C, E
+
 
 class SimulatorAce:
 
@@ -347,25 +343,25 @@ class SimulatorAce:
         for state in self.state_machine:
             for rule in self.state_machine[state]:
 
-                if "token" not in rule :
+                if "token" not in rule:
                     raise ValueError("We need a token in all rules !")
 
-                rule["regex_compile"] =  re.compile(rule['regex'], re.MULTILINE)
+                rule["regex_compile"] = re.compile(rule["regex"], re.MULTILINE)
                 rule["nb_groups"] = rule["regex_compile"].groups
-
 
                 if rule["nb_groups"] == 0:
                     if type(rule["token"]) != str:
                         raise ValueError(f"if regex has no groups, token must be a string. In this rule : {rule}!")
 
                 else:
-                    if type(rule["token"]) != list :
+                    if type(rule["token"]) != list:
                         raise ValueError(f"if regex has groups, token must be a list. In this rule : {rule}!")
 
                     else:
                         if rule["nb_groups"] != len(rule["token"]):
-                            raise ValueError(f"The number of groups in the regex is different from the number of tokens. In this rule : {rule}!")
-
+                            raise ValueError(
+                                f"The number of groups in the regex is different from the number of tokens. In this rule : {rule}!"
+                            )
 
     def highlight(self, code, start_token="start"):
         """Simulates the application of syntax highlighting state_machine on a code.
@@ -384,7 +380,6 @@ class SimulatorAce:
             output, token = self.highlight_rules_line(line, token)
             outputs.append(output)
         return "\n".join(outputs), token
-
 
     def highlight_rules_line(self, code, start_token="start"):
         """Simulates the application of syntax highlighting state_machine on a line of code.
@@ -425,34 +420,29 @@ class SimulatorAce:
 
             # if rule has only one groups
             if current_rule["nb_groups"] == 0:
-                tok    = current_rule['token']
-                start  = current_match.start()
+                tok = current_rule["token"]
+                start = current_match.start()
                 length = current_match.end() - current_match.start()
                 output.append(TOKEN_CODE[tok] * length)
 
             # if rule has only multiples groups
             else:
                 pos = current_match.start()
-                for i, submatch in enumerate(current_match.groups()):    
-                    tok = current_rule['token'][i%len(current_rule['token'])]        
+                for i, submatch in enumerate(current_match.groups()):
+                    tok = current_rule["token"][i % len(current_rule["token"])]
                     output.append(TOKEN_CODE[tok] * len(submatch))
                     pos += len(submatch)
-
-
 
             # get nexts values
             current_position = current_match.end()
 
-            if 'next' in current_rule:
-                current_state = current_rule['next']
+            if "next" in current_rule:
+                current_state = current_rule["next"]
 
             if current_position == len(code):
                 find_transition = False
             else:
                 find_transition, next_transition = self.find_match(code, current_position, current_state)
-
-
-
 
         # we color the last characters since the last match with the default coloring
         for c in range(current_position, len(code)):
@@ -460,10 +450,9 @@ class SimulatorAce:
 
         return "".join(output), current_state
 
-
     def find_match(self, code, current_position, current_state):
-        """ Find the next matching rule in the given code.
-        
+        """Find the next matching rule in the given code.
+
         If there are multiple rules that match the code in the given state,
         returns the one that matches earliest in the source string.
 
@@ -478,7 +467,7 @@ class SimulatorAce:
             The transition dictionary contains {rule, match} fields and should only be inspected if did_match is True.
         """
         current_match = None
-        next_transition = {"rule":{}, "match":None}
+        next_transition = {"rule": {}, "match": None}
         find_transition = False
 
         next_pos = len(code) + 1
@@ -488,12 +477,10 @@ class SimulatorAce:
             match = regex_compile.search(code, current_position)
 
             if match:
-                if match.start() < next_pos :
+                if match.start() < next_pos:
                     next_pos = match.start()
                     next_transition["rule"] = rule
                     next_transition["match"] = match
                     find_transition = True
 
         return find_transition, next_transition
-
-

--- a/tests/Tester.py
+++ b/tests/Tester.py
@@ -11,231 +11,280 @@ from hedy_content import ALL_KEYWORD_LANGUAGES, KEYWORDS
 
 
 class Snippet:
-  def __init__(self, filename, level, field_name, code, adventure_name=None):
-    self.filename = filename
-    self.level = level
-    self.field_name = field_name
-    self.code = code
-    filename_shorter = os.path.basename(filename)
-    self.language = filename_shorter.split(".")[0]
-    self.adventure_name = adventure_name
-    self.name = f'{self.language}-{self.level}-{self.field_name}'
+    def __init__(self, filename, level, field_name, code, adventure_name=None):
+        self.filename = filename
+        self.level = level
+        self.field_name = field_name
+        self.code = code
+        filename_shorter = os.path.basename(filename)
+        self.language = filename_shorter.split(".")[0]
+        self.adventure_name = adventure_name
+        self.name = f"{self.language}-{self.level}-{self.field_name}"
 
 
 class HedyTester(unittest.TestCase):
-  level = None
-  max_turtle_level = 10
-  equality_comparison_with_is = ['is', '=']
-  equality_comparison_commands = ['==', '=']
-  number_comparison_commands = ['>', '>=', '<', '<=']
-  comparison_commands = number_comparison_commands + ['!=']
-  arithmetic_operations = ['+', '-', '*', '/']
-  arithmetic_transpiled_operators = [('*', '*'), ('/', '//'), ('+', '+'), ('-', '-')]
-  quotes = ["'", '"']
+    level = None
+    max_turtle_level = 10
+    equality_comparison_with_is = ["is", "="]
+    equality_comparison_commands = ["==", "="]
+    number_comparison_commands = [">", ">=", "<", "<="]
+    comparison_commands = number_comparison_commands + ["!="]
+    arithmetic_operations = ["+", "-", "*", "/"]
+    arithmetic_transpiled_operators = [("*", "*"), ("/", "//"), ("+", "+"), ("-", "-")]
+    quotes = ["'", '"']
 
-  @staticmethod
-  @contextmanager
-  def captured_output():
-    new_out, new_err = io.StringIO(), io.StringIO()
-    old_out, old_err = sys.stdout, sys.stderr
-    try:
-      sys.stdout, sys.stderr = new_out, new_err
-      yield sys.stdout, sys.stderr
-    finally:
-      sys.stdout, sys.stderr = old_out, old_err
+    @staticmethod
+    @contextmanager
+    def captured_output():
+        new_out, new_err = io.StringIO(), io.StringIO()
+        old_out, old_err = sys.stdout, sys.stderr
+        try:
+            sys.stdout, sys.stderr = new_out, new_err
+            yield sys.stdout, sys.stderr
+        finally:
+            sys.stdout, sys.stderr = old_out, old_err
 
-  @staticmethod
-  def run_code(parse_result):
-    if parse_result.has_turtle:
-      code = utils.TURTLE_PREFIX_CODE + parse_result.code
-    else:
-      code = utils.NORMAL_PREFIX_CODE + parse_result.code
-# remove sleep comments to make program execution less slow
-    code = re.sub(r'time\.sleep\([^\n]*\)', 'pass', code)
+    @staticmethod
+    def run_code(parse_result):
+        if parse_result.has_turtle:
+            code = utils.TURTLE_PREFIX_CODE + parse_result.code
+        else:
+            code = utils.NORMAL_PREFIX_CODE + parse_result.code
+        # remove sleep comments to make program execution less slow
+        code = re.sub(r"time\.sleep\([^\n]*\)", "pass", code)
 
-    with HedyTester.captured_output() as (out, err):
-      exec(code)
-    return out.getvalue().strip()
+        with HedyTester.captured_output() as (out, err):
+            exec(code)
+        return out.getvalue().strip()
 
-  def name(self):
-    return inspect.stack()[1][3]
+    def name(self):
+        return inspect.stack()[1][3]
 
-  def is_not_turtle(self):
-    return (lambda result: not result.has_turtle)
+    def is_not_turtle(self):
+        return lambda result: not result.has_turtle
 
-  def is_turtle(self):
-    return (lambda result: result.has_turtle)
+    def is_turtle(self):
+        return lambda result: result.has_turtle
 
-  def result_in(self, list):
-    return (lambda result: HedyTester.run_code(result) in list)
+    def result_in(self, list):
+        return lambda result: HedyTester.run_code(result) in list
 
-  def exception_command(self, command):
-    return lambda c: c.exception.arguments['command'] == command
+    def exception_command(self, command):
+        return lambda c: c.exception.arguments["command"] == command
 
-  @staticmethod
-  def as_list_of_tuples(*args):
-    # used to conver a variable number of paralel list
-    # into a list of tuples to be used by the parametrized tester
-    # All of the lists need to have the same size
-    res = []
-    for i in range(len(args[0])):
-      t = tuple((item[i] for item in args))
-      res.append(t)
-    return res
+    @staticmethod
+    def as_list_of_tuples(*args):
+        # used to conver a variable number of paralel list
+        # into a list of tuples to be used by the parametrized tester
+        # All of the lists need to have the same size
+        res = []
+        for i in range(len(args[0])):
+            t = tuple((item[i] for item in args))
+            res.append(t)
+        return res
 
-  def codeToInvalidInfo(self, code):
-    instance = hedy.IsValid()
-    instance.level = self.level
-    program_root = hedy.parse_input(code, self.level, 'en')
-    is_valid = instance.transform(program_root)
-    _, invalid_info = is_valid
+    def codeToInvalidInfo(self, code):
+        instance = hedy.IsValid()
+        instance.level = self.level
+        program_root = hedy.parse_input(code, self.level, "en")
+        is_valid = instance.transform(program_root)
+        _, invalid_info = is_valid
 
-    return invalid_info[0].line, invalid_info[0].column
+        return invalid_info[0].line, invalid_info[0].column
 
-  def multi_level_tester(self, code, max_level=hedy.HEDY_MAX_LEVEL, expected=None, exception=None, extra_check_function=None, expected_commands=None, lang='en', translate=True, output=None):
-    # used to test the same code snippet over multiple levels
-    # Use exception to check for an exception
+    def multi_level_tester(
+        self,
+        code,
+        max_level=hedy.HEDY_MAX_LEVEL,
+        expected=None,
+        exception=None,
+        extra_check_function=None,
+        expected_commands=None,
+        lang="en",
+        translate=True,
+        output=None,
+    ):
+        # used to test the same code snippet over multiple levels
+        # Use exception to check for an exception
 
-    if max_level < self.level:
-      raise Exception('Level too low!')
+        if max_level < self.level:
+            raise Exception("Level too low!")
 
-    # ensure we never test levels above the max (useful for debugging)
-    max_level = min(max_level, hedy.HEDY_MAX_LEVEL)
+        # ensure we never test levels above the max (useful for debugging)
+        max_level = min(max_level, hedy.HEDY_MAX_LEVEL)
 
-    # make it clear in the output this is a multilevel tester
-    print('\n\n\n')
-    print('-----------------')
-    print('Multi-level test!')
-    print('\n')
+        # make it clear in the output this is a multilevel tester
+        print("\n\n\n")
+        print("-----------------")
+        print("Multi-level test!")
+        print("\n")
 
-    # Or use expect to check for an expected Python program
-    # In the second case, you can also pass an extra function to check
-    for level in range(self.level, max_level + 1):
-      self.single_level_tester(code, level, expected=expected, exception=exception, extra_check_function=extra_check_function, expected_commands=expected_commands, lang=lang, translate=translate, output=output)
-      print(f'Passed for level {level}')
+        # Or use expect to check for an expected Python program
+        # In the second case, you can also pass an extra function to check
+        for level in range(self.level, max_level + 1):
+            self.single_level_tester(
+                code,
+                level,
+                expected=expected,
+                exception=exception,
+                extra_check_function=extra_check_function,
+                expected_commands=expected_commands,
+                lang=lang,
+                translate=translate,
+                output=output,
+            )
+            print(f"Passed for level {level}")
 
-  def single_level_tester(self, code, level=None, exception=None, expected=None, extra_check_function=None, output=None, expected_commands=None, lang='en', translate=True):
-    if level is None: # no level set (from the multi-tester)? grap current level from class
-      level = self.level
-    if exception is not None:
-      with self.assertRaises(exception) as context:
-        result = hedy.transpile(code, level, lang)
+    def single_level_tester(
+        self,
+        code,
+        level=None,
+        exception=None,
+        expected=None,
+        extra_check_function=None,
+        output=None,
+        expected_commands=None,
+        lang="en",
+        translate=True,
+    ):
+        if level is None:  # no level set (from the multi-tester)? grap current level from class
+            level = self.level
+        if exception is not None:
+            with self.assertRaises(exception) as context:
+                result = hedy.transpile(code, level, lang)
 
-      if extra_check_function is not None:
-        self.assertTrue(extra_check_function(context))
+            if extra_check_function is not None:
+                self.assertTrue(extra_check_function(context))
 
-    if extra_check_function is None: # most programs have no turtle so make that the default
-      extra_check_function = self.is_not_turtle()
+        if extra_check_function is None:  # most programs have no turtle so make that the default
+            extra_check_function = self.is_not_turtle()
 
-    if expected is not None:
-      result = hedy.transpile(code, level, lang)
-      self.assertEqual(expected, result.code)
+        if expected is not None:
+            result = hedy.transpile(code, level, lang)
+            self.assertEqual(expected, result.code)
 
-      if translate:
-        if lang == 'en': # if it is English
-          # and if the code transpiles (evidenced by the fact that we reach this line) we should be able to translate too
+            if translate:
+                if lang == "en":  # if it is English
+                    # and if the code transpiles (evidenced by the fact that we reach this line) we should be able to translate too
 
-          #TODO FH Feb 2022: we pick Dutch here not really fair or good practice :D Maybe we should do a random language?
-          in_dutch = hedy_translation.translate_keywords(code, from_lang=lang, to_lang="nl", level=self.level)
-          back_in_english = hedy_translation.translate_keywords(in_dutch, from_lang="nl", to_lang=lang, level=self.level)
-          self.assert_translated_code_equal(code, back_in_english)
-        else: #not English? translate to it and back!
-          in_english = hedy_translation.translate_keywords(code, from_lang=lang, to_lang="en", level=self.level)
-          back_in_org = hedy_translation.translate_keywords(in_english, from_lang="en", to_lang=lang, level=self.level)
-          self.assert_translated_code_equal(code, back_in_org)
+                    # TODO FH Feb 2022: we pick Dutch here not really fair or good practice :D Maybe we should do a random language?
+                    in_dutch = hedy_translation.translate_keywords(code, from_lang=lang, to_lang="nl", level=self.level)
+                    back_in_english = hedy_translation.translate_keywords(
+                        in_dutch, from_lang="nl", to_lang=lang, level=self.level
+                    )
+                    self.assert_translated_code_equal(code, back_in_english)
+                else:  # not English? translate to it and back!
+                    in_english = hedy_translation.translate_keywords(
+                        code, from_lang=lang, to_lang="en", level=self.level
+                    )
+                    back_in_org = hedy_translation.translate_keywords(
+                        in_english, from_lang="en", to_lang=lang, level=self.level
+                    )
+                    self.assert_translated_code_equal(code, back_in_org)
 
-      all_commands = hedy.all_commands(code, level, lang)
-      if expected_commands is not None:
-        self.assertEqual(expected_commands, all_commands)
-      if (not 'ask' in all_commands) and (not 'input' in all_commands): #<- use this to run tests locally with unittest
-        self.assertTrue(self.validate_Python_code(result))
-      if output is not None:
-        self.assertEqual(output, HedyTester.run_code(result))
-        self.assertTrue(extra_check_function(result))
+            all_commands = hedy.all_commands(code, level, lang)
+            if expected_commands is not None:
+                self.assertEqual(expected_commands, all_commands)
+            if (not "ask" in all_commands) and (
+                not "input" in all_commands
+            ):  # <- use this to run tests locally with unittest
+                self.assertTrue(self.validate_Python_code(result))
+            if output is not None:
+                self.assertEqual(output, HedyTester.run_code(result))
+                self.assertTrue(extra_check_function(result))
 
-  def assert_translated_code_equal(self, orignal, translation):
-    # When we translate a program we lose information about the whitespaces of the original program.
-    # So when comparing the original and the translated code, we compress multiple whitespaces into one.
-    self.assertEqual(re.sub('\\s+', ' ', orignal), re.sub('\\s+', ' ', translation))
+    def assert_translated_code_equal(self, orignal, translation):
+        # When we translate a program we lose information about the whitespaces of the original program.
+        # So when comparing the original and the translated code, we compress multiple whitespaces into one.
+        self.assertEqual(re.sub("\\s+", " ", orignal), re.sub("\\s+", " ", translation))
 
-  @staticmethod
-  def validate_Hedy_code(snippet):
-    # Code used in the Adventure and Level Defaults tester to validate Hedy code
+    @staticmethod
+    def validate_Hedy_code(snippet):
+        # Code used in the Adventure and Level Defaults tester to validate Hedy code
 
-    try:
-      if len(snippet.code) != 0:   # We ignore empty code snippets or those of length 0
-        result = hedy.transpile(snippet.code, int(snippet.level), snippet.language)
-        all_commands = hedy.all_commands(snippet.code, snippet.level, snippet.language)
+        try:
+            if len(snippet.code) != 0:  # We ignore empty code snippets or those of length 0
+                result = hedy.transpile(snippet.code, int(snippet.level), snippet.language)
+                all_commands = hedy.all_commands(snippet.code, snippet.level, snippet.language)
 
-        if not result.has_turtle and (not 'ask' in all_commands) and (not 'input' in all_commands): #output from turtle cannot be captured
-          output = HedyTester.run_code(result)
-    except hedy.exceptions.CodePlaceholdersPresentException as E: # Code with blanks is allowed
-      pass
-    except OSError as E:
-      return True # programs with ask cannot be tested with output :(
-    except Exception as E:
-      return False
-    return True
+                if (
+                    not result.has_turtle and (not "ask" in all_commands) and (not "input" in all_commands)
+                ):  # output from turtle cannot be captured
+                    output = HedyTester.run_code(result)
+        except hedy.exceptions.CodePlaceholdersPresentException as E:  # Code with blanks is allowed
+            pass
+        except OSError as E:
+            return True  # programs with ask cannot be tested with output :(
+        except Exception as E:
+            return False
+        return True
 
-  @staticmethod
-  def validate_Python_code(parseresult):
-    # Code used in the Adventure and Level Defaults tester to validate Hedy code
+    @staticmethod
+    def validate_Python_code(parseresult):
+        # Code used in the Adventure and Level Defaults tester to validate Hedy code
 
-    try:
-        if not parseresult.has_turtle: #ouput from turtle cannot be captured
-          output = HedyTester.run_code(parseresult)
-    except hedy.exceptions.CodePlaceholdersPresentException as E: # Code with blanks is allowed
-      pass
-    except OSError as E:
-      return True # programs with ask cannot be tested with output :(
-    except Exception as E:
-      return False
-    return True
+        try:
+            if not parseresult.has_turtle:  # ouput from turtle cannot be captured
+                output = HedyTester.run_code(parseresult)
+        except hedy.exceptions.CodePlaceholdersPresentException as E:  # Code with blanks is allowed
+            pass
+        except OSError as E:
+            return True  # programs with ask cannot be tested with output :(
+        except Exception as E:
+            return False
+        return True
 
-  # The turtle commands get transpiled into big pieces of code that probably will change
-  # The followings methods abstract the specifics of the tranpilation and keep tests succinct
-  @staticmethod
-  def forward_transpiled(val):
-    return HedyTester.turtle_command_transpiled('forward', val)
+    # The turtle commands get transpiled into big pieces of code that probably will change
+    # The followings methods abstract the specifics of the tranpilation and keep tests succinct
+    @staticmethod
+    def forward_transpiled(val):
+        return HedyTester.turtle_command_transpiled("forward", val)
 
-  @staticmethod
-  def turn_transpiled(val):
-    return HedyTester.turtle_command_transpiled('right', val)
+    @staticmethod
+    def turn_transpiled(val):
+        return HedyTester.turtle_command_transpiled("right", val)
 
-  @staticmethod
-  def turtle_command_transpiled(command, val):
-    command_text = 'turn'
-    suffix = ''
-    if command == 'forward':
-      command_text = 'forward'
-      suffix = '\n      time.sleep(0.1)'
-    return textwrap.dedent(f"""\
+    @staticmethod
+    def turtle_command_transpiled(command, val):
+        command_text = "turn"
+        suffix = ""
+        if command == "forward":
+            command_text = "forward"
+            suffix = "\n      time.sleep(0.1)"
+        return textwrap.dedent(
+            f"""\
       trtl = {val}
       try:
         trtl = int(trtl)
       except ValueError:
         raise Exception(f'While running your program the command <span class="command-highlighted">{command_text}</span> received the value <span class="command-highlighted">{{trtl}}</span> which is not allowed. Try changing the value to a number.')
-      t.{command}(min(600, trtl) if trtl > 0 else max(-600, trtl)){suffix}""")
+      t.{command}(min(600, trtl) if trtl > 0 else max(-600, trtl)){suffix}"""
+        )
 
-  @staticmethod
-  def sleep_command_transpiled(val):
-    return textwrap.dedent(f"""\
+    @staticmethod
+    def sleep_command_transpiled(val):
+        return textwrap.dedent(
+            f"""\
         try:
           time.sleep(int({val}))
         except ValueError:
-          raise Exception(f'While running your program the command <span class="command-highlighted">sleep</span> received the value <span class="command-highlighted">{{{val}}}</span> which is not allowed. Try changing the value to a number.')""")
+          raise Exception(f'While running your program the command <span class="command-highlighted">sleep</span> received the value <span class="command-highlighted">{{{val}}}</span> which is not allowed. Try changing the value to a number.')"""
+        )
 
-  @staticmethod
-  def turtle_color_command_transpiled(val):
-    return textwrap.dedent(f"""\
+    @staticmethod
+    def turtle_color_command_transpiled(val):
+        return textwrap.dedent(
+            f"""\
       trtl = f'{val}'
       if trtl not in ['black', 'blue', 'brown', 'gray', 'green', 'orange', 'pink', 'purple', 'red', 'white', 'yellow']:
         raise Exception(f'While running your program the command <span class="command-highlighted">color</span> received the value <span class="command-highlighted">{{trtl}}</span> which is not allowed. Try using another color.')
-      t.pencolor(trtl)""")
+      t.pencolor(trtl)"""
+        )
 
-  @staticmethod
-  def input_transpiled(var_name, text):
-    return textwrap.dedent(f"""\
+    @staticmethod
+    def input_transpiled(var_name, text):
+        return textwrap.dedent(
+            f"""\
     {var_name} = input(f'''{text}''')
     try:
       {var_name} = int({var_name})
@@ -243,48 +292,51 @@ class HedyTester(unittest.TestCase):
       try:
         {var_name} = float({var_name})
       except ValueError:
-        pass""")
+        pass"""
+        )
 
-  @staticmethod
-  def remove_transpiled(list_name, value):
-    return textwrap.dedent(f"""\
+    @staticmethod
+    def remove_transpiled(list_name, value):
+        return textwrap.dedent(
+            f"""\
       try:
         {list_name}.remove({value})
       except:
-        pass""")
+        pass"""
+        )
 
-  # Used to overcome indentation issues when the above code is inserted
-  # in test cases which use different indentation style (e.g. 2 or 4 spaces)
-  @staticmethod
-  def dedent(*args):
-    return '\n'.join([textwrap.indent(textwrap.dedent(a[0]), a[1]) if type(a) is tuple else textwrap.dedent(a)
-                      for a in args])
+    # Used to overcome indentation issues when the above code is inserted
+    # in test cases which use different indentation style (e.g. 2 or 4 spaces)
+    @staticmethod
+    def dedent(*args):
+        return "\n".join(
+            [textwrap.indent(textwrap.dedent(a[0]), a[1]) if type(a) is tuple else textwrap.dedent(a) for a in args]
+        )
 
-  @staticmethod
-  def translate_keywords_in_snippets(snippets):
-    # fill keyword dict for all keyword languages
-    keyword_dict = {}
-    for lang in ALL_KEYWORD_LANGUAGES:
-      keyword_dict[lang] = KEYWORDS.get(lang)
-      for k, v in keyword_dict[lang].items():
-        if type(v) == str and "|" in v:
-          # when we have several options, pick the first one as default
-          keyword_dict[lang][k] = v.split('|')[0]
-    english_keywords = KEYWORDS.get("en")
+    @staticmethod
+    def translate_keywords_in_snippets(snippets):
+        # fill keyword dict for all keyword languages
+        keyword_dict = {}
+        for lang in ALL_KEYWORD_LANGUAGES:
+            keyword_dict[lang] = KEYWORDS.get(lang)
+            for k, v in keyword_dict[lang].items():
+                if type(v) == str and "|" in v:
+                    # when we have several options, pick the first one as default
+                    keyword_dict[lang][k] = v.split("|")[0]
+        english_keywords = KEYWORDS.get("en")
 
-    # We replace the code snippet placeholders with actual keywords to the code is valid: {print} -> print
-    for snippet in snippets:
-      try:
-        if snippet[1].language in ALL_KEYWORD_LANGUAGES.keys():
-          snippet[1].code = snippet[1].code.format(**keyword_dict[snippet[1].language])
-        else:
-          snippet[1].code = snippet[1].code.format(**english_keywords)
-      except KeyError:
-        print("This following snippet contains an invalid placeholder...")
-        print(snippet)
-      except ValueError:
-        print("This following snippet contains an unclosed invalid placeholder...")
-        print(snippet)
+        # We replace the code snippet placeholders with actual keywords to the code is valid: {print} -> print
+        for snippet in snippets:
+            try:
+                if snippet[1].language in ALL_KEYWORD_LANGUAGES.keys():
+                    snippet[1].code = snippet[1].code.format(**keyword_dict[snippet[1].language])
+                else:
+                    snippet[1].code = snippet[1].code.format(**english_keywords)
+            except KeyError:
+                print("This following snippet contains an invalid placeholder...")
+                print(snippet)
+            except ValueError:
+                print("This following snippet contains an unclosed invalid placeholder...")
+                print(snippet)
 
-
-    return snippets
+        return snippets

--- a/tests/test_abproxying.py
+++ b/tests/test_abproxying.py
@@ -1,20 +1,27 @@
 from website import ab_proxying
 import unittest
 
-class TestAbTesting(unittest.TestCase):
-  def test_extract_cookies(self):
-    set_cookie = 'session=eyJzZXNzaW9uX2lkIjoiODgwOGMxMjIxMmVmNGM5NjkzNTFhMWYxYzEyNGExNjUiLCJ2YWx1ZSI6IjEyMyJ9.YLOIMA.b71v_iV4DgyniHlpuyzdVJBkM5M; Secure; HttpOnly; Path=/; SameSite=Lax'
-    session = ab_proxying.extract_session_from_cookie(set_cookie, 'TheSecret')
-    self.assertEqual(session, {
-      'session_id': '8808c12212ef4c969351a1f1c124a165',
-      'value': '123',
-    })
 
-  def test_extract_cookies_with_invalid_secret(self):
-    """Test that we successfully decode the cookies, even if the secret key is wrong."""
-    set_cookie = 'session=eyJzZXNzaW9uX2lkIjoiODgwOGMxMjIxMmVmNGM5NjkzNTFhMWYxYzEyNGExNjUiLCJ2YWx1ZSI6IjEyMyJ9.YLOIMA.b71v_iV4DgyniHlpuyzdVJBkM5M; Secure; HttpOnly; Path=/; SameSite=Lax'
-    session = ab_proxying.extract_session_from_cookie(set_cookie, 'Banana')
-    self.assertEqual(session, {
-      'session_id': '8808c12212ef4c969351a1f1c124a165',
-      'value': '123',
-    })
+class TestAbTesting(unittest.TestCase):
+    def test_extract_cookies(self):
+        set_cookie = "session=eyJzZXNzaW9uX2lkIjoiODgwOGMxMjIxMmVmNGM5NjkzNTFhMWYxYzEyNGExNjUiLCJ2YWx1ZSI6IjEyMyJ9.YLOIMA.b71v_iV4DgyniHlpuyzdVJBkM5M; Secure; HttpOnly; Path=/; SameSite=Lax"
+        session = ab_proxying.extract_session_from_cookie(set_cookie, "TheSecret")
+        self.assertEqual(
+            session,
+            {
+                "session_id": "8808c12212ef4c969351a1f1c124a165",
+                "value": "123",
+            },
+        )
+
+    def test_extract_cookies_with_invalid_secret(self):
+        """Test that we successfully decode the cookies, even if the secret key is wrong."""
+        set_cookie = "session=eyJzZXNzaW9uX2lkIjoiODgwOGMxMjIxMmVmNGM5NjkzNTFhMWYxYzEyNGExNjUiLCJ2YWx1ZSI6IjEyMyJ9.YLOIMA.b71v_iV4DgyniHlpuyzdVJBkM5M; Secure; HttpOnly; Path=/; SameSite=Lax"
+        session = ab_proxying.extract_session_from_cookie(set_cookie, "Banana")
+        self.assertEqual(
+            session,
+            {
+                "session_id": "8808c12212ef4c969351a1f1c124a165",
+                "value": "123",
+            },
+        )

--- a/tests/test_distance_algo.py
+++ b/tests/test_distance_algo.py
@@ -2,122 +2,124 @@ import unittest
 import hedy
 from parameterized import parameterized
 
+
 class TestsKeywordSuggestions(unittest.TestCase):
+    def test_self_command_print(self):
+        invalid_command = "print"
+        keywords_en_level_1 = hedy.get_suggestions_for_language("en", 1)
+        closest = hedy.closest_command(invalid_command, keywords_en_level_1)
+        self.assertEqual("keyword", closest)
 
-  def test_self_command_print(self):
-    invalid_command = "print"
-    keywords_en_level_1 = hedy.get_suggestions_for_language('en', 1)
-    closest = hedy.closest_command(invalid_command, keywords_en_level_1)
-    self.assertEqual('keyword', closest)
+    def test_self_command_ask(self):
+        invalid_command = "ask"
+        keywords_en_level_1 = hedy.get_suggestions_for_language("en", 1)
+        closest = hedy.closest_command(invalid_command, keywords_en_level_1)
+        self.assertEqual("keyword", closest)
 
-  def test_self_command_ask(self):
-    invalid_command = "ask"
-    keywords_en_level_1 = hedy.get_suggestions_for_language('en', 1)
-    closest = hedy.closest_command(invalid_command, keywords_en_level_1)
-    self.assertEqual('keyword', closest)
+    def test_self_command_echo(self):
+        invalid_command = "echo"
+        keywords_en_level_1 = hedy.get_suggestions_for_language("en", 1)
+        closest = hedy.closest_command(invalid_command, keywords_en_level_1)
+        self.assertEqual("keyword", closest)
 
-  def test_self_command_echo(self):
-    invalid_command = "echo"
-    keywords_en_level_1 = hedy.get_suggestions_for_language('en', 1)
-    closest = hedy.closest_command(invalid_command, keywords_en_level_1)
-    self.assertEqual('keyword', closest)
+    def test_print_difference_1(self):
+        invalid_command = "pront"
+        keywords_en_level_1 = hedy.get_suggestions_for_language("en", 1)
+        closest = hedy.closest_command(invalid_command, keywords_en_level_1)
+        self.assertEqual("print", closest)
 
-  def test_print_difference_1(self):
-    invalid_command = "pront"
-    keywords_en_level_1 = hedy.get_suggestions_for_language('en', 1)
-    closest = hedy.closest_command(invalid_command, keywords_en_level_1)
-    self.assertEqual('print', closest)
+    def test_print_difference_2(self):
+        invalid_command = "prond"
+        keywords_en_level_1 = hedy.get_suggestions_for_language("en", 1)
+        closest = hedy.closest_command(invalid_command, keywords_en_level_1)
+        self.assertEqual("print", closest)
 
-  def test_print_difference_2(self):
-    invalid_command = "prond"
-    keywords_en_level_1 = hedy.get_suggestions_for_language('en', 1)
-    closest = hedy.closest_command(invalid_command, keywords_en_level_1)
-    self.assertEqual('print', closest)
+    def test_echo_command_1(self):
+        invalid_command = "echoo"
+        keywords_en_level_1 = hedy.get_suggestions_for_language("en", 1)
+        closest = hedy.closest_command(invalid_command, keywords_en_level_1)
+        self.assertEqual("echo", closest)
 
-  def test_echo_command_1(self):
-    invalid_command = "echoo"
-    keywords_en_level_1 = hedy.get_suggestions_for_language('en', 1)
-    closest = hedy.closest_command(invalid_command, keywords_en_level_1)
-    self.assertEqual('echo', closest)
+    def test_echo_command_2(self):
+        invalid_command = "ego"
+        keywords_en_level_1 = hedy.get_suggestions_for_language("en", 1)
+        closest = hedy.closest_command(invalid_command, keywords_en_level_1)
+        self.assertEqual("echo", closest)
 
-  def test_echo_command_2(self):
-    invalid_command = "ego"
-    keywords_en_level_1 = hedy.get_suggestions_for_language('en', 1)
-    closest = hedy.closest_command(invalid_command, keywords_en_level_1)
-    self.assertEqual('echo', closest)
+    def test_echo_command_3(self):
+        invalid_command = "eechooooooo"
+        keywords_en_level_1 = hedy.get_suggestions_for_language("en", 1)
+        closest = hedy.closest_command(invalid_command, keywords_en_level_1)
+        self.assertEqual(None, closest)
 
-  def test_echo_command_3(self):
-    invalid_command = "eechooooooo"
-    keywords_en_level_1 = hedy.get_suggestions_for_language('en', 1)
-    closest = hedy.closest_command(invalid_command, keywords_en_level_1)
-    self.assertEqual(None, closest)
+    def test_ask_command_nl(self):
+        invalid_command = "ask"
+        keywords_nl_level_1 = hedy.get_suggestions_for_language("nl", 1)
+        closest = hedy.closest_command(invalid_command, keywords_nl_level_1)
+        self.assertEqual("keyword", closest)
 
-  def test_ask_command_nl(self):
-    invalid_command = "ask"
-    keywords_nl_level_1 = hedy.get_suggestions_for_language('nl', 1)
-    closest = hedy.closest_command(invalid_command, keywords_nl_level_1)
-    self.assertEqual('keyword', closest)
-
-  @parameterized.expand([
-      (1  ,'print'  ,'pnirt'  ),
-      (1  ,'turn'   ,'tnru'   ),
-      (1 , 'turn'   ,'purn'   ),
-      (3  ,'sleep'  ,'sleepb' ),
-      (3 , 'at'     ,'mt'     ),
-      (4  ,'ask'    ,'sk'     ),
-      (4  ,'print'  ,'prtni'  ),
-      (4  ,'random' ,'nandom' ),
-      (4 , 'add'    ,'addg'   ),
-      (4 , 'print'  ,'pridnt' ),
-      (5  ,'add'    ,'wdd'    ),
-      (5 , 'else'   ,'elyse'  ),
-      (5 , 'else'   ,'esle'   ),
-      (5 , 'forward','fowrard'),
-      (5 , 'forward','fwroard'),
-      (5 , 'random' ,'arndom' ),
-      (6  ,'print'  ,'pritn'  ),
-      (6 , 'add'    ,'dda'    ),
-      (6 , 'else'   ,'eles'   ),
-      (6 , 'remove' ,'zremove'),
-      (6 , 'turn'   ,'tunr'   ),
-      (7 , 'print'  ,'pxrint' ),
-      (7 , 'print'  ,'pyrint' ),
-      (7 , 'random' ,'radnom' ),
-      (7 , 'times'  ,'tiems'  ),
-      (8 , 'ask'    ,'abk'    ),
-      (8 , 'remove' ,'reomve' ),
-      (8 , 'remove' ,'rmeove' ),
-      (8 , 'repeat' ,'repceat'),
-      (9  ,'from'   ,'rfom'   ),
-      (9 , 'remove' ,'reove'  ),
-      (9 , 'times'  ,'timers' ),
-      (10 ,'add'    ,'ajdd'   ),
-      (11 ,'at'     ,'rt'     ),
-      (11, 'for'    ,'or'     ),
-      (11, 'random' ,'raodnm' ),
-      (12 ,'in'     ,'inm'    ),
-      (12 ,'print'  ,'rint'   ),
-      (12, 'sleep'  ,'suleep' ),
-      (13, 'else'   ,'lese'   ),
-      (14 ,'remove' ,'remoe'  ),
-      (14, 'add'    ,'dadd'   ),
-      (14, 'range'  ,'raige'  ),
-      (15 ,'and'    ,'asnd'   ),
-      (15 ,'random' ,'rakdom' ),
-      (15, 'else'   ,'ese'    ),
-      (15, 'print'  ,'irpnt'  ),
-      (15, 'print'  ,'pribnt' ),
-      (15, 'random' ,'randoo' ),
-      (15, 'while'  ,'whcle'  ),
-      (16, 'print'  ,'prnit'  ),
-      (16, 'remove' ,'emove'  ),
-      (16, 'while'  ,'whilee' ),
-      (17, 'sleep'  ,'slkep'  ),
-      (18 ,'or'     ,'oru'    ),
-      (18 ,'sleep'  ,'slvep'  ),
-      (18, 'print'  ,'prinbt' ),
-    ])
-  def test_command_en(self,level,correct,mistake):
-    keywords = hedy.get_suggestions_for_language('en', level )
-    closest = hedy.closest_command(mistake, keywords)
-    self.assertEqual(correct, closest)
+    @parameterized.expand(
+        [
+            (1, "print", "pnirt"),
+            (1, "turn", "tnru"),
+            (1, "turn", "purn"),
+            (3, "sleep", "sleepb"),
+            (3, "at", "mt"),
+            (4, "ask", "sk"),
+            (4, "print", "prtni"),
+            (4, "random", "nandom"),
+            (4, "add", "addg"),
+            (4, "print", "pridnt"),
+            (5, "add", "wdd"),
+            (5, "else", "elyse"),
+            (5, "else", "esle"),
+            (5, "forward", "fowrard"),
+            (5, "forward", "fwroard"),
+            (5, "random", "arndom"),
+            (6, "print", "pritn"),
+            (6, "add", "dda"),
+            (6, "else", "eles"),
+            (6, "remove", "zremove"),
+            (6, "turn", "tunr"),
+            (7, "print", "pxrint"),
+            (7, "print", "pyrint"),
+            (7, "random", "radnom"),
+            (7, "times", "tiems"),
+            (8, "ask", "abk"),
+            (8, "remove", "reomve"),
+            (8, "remove", "rmeove"),
+            (8, "repeat", "repceat"),
+            (9, "from", "rfom"),
+            (9, "remove", "reove"),
+            (9, "times", "timers"),
+            (10, "add", "ajdd"),
+            (11, "at", "rt"),
+            (11, "for", "or"),
+            (11, "random", "raodnm"),
+            (12, "in", "inm"),
+            (12, "print", "rint"),
+            (12, "sleep", "suleep"),
+            (13, "else", "lese"),
+            (14, "remove", "remoe"),
+            (14, "add", "dadd"),
+            (14, "range", "raige"),
+            (15, "and", "asnd"),
+            (15, "random", "rakdom"),
+            (15, "else", "ese"),
+            (15, "print", "irpnt"),
+            (15, "print", "pribnt"),
+            (15, "random", "randoo"),
+            (15, "while", "whcle"),
+            (16, "print", "prnit"),
+            (16, "remove", "emove"),
+            (16, "while", "whilee"),
+            (17, "sleep", "slkep"),
+            (18, "or", "oru"),
+            (18, "sleep", "slvep"),
+            (18, "print", "prinbt"),
+        ]
+    )
+    def test_command_en(self, level, correct, mistake):
+        keywords = hedy.get_suggestions_for_language("en", level)
+        closest = hedy.closest_command(mistake, keywords)
+        self.assertEqual(correct, closest)

--- a/tests/test_dynamo.py
+++ b/tests/test_dynamo.py
@@ -6,314 +6,370 @@ import contextlib
 
 
 class Helpers:
-  def __init__(self):
-    # Necessary to make pylint happy
-    self.table = None
-    
-  def insert(self, *rows):
-    for row in rows:
-      self.table.create(row)
+    def __init__(self):
+        # Necessary to make pylint happy
+        self.table = None
 
-  def insert_sample_data(self):
-    self.insert(
-        dict(id='key', sort=1, x=1, y=1, m=9),
-        dict(id='key', sort=2, x=1, y=3, m=9),
-        dict(id='key', sort=3, x=1, y=2, m=8))
+    def insert(self, *rows):
+        for row in rows:
+            self.table.create(row)
 
-  def get_pages(self, key, **kwargs):
-    ret = []
+    def insert_sample_data(self):
+        self.insert(
+            dict(id="key", sort=1, x=1, y=1, m=9),
+            dict(id="key", sort=2, x=1, y=3, m=9),
+            dict(id="key", sort=3, x=1, y=2, m=8),
+        )
 
-    p = self.table.get_many(key, **kwargs)
-    while True:
-      if p.records:
-        ret.append(p.records)
+    def get_pages(self, key, **kwargs):
+        ret = []
 
-      if not p.next_page_token: break
-      p = self.table.get_many(key, **kwargs, pagination_token=p.next_page_token)
-    return ret
+        p = self.table.get_many(key, **kwargs)
+        while True:
+            if p.records:
+                ret.append(p.records)
+
+            if not p.next_page_token:
+                break
+            p = self.table.get_many(key, **kwargs, pagination_token=p.next_page_token)
+        return ret
+
 
 class TestDynamoAbstraction(unittest.TestCase):
-  def setUp(self):
-    self.table = dynamo.Table(dynamo.MemoryStorage(), 'table', 'id')
+    def setUp(self):
+        self.table = dynamo.Table(dynamo.MemoryStorage(), "table", "id")
 
-  def test_set_manipulation(self):
-    """Test that adding to a set and removing from a set works."""
-    self.table.create(dict(
-      id='key',
-      values=set(['a', 'b', 'c']),
-    ))
+    def test_set_manipulation(self):
+        """Test that adding to a set and removing from a set works."""
+        self.table.create(
+            dict(
+                id="key",
+                values=set(["a", "b", "c"]),
+            )
+        )
 
-    self.table.update(dict(id='key'), dict(
-      values=dynamo.DynamoAddToStringSet('x', 'y'),
-    ))
+        self.table.update(
+            dict(id="key"),
+            dict(
+                values=dynamo.DynamoAddToStringSet("x", "y"),
+            ),
+        )
 
-    final = self.table.get(dict(id='key'))
-    self.assertEqual(final['values'], set(['a', 'b', 'c', 'x', 'y']))
+        final = self.table.get(dict(id="key"))
+        self.assertEqual(final["values"], set(["a", "b", "c", "x", "y"]))
 
-    self.table.update(dict(id='key'), dict(
-      values=dynamo.DynamoRemoveFromStringSet('b', 'c'),
-    ))
+        self.table.update(
+            dict(id="key"),
+            dict(
+                values=dynamo.DynamoRemoveFromStringSet("b", "c"),
+            ),
+        )
 
-    final = self.table.get(dict(id='key'))
-    self.assertEqual(final['values'], set(['a', 'x', 'y']))
+        final = self.table.get(dict(id="key"))
+        self.assertEqual(final["values"], set(["a", "x", "y"]))
 
-  def test_cannot_set_manipulate_lists(self):
-    """Test that if a value originally got created as a 'list', we cannot
-    use set manipulation on it.
+    def test_cannot_set_manipulate_lists(self):
+        """Test that if a value originally got created as a 'list', we cannot
+        use set manipulation on it.
 
-    This also doesn't work in Real DynamoDB, our in-memory API shouldn't make
-    this appear to work.
-    """
-    self.table.create(dict(
-      id='key',
-      values=['a', 'b', 'c'],  # List instead of set
-    ))
+        This also doesn't work in Real DynamoDB, our in-memory API shouldn't make
+        this appear to work.
+        """
+        self.table.create(
+            dict(
+                id="key",
+                values=["a", "b", "c"],  # List instead of set
+            )
+        )
 
-    with self.assertRaises(TypeError):
-      self.table.update(dict(id='key'), dict(
-        values=dynamo.DynamoAddToStringSet('x', 'y'),
-      ))
+        with self.assertRaises(TypeError):
+            self.table.update(
+                dict(id="key"),
+                dict(
+                    values=dynamo.DynamoAddToStringSet("x", "y"),
+                ),
+            )
 
-  def test_sets_are_serialized_properly(self):
-    """Test that adding to a set and removing from a set works."""
-    with with_clean_file('test.json'):
-      table = dynamo.Table(dynamo.MemoryStorage('test.json'), 'table', 'id')
-      table.create(dict(
-        id='key',
-        values=set(['a', 'b', 'c']),
-      ))
+    def test_sets_are_serialized_properly(self):
+        """Test that adding to a set and removing from a set works."""
+        with with_clean_file("test.json"):
+            table = dynamo.Table(dynamo.MemoryStorage("test.json"), "table", "id")
+            table.create(
+                dict(
+                    id="key",
+                    values=set(["a", "b", "c"]),
+                )
+            )
 
-      table = dynamo.Table(dynamo.MemoryStorage('test.json'), 'table', 'id')
-      final = table.get(dict(id='key'))
-      self.assertEqual(final['values'], set(['a', 'b', 'c']))
+            table = dynamo.Table(dynamo.MemoryStorage("test.json"), "table", "id")
+            final = table.get(dict(id="key"))
+            self.assertEqual(final["values"], set(["a", "b", "c"]))
 
 
 class TestSortKeysInMemory(unittest.TestCase):
-  """Test that the operations work on an in-memory table with a sort key."""
-  def setUp(self):
-    self.table = dynamo.Table(dynamo.MemoryStorage(), 'table', partition_key='id', sort_key='sort')
+    """Test that the operations work on an in-memory table with a sort key."""
 
-  def test_put_and_get(self):
-    self.table.create(dict(
-      id='key',
-      sort='sort',
-      value='V',
-    ))
+    def setUp(self):
+        self.table = dynamo.Table(dynamo.MemoryStorage(), "table", partition_key="id", sort_key="sort")
 
-    ret = self.table.get(dict(id='key', sort='sort'))
-    self.assertEqual(ret['value'], 'V')
+    def test_put_and_get(self):
+        self.table.create(
+            dict(
+                id="key",
+                sort="sort",
+                value="V",
+            )
+        )
 
-  def test_put_and_get_many(self):
-    # Insert in reverse order
-    self.table.create(dict(id='key', sort='b', value='B'))
-    self.table.create(dict(id='key', sort='a', value='A'))
+        ret = self.table.get(dict(id="key", sort="sort"))
+        self.assertEqual(ret["value"], "V")
 
-    # Get them back in the right order
-    ret = list(self.table.get_many(dict(id='key')))
-    self.assertEqual(ret, [
-      dict(id='key', sort='a', value='A'),
-      dict(id='key', sort='b', value='B'),
-    ])
+    def test_put_and_get_many(self):
+        # Insert in reverse order
+        self.table.create(dict(id="key", sort="b", value="B"))
+        self.table.create(dict(id="key", sort="a", value="A"))
 
-  def test_updates(self):
-    # Two updates to a record with a sort key
-    self.table.update(dict(id='key', sort='s'), dict(x='x'))
-    self.table.update(dict(id='key', sort='s'), dict(y='y'))
+        # Get them back in the right order
+        ret = list(self.table.get_many(dict(id="key")))
+        self.assertEqual(
+            ret,
+            [
+                dict(id="key", sort="a", value="A"),
+                dict(id="key", sort="b", value="B"),
+            ],
+        )
 
-    ret = self.table.get(dict(id='key', sort='s'))
-    self.assertEqual(ret, dict(id='key', sort='s', x='x', y='y'))
+    def test_updates(self):
+        # Two updates to a record with a sort key
+        self.table.update(dict(id="key", sort="s"), dict(x="x"))
+        self.table.update(dict(id="key", sort="s"), dict(y="y"))
+
+        ret = self.table.get(dict(id="key", sort="s"))
+        self.assertEqual(ret, dict(id="key", sort="s", x="x", y="y"))
 
 
 class TestQueryInMemory(unittest.TestCase, Helpers):
-  """Test that the query work on an in-memory table."""
+    """Test that the query work on an in-memory table."""
 
-  def setUp(self):
-    self.table = dynamo.Table(dynamo.MemoryStorage(), 'table', partition_key='id', sort_key='sort',
-                              indexed_fields=[dynamo.IndexKey('x', 'y'), dynamo.IndexKey('m')])
+    def setUp(self):
+        self.table = dynamo.Table(
+            dynamo.MemoryStorage(),
+            "table",
+            partition_key="id",
+            sort_key="sort",
+            indexed_fields=[dynamo.IndexKey("x", "y"), dynamo.IndexKey("m")],
+        )
 
-  def test_query(self):
-    self.table.create({'id': 'key', 'sort': 1, 'm': 'val'})
-    self.table.create({'id': 'key', 'sort': 2, 'm': 'another'})
+    def test_query(self):
+        self.table.create({"id": "key", "sort": 1, "m": "val"})
+        self.table.create({"id": "key", "sort": 2, "m": "another"})
 
-    ret = list(self.table.get_many({'id': 'key'}))
+        ret = list(self.table.get_many({"id": "key"}))
 
-    self.assertEqual(ret, [
-      {'id': 'key', 'sort': 1, 'm': 'val'},
-      {'id': 'key', 'sort': 2, 'm': 'another'}
-    ])
+        self.assertEqual(ret, [{"id": "key", "sort": 1, "m": "val"}, {"id": "key", "sort": 2, "m": "another"}])
 
-  def test_between_query(self):
-    self.table.create({'id': 'key', 'sort': 1, 'x': 'x'})
-    self.table.create({'id': 'key', 'sort': 2, 'x': 'y'})
-    self.table.create({'id': 'key', 'sort': 3, 'x': 'z'})
+    def test_between_query(self):
+        self.table.create({"id": "key", "sort": 1, "x": "x"})
+        self.table.create({"id": "key", "sort": 2, "x": "y"})
+        self.table.create({"id": "key", "sort": 3, "x": "z"})
 
-    ret = list(self.table.get_many({
-      'id': 'key',
-      'sort': dynamo.Between(2, 5),
-    }))
-    self.assertEqual(ret, [
-      {'id': 'key', 'sort': 2, 'x': 'y'},
-      {'id': 'key', 'sort': 3, 'x': 'z'},
-    ])
+        ret = list(
+            self.table.get_many(
+                {
+                    "id": "key",
+                    "sort": dynamo.Between(2, 5),
+                }
+            )
+        )
+        self.assertEqual(
+            ret,
+            [
+                {"id": "key", "sort": 2, "x": "y"},
+                {"id": "key", "sort": 3, "x": "z"},
+            ],
+        )
 
-  def test_query_index(self):
-    self.table.create({'id': 'key', 'sort': 1, 'm': 'val'})
-    self.table.create({'id': 'key', 'sort': 2, 'm': 'another'})
+    def test_query_index(self):
+        self.table.create({"id": "key", "sort": 1, "m": "val"})
+        self.table.create({"id": "key", "sort": 2, "m": "another"})
 
-    ret = list(self.table.get_many({'m': 'val'}))
+        ret = list(self.table.get_many({"m": "val"}))
 
-    self.assertEqual(ret, [
-      {'id': 'key', 'sort': 1, 'm': 'val'}
-    ])
+        self.assertEqual(ret, [{"id": "key", "sort": 1, "m": "val"}])
 
-  def test_query_index_with_partition_key(self):
-    self.table.create({'id': 'key', 'sort': 1, 'x': 'val', 'y': 0})
-    self.table.create({'id': 'key', 'sort': 2, 'x': 'val', 'y': 1})
-    self.table.create({'id': 'key', 'sort': 3, 'x': 'val', 'y': 1})
-    self.table.create({'id': 'key', 'sort': 4, 'x': 'another_val', 'y': 2})
+    def test_query_index_with_partition_key(self):
+        self.table.create({"id": "key", "sort": 1, "x": "val", "y": 0})
+        self.table.create({"id": "key", "sort": 2, "x": "val", "y": 1})
+        self.table.create({"id": "key", "sort": 3, "x": "val", "y": 1})
+        self.table.create({"id": "key", "sort": 4, "x": "another_val", "y": 2})
 
-    ret = list(self.table.get_many({'x': 'val'}))
+        ret = list(self.table.get_many({"x": "val"}))
 
-    self.assertEqual(ret, [
-      {'id': 'key', 'sort': 1, 'x': 'val', 'y': 0},
-      {'id': 'key', 'sort': 2, 'x': 'val', 'y': 1},
-      {'id': 'key', 'sort': 3, 'x': 'val', 'y': 1}
-    ])
+        self.assertEqual(
+            ret,
+            [
+                {"id": "key", "sort": 1, "x": "val", "y": 0},
+                {"id": "key", "sort": 2, "x": "val", "y": 1},
+                {"id": "key", "sort": 3, "x": "val", "y": 1},
+            ],
+        )
 
-  def test_query_index_with_partition_sort_key(self):
-    self.table.create({'id': 'key', 'sort': 1, 'x': 'val', 'y': 0})
-    self.table.create({'id': 'key', 'sort': 2, 'x': 'val', 'y': 1})
-    self.table.create({'id': 'key', 'sort': 3, 'x': 'val', 'y': 1})
-    self.table.create({'id': 'key', 'sort': 4, 'x': 'another_val', 'y': 2})
+    def test_query_index_with_partition_sort_key(self):
+        self.table.create({"id": "key", "sort": 1, "x": "val", "y": 0})
+        self.table.create({"id": "key", "sort": 2, "x": "val", "y": 1})
+        self.table.create({"id": "key", "sort": 3, "x": "val", "y": 1})
+        self.table.create({"id": "key", "sort": 4, "x": "another_val", "y": 2})
 
-    ret = list(self.table.get_many({'x': 'val', 'y': 1}))
+        ret = list(self.table.get_many({"x": "val", "y": 1}))
 
-    self.assertEqual(ret, [
-      {'id': 'key', 'sort': 2, 'x': 'val', 'y': 1},
-      {'id': 'key', 'sort': 3, 'x': 'val', 'y': 1}
-    ])
+        self.assertEqual(
+            ret, [{"id": "key", "sort": 2, "x": "val", "y": 1}, {"id": "key", "sort": 3, "x": "val", "y": 1}]
+        )
 
-  def test_query_index_sort_key_between(self):
-    self.table.create({'id': 'key', 'sort': 1, 'x': 'val', 'y': 1})
-    self.table.create({'id': 'key', 'sort': 2, 'x': 'val', 'y': 3})
-    self.table.create({'id': 'key', 'sort': 3, 'x': 'val', 'y': 6})
+    def test_query_index_sort_key_between(self):
+        self.table.create({"id": "key", "sort": 1, "x": "val", "y": 1})
+        self.table.create({"id": "key", "sort": 2, "x": "val", "y": 3})
+        self.table.create({"id": "key", "sort": 3, "x": "val", "y": 6})
 
-    ret = list(self.table.get_many({
-      'x': 'val',
-      'y': dynamo.Between(2, 5),
-    }))
-    self.assertEqual(ret, [
-      {'id': 'key', 'sort': 2, 'x': 'val', 'y': 3}
-    ])
+        ret = list(
+            self.table.get_many(
+                {
+                    "x": "val",
+                    "y": dynamo.Between(2, 5),
+                }
+            )
+        )
+        self.assertEqual(ret, [{"id": "key", "sort": 2, "x": "val", "y": 3}])
 
-  def test_paginated_query(self):
-    self.insert_sample_data()
-    pages = self.get_pages({ 'id': 'key' }, limit=1)
+    def test_paginated_query(self):
+        self.insert_sample_data()
+        pages = self.get_pages({"id": "key"}, limit=1)
 
-    self.assertEqual(pages, [
-      [dict(id='key', sort=1, x=1, y=1, m=9)],
-      [dict(id='key', sort=2, x=1, y=3, m=9)],
-      [dict(id='key', sort=3, x=1, y=2, m=8)],
-    ])
+        self.assertEqual(
+            pages,
+            [
+                [dict(id="key", sort=1, x=1, y=1, m=9)],
+                [dict(id="key", sort=2, x=1, y=3, m=9)],
+                [dict(id="key", sort=3, x=1, y=2, m=8)],
+            ],
+        )
 
-  def test_paginated_query_reverse(self):
-    self.insert_sample_data()
-    pages = self.get_pages({ 'id': 'key' }, limit=1, reverse=True)
+    def test_paginated_query_reverse(self):
+        self.insert_sample_data()
+        pages = self.get_pages({"id": "key"}, limit=1, reverse=True)
 
-    self.assertEqual(pages, [
-      [dict(id='key', sort=3, x=1, y=2, m=8)],
-      [dict(id='key', sort=2, x=1, y=3, m=9)],
-      [dict(id='key', sort=1, x=1, y=1, m=9)],
-    ])
+        self.assertEqual(
+            pages,
+            [
+                [dict(id="key", sort=3, x=1, y=2, m=8)],
+                [dict(id="key", sort=2, x=1, y=3, m=9)],
+                [dict(id="key", sort=1, x=1, y=1, m=9)],
+            ],
+        )
 
-  def test_paginated_query_on_sortkey_index(self):
-    self.insert_sample_data()
-    pages = self.get_pages({ 'x': 1 }, limit=1)
+    def test_paginated_query_on_sortkey_index(self):
+        self.insert_sample_data()
+        pages = self.get_pages({"x": 1}, limit=1)
 
-    self.assertEqual(pages, [
-      [dict(id='key', sort=1, x=1, y=1, m=9)],
-      [dict(id='key', sort=3, x=1, y=2, m=8)],
-      [dict(id='key', sort=2, x=1, y=3, m=9)],
-    ])
+        self.assertEqual(
+            pages,
+            [
+                [dict(id="key", sort=1, x=1, y=1, m=9)],
+                [dict(id="key", sort=3, x=1, y=2, m=8)],
+                [dict(id="key", sort=2, x=1, y=3, m=9)],
+            ],
+        )
 
-  def test_paginated_query_on_sortkey_index_reverse(self):
-    self.insert_sample_data()
-    pages = self.get_pages({ 'x': 1 }, limit=1, reverse=True)
+    def test_paginated_query_on_sortkey_index_reverse(self):
+        self.insert_sample_data()
+        pages = self.get_pages({"x": 1}, limit=1, reverse=True)
 
-    self.assertEqual(pages, [
-      [dict(id='key', sort=2, x=1, y=3, m=9)],
-      [dict(id='key', sort=3, x=1, y=2, m=8)],
-      [dict(id='key', sort=1, x=1, y=1, m=9)],
-    ])
+        self.assertEqual(
+            pages,
+            [
+                [dict(id="key", sort=2, x=1, y=3, m=9)],
+                [dict(id="key", sort=3, x=1, y=2, m=8)],
+                [dict(id="key", sort=1, x=1, y=1, m=9)],
+            ],
+        )
 
-  def test_paginated_query_on_partitionkey_index(self):
-    self.insert_sample_data()
-    pages = self.get_pages({ 'm': 9 }, limit=1)
+    def test_paginated_query_on_partitionkey_index(self):
+        self.insert_sample_data()
+        pages = self.get_pages({"m": 9}, limit=1)
 
-    self.assertEqual(pages, [
-      [dict(id='key', sort=1, x=1, y=1, m=9)],
-      [dict(id='key', sort=2, x=1, y=3, m=9)],
-    ])
+        self.assertEqual(
+            pages,
+            [
+                [dict(id="key", sort=1, x=1, y=1, m=9)],
+                [dict(id="key", sort=2, x=1, y=3, m=9)],
+            ],
+        )
 
-  def test_paginated_query_on_partitionkey_index_reverse(self):
-    self.insert_sample_data()
-    pages = self.get_pages({ 'm': 9 }, limit=1, reverse=True)
+    def test_paginated_query_on_partitionkey_index_reverse(self):
+        self.insert_sample_data()
+        pages = self.get_pages({"m": 9}, limit=1, reverse=True)
 
-    self.assertEqual(pages, [
-      [dict(id='key', sort=2, x=1, y=3, m=9)],
-      [dict(id='key', sort=1, x=1, y=1, m=9)],
-    ])
+        self.assertEqual(
+            pages,
+            [
+                [dict(id="key", sort=2, x=1, y=3, m=9)],
+                [dict(id="key", sort=1, x=1, y=1, m=9)],
+            ],
+        )
 
-  def test_paginated_scan(self):
-    self.insert(
-        dict(id='key', sort=1, y=1),
-        dict(id='key', sort=2, y=3),
-        dict(id='key', sort=3, y=6))
+    def test_paginated_scan(self):
+        self.insert(dict(id="key", sort=1, y=1), dict(id="key", sort=2, y=3), dict(id="key", sort=3, y=6))
 
-    ret = self.table.scan(limit=1)
-    self.assertEqual(ret[0], {'id': 'key', 'sort': 1, 'y': 1})
+        ret = self.table.scan(limit=1)
+        self.assertEqual(ret[0], {"id": "key", "sort": 1, "y": 1})
 
-    ret = self.table.scan(limit=1, pagination_token=ret.next_page_token)
-    self.assertEqual(ret[0], {'id': 'key', 'sort': 2, 'y': 3})
+        ret = self.table.scan(limit=1, pagination_token=ret.next_page_token)
+        self.assertEqual(ret[0], {"id": "key", "sort": 2, "y": 3})
 
-    ret = self.table.scan(limit=1, pagination_token=ret.next_page_token)
-    self.assertEqual(ret[0], {'id': 'key', 'sort': 3, 'y': 6})
+        ret = self.table.scan(limit=1, pagination_token=ret.next_page_token)
+        self.assertEqual(ret[0], {"id": "key", "sort": 3, "y": 6})
 
-    self.assertIsNone(ret.next_page_token)
+        self.assertIsNone(ret.next_page_token)
+
 
 class TestSortKeysAgainstAws(unittest.TestCase):
-  """Test that the operations send out appropriate Dynamo requests."""
-  def setUp(self):
-    self.db = mock.Mock()
-    self.table = dynamo.Table(dynamo.AwsDynamoStorage(self.db, ''), 'table', partition_key='id', sort_key='sort')
+    """Test that the operations send out appropriate Dynamo requests."""
 
-    self.db.query.return_value = { 'Items': [] }
+    def setUp(self):
+        self.db = mock.Mock()
+        self.table = dynamo.Table(dynamo.AwsDynamoStorage(self.db, ""), "table", partition_key="id", sort_key="sort")
 
-  def test_between_query(self):
-    self.table.get_many({
-      'id': 'key',
-      'sort': dynamo.Between(2, 5),
-    })
-    self.db.query.assert_called_with(
-      KeyConditionExpression='#id = :id AND #sort BETWEEN :sort_min AND :sort_max',
-      ExpressionAttributeValues={':id': {'S': 'key'}, ':sort_min': {'N': '2'}, ':sort_max': {'N': '5'}},
-      ExpressionAttributeNames={'#id': 'id', '#sort': 'sort'},
-      TableName=mock.ANY,
-      ScanIndexForward=mock.ANY)
+        self.db.query.return_value = {"Items": []}
+
+    def test_between_query(self):
+        self.table.get_many(
+            {
+                "id": "key",
+                "sort": dynamo.Between(2, 5),
+            }
+        )
+        self.db.query.assert_called_with(
+            KeyConditionExpression="#id = :id AND #sort BETWEEN :sort_min AND :sort_max",
+            ExpressionAttributeValues={":id": {"S": "key"}, ":sort_min": {"N": "2"}, ":sort_max": {"N": "5"}},
+            ExpressionAttributeNames={"#id": "id", "#sort": "sort"},
+            TableName=mock.ANY,
+            ScanIndexForward=mock.ANY,
+        )
 
 
 def try_to_delete(filename):
-  if os.path.exists(filename):
-    os.unlink(filename)
+    if os.path.exists(filename):
+        os.unlink(filename)
+
 
 @contextlib.contextmanager
 def with_clean_file(filename):
-  """Remove file before starting, and after running.
+    """Remove file before starting, and after running.
 
-  Intended for tempfiles used in tests.
-  """
-  try_to_delete(filename)
-  try:
-    yield
-  finally:
+    Intended for tempfiles used in tests.
+    """
     try_to_delete(filename)
+    try:
+        yield
+    finally:
+        try_to_delete(filename)

--- a/tests/test_highlighting/test_WEBSITE.py
+++ b/tests/test_highlighting/test_WEBSITE.py
@@ -1,14 +1,9 @@
 from tests.Highlighter import HighlightTester
 
+
 class HighlighterTestWebSite(HighlightTester):
-
-
     def test_1_1(self):
-        self.assert_highlighted_chr(
-            "print hello world!",
-            "KKKKK TTTTTTTTTTTT",
-            level="level1", lang='en')
-
+        self.assert_highlighted_chr("print hello world!", "KKKKK TTTTTTTTTTTT", level="level1", lang="en")
 
     def test_1_2(self):
         self.assert_highlighted_chr_multi_line(
@@ -16,31 +11,24 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKKK TTTTTT",
             "print Welcome to Hedy!",
             "KKKKK TTTTTTTTTTTTTTTT",
-            level="level1", lang='en')
-
+            level="level1",
+            lang="en",
+        )
 
     def test_1_3(self):
         self.assert_highlighted_chr_multi_line(
-            "ask What is your name?",
-            "KKK TTTTTTTTTTTTTTTTTT",
-            "echo hello",
-            "KKKK TTTTT",
-            level="level1", lang='en')
-
+            "ask What is your name?", "KKK TTTTTTTTTTTTTTTTTT", "echo hello", "KKKK TTTTT", level="level1", lang="en"
+        )
 
     def test_1_4(self):
         self.assert_highlighted_chr(
-            "print Your story starts here",
-            "KKKKK TTTTTTTTTTTTTTTTTTTTTT",
-            level="level1", lang='en')
-
+            "print Your story starts here", "KKKKK TTTTTTTTTTTTTTTTTTTTTT", level="level1", lang="en"
+        )
 
     def test_1_5(self):
         self.assert_highlighted_chr(
-            "ask who is the star in your story?",
-            "KKK TTTTTTTTTTTTTTTTTTTTTTTTTTTTTT",
-            level="level1", lang='en')
-
+            "ask who is the star in your story?", "KKK TTTTTTTTTTTTTTTTTTTTTTTTTTTTTT", level="level1", lang="en"
+        )
 
     def test_1_6(self):
         self.assert_highlighted_chr_multi_line(
@@ -54,15 +42,12 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKKK TTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT",
             "print He's afraid this is a haunted forest",
             "KKKKK TTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT",
-            level="level1", lang='en')
-
+            level="level1",
+            lang="en",
+        )
 
     def test_1_7(self):
-        self.assert_highlighted_chr(
-            "print Im Hedy the parrot",
-            "KKKKK TTTTTTTTTTTTTTTTTT",
-            level="level1", lang='en')
-
+        self.assert_highlighted_chr("print Im Hedy the parrot", "KKKKK TTTTTTTTTTTTTTTTTT", level="level1", lang="en")
 
     def test_1_8(self):
         self.assert_highlighted_chr_multi_line(
@@ -74,17 +59,14 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKK",
             "echo",
             "KKKK",
-            level="level1", lang='en')
-
+            level="level1",
+            lang="en",
+        )
 
     def test_1_9(self):
         self.assert_highlighted_chr_multi_line(
-            "forward 50",
-            "KKKKKKK TT",
-            "turn left",
-            "KKKK TTTT",
-            level="level1", lang='en')
-
+            "forward 50", "KKKKKKK TT", "turn left", "KKKK TTTT", level="level1", lang="en"
+        )
 
     def test_1_10(self):
         self.assert_highlighted_chr_multi_line(
@@ -96,15 +78,17 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKK TTTT",
             "forward 50",
             "KKKKKKK TT",
-            level="level1", lang='en')
-
+            level="level1",
+            lang="en",
+        )
 
     def test_1_11(self):
         self.assert_highlighted_chr(
             "print Welcome to your own rock scissors paper!",
             "KKKKK TTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT",
-            level="level1", lang='en')
-
+            level="level1",
+            lang="en",
+        )
 
     def test_1_12(self):
         self.assert_highlighted_chr_multi_line(
@@ -114,15 +98,12 @@ class HighlighterTestWebSite(HighlightTester):
             "KKK TTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT",
             "echo so your choice was:",
             "KKKK TTTTTTTTTTTTTTTTTTT",
-            level="level1", lang='en')
-
+            level="level1",
+            lang="en",
+        )
 
     def test_1_13(self):
-        self.assert_highlighted_chr(
-            "# place your code here",
-            "CCCCCCCCCCCCCCCCCCCCCC",
-            level="level1", lang='en')
-
+        self.assert_highlighted_chr("# place your code here", "CCCCCCCCCCCCCCCCCCCCCC", level="level1", lang="en")
 
     def test_1_14(self):
         self.assert_highlighted_chr_multi_line(
@@ -136,8 +117,9 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKKK TTTTTTTTTTTTTTTTT",
             "echo Your name is",
             "KKKK TTTTTTTTTTTT",
-            level="level1", lang='en')
-
+            level="level1",
+            lang="en",
+        )
 
     def test_1_15(self):
         self.assert_highlighted_chr_multi_line(
@@ -151,15 +133,12 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKKK TTTTTTTTTTTTTTTTTTTTTTTTTT",
             "print It's on its way!",
             "KKKKK TTTTTTTTTTTTTTTT",
-            level="level1", lang='en')
-
+            level="level1",
+            lang="en",
+        )
 
     def test_1_16(self):
-        self.assert_highlighted_chr(
-            "print How did I get here?",
-            "KKKKK TTTTTTTTTTTTTTTTTTT",
-            level="level1", lang='en')
-
+        self.assert_highlighted_chr("print How did I get here?", "KKKKK TTTTTTTTTTTTTTTTTTT", level="level1", lang="en")
 
     def test_1_17(self):
         self.assert_highlighted_chr_multi_line(
@@ -187,15 +166,12 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKK TTTTTTTTTTTTT",
             "print ...?",
             "KKKKK TTTT",
-            level="level1", lang='en')
-
+            level="level1",
+            lang="en",
+        )
 
     def test_1_18(self):
-        self.assert_highlighted_chr(
-            "print Let's go!",
-            "KKKKK TTTTTTTTT",
-            level="level1", lang='en')
-
+        self.assert_highlighted_chr("print Let's go!", "KKKKK TTTTTTTTT", level="level1", lang="en")
 
     def test_1_19(self):
         self.assert_highlighted_chr_multi_line(
@@ -209,14 +185,12 @@ class HighlighterTestWebSite(HighlightTester):
             "KKK TTTTTTTTTTTTTTTTTTTTTTTTTTTTT",
             "echo So you want ",
             "KKKK TTTTTTTTTTTT",
-            level="level1", lang='en')
+            level="level1",
+            lang="en",
+        )
 
     def test_2_1(self):
-        self.assert_highlighted_chr(
-            "print hello world!",
-            "KKKKK TTTTTTTTTTTT",
-            level="level2", lang='en')
-
+        self.assert_highlighted_chr("print hello world!", "KKKKK TTTTTTTTTTTT", level="level2", lang="en")
 
     def test_2_2(self):
         self.assert_highlighted_chr_multi_line(
@@ -226,8 +200,9 @@ class HighlighterTestWebSite(HighlightTester):
             "TTT KK TT",
             "print name is age years old",
             "KKKKK TTTTTTTTTTTTTTTTTTTTT",
-            level="level2", lang='en')
-
+            level="level2",
+            lang="en",
+        )
 
     def test_2_3(self):
         self.assert_highlighted_chr_multi_line(
@@ -235,8 +210,9 @@ class HighlighterTestWebSite(HighlightTester):
             "TTTTTT KK KKK TTTTTTTTTTTTTTTTTT",
             "print Hello answer",
             "KKKKK TTTTTTTTTTTT",
-            level="level2", lang='en')
-
+            level="level2",
+            lang="en",
+        )
 
     def test_2_4(self):
         self.assert_highlighted_chr_multi_line(
@@ -246,15 +222,12 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKKK T",
             "print green!",
             "KKKKK TTTTTT",
-            level="level2", lang='en')
-
+            level="level2",
+            lang="en",
+        )
 
     def test_2_5(self):
-        self.assert_highlighted_chr(
-            "print Your story",
-            "KKKKK TTTTTTTTTT",
-            level="level2", lang='en')
-
+        self.assert_highlighted_chr("print Your story", "KKKKK TTTTTTTTTT", level="level2", lang="en")
 
     def test_2_6(self):
         self.assert_highlighted_chr_multi_line(
@@ -270,15 +243,12 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKKK",
             "print name is afraid this is a haunted forest",
             "KKKKK TTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT",
-            level="level2", lang='en')
-
+            level="level2",
+            lang="en",
+        )
 
     def test_2_7(self):
-        self.assert_highlighted_chr(
-            "print Im Hedy the parrot!",
-            "KKKKK TTTTTTTTTTTTTTTTTTT",
-            level="level2", lang='en')
-
+        self.assert_highlighted_chr("print Im Hedy the parrot!", "KKKKK TTTTTTTTTTTTTTTTTTT", level="level2", lang="en")
 
     def test_2_8(self):
         self.assert_highlighted_chr_multi_line(
@@ -296,8 +266,9 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKKK",
             "print name",
             "KKKKK TTTT",
-            level="level2", lang='en')
-
+            level="level2",
+            lang="en",
+        )
 
     def test_2_9(self):
         self.assert_highlighted_chr_multi_line(
@@ -309,8 +280,9 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKK TTTT",
             "forward 25",
             "KKKKKKK TT",
-            level="level2", lang='en')
-
+            level="level2",
+            lang="en",
+        )
 
     def test_2_10(self):
         self.assert_highlighted_chr_multi_line(
@@ -326,24 +298,17 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKK TTTTT",
             "forward 25",
             "KKKKKKK TT",
-            level="level2", lang='en')
-
+            level="level2",
+            lang="en",
+        )
 
     def test_2_11(self):
-        self.assert_highlighted_chr(
-            "# place your code here",
-            "CCCCCCCCCCCCCCCCCCCCCC",
-            level="level2", lang='en')
-
+        self.assert_highlighted_chr("# place your code here", "CCCCCCCCCCCCCCCCCCCCCC", level="level2", lang="en")
 
     def test_2_12(self):
         self.assert_highlighted_chr_multi_line(
-            "choice is _",
-            "TTTTTT KK I",
-            "print I choose choice",
-            "KKKKK TTTTTTTTTTTTTTT",
-            level="level2", lang='en')
-
+            "choice is _", "TTTTTT KK I", "print I choose choice", "KKKKK TTTTTTTTTTTTTTT", level="level2", lang="en"
+        )
 
     def test_2_13(self):
         self.assert_highlighted_chr_multi_line(
@@ -365,15 +330,12 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKKK TTTTTTTTTTTTTTTTTTTTTTTTT",
             "print Your food and drinks will be right there!",
             "KKKKK TTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT",
-            level="level2", lang='en')
-
+            level="level2",
+            lang="en",
+        )
 
     def test_2_14(self):
-        self.assert_highlighted_chr(
-            "monster1 is _",
-            "TTTTTTTT KK I",
-            level="level2", lang='en')
-
+        self.assert_highlighted_chr("monster1 is _", "TTTTTTTT KK I", level="level2", lang="en")
 
     def test_2_15(self):
         self.assert_highlighted_chr_multi_line(
@@ -393,22 +355,17 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKKK TTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT",
             "print But as you enter monster_3 attacks you!",
             "KKKKK TTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT",
-            level="level2", lang='en')
-
+            level="level2",
+            lang="en",
+        )
 
     def test_2_16(self):
         self.assert_highlighted_chr(
-            "print Let's go to the next level!",
-            "KKKKK TTTTTTTTTTTTTTTTTTTTTTTTTTT",
-            level="level2", lang='en')
-
+            "print Let's go to the next level!", "KKKKK TTTTTTTTTTTTTTTTTTTTTTTTTTT", level="level2", lang="en"
+        )
 
     def test_3_1(self):
-        self.assert_highlighted_chr_multi_line(
-            "print hello world!",
-            "KKKKK TTTTTTTTTTTT",
-            level="level3", lang='en')
-
+        self.assert_highlighted_chr_multi_line("print hello world!", "KKKKK TTTTTTTTTTTT", level="level3", lang="en")
 
     def test_3_2(self):
         self.assert_highlighted_chr_multi_line(
@@ -416,8 +373,9 @@ class HighlighterTestWebSite(HighlightTester):
             "TTTTTTT KK TTTK TTTK TTTTTTTT",
             "print animals at random",
             "KKKKK TTTTTTT KK KKKKKK",
-            level="level3", lang='en')
-
+            level="level3",
+            lang="en",
+        )
 
     def test_3_3(self):
         self.assert_highlighted_chr_multi_line(
@@ -429,15 +387,12 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKKKK TTT KKKK TTTTTTT",
             "print animals at random",
             "KKKKK TTTTTTT KK KKKKKK",
-            level="level3", lang='en')
-
+            level="level3",
+            lang="en",
+        )
 
     def test_3_4(self):
-        self.assert_highlighted_chr_multi_line(
-            "print Your story",
-            "KKKKK TTTTTTTTTT",
-            level="level3", lang='en')
-
+        self.assert_highlighted_chr_multi_line("print Your story", "KKKKK TTTTTTTTTT", level="level3", lang="en")
 
     def test_3_5(self):
         self.assert_highlighted_chr_multi_line(
@@ -445,8 +400,9 @@ class HighlighterTestWebSite(HighlightTester):
             "TTTTTTT KK TK TK TK T",
             "print He now hears the sound of an animals at random",
             "KKKKK TTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT KK KKKKKK",
-            level="level3", lang='en')
-
+            level="level3",
+            lang="en",
+        )
 
     def test_3_6(self):
         self.assert_highlighted_chr_multi_line(
@@ -460,8 +416,9 @@ class HighlighterTestWebSite(HighlightTester):
             "KKK TTTTTT KK TTTTTTT",
             "print it was a animals at random",
             "KKKKK TTTTTTTTTTTTTTTT KK KKKKKK",
-            level="level3", lang='en')
-
+            level="level3",
+            lang="en",
+        )
 
     def test_3_7(self):
         self.assert_highlighted_chr_multi_line(
@@ -475,8 +432,9 @@ class HighlighterTestWebSite(HighlightTester):
             "TTTT KK KKK TTTTTTTTTTTTTTTTTTTTTTTTTT",
             "remove dump from bag",
             "KKKKKK TTTT KKKK TTT",
-            level="level3", lang='en')
-
+            level="level3",
+            lang="en",
+        )
 
     def test_3_8(self):
         self.assert_highlighted_chr_multi_line(
@@ -492,15 +450,14 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKKK TTTTTTTTTTTTTTTTTTTTTT",
             "print 🦜 words at random",
             "KKKKK TTTTTTT KK KKKKKK",
-            level="level3", lang='en')
-
+            level="level3",
+            lang="en",
+        )
 
     def test_3_9(self):
         self.assert_highlighted_chr_multi_line(
-            "# place your code here",
-            "CCCCCCCCCCCCCCCCCCCCCC",
-            level="level3", lang='en')
-
+            "# place your code here", "CCCCCCCCCCCCCCCCCCCCCC", level="level3", lang="en"
+        )
 
     def test_3_10(self):
         self.assert_highlighted_chr_multi_line(
@@ -510,15 +467,14 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKK TTTTTT KK KKKKKK",
             "forward 25",
             "KKKKKKK TT",
-            level="level3", lang='en')
-
+            level="level3",
+            lang="en",
+        )
 
     def test_3_11(self):
         self.assert_highlighted_chr_multi_line(
-            "print Who does the dishes?",
-            "KKKKK TTTTTTTTTTTTTTTTTTTT",
-            level="level3", lang='en')
-
+            "print Who does the dishes?", "KKKKK TTTTTTTTTTTTTTTTTTTT", level="level3", lang="en"
+        )
 
     def test_3_12(self):
         self.assert_highlighted_chr_multi_line(
@@ -526,8 +482,9 @@ class HighlighterTestWebSite(HighlightTester):
             "TTTTTT KK TTTK TTTK TTTTK TTTTTT",
             "print people at random",
             "KKKKK TTTTTT KK KKKKKK",
-            level="level3", lang='en')
-
+            level="level3",
+            lang="en",
+        )
 
     def test_3_13(self):
         self.assert_highlighted_chr_multi_line(
@@ -539,15 +496,17 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKKKK TTTTTTTTT KKKK TTTTTT",
             "print people at random does the dishes",
             "KKKKK TTTTTT KK KKKKKK TTTTTTTTTTTTTTT",
-            level="level3", lang='en')
-
+            level="level3",
+            lang="en",
+        )
 
     def test_3_14(self):
         self.assert_highlighted_chr_multi_line(
             "print What will the die indicate this time?",
             "KKKKK TTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT",
-            level="level3", lang='en')
-
+            level="level3",
+            lang="en",
+        )
 
     def test_3_15(self):
         self.assert_highlighted_chr_multi_line(
@@ -555,15 +514,17 @@ class HighlighterTestWebSite(HighlightTester):
             "TTTTTTT KK TK TK TK TK TK TTTTTTTTT",
             "print choices at random",
             "KKKKK TTTTTTT KK KKKKKK",
-            level="level3", lang='en')
-
+            level="level3",
+            lang="en",
+        )
 
     def test_3_16(self):
         self.assert_highlighted_chr_multi_line(
             "print Welcome to your own rock scissors paper!",
             "KKKKK TTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT",
-            level="level3", lang='en')
-
+            level="level3",
+            lang="en",
+        )
 
     def test_3_17(self):
         self.assert_highlighted_chr_multi_line(
@@ -571,8 +532,9 @@ class HighlighterTestWebSite(HighlightTester):
             "TTTTTTT KK TTTTK TTTTTK TTTTTTTT",
             "print choices at random",
             "KKKKK TTTTTTT KK KKKKKK",
-            level="level3", lang='en')
-
+            level="level3",
+            lang="en",
+        )
 
     def test_3_18(self):
         self.assert_highlighted_chr_multi_line(
@@ -590,8 +552,9 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKKK T",
             "print answers at random",
             "KKKKK TTTTTTT KK KKKKKK",
-            level="level3", lang='en')
-
+            level="level3",
+            lang="en",
+        )
 
     def test_3_19(self):
         self.assert_highlighted_chr_multi_line(
@@ -605,8 +568,9 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKKKK TTTTTTTTT KKKK TTTTTTT",
             "print You get a flavors at random milkshake",
             "KKKKK TTTTTTTTTTTTTTTTT KK KKKKKK TTTTTTTTT",
-            level="level3", lang='en')
-
+            level="level3",
+            lang="en",
+        )
 
     def test_3_20(self):
         self.assert_highlighted_chr_multi_line(
@@ -636,8 +600,9 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKKK TTTTTTTTTTTTTTTTTTTT KK KKKKKK",
             "print Thank you and enjoy your meal!",
             "KKKKK TTTTTTTTTTTTTTTTTTTTTTTTTTTTTT",
-            level="level3", lang='en')
-
+            level="level3",
+            lang="en",
+        )
 
     def test_3_21(self):
         self.assert_highlighted_chr_multi_line(
@@ -657,8 +622,9 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKKK",
             "print monsters at random",
             "KKKKK TTTTTTTT KK KKKKKK",
-            level="level3", lang='en')
-
+            level="level3",
+            lang="en",
+        )
 
     def test_3_22(self):
         self.assert_highlighted_chr_multi_line(
@@ -666,22 +632,17 @@ class HighlighterTestWebSite(HighlightTester):
             "TTTT KK TTTTTT",
             "print My name is name",
             "KKKKK TTTTTTTTTTTTTTT",
-            level="level3", lang='en')
-
+            level="level3",
+            lang="en",
+        )
 
     def test_3_23(self):
         self.assert_highlighted_chr(
-            "print Let's go to the next level!",
-            "KKKKK TTTTTTTTTTTTTTTTTTTTTTTTTTT",
-            level="level3", lang='en')
-
+            "print Let's go to the next level!", "KKKKK TTTTTTTTTTTTTTTTTTTTTTTTTTT", level="level3", lang="en"
+        )
 
     def test_4_1(self):
-        self.assert_highlighted_chr_multi_line(
-            "print 'Hello world'",
-            "KKKKK SSSSSSSSSSSSS",
-            level="level4", lang='en')
-
+        self.assert_highlighted_chr_multi_line("print 'Hello world'", "KKKKK SSSSSSSSSSSSS", level="level4", lang="en")
 
     def test_4_2(self):
         self.assert_highlighted_chr_multi_line(
@@ -691,15 +652,17 @@ class HighlighterTestWebSite(HighlightTester):
             "TTTTTT KK KKK SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS",
             "print 'We need to use ' answer",
             "KKKKK SSSSSSSSSSSSSSSSS TTTTTT",
-            level="level4", lang='en')
-
+            level="level4",
+            lang="en",
+        )
 
     def test_4_3(self):
         self.assert_highlighted_chr_multi_line(
             "print 'Your story will be printed here!'",
             "KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS",
-            level="level4", lang='en')
-
+            level="level4",
+            lang="en",
+        )
 
     def test_4_4(self):
         self.assert_highlighted_chr_multi_line(
@@ -717,8 +680,9 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSS TTTTTTT KK KKKKKK",
             "print name 'is afraid this is a haunted forest'",
             "KKKKK TTTT SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS",
-            level="level4", lang='en')
-
+            level="level4",
+            lang="en",
+        )
 
     def test_4_5(self):
         self.assert_highlighted_chr_multi_line(
@@ -730,8 +694,9 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKK TTTTT",
             "forward 25",
             "KKKKKKK TT",
-            level="level4", lang='en')
-
+            level="level4",
+            lang="en",
+        )
 
     def test_4_6(self):
         self.assert_highlighted_chr_multi_line(
@@ -747,15 +712,14 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKK TTTTT",
             "forward 25",
             "KKKKKKK TT",
-            level="level4", lang='en')
-
+            level="level4",
+            lang="en",
+        )
 
     def test_4_7(self):
         self.assert_highlighted_chr_multi_line(
-            "print 'Who does the dishes?'",
-            "KKKKK SSSSSSSSSSSSSSSSSSSSSS",
-            level="level4", lang='en')
-
+            "print 'Who does the dishes?'", "KKKKK SSSSSSSSSSSSSSSSSSSSSS", level="level4", lang="en"
+        )
 
     def test_4_8(self):
         self.assert_highlighted_chr_multi_line(
@@ -767,8 +731,9 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKKK",
             "print people at _",
             "KKKKK TTTTTT KK I",
-            level="level4", lang='en')
-
+            level="level4",
+            lang="en",
+        )
 
     def test_4_9(self):
         self.assert_highlighted_chr_multi_line(
@@ -780,15 +745,17 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKKK",
             "print people at random",
             "KKKKK TTTTTT KK KKKKKK",
-            level="level4", lang='en')
-
+            level="level4",
+            lang="en",
+        )
 
     def test_4_10(self):
         self.assert_highlighted_chr_multi_line(
             "print 'What will the die indicate this time?'",
             "KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS",
-            level="level4", lang='en')
-
+            level="level4",
+            lang="en",
+        )
 
     def test_4_11(self):
         self.assert_highlighted_chr_multi_line(
@@ -798,8 +765,9 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKKK I TTTTTTTTT I",
             "print _ _ _ # here you have to program the choice",
             "KKKKK I I I CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC",
-            level="level4", lang='en')
-
+            level="level4",
+            lang="en",
+        )
 
     def test_4_12(self):
         self.assert_highlighted_chr_multi_line(
@@ -809,15 +777,17 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKKK SSSSSSSSSSSSS",
             "print choices at random # here you have to program the choice",
             "KKKKK TTTTTTT KK KKKKKK CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC",
-            level="level4", lang='en')
-
+            level="level4",
+            lang="en",
+        )
 
     def test_4_13(self):
         self.assert_highlighted_chr_multi_line(
             "print 'Welcome to your own rock scissors paper!'",
             "KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS",
-            level="level4", lang='en')
-
+            level="level4",
+            lang="en",
+        )
 
     def test_4_14(self):
         self.assert_highlighted_chr_multi_line(
@@ -825,8 +795,9 @@ class HighlighterTestWebSite(HighlightTester):
             "TTTTTTT KK TTTTK TTTTTK TTTTTTTT",
             "print _ The computer chose: _ _ at _",
             "KKKKK I TTTTTTTTTTTTTTTTTTT I I KK I",
-            level="level4", lang='en')
-
+            level="level4",
+            lang="en",
+        )
 
     def test_4_15(self):
         self.assert_highlighted_chr_multi_line(
@@ -834,15 +805,14 @@ class HighlighterTestWebSite(HighlightTester):
             "TTTTTTT KK TTTTK TTTTTK TTTTTTTT",
             "print ' The computer chose: ' choices at random",
             "KKKKK SSSSSSSSSSSSSSSSSSSSSSS TTTTTTT KK KKKKKK",
-            level="level4", lang='en')
-
+            level="level4",
+            lang="en",
+        )
 
     def test_4_16(self):
         self.assert_highlighted_chr_multi_line(
-            "# place your code here",
-            "CCCCCCCCCCCCCCCCCCCCCC",
-            level="level4", lang='en')
-
+            "# place your code here", "CCCCCCCCCCCCCCCCCCCCCC", level="level4", lang="en"
+        )
 
     def test_4_17(self):
         self.assert_highlighted_chr_multi_line(
@@ -860,8 +830,9 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKKK T",
             "print answers at random",
             "KKKKK TTTTTTT KK KKKKKK",
-            level="level4", lang='en')
-
+            level="level4",
+            lang="en",
+        )
 
     def test_4_18(self):
         self.assert_highlighted_chr_multi_line(
@@ -883,8 +854,9 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSSS",
             "print 'Your ' food ' and ' drinks ' will be right there!'",
             "KKKKK SSSSSSS TTTT SSSSSSS TTTTTT SSSSSSSSSSSSSSSSSSSSSSS",
-            level="level4", lang='en')
-
+            level="level4",
+            lang="en",
+        )
 
     def test_4_19(self):
         self.assert_highlighted_chr_multi_line(
@@ -904,22 +876,22 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKKK",
             "print monsters at random",
             "KKKKK TTTTTTTT KK KKKKKK",
-            level="level4", lang='en')
-
+            level="level4",
+            lang="en",
+        )
 
     def test_4_20(self):
         self.assert_highlighted_chr_multi_line(
-            "print 'Lets go to the next level!'",
-            "KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSSSS",
-            level="level4", lang='en')
-
+            "print 'Lets go to the next level!'", "KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSSSS", level="level4", lang="en"
+        )
 
     def test_4_21(self):
         self.assert_highlighted_chr_multi_line(
             "password is ask 'What is the correct password?'",
             "TTTTTTTT KK KKK SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS",
-            level="level4", lang='en')
-
+            level="level4",
+            lang="en",
+        )
 
     def test_5_1(self):
         self.assert_highlighted_chr_multi_line(
@@ -927,8 +899,9 @@ class HighlighterTestWebSite(HighlightTester):
             "TTTT KK KKK SSSSSSSSSSSSSSSSSSSS",
             "if name is Hedy print 'cool!' else print 'meh'",
             "KK TTTT KK TTTT KKKKK SSSSSSS KKKK KKKKK SSSSS",
-            level="level5", lang='en')
-
+            level="level5",
+            lang="en",
+        )
 
     def test_5_2(self):
         self.assert_highlighted_chr_multi_line(
@@ -936,8 +909,9 @@ class HighlighterTestWebSite(HighlightTester):
             "TTTT KK KKK SSSSSSSSSSSSSSSSSSSS",
             "if name is Hedy print 'nice' else print 'boo!'",
             "KK TTTT KK TTTT KKKKK SSSSSS KKKK KKKKK SSSSSS",
-            level="level5", lang='en')
-
+            level="level5",
+            lang="en",
+        )
 
     def test_5_3(self):
         self.assert_highlighted_chr_multi_line(
@@ -949,8 +923,9 @@ class HighlighterTestWebSite(HighlightTester):
             "KK TTTTTTTTTTTTTT KK TTTTTTTTTTTTT KKKKK SSSSSSSSS",
             "else print 'meh'",
             "KKKK KKKKK SSSSS",
-            level="level5", lang='en')
-
+            level="level5",
+            lang="en",
+        )
 
     def test_5_4(self):
         self.assert_highlighted_chr_multi_line(
@@ -960,8 +935,9 @@ class HighlighterTestWebSite(HighlightTester):
             "KK TTTT KK TTTT KKKKK SSSSSS",
             "else print 'boo!'",
             "KKKK KKKKK SSSSSS",
-            level="level5", lang='en')
-
+            level="level5",
+            lang="en",
+        )
 
     def test_5_5(self):
         self.assert_highlighted_chr_multi_line(
@@ -977,15 +953,14 @@ class HighlighterTestWebSite(HighlightTester):
             "KK TTT KK TTTT KKKKK TTTT SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS",
             "else print 'The monster eats' name",
             "KKKK KKKKK SSSSSSSSSSSSSSSSSS TTTT",
-            level="level5", lang='en')
-
+            level="level5",
+            lang="en",
+        )
 
     def test_5_6(self):
         self.assert_highlighted_chr(
-            "print 'Here your story will start!'",
-            "KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSSSSS",
-            level="level5", lang='en')
-
+            "print 'Here your story will start!'", "KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSSSSS", level="level5", lang="en"
+        )
 
     def test_5_7(self):
         self.assert_highlighted_chr_multi_line(
@@ -1007,15 +982,12 @@ class HighlighterTestWebSite(HighlightTester):
             "KK TTTTTTTTT KK TTTTTTTT KKKKK SSSSSSSSSSSSSSSSSSSSSS",
             "else print '🧒 No, Hedy! Say ' new_word",
             "KKKK KKKKK SSSSSSSSSSSSSSSSSS TTTTTTTT",
-            level="level5", lang='en')
-
+            level="level5",
+            lang="en",
+        )
 
     def test_5_8(self):
-        self.assert_highlighted_chr(
-            "# place your code here",
-            "CCCCCCCCCCCCCCCCCCCCCC",
-            level="level5", lang='en')
-
+        self.assert_highlighted_chr("# place your code here", "CCCCCCCCCCCCCCCCCCCCCC", level="level5", lang="en")
 
     def test_5_9(self):
         self.assert_highlighted_chr_multi_line(
@@ -1043,8 +1015,9 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKK TTTTT",
             "forward 25",
             "KKKKKKK TT",
-            level="level5", lang='en')
-
+            level="level5",
+            lang="en",
+        )
 
     def test_5_10(self):
         self.assert_highlighted_chr_multi_line(
@@ -1058,14 +1031,14 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKK TTTTT",
             "forward 25",
             "KKKKKKK TT",
-            level="level5", lang='en')
+            level="level5",
+            lang="en",
+        )
 
     def test_5_12(self):
         self.assert_highlighted_chr(
-            "print 'Who does the dishes?'",
-            "KKKKK SSSSSSSSSSSSSSSSSSSSSS",
-            level="level5", lang='en')
-
+            "print 'Who does the dishes?'", "KKKKK SSSSSSSSSSSSSSSSSSSSSS", level="level5", lang="en"
+        )
 
     def test_5_13(self):
         self.assert_highlighted_chr_multi_line(
@@ -1077,15 +1050,17 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKKK SSSSSSSSSS I SSSSSSSS",
             "if _ is earthworm print 'You can stop throwing.' _ print 'You have to hear it again!'",
             "KK I KK TTTTTTTTT KKKKK SSSSSSSSSSSSSSSSSSSSSSSS I KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSSSS",
-            level="level5", lang='en')
-
+            level="level5",
+            lang="en",
+        )
 
     def test_5_14(self):
         self.assert_highlighted_chr(
             "print 'What will the die indicate this time?'",
             "KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS",
-            level="level5", lang='en')
-
+            level="level5",
+            lang="en",
+        )
 
     def test_5_15(self):
         self.assert_highlighted_chr_multi_line(
@@ -1101,15 +1076,17 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKKK SSSSSSSSSSSSSSSSS I",
             "if _ is _ print 'tie!' else print 'no tie'",
             "KK I KK I KKKKK SSSSSS KKKK KKKKK SSSSSSSS",
-            level="level5", lang='en')
-
+            level="level5",
+            lang="en",
+        )
 
     def test_5_16(self):
         self.assert_highlighted_chr(
             "print 'Welcome to your own rock scissors paper!'",
             "KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS",
-            level="level5", lang='en')
-
+            level="level5",
+            lang="en",
+        )
 
     def test_5_17(self):
         self.assert_highlighted_chr_multi_line(
@@ -1139,8 +1116,9 @@ class HighlighterTestWebSite(HighlightTester):
             "KK TTTTTTTT KK TT KKKKK SSSSSSSSSSS KKKK KKKKK SSSSSS TTTTTTTT",
             "print 'Thank you for your order and enjoy your meal!'",
             "KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS",
-            level="level5", lang='en')
-
+            level="level5",
+            lang="en",
+        )
 
     def test_5_18(self):
         self.assert_highlighted_chr_multi_line(
@@ -1152,8 +1130,9 @@ class HighlighterTestWebSite(HighlightTester):
             "TTTTTT KK KKK SSSSSSSSSSSSSS",
             "if person is Hedy print 'You will definitely win!🤩' else print 'Bad luck! Someone else will win!😭'",
             "KK TTTTTT KK TTTT KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSSS KKKK KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS",
-            level="level5", lang='en')
-
+            level="level5",
+            lang="en",
+        )
 
     def test_5_19(self):
         self.assert_highlighted_chr_multi_line(
@@ -1169,8 +1148,9 @@ class HighlighterTestWebSite(HighlightTester):
             "TTTTTTTTT KK TTTTTTTTTTTTTTTTTTTTK TTTTTTTTTTTTTTTTTTTTTTTK TTTTTTTTT",
             "if person is Hedy print goodanswer at random else print badanswer at random",
             "KK TTTTTT KK TTTT KKKKK TTTTTTTTTT KK KKKKKK KKKK KKKKK TTTTTTTTT KK KKKKKK",
-            level="level5", lang='en')
-
+            level="level5",
+            lang="en",
+        )
 
     def test_5_20(self):
         self.assert_highlighted_chr_multi_line(
@@ -1194,8 +1174,9 @@ class HighlighterTestWebSite(HighlightTester):
             "KK TTTTTTTTTTT KK TTTTTTTTTTTT KKKKK SSSSSSSSSSSSSSSSSSSSSSS",
             "else print 'Oh no! You are being eaten by a...' monsters at random",
             "KKKK KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS TTTTTTTT KK KKKKKK",
-            level="level5", lang='en')
-
+            level="level5",
+            lang="en",
+        )
 
     def test_5_21(self):
         self.assert_highlighted_chr_multi_line(
@@ -1213,8 +1194,9 @@ class HighlighterTestWebSite(HighlightTester):
             "KK TTTT KK TTTTTTTTTT KKKKK SSSSSSSS",
             "else print 'No, frog is grenouille'",
             "KKKK KKKKK SSSSSSSSSSSSSSSSSSSSSSSS",
-            level="level5", lang='en')
-
+            level="level5",
+            lang="en",
+        )
 
     def test_5_22(self):
         self.assert_highlighted_chr_multi_line(
@@ -1236,21 +1218,19 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKKK SSSSSSSSSSSSSSS TTTTT SSSSSSSSSSSSSSSSSSSS TTTTT SSSSSSSSS",
             "print 'The drinks are free in this level because Hedy cant calculate the price yet...'",
             "KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS",
-            level="level5", lang='en')
-
+            level="level5",
+            lang="en",
+        )
 
     def test_5_23(self):
         self.assert_highlighted_chr(
-            "print 'On to the next level!'",
-            "KKKKK SSSSSSSSSSSSSSSSSSSSSSS",
-            level="level5", lang='en')
+            "print 'On to the next level!'", "KKKKK SSSSSSSSSSSSSSSSSSSSSSS", level="level5", lang="en"
+        )
 
     def test_6_1(self):
         self.assert_highlighted_chr(
-            "print '5 times 5 is ' 5 * 5",
-            "KKKKK SSSSSSSSSSSSSSS N K N",
-            level="level6", lang='en')
-
+            "print '5 times 5 is ' 5 * 5", "KKKKK SSSSSSSSSSSSSSS N K N", level="level6", lang="en"
+        )
 
     def test_6_2(self):
         self.assert_highlighted_chr_multi_line(
@@ -1260,17 +1240,14 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKKK SSSSSSSSSSSSSSS N K N",
             "print '5 times 5 is ' 5 * 5",
             "KKKKK SSSSSSSSSSSSSSS N K N",
-            level="level6", lang='en')
-
+            level="level6",
+            lang="en",
+        )
 
     def test_6_3(self):
         self.assert_highlighted_chr_multi_line(
-            "name = Hedy",
-            "TTTT K TTTT",
-            "answer = 20 + 4",
-            "TTTTTT K NN K N",
-            level="level6", lang='en')
-
+            "name = Hedy", "TTTT K TTTT", "answer = 20 + 4", "TTTTTT K NN K N", level="level6", lang="en"
+        )
 
     def test_6_4(self):
         self.assert_highlighted_chr_multi_line(
@@ -1286,15 +1263,12 @@ class HighlighterTestWebSite(HighlightTester):
             "TTTTT K TTTTT K N",
             "print verse ' bottles of beer on the wall'",
             "KKKKK TTTTT SSSSSSSSSSSSSSSSSSSSSSSSSSSSSS",
-            level="level6", lang='en')
-
+            level="level6",
+            lang="en",
+        )
 
     def test_6_5(self):
-        self.assert_highlighted_chr(
-            "print 'Baby shark'",
-            "KKKKK SSSSSSSSSSSS",
-            level="level6", lang='en')
-
+        self.assert_highlighted_chr("print 'Baby shark'", "KKKKK SSSSSSSSSSSS", level="level6", lang="en")
 
     def test_6_6(self):
         self.assert_highlighted_chr_multi_line(
@@ -1326,15 +1300,12 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKKKKK NN",
             "turn angle",
             "KKKK TTTTT",
-            level="level6", lang='en')
-
+            level="level6",
+            lang="en",
+        )
 
     def test_6_7(self):
-        self.assert_highlighted_chr(
-            "print 'Drawing figures'",
-            "KKKKK SSSSSSSSSSSSSSSSS",
-            level="level6", lang='en')
-
+        self.assert_highlighted_chr("print 'Drawing figures'", "KKKKK SSSSSSSSSSSSSSSSS", level="level6", lang="en")
 
     def test_6_8(self):
         self.assert_highlighted_chr_multi_line(
@@ -1350,8 +1321,9 @@ class HighlighterTestWebSite(HighlightTester):
             "KK TTTTTTTTTT KK TTTT TTTTTTTTTTT K TTTTTTTTTTT K N",
             "print 'Emma will do the dishes this week' emma_washes 'times'",
             "KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS TTTTTTTTTTT SSSSSSS",
-            level="level6", lang='en')
-
+            level="level6",
+            lang="en",
+        )
 
     def test_6_9(self):
         self.assert_highlighted_chr_multi_line(
@@ -1371,15 +1343,14 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKKKK TTTTTTTTTT KKKK TTTTTT",
             "dishwasher = people at random",
             "TTTTTTTTTT K TTTTTT KK KKKKKK",
-            level="level6", lang='en')
-
+            level="level6",
+            lang="en",
+        )
 
     def test_6_10(self):
         self.assert_highlighted_chr(
-            "print 'Who does the dishes?'",
-            "KKKKK SSSSSSSSSSSSSSSSSSSSSS",
-            level="level6", lang='en')
-
+            "print 'Who does the dishes?'", "KKKKK SSSSSSSSSSSSSSSSSSSSSS", level="level6", lang="en"
+        )
 
     def test_6_11(self):
         self.assert_highlighted_chr_multi_line(
@@ -1395,15 +1366,17 @@ class HighlighterTestWebSite(HighlightTester):
             "KK TTTTT KK TTTTTTTTT TTTTTT K TTTTTT K N KKKK TTTTTT K TTTTTT K TTTTT",
             "print 'those are' points ' point'",
             "KKKKK SSSSSSSSSSS TTTTTT SSSSSSSS",
-            level="level6", lang='en')
-
+            level="level6",
+            lang="en",
+        )
 
     def test_6_12(self):
         self.assert_highlighted_chr(
             "print 'What will the die indicate this time?'",
             "KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS",
-            level="level6", lang='en')
-
+            level="level6",
+            lang="en",
+        )
 
     def test_6_13(self):
         self.assert_highlighted_chr_multi_line(
@@ -1415,8 +1388,9 @@ class HighlighterTestWebSite(HighlightTester):
             "KK TTTTTT KK TTTTTTTTTTTTTT KKKKK SSSSSSSSSSS",
             "else print 'Wrong! It was ' correct_answer",
             "KKKK KKKKK SSSSSSSSSSSSSSSS TTTTTTTTTTTTTT",
-            level="level6", lang='en')
-
+            level="level6",
+            lang="en",
+        )
 
     def test_6_14(self):
         self.assert_highlighted_chr_multi_line(
@@ -1436,15 +1410,14 @@ class HighlighterTestWebSite(HighlightTester):
             "KK TTTTTT KK TTTTTTTTTTTTTT KKKKK SSSSSS",
             "else print 'mistake! it was ' correct_answer",
             "KKKK KKKKK SSSSSSSSSSSSSSSSSS TTTTTTTTTTTTTT",
-            level="level6", lang='en')
-
+            level="level6",
+            lang="en",
+        )
 
     def test_6_15(self):
         self.assert_highlighted_chr(
-            "print 'Welcome to this calculator!'",
-            "KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSSSSS",
-            level="level6", lang='en')
-
+            "print 'Welcome to this calculator!'", "KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSSSSS", level="level6", lang="en"
+        )
 
     def test_6_16(self):
         self.assert_highlighted_chr_multi_line(
@@ -1470,8 +1443,9 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKKK SSSSSSSSSSSSSSS TTTTT SSSSSSSSSSSSSSSSSS",
             "print 'Thank you, enjoy your meal!'",
             "KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSSSSS",
-            level="level6", lang='en')
-
+            level="level6",
+            lang="en",
+        )
 
     def test_6_17(self):
         self.assert_highlighted_chr_multi_line(
@@ -1513,15 +1487,12 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKKK SSSSSSSSSSSSSSS TTTTT SSSSSSSSSSSSSSSSSS",
             "print 'Thank you, enjoy your meal!'",
             "KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSSSSS",
-            level="level6", lang='en')
-
+            level="level6",
+            lang="en",
+        )
 
     def test_6_18(self):
-        self.assert_highlighted_chr(
-            "# place your code here",
-            "CCCCCCCCCCCCCCCCCCCCCC",
-            level="level6", lang='en')
-
+        self.assert_highlighted_chr("# place your code here", "CCCCCCCCCCCCCCCCCCCCCC", level="level6", lang="en")
 
     def test_6_19(self):
         self.assert_highlighted_chr_multi_line(
@@ -1561,8 +1532,9 @@ class HighlighterTestWebSite(HighlightTester):
             "TTTTTT K TTTTTT K TTTTTTTT",
             "print 'You are ' result ' percent smart.'",
             "KKKKK SSSSSSSSSS TTTTTT SSSSSSSSSSSSSSSSS",
-            level="level6", lang='en')
-
+            level="level6",
+            lang="en",
+        )
 
     def test_6_20(self):
         self.assert_highlighted_chr_multi_line(
@@ -1574,23 +1546,19 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSS",
             "print 'happy birthday to you'",
             "KKKKK SSSSSSSSSSSSSSSSSSSSSSS",
-            level="level6", lang='en')
-
+            level="level6",
+            lang="en",
+        )
 
     def test_6_21(self):
         self.assert_highlighted_chr(
-            "print 'On to the next level!'",
-            "KKKKK SSSSSSSSSSSSSSSSSSSSSSS",
-            level="level6", lang='en')
-
-
+            "print 'On to the next level!'", "KKKKK SSSSSSSSSSSSSSSSSSSSSSS", level="level6", lang="en"
+        )
 
     def test_7_1(self):
         self.assert_highlighted_chr(
-            "repeat 3 times print 'Hedy is fun!'",
-            "KKKKKK N KKKKK KKKKK SSSSSSSSSSSSSS",
-            level="level7", lang='en')
-
+            "repeat 3 times print 'Hedy is fun!'", "KKKKKK N KKKKK KKKKK SSSSSSSSSSSSSS", level="level7", lang="en"
+        )
 
     def test_7_2(self):
         self.assert_highlighted_chr_multi_line(
@@ -1600,15 +1568,14 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKKKK N KKKKK KKKKK SSSSSSS",
             "print 'Why is nobody helping me?'",
             "KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSSS",
-            level="level7", lang='en')
-
+            level="level7",
+            lang="en",
+        )
 
     def test_7_3(self):
         self.assert_highlighted_chr(
-            "repeat 5 times print 'Help!'",
-            "KKKKKK N KKKKK KKKKK SSSSSSS",
-            level="level7", lang='en')
-
+            "repeat 5 times print 'Help!'", "KKKKKK N KKKKK KKKKK SSSSSSS", level="level7", lang="en"
+        )
 
     def test_7_4(self):
         self.assert_highlighted_chr_multi_line(
@@ -1616,15 +1583,12 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKKKK I I KKKKK SSSSSSSSSSSSSSSSSSSSSSSSS",
             "print 'Baby Shark'",
             "KKKKK SSSSSSSSSSSS",
-            level="level7", lang='en')
-
+            level="level7",
+            lang="en",
+        )
 
     def test_7_5(self):
-        self.assert_highlighted_chr(
-            "print 'Baby Shark'",
-            "KKKKK SSSSSSSSSSSS",
-            level="level7", lang='en')
-
+        self.assert_highlighted_chr("print 'Baby Shark'", "KKKKK SSSSSSSSSSSS", level="level7", lang="en")
 
     def test_7_6(self):
         self.assert_highlighted_chr_multi_line(
@@ -1632,8 +1596,9 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKKK SSSSSSSSSSSSSS",
             "repeat 3 times forward 10",
             "KKKKKK N KKKKK KKKKKKK NN",
-            level="level7", lang='en')
-
+            level="level7",
+            lang="en",
+        )
 
     def test_7_7(self):
         self.assert_highlighted_chr_multi_line(
@@ -1641,15 +1606,14 @@ class HighlighterTestWebSite(HighlightTester):
             "TTTTTT K TTTK TTTK TTTTK TTTTTT",
             "repeat _ _ print 'the dishwasher is' _",
             "KKKKKK I I KKKKK SSSSSSSSSSSSSSSSSSS I",
-            level="level7", lang='en')
-
+            level="level7",
+            lang="en",
+        )
 
     def test_7_8(self):
         self.assert_highlighted_chr(
-            "print 'Who does the dishes?'",
-            "KKKKK SSSSSSSSSSSSSSSSSSSSSS",
-            level="level7", lang='en')
-
+            "print 'Who does the dishes?'", "KKKKK SSSSSSSSSSSSSSSSSSSSSS", level="level7", lang="en"
+        )
 
     def test_7_9(self):
         self.assert_highlighted_chr_multi_line(
@@ -1657,15 +1621,17 @@ class HighlighterTestWebSite(HighlightTester):
             "TTTTTTT K NK NK NK NK NK TTTTTTTTT",
             "repeat _ _ print _ _ _",
             "KKKKKK I I KKKKK I I I",
-            level="level7", lang='en')
-
+            level="level7",
+            lang="en",
+        )
 
     def test_7_10(self):
         self.assert_highlighted_chr(
             "print 'What will the die indicate this time?'",
             "KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS",
-            level="level7", lang='en')
-
+            level="level7",
+            lang="en",
+        )
 
     def test_7_11(self):
         self.assert_highlighted_chr_multi_line(
@@ -1677,15 +1643,12 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKKKK TTTTTT KKKKK TTTT K KKK SSSSSSSSSSSSSSSSSSSSSSSSSSSSS",
             "print 'Thanks for your order! Its coming right up!'",
             "KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS",
-            level="level7", lang='en')
-
+            level="level7",
+            lang="en",
+        )
 
     def test_7_12(self):
-        self.assert_highlighted_chr(
-            "# place your code here",
-            "CCCCCCCCCCCCCCCCCCCCCC",
-            level="level7", lang='en')
-
+        self.assert_highlighted_chr("# place your code here", "CCCCCCCCCCCCCCCCCCCCCC", level="level7", lang="en")
 
     def test_7_13(self):
         self.assert_highlighted_chr_multi_line(
@@ -1699,22 +1662,22 @@ class HighlighterTestWebSite(HighlightTester):
             "TTTTTT K TTTK TTK TTTTT",
             "repeat 3 times print 'My crystal ball says... ' answer at random",
             "KKKKKK N KKKKK KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSS TTTTTT KK KKKKKK",
-            level="level7", lang='en')
-
+            level="level7",
+            lang="en",
+        )
 
     def test_7_14(self):
         self.assert_highlighted_chr(
             "repeat 5 times print 'In the next level you can repeat multiple lines of code at once!'",
             "KKKKKK N KKKKK KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS",
-            level="level7", lang='en')
-
+            level="level7",
+            lang="en",
+        )
 
     def test_7_15(self):
         self.assert_highlighted_chr(
-            "print 'Lets go to the next level!'",
-            "KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSSSS",
-            level="level7", lang='en')
-
+            "print 'Lets go to the next level!'", "KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSSSS", level="level7", lang="en"
+        )
 
     def test_8_1(self):
         self.assert_highlighted_chr_multi_line(
@@ -1724,8 +1687,9 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKKK SSSSSSSSSSSSS",
             "print 'This will be printed 5 times'",
             "KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSSSSSS",
-            level="level8", lang='en')
-
+            level="level8",
+            lang="en",
+        )
 
     def test_8_2(self):
         self.assert_highlighted_chr_multi_line(
@@ -1735,8 +1699,9 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKKK SSSSSSSSSSSSSSSS",
             "print 'This is all repeated 5 times'",
             "KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSSSSSS",
-            level="level8", lang='en')
-
+            level="level8",
+            lang="en",
+        )
 
     def test_8_3(self):
         self.assert_highlighted_chr_multi_line(
@@ -1762,15 +1727,12 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSSSS",
             "print 'The T-rex closes in and eats him in one big bite!🦖'",
             "KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS",
-            level="level8", lang='en')
-
+            level="level8",
+            lang="en",
+        )
 
     def test_8_4(self):
-        self.assert_highlighted_chr(
-            "# place your code here",
-            "CCCCCCCCCCCCCCCCCCCCCC",
-            level="level8", lang='en')
-
+        self.assert_highlighted_chr("# place your code here", "CCCCCCCCCCCCCCCCCCCCCC", level="level8", lang="en")
 
     def test_8_5(self):
         self.assert_highlighted_chr_multi_line(
@@ -1788,8 +1750,9 @@ class HighlighterTestWebSite(HighlightTester):
             "TTTTT K TTTTT K N",
             "print verse ' bottles of beer on the wall'",
             "KKKKK TTTTT SSSSSSSSSSSSSSSSSSSSSSSSSSSSSS",
-            level="level8", lang='en')
-
+            level="level8",
+            lang="en",
+        )
 
     def test_8_6(self):
         self.assert_highlighted_chr_multi_line(
@@ -1801,8 +1764,9 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKK TTTTT",
             "forward 50",
             "KKKKKKK NN",
-            level="level8", lang='en')
-
+            level="level8",
+            lang="en",
+        )
 
     def test_8_7(self):
         self.assert_highlighted_chr_multi_line(
@@ -1816,15 +1780,17 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKK I",
             "forward _",
             "KKKKKKK I",
-            level="level8", lang='en')
-
+            level="level8",
+            lang="en",
+        )
 
     def test_8_8(self):
         self.assert_highlighted_chr(
             "hoeken = ask 'How many angles should I draw?'",
             "TTTTTT K KKK SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS",
-            level="level8", lang='en')
-
+            level="level8",
+            lang="en",
+        )
 
     def test_8_9(self):
         self.assert_highlighted_chr_multi_line(
@@ -1844,8 +1810,9 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKKK SSSSSSSSSSSSSSSSSSSSSSSSS",
             "print 'Enjoy your meal!'",
             "KKKKK SSSSSSSSSSSSSSSSSS",
-            level="level8", lang='en')
-
+            level="level8",
+            lang="en",
+        )
 
     def test_8_10(self):
         self.assert_highlighted_chr_multi_line(
@@ -1865,8 +1832,9 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKKK",
             "print 'My crystal ball says...' answers at random",
             "KKKKK SSSSSSSSSSSSSSSSSSSSSSSSS TTTTTTT KK KKKKKK",
-            level="level8", lang='en')
-
+            level="level8",
+            lang="en",
+        )
 
     def test_8_11(self):
         self.assert_highlighted_chr_multi_line(
@@ -1886,16 +1854,14 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKK",
             "print 'Okay, you can stay here for a little longer!'",
             "KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS",
-            level="level8", lang='en')
-
+            level="level8",
+            lang="en",
+        )
 
     def test_8_12(self):
         self.assert_highlighted_chr(
-            "print 'Lets go to the next level!'",
-            "KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSSSS",
-            level="level8", lang='en')
-
-
+            "print 'Lets go to the next level!'", "KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSSSS", level="level8", lang="en"
+        )
 
     def test_9_1(self):
         self.assert_highlighted_chr_multi_line(
@@ -1911,8 +1877,9 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKK",
             "print 'pizza is better'",
             "KKKKK SSSSSSSSSSSSSSSSS",
-            level="level9", lang='en')
-
+            level="level9",
+            lang="en",
+        )
 
     def test_9_2(self):
         self.assert_highlighted_chr_multi_line(
@@ -1940,8 +1907,9 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKK",
             "print 'Robin goes home'",
             "KKKKK SSSSSSSSSSSSSSSSS",
-            level="level9", lang='en')
-
+            level="level9",
+            lang="en",
+        )
 
     def test_9_3(self):
         self.assert_highlighted_chr_multi_line(
@@ -1995,15 +1963,12 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS",
             "print 'She walks back'",
             "KKKKK SSSSSSSSSSSSSSSS",
-            level="level9", lang='en')
-
+            level="level9",
+            lang="en",
+        )
 
     def test_9_4(self):
-        self.assert_highlighted_chr(
-            "# place your code here",
-            "CCCCCCCCCCCCCCCCCCCCCC",
-            level="level9", lang='en')
-
+        self.assert_highlighted_chr("# place your code here", "CCCCCCCCCCCCCCCCCCCCCC", level="level9", lang="en")
 
     def test_9_5(self):
         self.assert_highlighted_chr_multi_line(
@@ -2033,8 +1998,9 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKKK SSSSSSSSSSS",
             "# finish this code",
             "CCCCCCCCCCCCCCCCCC",
-            level="level9", lang='en')
-
+            level="level9",
+            lang="en",
+        )
 
     def test_9_6(self):
         self.assert_highlighted_chr_multi_line(
@@ -2062,15 +2028,14 @@ class HighlighterTestWebSite(HighlightTester):
             "TTTTT K TTTTT K N",
             "print 'Great job! Your score is... ' score ' out of 10!'",
             "KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSSSSSS TTTTT SSSSSSSSSSSSS",
-            level="level9", lang='en')
-
+            level="level9",
+            lang="en",
+        )
 
     def test_9_7(self):
         self.assert_highlighted_chr(
-            "print 'Welcome to this calculator!'",
-            "KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSSSSS",
-            level="level9", lang='en')
-
+            "print 'Welcome to this calculator!'", "KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSSSSS", level="level9", lang="en"
+        )
 
     def test_9_8(self):
         self.assert_highlighted_chr_multi_line(
@@ -2112,8 +2077,9 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKKK SSSSSSSSSSSSSSS TTTTT SSSSSSSSS",
             "print 'Enjoy your meal!'",
             "KKKKK SSSSSSSSSSSSSSSSSS",
-            level="level9", lang='en')
-
+            level="level9",
+            lang="en",
+        )
 
     def test_9_9(self):
         self.assert_highlighted_chr_multi_line(
@@ -2153,15 +2119,17 @@ class HighlighterTestWebSite(HighlightTester):
             "KK TTTTTT KK TTTTT",
             "print 'Great! You survived!'",
             "KKKKK SSSSSSSSSSSSSSSSSSSSSS",
-            level="level9", lang='en')
-
+            level="level9",
+            lang="en",
+        )
 
     def test_9_10(self):
         self.assert_highlighted_chr(
             "print 'Escape from the haunted house!'",
             "KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS",
-            level="level9", lang='en')
-
+            level="level9",
+            lang="en",
+        )
 
     def test_9_11(self):
         self.assert_highlighted_chr_multi_line(
@@ -2173,15 +2141,14 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS",
             "print 'if youre happy and you know it clap your hands'",
             "KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS",
-            level="level9", lang='en')
-
+            level="level9",
+            lang="en",
+        )
 
     def test_9_12(self):
         self.assert_highlighted_chr(
-            "print 'Lets go to the next level!'",
-            "KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSSSS",
-            level="level9", lang='en')
-
+            "print 'Lets go to the next level!'", "KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSSSS", level="level9", lang="en"
+        )
 
     def test_10_1(self):
         self.assert_highlighted_chr_multi_line(
@@ -2191,8 +2158,9 @@ class HighlighterTestWebSite(HighlightTester):
             "KKK TTTTTT KK TTTTTTT",
             "print 'I love ' animal",
             "KKKKK SSSSSSSSS TTTTTT",
-            level="level10", lang='en')
-
+            level="level10",
+            lang="en",
+        )
 
     def test_10_2(self):
         self.assert_highlighted_chr_multi_line(
@@ -2216,15 +2184,12 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKKK SSSSSSSSSSSSSSSSSS",
             "print 'I see all the animals looking at me!'",
             "KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS",
-            level="level10", lang='en')
-
+            level="level10",
+            lang="en",
+        )
 
     def test_10_3(self):
-        self.assert_highlighted_chr(
-            "# place your code here",
-            "CCCCCCCCCCCCCCCCCCCCCC",
-            level="level10", lang='en')
-
+        self.assert_highlighted_chr("# place your code here", "CCCCCCCCCCCCCCCCCCCCCC", level="level10", lang="en")
 
     def test_10_4(self):
         self.assert_highlighted_chr_multi_line(
@@ -2286,8 +2251,9 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKKK SSSSSSSSSS TTTTT",
             "print 'everywhere a ' sound sound",
             "KKKKK SSSSSSSSSSSSSSS TTTTT TTTTT",
-            level="level10", lang='en')
-
+            level="level10",
+            lang="en",
+        )
 
     def test_10_5(self):
         self.assert_highlighted_chr_multi_line(
@@ -2299,8 +2265,9 @@ class HighlighterTestWebSite(HighlightTester):
             "KKK TTT KK TTTT",
             "print names at random ' does the dishes on ' day",
             "KKKKK TTTTT KK KKKKKK SSSSSSSSSSSSSSSSSSSSSS TTT",
-            level="level10", lang='en')
-
+            level="level10",
+            lang="en",
+        )
 
     def test_10_6(self):
         self.assert_highlighted_chr_multi_line(
@@ -2314,8 +2281,9 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKKK TTTTTT SSSSSSSSSS TTTTTTT KK KKKKKK",
             "sleep",
             "KKKKK",
-            level="level10", lang='en')
-
+            level="level10",
+            lang="en",
+        )
 
     def test_10_7(self):
         self.assert_highlighted_chr_multi_line(
@@ -2327,8 +2295,9 @@ class HighlighterTestWebSite(HighlightTester):
             "KKK TTTTTT KK TTTTTTT",
             "print player ' chooses ' choices at random",
             "KKKKK TTTTTT SSSSSSSSSSS TTTTTTT KK KKKKKK",
-            level="level10", lang='en')
-
+            level="level10",
+            lang="en",
+        )
 
     def test_10_8(self):
         self.assert_highlighted_chr_multi_line(
@@ -2350,8 +2319,9 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKK",
             "print 'Thats wrong. The right answer is ' correct",
             "KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS TTTTTTT",
-            level="level10", lang='en')
-
+            level="level10",
+            lang="en",
+        )
 
     def test_10_9(self):
         self.assert_highlighted_chr_multi_line(
@@ -2363,8 +2333,9 @@ class HighlighterTestWebSite(HighlightTester):
             "TTTT K KKK SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS TTTTTT SSS",
             "print food ' will be your ' course",
             "KKKKK TTTT SSSSSSSSSSSSSSSS TTTTTT",
-            level="level10", lang='en')
-
+            level="level10",
+            lang="en",
+        )
 
     def test_10_10(self):
         self.assert_highlighted_chr_multi_line(
@@ -2380,15 +2351,17 @@ class HighlighterTestWebSite(HighlightTester):
             "TTTT K KKK TTTT SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS TTTTTT SSS",
             "print name ' orders ' food ' as their ' course",
             "KKKKK TTTT SSSSSSSSSS TTTT SSSSSSSSSSSS TTTTTT",
-            level="level10", lang='en')
-
+            level="level10",
+            lang="en",
+        )
 
     def test_10_11(self):
         self.assert_highlighted_chr(
             "courses = appetizer, main course, dessert",
             "TTTTTTT K TTTTTTTTTK TTTTTTTTTTTK TTTTTTT",
-            level="level10", lang='en')
-
+            level="level10",
+            lang="en",
+        )
 
     def test_10_12(self):
         self.assert_highlighted_chr_multi_line(
@@ -2410,8 +2383,9 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKKK TTTT SSSSSSSSSSSSSS TTTT KK KKKKKK SSSSSSSSSSSSSSSS",
             "sleep",
             "KKKKK",
-            level="level10", lang='en')
-
+            level="level10",
+            lang="en",
+        )
 
     def test_10_13(self):
         self.assert_highlighted_chr_multi_line(
@@ -2431,25 +2405,24 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKKK TTTT SSSSSSSSSSSSSSS TTTTTTTT KK KKKKKK",
             "print name 's greatest fear is ' fears at random",
             "KKKKK TTTT SSSSSSSSSSSSSSSSSSSSS TTTTT KK KKKKKK",
-            level="level10", lang='en')
-
+            level="level10",
+            lang="en",
+        )
 
     def test_10_14(self):
         self.assert_highlighted_chr(
-            "print 'Lets go to the next level!'",
-            "KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSSSS",
-            level="level10", lang='en')
+            "print 'Lets go to the next level!'", "KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSSSS", level="level10", lang="en"
+        )
 
-
-    
     def test_11_1(self):
         self.assert_highlighted_chr_multi_line(
             "for counter in range 1 to 5",
             "KKK TTTTTTT KK KKKKK N KK N",
             "print counter",
             "KKKKK TTTTTTT",
-            level="level11", lang='en')
-
+            level="level11",
+            lang="en",
+        )
 
     def test_11_2(self):
         self.assert_highlighted_chr_multi_line(
@@ -2469,15 +2442,12 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKK",
             "print 'NO MORE MONKEYS JUMPING ON THE BED!'",
             "KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS",
-            level="level11", lang='en')
-
+            level="level11",
+            lang="en",
+        )
 
     def test_11_3(self):
-        self.assert_highlighted_chr(
-            "# place your code here",
-            "CCCCCCCCCCCCCCCCCCCCCC",
-            level="level11", lang='en')
-
+        self.assert_highlighted_chr("# place your code here", "CCCCCCCCCCCCCCCCCCCCCC", level="level11", lang="en")
 
     def test_11_4(self):
         self.assert_highlighted_chr_multi_line(
@@ -2507,8 +2477,9 @@ class HighlighterTestWebSite(HighlightTester):
             "TTTTT K N K TTTTTT",
             "print 'That will be ' price ' dollars, please!'",
             "KKKKK SSSSSSSSSSSSSSS TTTTT SSSSSSSSSSSSSSSSSSS",
-            level="level11", lang='en')
-
+            level="level11",
+            lang="en",
+        )
 
     def test_11_5(self):
         self.assert_highlighted_chr_multi_line(
@@ -2550,15 +2521,17 @@ class HighlighterTestWebSite(HighlightTester):
             "KK TTTTTT KK TTTTT",
             "print 'Great! You survived!'",
             "KKKKK SSSSSSSSSSSSSSSSSSSSSS",
-            level="level11", lang='en')
-
+            level="level11",
+            lang="en",
+        )
 
     def test_11_6(self):
         self.assert_highlighted_chr(
             "print 'Escape from the haunted house!'",
             "KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS",
-            level="level11", lang='en')
-
+            level="level11",
+            lang="en",
+        )
 
     def test_11_7(self):
         self.assert_highlighted_chr_multi_line(
@@ -2570,24 +2543,24 @@ class HighlighterTestWebSite(HighlightTester):
             "TTTT K TTTTTTTTTTTTTTTTTTTTT",
             "print show 'is my favorite show!'",
             "KKKKK TTTT SSSSSSSSSSSSSSSSSSSSSS",
-            level="level11", lang='en')
-
+            level="level11",
+            lang="en",
+        )
 
     def test_11_8(self):
         self.assert_highlighted_chr(
-            "print 'Lets go to the next level!'",
-            "KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSSSS",
-            level="level11", lang='en')
+            "print 'Lets go to the next level!'", "KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSSSS", level="level11", lang="en"
+        )
 
-    
     def test_12_1(self):
         self.assert_highlighted_chr_multi_line(
             "print 'decimal numbers now need to use a dot'",
             "KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS",
             "print 2.5 + 2.5",
             "KKKKK NNN K NNN",
-            level="level12", lang='en')
-
+            level="level12",
+            lang="en",
+        )
 
     def test_12_2(self):
         self.assert_highlighted_chr_multi_line(
@@ -2595,8 +2568,9 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS",
             "print 2.5 + 2.5",
             "KKKKK NNN K NNN",
-            level="level12", lang='en')
-
+            level="level12",
+            lang="en",
+        )
 
     def test_12_3(self):
         self.assert_highlighted_chr_multi_line(
@@ -2604,8 +2578,9 @@ class HighlighterTestWebSite(HighlightTester):
             "TTTT K SSSSSSSSSSSSSSSS",
             "print 'Hello ' name",
             "KKKKK SSSSSSSS TTTT",
-            level="level12", lang='en')
-
+            level="level12",
+            lang="en",
+        )
 
     def test_12_4(self):
         self.assert_highlighted_chr_multi_line(
@@ -2613,8 +2588,9 @@ class HighlighterTestWebSite(HighlightTester):
             "TTTTTTTTTTT K SSSSSSSSSSSK SSSSSSSSK SSSSSSSSSS",
             "print superheroes at random",
             "KKKKK TTTTTTTTTTT KK KKKKKK",
-            level="level12", lang='en')
-
+            level="level12",
+            lang="en",
+        )
 
     def test_12_5(self):
         self.assert_highlighted_chr_multi_line(
@@ -2624,17 +2600,14 @@ class HighlighterTestWebSite(HighlightTester):
             "KK TTTT K SSSSSSSSSSSSSSSS",
             "print 'Hi there!'",
             "KKKKK SSSSSSSSSSS",
-            level="level12", lang='en')
-
+            level="level12",
+            lang="en",
+        )
 
     def test_12_6(self):
         self.assert_highlighted_chr_multi_line(
-            "score = 25",
-            "TTTTT K NN",
-            "print 'You got ' score",
-            "KKKKK SSSSSSSSSS TTTTT",
-            level="level12", lang='en')
-
+            "score = 25", "TTTTT K NN", "print 'You got ' score", "KKKKK SSSSSSSSSS TTTTT", level="level12", lang="en"
+        )
 
     def test_12_7(self):
         self.assert_highlighted_chr_multi_line(
@@ -2644,8 +2617,9 @@ class HighlighterTestWebSite(HighlightTester):
             "T K SSSSSSSS",
             "print a + b",
             "KKKKK T K T",
-            level="level12", lang='en')
-
+            level="level12",
+            lang="en",
+        )
 
     def test_12_8(self):
         self.assert_highlighted_chr_multi_line(
@@ -2653,15 +2627,12 @@ class HighlighterTestWebSite(HighlightTester):
             "TTTT K SSSSSSSSSSSSSSSSSSSSSS",
             "print name ' was eating a piece of cake, when suddenly...'",
             "KKKKK TTTT SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS",
-            level="level12", lang='en')
-
+            level="level12",
+            lang="en",
+        )
 
     def test_12_9(self):
-        self.assert_highlighted_chr(
-            "# place your code here",
-            "CCCCCCCCCCCCCCCCCCCCCC",
-            level="level12", lang='en')
-
+        self.assert_highlighted_chr("# place your code here", "CCCCCCCCCCCCCCCCCCCCCC", level="level12", lang="en")
 
     def test_12_10(self):
         self.assert_highlighted_chr_multi_line(
@@ -2681,8 +2652,9 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS",
             "print action",
             "KKKKK TTTTTT",
-            level="level12", lang='en')
-
+            level="level12",
+            lang="en",
+        )
 
     def test_12_11(self):
         self.assert_highlighted_chr_multi_line(
@@ -2694,8 +2666,9 @@ class HighlighterTestWebSite(HighlightTester):
             "TTTTTT K TTTTTTT K TTTTTTT",
             "print number1 ' plus ' number2 ' is ' answer",
             "KKKKK TTTTTTT SSSSSSSS TTTTTTT SSSSSS TTTTTT",
-            level="level12", lang='en')
-
+            level="level12",
+            lang="en",
+        )
 
     def test_12_12(self):
         self.assert_highlighted_chr_multi_line(
@@ -2723,8 +2696,9 @@ class HighlighterTestWebSite(HighlightTester):
             "TTTTT K TTTTT K NNNN",
             "print 'That will be ' price ' dollar, please'",
             "KKKKK SSSSSSSSSSSSSSS TTTTT SSSSSSSSSSSSSSSSS",
-            level="level12", lang='en')
-
+            level="level12",
+            lang="en",
+        )
 
     def test_12_13(self):
         self.assert_highlighted_chr_multi_line(
@@ -2738,8 +2712,9 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKKK",
             "print fortunes at random",
             "KKKKK TTTTTTTT KK KKKKKK",
-            level="level12", lang='en')
-
+            level="level12",
+            lang="en",
+        )
 
     def test_12_14(self):
         self.assert_highlighted_chr_multi_line(
@@ -2759,8 +2734,9 @@ class HighlighterTestWebSite(HighlightTester):
             "TTTTT K TTTTTTT K TTTTTTTTT",
             "print 'You can buy a ' wish ' in ' weeks ' weeks.'",
             "KKKKK SSSSSSSSSSSSSSSS TTTT SSSSSS TTTTT SSSSSSSSS",
-            level="level12", lang='en')
-
+            level="level12",
+            lang="en",
+        )
 
     def test_12_15(self):
         self.assert_highlighted_chr_multi_line(
@@ -2786,15 +2762,12 @@ class HighlighterTestWebSite(HighlightTester):
             "T KK SSSSSSSSSSSSSSSS",
             "print a + b",
             "KKKKK T K T",
-            level="level12", lang='en')
-
+            level="level12",
+            lang="en",
+        )
 
     def test_12_16(self):
-        self.assert_highlighted_chr(
-            "## place your code here",
-            "CCCCCCCCCCCCCCCCCCCCCCC",
-            level="level12", lang='en')
-
+        self.assert_highlighted_chr("## place your code here", "CCCCCCCCCCCCCCCCCCCCCCC", level="level12", lang="en")
 
     def test_12_17(self):
         self.assert_highlighted_chr_multi_line(
@@ -2816,15 +2789,14 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKK",
             "print 'Access denied!'",
             "KKKKK SSSSSSSSSSSSSSSS",
-            level="level12", lang='en')
-
+            level="level12",
+            lang="en",
+        )
 
     def test_12_18(self):
         self.assert_highlighted_chr(
-            "print 'Lets go to the next level!'",
-            "KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSSSS",
-            level="level12", lang='en')
-
+            "print 'Lets go to the next level!'", "KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSSSS", level="level12", lang="en"
+        )
 
     def test_13_1(self):
         self.assert_highlighted_chr_multi_line(
@@ -2836,8 +2808,9 @@ class HighlighterTestWebSite(HighlightTester):
             "KK TTTT KK SSSSSS KKK TTT KK N",
             "print 'You are the real Hedy!'",
             "KKKKK SSSSSSSSSSSSSSSSSSSSSSSS",
-            level="level13", lang='en')
-
+            level="level13",
+            lang="en",
+        )
 
     def test_13_2(self):
         self.assert_highlighted_chr_multi_line(
@@ -2887,15 +2860,12 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS",
             "sword = 'found'",
             "TTTTT K SSSSSSS",
-            level="level13", lang='en')
-
+            level="level13",
+            lang="en",
+        )
 
     def test_13_3(self):
-        self.assert_highlighted_chr(
-            "# place your code here",
-            "CCCCCCCCCCCCCCCCCCCCCC",
-            level="level13", lang='en')
-
+        self.assert_highlighted_chr("# place your code here", "CCCCCCCCCCCCCCCCCCCCCC", level="level13", lang="en")
 
     def test_13_4(self):
         self.assert_highlighted_chr_multi_line(
@@ -2921,8 +2891,9 @@ class HighlighterTestWebSite(HighlightTester):
             "KK TTTTTTTTTTTTTTT KK SSSSSS KKK TTTTTTTTTTT KK SSSSSSSSSS",
             "print 'The computer wins!'",
             "KKKKK SSSSSSSSSSSSSSSSSSSS",
-            level="level13", lang='en')
-
+            level="level13",
+            lang="en",
+        )
 
     def test_13_5(self):
         self.assert_highlighted_chr_multi_line(
@@ -2940,8 +2911,9 @@ class HighlighterTestWebSite(HighlightTester):
             "TTTTT K TTTTT K N",
             "print 'That will be ' price ' dollars'",
             "KKKKK SSSSSSSSSSSSSSS TTTTT SSSSSSSSSS",
-            level="level13", lang='en')
-
+            level="level13",
+            lang="en",
+        )
 
     def test_13_6(self):
         self.assert_highlighted_chr_multi_line(
@@ -2951,8 +2923,9 @@ class HighlighterTestWebSite(HighlightTester):
             "KK TTTTTT KK SSSSSSS KK TTTTTT KK SSSSSSS",
             "print 'Thats a healthy choice'",
             "KKKKK SSSSSSSSSSSSSSSSSSSSSSSS",
-            level="level13", lang='en')
-
+            level="level13",
+            lang="en",
+        )
 
     def test_13_7(self):
         self.assert_highlighted_chr_multi_line(
@@ -2968,15 +2941,12 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKK",
             "print 'Go to the trainstation at 10.00'",
             "KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS",
-            level="level13", lang='en')
-
+            level="level13",
+            lang="en",
+        )
 
     def test_13_8(self):
-        self.assert_highlighted_chr(
-            "## place your code here",
-            "CCCCCCCCCCCCCCCCCCCCCCC",
-            level="level13", lang='en')
-
+        self.assert_highlighted_chr("## place your code here", "CCCCCCCCCCCCCCCCCCCCCCC", level="level13", lang="en")
 
     def test_13_9(self):
         self.assert_highlighted_chr_multi_line(
@@ -2996,15 +2966,14 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKK",
             "print 'Great! You have passed the subject!'",
             "KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS",
-            level="level13", lang='en')
-
+            level="level13",
+            lang="en",
+        )
 
     def test_13_10(self):
         self.assert_highlighted_chr(
-            "print 'Lets go to the next level!'",
-            "KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSSSS",
-            level="level13", lang='en')
-
+            "print 'Lets go to the next level!'", "KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSSSS", level="level13", lang="en"
+        )
 
     def test_14_1(self):
         self.assert_highlighted_chr_multi_line(
@@ -3018,8 +2987,9 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKK",
             "print 'You are older than me!'",
             "KKKKK SSSSSSSSSSSSSSSSSSSSSSSS",
-            level="level14", lang='en')
-
+            level="level14",
+            lang="en",
+        )
 
     def test_14_2(self):
         self.assert_highlighted_chr_multi_line(
@@ -3029,8 +2999,9 @@ class HighlighterTestWebSite(HighlightTester):
             "KK TTT K NN",
             "print 'You are older than I am!'",
             "KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSS",
-            level="level14", lang='en')
-
+            level="level14",
+            lang="en",
+        )
 
     def test_14_3(self):
         self.assert_highlighted_chr_multi_line(
@@ -3040,8 +3011,9 @@ class HighlighterTestWebSite(HighlightTester):
             "KK TTTT KK SSSSSS",
             "print 'You are coo!'",
             "KKKKK SSSSSSSSSSSSSS",
-            level="level14", lang='en')
-
+            level="level14",
+            lang="en",
+        )
 
     def test_14_4(self):
         self.assert_highlighted_chr_multi_line(
@@ -3051,8 +3023,9 @@ class HighlighterTestWebSite(HighlightTester):
             "KK TTTT KK SSSSSS",
             "print 'You are not Hedy'",
             "KKKKK SSSSSSSSSSSSSSSSSS",
-            level="level14", lang='en')
-
+            level="level14",
+            lang="en",
+        )
 
     def test_14_5(self):
         self.assert_highlighted_chr_multi_line(
@@ -3084,15 +3057,12 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKKK SSSSSSSSSS",
             "game = 'over'",
             "TTTT K SSSSSS",
-            level="level14", lang='en')
-
+            level="level14",
+            lang="en",
+        )
 
     def test_14_6(self):
-        self.assert_highlighted_chr(
-            "# place your code here",
-            "CCCCCCCCCCCCCCCCCCCCCC",
-            level="level14", lang='en')
-
+        self.assert_highlighted_chr("# place your code here", "CCCCCCCCCCCCCCCCCCCCCC", level="level14", lang="en")
 
     def test_14_7(self):
         self.assert_highlighted_chr_multi_line(
@@ -3136,8 +3106,9 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKK",
             "print 'GAME OVER'",
             "KKKKK SSSSSSSSSSS",
-            level="level14", lang='en')
-
+            level="level14",
+            lang="en",
+        )
 
     def test_14_8(self):
         self.assert_highlighted_chr_multi_line(
@@ -3163,8 +3134,9 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKKK SSSSSSSSSSSSSSSSSSSSSSSS",
             "print 'Lets go shopping!'",
             "KKKKK SSSSSSSSSSSSSSSSSSS",
-            level="level14", lang='en')
-
+            level="level14",
+            lang="en",
+        )
 
     def test_14_9(self):
         self.assert_highlighted_chr_multi_line(
@@ -3202,8 +3174,9 @@ class HighlighterTestWebSite(HighlightTester):
             "KK TTTTTTTT K TTTTTTTT",
             "print 'You belong to the B club'",
             "KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSS",
-            level="level14", lang='en')
-
+            level="level14",
+            lang="en",
+        )
 
     def test_14_10(self):
         self.assert_highlighted_chr_multi_line(
@@ -3223,15 +3196,14 @@ class HighlighterTestWebSite(HighlightTester):
             "KK TTTTTT KK SSSSS",
             "print 'Ok we will continue'",
             "KKKKK SSSSSSSSSSSSSSSSSSSSS",
-            level="level14", lang='en')
-
+            level="level14",
+            lang="en",
+        )
 
     def test_14_11(self):
         self.assert_highlighted_chr(
-            "print 'Lets go to the next level!'",
-            "KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSSSS",
-            level="level14", lang='en')
-
+            "print 'Lets go to the next level!'", "KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSSSS", level="level14", lang="en"
+        )
 
     def test_15_1(self):
         self.assert_highlighted_chr_multi_line(
@@ -3243,8 +3215,9 @@ class HighlighterTestWebSite(HighlightTester):
             "TTTTTT K KKK SSSSSSSSSSSSSSSSSSSS",
             "print 'A correct answer has been given'",
             "KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS",
-            level="level15", lang='en')
-
+            level="level15",
+            lang="en",
+        )
 
     def test_15_2(self):
         self.assert_highlighted_chr_multi_line(
@@ -3272,15 +3245,12 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSSS TTTTTTTT",
             "print 'Now you can enter the house!'",
             "KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSSSSSS",
-            level="level15", lang='en')
-
+            level="level15",
+            lang="en",
+        )
 
     def test_15_3(self):
-        self.assert_highlighted_chr(
-            "# place your code here",
-            "CCCCCCCCCCCCCCCCCCCCCC",
-            level="level15", lang='en')
-
+        self.assert_highlighted_chr("# place your code here", "CCCCCCCCCCCCCCCCCCCCCC", level="level15", lang="en")
 
     def test_15_4(self):
         self.assert_highlighted_chr_multi_line(
@@ -3302,8 +3272,9 @@ class HighlighterTestWebSite(HighlightTester):
             "TTTTT K TTTTT K N",
             "print 'Yes! You have thrown 6 in ' tries ' tries.'",
             "KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSSSS TTTTT SSSSSSSSS",
-            level="level15", lang='en')
-
+            level="level15",
+            lang="en",
+        )
 
     def test_15_5(self):
         self.assert_highlighted_chr_multi_line(
@@ -3335,8 +3306,9 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKKK SSSSSSSSSS",
             "won = 'yes'",
             "TTT K SSSSS",
-            level="level15", lang='en')
-
+            level="level15",
+            lang="en",
+        )
 
     def test_15_6(self):
         self.assert_highlighted_chr_multi_line(
@@ -3366,8 +3338,9 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKKK SSSSSSSSSSS",
             "print 'You win!'",
             "KKKKK SSSSSSSSSS",
-            level="level15", lang='en')
-
+            level="level15",
+            lang="en",
+        )
 
     def test_15_7(self):
         self.assert_highlighted_chr_multi_line(
@@ -3385,8 +3358,9 @@ class HighlighterTestWebSite(HighlightTester):
             "TTTT K KKK SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS",
             "print 'Thank you!'",
             "KKKKK SSSSSSSSSSSS",
-            level="level15", lang='en')
-
+            level="level15",
+            lang="en",
+        )
 
     def test_15_8(self):
         self.assert_highlighted_chr_multi_line(
@@ -3408,15 +3382,14 @@ class HighlighterTestWebSite(HighlightTester):
             "KKK TTTTT KK TTTTTT",
             "print 'A ' animal ' says ' sound",
             "KKKKK SSSS TTTTTT SSSSSSSS TTTTT",
-            level="level15", lang='en')
-
+            level="level15",
+            lang="en",
+        )
 
     def test_15_9(self):
         self.assert_highlighted_chr(
-            "print 'Lets go to the next level!'",
-            "KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSSSS",
-            level="level15", lang='en')
-
+            "print 'Lets go to the next level!'", "KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSSSS", level="level15", lang="en"
+        )
 
     def test_16_1(self):
         self.assert_highlighted_chr_multi_line(
@@ -3424,8 +3397,9 @@ class HighlighterTestWebSite(HighlightTester):
             "TTTTT K KSSSSSSSK SSSSSSSSK SSSSSSSSK",
             "print fruit",
             "KKKKK TTTTT",
-            level="level16", lang='en')
-
+            level="level16",
+            lang="en",
+        )
 
     def test_16_2(self):
         self.assert_highlighted_chr_multi_line(
@@ -3439,8 +3413,9 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKKK SSSSSSSSSSSSSSSSSSSSSS TTTTTTTKTK",
             "print 'is ' lucky_numbers[i]",
             "KKKKK SSSSS TTTTTTTTTTTTTKTK",
-            level="level16", lang='en')
-
+            level="level16",
+            lang="en",
+        )
 
     def test_16_3(self):
         self.assert_highlighted_chr_multi_line(
@@ -3488,15 +3463,12 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSS",
             "print 'early in the morning'",
             "KKKKK SSSSSSSSSSSSSSSSSSSSSS",
-            level="level16", lang='en')
-
+            level="level16",
+            lang="en",
+        )
 
     def test_16_4(self):
-        self.assert_highlighted_chr(
-            "# place your code here",
-            "CCCCCCCCCCCCCCCCCCCCCC",
-            level="level16", lang='en')
-
+        self.assert_highlighted_chr("# place your code here", "CCCCCCCCCCCCCCCCCCCCCC", level="level16", lang="en")
 
     def test_16_5(self):
         self.assert_highlighted_chr_multi_line(
@@ -3548,8 +3520,9 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKKK TTTTTTTTKTK",
             "print 'GAME OVER'",
             "KKKKK SSSSSSSSSSS",
-            level="level16", lang='en')
-
+            level="level16",
+            lang="en",
+        )
 
     def test_16_6(self):
         self.assert_highlighted_chr_multi_line(
@@ -3577,8 +3550,9 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKKK SSSSSSSSS TTTTTTTTTTTTKTK SSSSSSSSS TTTTTTTTTTTKTK",
             "print 'You gave ' score ' correct answers.'",
             "KKKKK SSSSSSSSSSS TTTTT SSSSSSSSSSSSSSSSSSS",
-            level="level16", lang='en')
-
+            level="level16",
+            lang="en",
+        )
 
     def test_16_7(self):
         self.assert_highlighted_chr_multi_line(
@@ -3596,15 +3570,14 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKK",
             "print 'Yikes...'",
             "KKKKK SSSSSSSSSS",
-            level="level16", lang='en')
-
+            level="level16",
+            lang="en",
+        )
 
     def test_16_8(self):
         self.assert_highlighted_chr(
-            "print 'Lets go to the next level!'",
-            "KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSSSS",
-            level="level16", lang='en')
-
+            "print 'Lets go to the next level!'", "KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSSSS", level="level16", lang="en"
+        )
 
     def test_17_1(self):
         self.assert_highlighted_chr_multi_line(
@@ -3614,8 +3587,9 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKKK T",
             "print 'Ready or not, here I come!'",
             "KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSSSS",
-            level="level17", lang='en')
-
+            level="level17",
+            lang="en",
+        )
 
     def test_17_2(self):
         self.assert_highlighted_chr_multi_line(
@@ -3637,14 +3611,14 @@ class HighlighterTestWebSite(HighlightTester):
             "KKKKK",
             "print 'Better luck next time..'",
             "KKKKK SSSSSSSSSSSSSSSSSSSSSSSSS",
-            level="level17", lang='en')
-
+            level="level17",
+            lang="en",
+        )
 
     def test_17_3(self):
         self.assert_highlighted_chr(
-            "print 'Lets go to the next level!'",
-            "KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSSSS",
-            level="level17", lang='en')
+            "print 'Lets go to the next level!'", "KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSSSS", level="level17", lang="en"
+        )
 
     def test_18_1(self):
         self.assert_highlighted_chr_multi_line(
@@ -3652,8 +3626,9 @@ class HighlighterTestWebSite(HighlightTester):
             "TTTT K SSSSSS",
             "print('My name is ', naam)",
             "KKKKKKSSSSSSSSSSSSSK TTTTK",
-            level="level18", lang='en')
-
+            level="level18",
+            lang="en",
+        )
 
     def test_18_2(self):
         self.assert_highlighted_chr_multi_line(
@@ -3663,13 +3638,9 @@ class HighlighterTestWebSite(HighlightTester):
             "TTTT K SSSSSS",
             "print('my name is ', name)",
             "KKKKKKSSSSSSSSSSSSSK TTTTK",
-            level="level18", lang='en')
-
+            level="level18",
+            lang="en",
+        )
 
     def test_18_3(self):
-        self.assert_highlighted_chr(
-            "print ('Great job!!!')",
-            "KKKKK KSSSSSSSSSSSSSSK",
-            level="level18", lang='en')
-
-
+        self.assert_highlighted_chr("print ('Great job!!!')", "KKKKK KSSSSSSSSSSSSSSK", level="level18", lang="en")

--- a/tests/test_highlighting/test_affectation.py
+++ b/tests/test_highlighting/test_affectation.py
@@ -1,76 +1,61 @@
 from tests.Highlighter import HighlightTester
 from parameterized import parameterized
 
+
 class HighlighterTestAffectation(HighlightTester):
-
-
-    @parameterized.expand([
-        ("level2"),
-        ("level3"),
-        ("level4"),
-    ])
+    @parameterized.expand(
+        [
+            ("level2"),
+            ("level3"),
+            ("level4"),
+        ]
+    )
     def test_is(self, level):
-        self.assert_highlighted_chr(
-            "sword is lost",
-            "TTTTT KK TTTT",
-            level=level, lang="en")
+        self.assert_highlighted_chr("sword is lost", "TTTTT KK TTTT", level=level, lang="en")
 
-
-    @parameterized.expand([
-        ("level5"),
-        ("level6"),
-        ("level7"),
-        ("level8"),
-        ("level9"),
-        ("level10"),
-        ("level11"),
-        ("level12"),
-        ("level13"),
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-    ])
+    @parameterized.expand(
+        [
+            ("level5"),
+            ("level6"),
+            ("level7"),
+            ("level8"),
+            ("level9"),
+            ("level10"),
+            ("level11"),
+            ("level12"),
+            ("level13"),
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+        ]
+    )
     def test_is_string(self, level):
-        self.assert_highlighted_chr(
-            "sword is 'lost'",
-            "TTTTT KK SSSSSS",
-            level=level, lang="en")
+        self.assert_highlighted_chr("sword is 'lost'", "TTTTT KK SSSSSS", level=level, lang="en")
 
-
-    @parameterized.expand([
-        ("level4"),
-    ])
+    @parameterized.expand(
+        [
+            ("level4"),
+        ]
+    )
     def test_is_string_unquote(self, level):
-        self.assert_highlighted_chr(
-            "sword is 'lost'",
-            "TTTTT KK TTTTTT",
-            level=level, lang="en")
+        self.assert_highlighted_chr("sword is 'lost'", "TTTTT KK TTTTTT", level=level, lang="en")
 
-
-
-
-    @parameterized.expand([
-        ("level6"),
-        ("level7"),
-        ("level8"),
-        ("level9"),
-        ("level10"),
-        ("level11"),
-        ("level12"),
-        ("level13"),
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-    ])
+    @parameterized.expand(
+        [
+            ("level6"),
+            ("level7"),
+            ("level8"),
+            ("level9"),
+            ("level10"),
+            ("level11"),
+            ("level12"),
+            ("level13"),
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+        ]
+    )
     def test_is_string_equal(self, level):
-        self.assert_highlighted_chr(
-            "sword = 'lost'",
-            "TTTTT K SSSSSS",
-            level=level, lang="en")
-
-
-
-
-
+        self.assert_highlighted_chr("sword = 'lost'", "TTTTT K SSSSSS", level=level, lang="en")

--- a/tests/test_highlighting/test_arabic.py
+++ b/tests/test_highlighting/test_arabic.py
@@ -1,189 +1,181 @@
 from tests.Highlighter import HighlightTester
 from parameterized import parameterized
 
+
 class HighlighterTestPrintArabic(HighlightTester):
-
-    @parameterized.expand([
-        ("level1"),
-        ("level2"),
-        ("level3"),
-    ])
+    @parameterized.expand(
+        [
+            ("level1"),
+            ("level2"),
+            ("level3"),
+        ]
+    )
     def test_print1(self, level):
-        self.assert_highlighted_chr(
-            "قول مرحبا أيها العالم!",
-            "KKK TTTTTTTTTTTTTTTTTT",
-            level=level, lang='ar')
+        self.assert_highlighted_chr("قول مرحبا أيها العالم!", "KKK TTTTTTTTTTTTTTTTTT", level=level, lang="ar")
 
-    @parameterized.expand([
-        ("level4"),
-        ("level5"),
-        ("level6"),
-        ("level7"),
-        ("level8"),
-        ("level9"),
-        ("level10"),
-        ("level11"),
-        ("level12"),
-        ("level13"),
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-    ])
+    @parameterized.expand(
+        [
+            ("level4"),
+            ("level5"),
+            ("level6"),
+            ("level7"),
+            ("level8"),
+            ("level9"),
+            ("level10"),
+            ("level11"),
+            ("level12"),
+            ("level13"),
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+        ]
+    )
     def test_print2(self, level):
-        self.assert_highlighted_chr(
-            'قول "مرحبا أيها العالم"',
-            "KKK SSSSSSSSSSSSSSSSSSS",
-            level=level, lang='ar')
+        self.assert_highlighted_chr('قول "مرحبا أيها العالم"', "KKK SSSSSSSSSSSSSSSSSSS", level=level, lang="ar")
 
-
-
-    @parameterized.expand([
-        ("level3"),
-        ("level4"),
-        ("level5"),
-        ("level6"),
-        ("level7"),
-        ("level8"),
-        ("level9"),
-        ("level10"),
-        ("level11"),
-        ("level12"),
-        ("level13"),
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-    ])
+    @parameterized.expand(
+        [
+            ("level3"),
+            ("level4"),
+            ("level5"),
+            ("level6"),
+            ("level7"),
+            ("level8"),
+            ("level9"),
+            ("level10"),
+            ("level11"),
+            ("level12"),
+            ("level13"),
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+        ]
+    )
     def test_print_random_alone(self, level):
-        self.assert_highlighted_chr(
-            "قول حيواناتي بشكل عشوائي",
-            "KKK TTTTTTTT KKKK KKKKKK",
-            level=level, lang='ar')
-
-
+        self.assert_highlighted_chr("قول حيواناتي بشكل عشوائي", "KKK TTTTTTTT KKKK KKKKKK", level=level, lang="ar")
 
     def test_print_random1(self):
         self.assert_highlighted_chr(
             "قول حيواناتي بشكل عشوائي مرحبا أيها العالم!",
             "KKK TTTTTTTT KKKK KKKKKK TTTTTTTTTTTTTTTTTT",
-            level="level3", lang='ar')
+            level="level3",
+            lang="ar",
+        )
 
-    @parameterized.expand([
-        ("level4"),
-        ("level5"),
-        ("level6"),
-        ("level7"),
-        ("level8"),
-        ("level9"),
-        ("level10"),
-        ("level11"),
-        ("level12"),
-        ("level13"),
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-    ])
+    @parameterized.expand(
+        [
+            ("level4"),
+            ("level5"),
+            ("level6"),
+            ("level7"),
+            ("level8"),
+            ("level9"),
+            ("level10"),
+            ("level11"),
+            ("level12"),
+            ("level13"),
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+        ]
+    )
     def test_print_random2(self, level):
         self.assert_highlighted_chr(
             'قول حيواناتي بشكل عشوائي "مرحبا أيها العالم!"',
             "KKK TTTTTTTT KKKK KKKKKK SSSSSSSSSSSSSSSSSSSS",
-            level=level, lang='ar')
+            level=level,
+            lang="ar",
+        )
 
-
-    @parameterized.expand([
-        ("level6"),
-        ("level7"),
-        ("level8"),
-        ("level9"),
-        ("level10"),
-        ("level11"),
-        ("level12"),
-        ("level13"),
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-    ])
+    @parameterized.expand(
+        [
+            ("level6"),
+            ("level7"),
+            ("level8"),
+            ("level9"),
+            ("level10"),
+            ("level11"),
+            ("level12"),
+            ("level13"),
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+        ]
+    )
     def test_is_number_equal_plus(self, level):
-        self.assert_highlighted_chr(
-            "sword = ١٢٣٤٦ + ٧٨٥٦٤",
-            "TTTTT K NNNNN K NNNNN",
-            level=level, lang="ar")
+        self.assert_highlighted_chr("sword = ١٢٣٤٦ + ٧٨٥٦٤", "TTTTT K NNNNN K NNNNN", level=level, lang="ar")
 
-
-    @parameterized.expand([
-        ("level12"),
-        ("level13"),
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-    ])
+    @parameterized.expand(
+        [
+            ("level12"),
+            ("level13"),
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+        ]
+    )
     def test_is_number_equal_float_plus(self, level):
-        self.assert_highlighted_chr(
-            "sword = ١٢٣.٤٦ + ٧٩٤٩.٨",
-            "TTTTT K NNNNNN K NNNNNN",
-            level=level, lang="ar")
+        self.assert_highlighted_chr("sword = ١٢٣.٤٦ + ٧٩٤٩.٨", "TTTTT K NNNNNN K NNNNNN", level=level, lang="ar")
 
-
-    @parameterized.expand([
-        ("level6"),
-        ("level7"),
-        ("level8"),
-        ("level9"),
-        ("level10"),
-        ("level11"),
-        ("level12"),
-        ("level13"),
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-    ])
+    @parameterized.expand(
+        [
+            ("level6"),
+            ("level7"),
+            ("level8"),
+            ("level9"),
+            ("level10"),
+            ("level11"),
+            ("level12"),
+            ("level13"),
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+        ]
+    )
     def test_print_mul(self, level):
         self.assert_highlighted_chr(
-            'قول "مرحبا أيها العالم" ١٢٣٤٦ * ٧٩٤٩٨',
-            "KKK SSSSSSSSSSSSSSSSSSS NNNNN K NNNNN",
-            level=level, lang='ar')
+            'قول "مرحبا أيها العالم" ١٢٣٤٦ * ٧٩٤٩٨', "KKK SSSSSSSSSSSSSSSSSSS NNNNN K NNNNN", level=level, lang="ar"
+        )
 
-    @parameterized.expand([
-        ("level12"),
-        ("level13"),
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-    ])
+    @parameterized.expand(
+        [
+            ("level12"),
+            ("level13"),
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+        ]
+    )
     def test_print_div_float(self, level):
         self.assert_highlighted_chr(
-            'قول "مرحبا أيها العالم" ١٢٣.٤٦ / ٧٩٤٩.٨',
-            "KKK SSSSSSSSSSSSSSSSSSS NNNNNN K NNNNNN",
-            level=level, lang='ar')
+            'قول "مرحبا أيها العالم" ١٢٣.٤٦ / ٧٩٤٩.٨', "KKK SSSSSSSSSSSSSSSSSSS NNNNNN K NNNNNN", level=level, lang="ar"
+        )
 
-    @parameterized.expand([
-        ("level3"),
-        ("level4"),
-        ("level5"),
-        ("level6"),
-        ("level7"),
-        ("level8"),
-        ("level9"),
-        ("level10"),
-        ("level11"),
-        ("level12"),
-        ("level13"),
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-    ])
+    @parameterized.expand(
+        [
+            ("level3"),
+            ("level4"),
+            ("level5"),
+            ("level6"),
+            ("level7"),
+            ("level8"),
+            ("level9"),
+            ("level10"),
+            ("level11"),
+            ("level12"),
+            ("level13"),
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+        ]
+    )
     def test_print_comma(self, level):
-        self.assert_highlighted_chr(
-            'الحيوانات هو كلب، قطة، جمل',
-            "TTTTTTTTT KK TTTK TTTK TTT",
-            level=level, lang='ar')
-
-
-
+        self.assert_highlighted_chr("الحيوانات هو كلب، قطة، جمل", "TTTTTTTTT KK TTTK TTTK TTT", level=level, lang="ar")

--- a/tests/test_highlighting/test_ask_echo.py
+++ b/tests/test_highlighting/test_ask_echo.py
@@ -1,42 +1,21 @@
 from tests.Highlighter import HighlightTester
 from parameterized import parameterized
 
+
 class HighlighterTestAskEcho(HighlightTester):
-
-
-
     def test_echo_alone(self):
-        self.assert_highlighted_chr(
-            "echo",
-            "KKKK",
-            level="level1", lang="en")
-
+        self.assert_highlighted_chr("echo", "KKKK", level="level1", lang="en")
 
     def test_echo1(self):
-        self.assert_highlighted_chr(
-            "echo aavhzrbz",
-            "KKKK TTTTTTTT",
-            level="level1", lang="en")
-
+        self.assert_highlighted_chr("echo aavhzrbz", "KKKK TTTTTTTT", level="level1", lang="en")
 
     def test_echo2(self):
-        self.assert_highlighted_chr(
-            "echo Jouw naam is",
-            "KKKK TTTTTTTTTTTT",
-            level="level1", lang="en")
-
+        self.assert_highlighted_chr("echo Jouw naam is", "KKKK TTTTTTTTTTTT", level="level1", lang="en")
 
     def test_ask1(self):
-        self.assert_highlighted_chr(
-            "ask aavhzrbz",
-            "KKK TTTTTTTT",
-            level="level1", lang="en")
-
+        self.assert_highlighted_chr("ask aavhzrbz", "KKK TTTTTTTT", level="level1", lang="en")
 
     def test_ask2(self):
         self.assert_highlighted_chr(
-            "ask What would you like to order?",
-            "KKK TTTTTTTTTTTTTTTTTTTTTTTTTTTTT",
-            level="level1", lang="en")
-
-
+            "ask What would you like to order?", "KKK TTTTTTTTTTTTTTTTTTTTTTTTTTTTT", level="level1", lang="en"
+        )

--- a/tests/test_highlighting/test_chinese.py
+++ b/tests/test_highlighting/test_chinese.py
@@ -1,93 +1,85 @@
 from tests.Highlighter import HighlightTester
 from parameterized import parameterized
 
+
 class HighlighterTestPrintChinese(HighlightTester):
-
-    @parameterized.expand([
-        ("level1"),
-        ("level2"),
-        ("level3"),
-    ])
+    @parameterized.expand(
+        [
+            ("level1"),
+            ("level2"),
+            ("level3"),
+        ]
+    )
     def test_print1(self, level):
-        self.assert_highlighted_chr(
-            "打印 你好世界!",
-            "KK TTTTT",
-            level=level, lang='zh_Hans')
+        self.assert_highlighted_chr("打印 你好世界!", "KK TTTTT", level=level, lang="zh_Hans")
 
-    @parameterized.expand([
-        ("level4"),
-        ("level5"),
-        ("level6"),
-        ("level7"),
-        ("level8"),
-        ("level9"),
-        ("level10"),
-        ("level11"),
-        ("level12"),
-        ("level13"),
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-    ])
+    @parameterized.expand(
+        [
+            ("level4"),
+            ("level5"),
+            ("level6"),
+            ("level7"),
+            ("level8"),
+            ("level9"),
+            ("level10"),
+            ("level11"),
+            ("level12"),
+            ("level13"),
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+        ]
+    )
     def test_print2(self, level):
-        self.assert_highlighted_chr(
-            "打印 '从现在开始你们需要使用引号！'",
-            "KK SSSSSSSSSSSSSSSS",
-            level=level, lang='zh_Hans')
+        self.assert_highlighted_chr("打印 '从现在开始你们需要使用引号！'", "KK SSSSSSSSSSSSSSSS", level=level, lang="zh_Hans")
 
-
-
-    @parameterized.expand([
-        ("level3"),
-        ("level4"),
-        ("level5"),
-        ("level6"),
-        ("level7"),
-        ("level8"),
-        ("level9"),
-        ("level10"),
-        ("level11"),
-        ("level12"),
-        ("level13"),
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-    ])
+    @parameterized.expand(
+        [
+            ("level3"),
+            ("level4"),
+            ("level5"),
+            ("level6"),
+            ("level7"),
+            ("level8"),
+            ("level9"),
+            ("level10"),
+            ("level11"),
+            ("level12"),
+            ("level13"),
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+        ]
+    )
     def test_print_random_alone(self, level):
-        self.assert_highlighted_chr(
-            "打印 动物们 在 随机",
-            "KK TTT K KK",
-            level=level, lang='zh_Hans')
-
-
+        self.assert_highlighted_chr("打印 动物们 在 随机", "KK TTT K KK", level=level, lang="zh_Hans")
 
     def test_print_random1(self):
         self.assert_highlighted_chr(
-            "打印 从现在开始我们需要使用什么？ 答案 在 随机",
-            "KK TTTTTTTTTTTTTT TT K KK",
-            level="level3", lang='zh_Hans')
+            "打印 从现在开始我们需要使用什么？ 答案 在 随机", "KK TTTTTTTTTTTTTT TT K KK", level="level3", lang="zh_Hans"
+        )
 
-    @parameterized.expand([
-        ("level4"),
-        ("level5"),
-        ("level6"),
-        ("level7"),
-        ("level8"),
-        ("level9"),
-        ("level10"),
-        ("level11"),
-        ("level12"),
-        ("level13"),
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-    ])
+    @parameterized.expand(
+        [
+            ("level4"),
+            ("level5"),
+            ("level6"),
+            ("level7"),
+            ("level8"),
+            ("level9"),
+            ("level10"),
+            ("level11"),
+            ("level12"),
+            ("level13"),
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+        ]
+    )
     def test_print_random2(self, level):
         self.assert_highlighted_chr(
-            "打印 '从现在开始我们需要使用什么？' 答案 在 随机",
-            "KK SSSSSSSSSSSSSSSS TT K KK",
-            level=level, lang='zh_Hans')
-
+            "打印 '从现在开始我们需要使用什么？' 答案 在 随机", "KK SSSSSSSSSSSSSSSS TT K KK", level=level, lang="zh_Hans"
+        )

--- a/tests/test_highlighting/test_comment.py
+++ b/tests/test_highlighting/test_comment.py
@@ -1,30 +1,31 @@
 from tests.Highlighter import HighlightTester
 from parameterized import parameterized
 
-class HighlighterTestComment(HighlightTester):
 
-    @parameterized.expand([
-        ("level1"),
-        ("level2"),
-        ("level3"),
-        ("level4"),
-        ("level5"),
-        ("level6"),
-        ("level7"),
-        ("level8"),
-        ("level9"),
-        ("level10"),
-        ("level11"),
-        ("level12"),
-        ("level13"),
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-        ("level18"),
-    ])
+class HighlighterTestComment(HighlightTester):
+    @parameterized.expand(
+        [
+            ("level1"),
+            ("level2"),
+            ("level3"),
+            ("level4"),
+            ("level5"),
+            ("level6"),
+            ("level7"),
+            ("level8"),
+            ("level9"),
+            ("level10"),
+            ("level11"),
+            ("level12"),
+            ("level13"),
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+            ("level18"),
+        ]
+    )
     def test_comment(self, level):
         self.assert_highlighted_chr(
-            "# Maak jouw eigen code hier",
-            "CCCCCCCCCCCCCCCCCCCCCCCCCCC",
-            level=level, lang="en")
+            "# Maak jouw eigen code hier", "CCCCCCCCCCCCCCCCCCCCCCCCCCC", level=level, lang="en"
+        )

--- a/tests/test_highlighting/test_for.py
+++ b/tests/test_highlighting/test_for.py
@@ -1,53 +1,50 @@
 from tests.Highlighter import HighlightTester
 from parameterized import parameterized
 
+
 class HighlighterTestFor(HighlightTester):
-
-    @parameterized.expand([
-        ("level10"),
-        ("level11"),
-        ("level12"),
-        ("level13"),
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-        ("level18"),
-    ])
+    @parameterized.expand(
+        [
+            ("level10"),
+            ("level11"),
+            ("level12"),
+            ("level13"),
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+            ("level18"),
+        ]
+    )
     def test_for(self, level):
-        self.assert_highlighted_chr(
-            "for animal in animals",
-            "KKK TTTTTT KK TTTTTTT",
-            level=level, lang="en")
+        self.assert_highlighted_chr("for animal in animals", "KKK TTTTTT KK TTTTTTT", level=level, lang="en")
 
-    @parameterized.expand([
-        ("level11"),
-        ("level12"),
-        ("level13"),
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-        ("level18"),
-    ])
+    @parameterized.expand(
+        [
+            ("level11"),
+            ("level12"),
+            ("level13"),
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+            ("level18"),
+        ]
+    )
     def test_for_range1(self, level):
-        self.assert_highlighted_chr(
-            "for i in range 1 to 3",
-            "KKK T KK KKKKK N KK N",
-            level=level, lang="en")
+        self.assert_highlighted_chr("for i in range 1 to 3", "KKK T KK KKKKK N KK N", level=level, lang="en")
 
-    @parameterized.expand([
-        ("level11"),
-        ("level12"),
-        ("level13"),
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-        ("level18"),
-    ])
+    @parameterized.expand(
+        [
+            ("level11"),
+            ("level12"),
+            ("level13"),
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+            ("level18"),
+        ]
+    )
     def test_for_range2(self, level):
-        self.assert_highlighted_chr(
-            "for i in range 1 to people",
-            "KKK T KK KKKKK N KK TTTTTT",
-            level=level, lang="en")
+        self.assert_highlighted_chr("for i in range 1 to people", "KKK T KK KKKKK N KK TTTTTT", level=level, lang="en")

--- a/tests/test_highlighting/test_highlighting_simulation.py
+++ b/tests/test_highlighting/test_highlighting_simulation.py
@@ -1,72 +1,106 @@
-from tests.Highlighter import HighlightTester,SimulatorAce
+from tests.Highlighter import HighlightTester, SimulatorAce
 
 RULES = {
-    "rules1" : {'start': [{'regex': 'b', 'token': 'keyword', 'next': 'StateB'}, {'regex': 'a', 'token': 'constant.character', 'next': 'StateA'}, {'regex': '[^abc]', 'token': 'comment', 'next': 'start'}], 'StateA': [{'regex': '[^c]', 'token': 'invalid', 'next': 'StateA'}, {'regex': 'c', 'token': 'keyword', 'next': 'StateA'}], 'StateB': [{'regex': '[^c]', 'token': 'variable', 'next': 'StateB'}]},
-    "rules2" : {'start': [{'regex': 'b', 'token': 'keyword', 'next': 'StateB'}, {'regex': 'ba', 'token': 'constant.character', 'next': 'StateA'}, {'regex': '[^abcd]', 'token': 'comment', 'next': 'start'}], 'StateA': [{'regex': '[^c]', 'token': 'invalid', 'next': 'StateA'}, {'regex': 'c', 'token': 'keyword', 'next': 'StateA'}], 'StateB': [{'regex': '[^c]', 'token': 'variable', 'next': 'StateB'}]},
-    "rules3" : {'start': [{'regex': 'ba', 'token': 'constant.character', 'next': 'StateA'}, {'regex': 'b', 'token': 'keyword', 'next': 'StateB'}, {'regex': '[^abcd]', 'token': 'comment', 'next': 'start'}], 'StateA': [{'regex': '[^c]', 'token': 'invalid', 'next': 'StateA'}, {'regex': 'c', 'token': 'keyword', 'next': 'StateA'}], 'StateB': [{'regex': '[^c]', 'token': 'variable', 'next': 'StateB'}]},
-    "rules4" : {'start': [{'regex': '[ac]', 'token': 'keyword', 'next': 'StateB'}, {'regex': '[bc]', 'token': 'constant.character', 'next': 'StateA'}, {'regex': 'tie\nmen', 'token': 'variable', 'next': 'start'}, {'regex': '[^abcd]', 'token': 'comment', 'next': 'start'}], 'StateA': [{'regex': '[^c]', 'token': 'invalid', 'next': 'StateA'}, {'regex': 'c', 'token': 'keyword', 'next': 'StateA'}, {'regex': '$', 'token': 'invalid', 'next': 'StateE'}], 'StateB': [{'regex': '[^c]', 'token': 'variable', 'next': 'StateB'}, {'regex': '$', 'token': 'invalid', 'next': 'StateE'}], 'StateE': [{'regex': 'e', 'token': 'variable', 'next': 'start'}, {'regex': 'Test', 'token': 'comment'}]},
+    "rules1": {
+        "start": [
+            {"regex": "b", "token": "keyword", "next": "StateB"},
+            {"regex": "a", "token": "constant.character", "next": "StateA"},
+            {"regex": "[^abc]", "token": "comment", "next": "start"},
+        ],
+        "StateA": [
+            {"regex": "[^c]", "token": "invalid", "next": "StateA"},
+            {"regex": "c", "token": "keyword", "next": "StateA"},
+        ],
+        "StateB": [{"regex": "[^c]", "token": "variable", "next": "StateB"}],
+    },
+    "rules2": {
+        "start": [
+            {"regex": "b", "token": "keyword", "next": "StateB"},
+            {"regex": "ba", "token": "constant.character", "next": "StateA"},
+            {"regex": "[^abcd]", "token": "comment", "next": "start"},
+        ],
+        "StateA": [
+            {"regex": "[^c]", "token": "invalid", "next": "StateA"},
+            {"regex": "c", "token": "keyword", "next": "StateA"},
+        ],
+        "StateB": [{"regex": "[^c]", "token": "variable", "next": "StateB"}],
+    },
+    "rules3": {
+        "start": [
+            {"regex": "ba", "token": "constant.character", "next": "StateA"},
+            {"regex": "b", "token": "keyword", "next": "StateB"},
+            {"regex": "[^abcd]", "token": "comment", "next": "start"},
+        ],
+        "StateA": [
+            {"regex": "[^c]", "token": "invalid", "next": "StateA"},
+            {"regex": "c", "token": "keyword", "next": "StateA"},
+        ],
+        "StateB": [{"regex": "[^c]", "token": "variable", "next": "StateB"}],
+    },
+    "rules4": {
+        "start": [
+            {"regex": "[ac]", "token": "keyword", "next": "StateB"},
+            {"regex": "[bc]", "token": "constant.character", "next": "StateA"},
+            {"regex": "tie\nmen", "token": "variable", "next": "start"},
+            {"regex": "[^abcd]", "token": "comment", "next": "start"},
+        ],
+        "StateA": [
+            {"regex": "[^c]", "token": "invalid", "next": "StateA"},
+            {"regex": "c", "token": "keyword", "next": "StateA"},
+            {"regex": "$", "token": "invalid", "next": "StateE"},
+        ],
+        "StateB": [
+            {"regex": "[^c]", "token": "variable", "next": "StateB"},
+            {"regex": "$", "token": "invalid", "next": "StateE"},
+        ],
+        "StateE": [{"regex": "e", "token": "variable", "next": "start"}, {"regex": "Test", "token": "comment"}],
+    },
 }
 
 
 class HighlighterTestLeveLSimulation(HighlightTester):
-
     def assert_highlighted_chr(self, code, expected, rule_name, start_token="start", last_state="start"):
 
         rules = RULES[rule_name]
 
         self.check(code, expected, rules, start_token, last_state)
 
-
-
     def test_1(self):
-        self.assert_highlighted_chr(
-            "qmczqdqaqmcqbadqcc",
-            "CCTCCCCSIIKIIIIIKK",
-            rule_name="rules1",last_state="StateA")
+        self.assert_highlighted_chr("qmczqdqaqmcqbadqcc", "CCTCCCCSIIKIIIIIKK", rule_name="rules1", last_state="StateA")
 
     def test_2(self):
-        self.assert_highlighted_chr(
-            "qmczqdqbqmcqbadqcc",
-            "CCTCCCCKNNTNNNNNTT",
-            rule_name="rules1",last_state="StateB")
-
-
+        self.assert_highlighted_chr("qmczqdqbqmcqbadqcc", "CCTCCCCKNNTNNNNNTT", rule_name="rules1", last_state="StateB")
 
     def test_3(self):
         self.assert_highlighted_chr(
-            "qmaaqgbeveqmcbazqdqaqmcqbadqcc",
-            "CCTTCCKNNNNNTNNNNNNNNNTNNNNNTT",
-            rule_name="rules2",last_state="StateB")
+            "qmaaqgbeveqmcbazqdqaqmcqbadqcc", "CCTTCCKNNNNNTNNNNNNNNNTNNNNNTT", rule_name="rules2", last_state="StateB"
+        )
 
     def test_4(self):
         self.assert_highlighted_chr(
             "qmaaqgbaeveqmcbazqdqaqmcqbadqcc",
             "CCTTCCKNNNNNNTNNNNNNNNNTNNNNNTT",
-            rule_name="rules2",last_state="StateB")
+            rule_name="rules2",
+            last_state="StateB",
+        )
 
     def test_5(self):
         self.assert_highlighted_chr(
-            "qmaaqgbeveqmcbazqdqaqmcqbadqcc",
-            "CCTTCCKNNNNNTNNNNNNNNNTNNNNNTT",
-            rule_name="rules3",last_state="StateB")
+            "qmaaqgbeveqmcbazqdqaqmcqbadqcc", "CCTTCCKNNNNNTNNNNNNNNNTNNNNNTT", rule_name="rules3", last_state="StateB"
+        )
 
     def test_6(self):
         self.assert_highlighted_chr(
             "qmaaqgbaeveqmcbazqdqaqmcqbadqcc",
             "CCTTCCSSIIIIIKIIIIIIIIIKIIIIIKK",
-            rule_name="rules3",last_state="StateA")
-
-
-
-
-
+            rule_name="rules3",
+            last_state="StateA",
+        )
 
     def test_7(self):
         self.assert_highlighted_chr(
             "qmczqdqaqmcqbadq\ngrbnorbTestananaeqwswsmsazqdqaqmcqbadqcc\ngrbnorbTestananaeqwswsmsazqdqaqmcqbadqcc\n\ngrbnorbTestananaeqwswsmsbzqdqaqmcqbadqcc\ngrbnorbTestananaeqwswsmsazqdqaqmcqbadqcc\n\ngrbnorbTestananaeqwswsmsbzqdqaqmcqbadqcc",
             "CCKNNNNNNNTNNNNN\nNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNTNNNNNTT\nTTTTTTTCCCCTTTTTNCCCCCCCKNNNNNNNTNNNNNTT\n\nTTTTTTTCCCCTTTTTNCCCCCCCSIIIIIIIKIIIIIKK\nIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIKIIIIIKK\n\nTTTTTTTCCCCTTTTTNCCCCCCCSIIIIIIIKIIIIIKK",
-            rule_name="rules4",last_state="StateA")
-
-
-
-
+            rule_name="rules4",
+            last_state="StateA",
+        )

--- a/tests/test_highlighting/test_if_block.py
+++ b/tests/test_highlighting/test_if_block.py
@@ -1,349 +1,307 @@
 from tests.Highlighter import HighlightTester
 from parameterized import parameterized
 
+
 class HighlighterTestIfBlock(HighlightTester):
-
-
-
-    @parameterized.expand([
-        ("level8"),
-        ("level9"),
-        ("level10"),
-        ("level11"),
-        ("level12"),
-        ("level13"),
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-    ])
+    @parameterized.expand(
+        [
+            ("level8"),
+            ("level9"),
+            ("level10"),
+            ("level11"),
+            ("level12"),
+            ("level13"),
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+        ]
+    )
     def test_if_is1(self, level):
-        self.assert_highlighted_chr(
-            "if answer is yes",
-            "KK TTTTTT KK TTT",
-            level=level, lang="en")
+        self.assert_highlighted_chr("if answer is yes", "KK TTTTTT KK TTT", level=level, lang="en")
 
-    @parameterized.expand([
-        ("level8"),
-        ("level9"),
-        ("level10"),
-        ("level11"),
-        ("level12"),
-        ("level13"),
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-    ])
+    @parameterized.expand(
+        [
+            ("level8"),
+            ("level9"),
+            ("level10"),
+            ("level11"),
+            ("level12"),
+            ("level13"),
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+        ]
+    )
     def test_if_is2(self, level):
-        self.assert_highlighted_chr(
-            "if answer is 'yes'",
-            "KK TTTTTT KK SSSSS",
-            level=level, lang="en")
+        self.assert_highlighted_chr("if answer is 'yes'", "KK TTTTTT KK SSSSS", level=level, lang="en")
 
-    @parameterized.expand([
-        ("level8"),
-        ("level9"),
-        ("level10"),
-        ("level11"),
-        ("level12"),
-        ("level13"),
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-    ])
+    @parameterized.expand(
+        [
+            ("level8"),
+            ("level9"),
+            ("level10"),
+            ("level11"),
+            ("level12"),
+            ("level13"),
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+        ]
+    )
     def test_if_is3(self, level):
-        self.assert_highlighted_chr(
-            "if answer is 4242",
-            "KK TTTTTT KK NNNN",
-            level=level, lang="en")
+        self.assert_highlighted_chr("if answer is 4242", "KK TTTTTT KK NNNN", level=level, lang="en")
 
-
-    @parameterized.expand([
-        ("level8"),
-        ("level9"),
-        ("level10"),
-        ("level11"),
-        ("level12"),
-        ("level13"),
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-    ])
+    @parameterized.expand(
+        [
+            ("level8"),
+            ("level9"),
+            ("level10"),
+            ("level11"),
+            ("level12"),
+            ("level13"),
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+        ]
+    )
     def test_if_eq1(self, level):
-        self.assert_highlighted_chr(
-            "if answer == yes",
-            "KK TTTTTT KK TTT",
-            level=level, lang="en")
+        self.assert_highlighted_chr("if answer == yes", "KK TTTTTT KK TTT", level=level, lang="en")
 
-    @parameterized.expand([
-        ("level8"),
-        ("level9"),
-        ("level10"),
-        ("level11"),
-        ("level12"),
-        ("level13"),
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-    ])
+    @parameterized.expand(
+        [
+            ("level8"),
+            ("level9"),
+            ("level10"),
+            ("level11"),
+            ("level12"),
+            ("level13"),
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+        ]
+    )
     def test_if_eq2(self, level):
-        self.assert_highlighted_chr(
-            "if answer == 'yes'",
-            "KK TTTTTT KK SSSSS",
-            level=level, lang="en")
+        self.assert_highlighted_chr("if answer == 'yes'", "KK TTTTTT KK SSSSS", level=level, lang="en")
 
-    @parameterized.expand([
-        ("level8"),
-        ("level9"),
-        ("level10"),
-        ("level11"),
-        ("level12"),
-        ("level13"),
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-    ])
+    @parameterized.expand(
+        [
+            ("level8"),
+            ("level9"),
+            ("level10"),
+            ("level11"),
+            ("level12"),
+            ("level13"),
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+        ]
+    )
     def test_if_eq3(self, level):
-        self.assert_highlighted_chr(
-            "if answer == 4242",
-            "KK TTTTTT KK NNNN",
-            level=level, lang="en")
+        self.assert_highlighted_chr("if answer == 4242", "KK TTTTTT KK NNNN", level=level, lang="en")
 
-
-    @parameterized.expand([
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-    ])
+    @parameterized.expand(
+        [
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+        ]
+    )
     def test_if_diff1(self, level):
-        self.assert_highlighted_chr(
-            "if answer != yes",
-            "KK TTTTTT KK TTT",
-            level=level, lang="en")
+        self.assert_highlighted_chr("if answer != yes", "KK TTTTTT KK TTT", level=level, lang="en")
 
-    @parameterized.expand([
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-    ])
+    @parameterized.expand(
+        [
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+        ]
+    )
     def test_if_diff2(self, level):
-        self.assert_highlighted_chr(
-            "if answer != 'yes'",
-            "KK TTTTTT KK SSSSS",
-            level=level, lang="en")
+        self.assert_highlighted_chr("if answer != 'yes'", "KK TTTTTT KK SSSSS", level=level, lang="en")
 
-    @parameterized.expand([
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-    ])
+    @parameterized.expand(
+        [
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+        ]
+    )
     def test_if_diff3(self, level):
-        self.assert_highlighted_chr(
-            "if answer != 4242",
-            "KK TTTTTT KK NNNN",
-            level=level, lang="en")
+        self.assert_highlighted_chr("if answer != 4242", "KK TTTTTT KK NNNN", level=level, lang="en")
 
-
-
-    @parameterized.expand([
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-    ])
+    @parameterized.expand(
+        [
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+        ]
+    )
     def test_if_sup1(self, level):
-        self.assert_highlighted_chr(
-            "if answer <= yes",
-            "KK TTTTTT KK TTT",
-            level=level, lang="en")
+        self.assert_highlighted_chr("if answer <= yes", "KK TTTTTT KK TTT", level=level, lang="en")
 
-    @parameterized.expand([
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-    ])
+    @parameterized.expand(
+        [
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+        ]
+    )
     def test_if_sup2(self, level):
-        self.assert_highlighted_chr(
-            "if answer <= 'yes'",
-            "KK TTTTTT KK SSSSS",
-            level=level, lang="en")
+        self.assert_highlighted_chr("if answer <= 'yes'", "KK TTTTTT KK SSSSS", level=level, lang="en")
 
-    @parameterized.expand([
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-    ])
+    @parameterized.expand(
+        [
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+        ]
+    )
     def test_if_sup3(self, level):
-        self.assert_highlighted_chr(
-            "if answer <= 4242",
-            "KK TTTTTT KK NNNN",
-            level=level, lang="en")
+        self.assert_highlighted_chr("if answer <= 4242", "KK TTTTTT KK NNNN", level=level, lang="en")
 
-
-
-    @parameterized.expand([
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-    ])
+    @parameterized.expand(
+        [
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+        ]
+    )
     def test_if_inf1(self, level):
-        self.assert_highlighted_chr(
-            "if answer >= yes",
-            "KK TTTTTT KK TTT",
-            level=level, lang="en")
+        self.assert_highlighted_chr("if answer >= yes", "KK TTTTTT KK TTT", level=level, lang="en")
 
-    @parameterized.expand([
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-    ])
+    @parameterized.expand(
+        [
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+        ]
+    )
     def test_if_inf2(self, level):
-        self.assert_highlighted_chr(
-            "if answer >= 'yes'",
-            "KK TTTTTT KK SSSSS",
-            level=level, lang="en")
+        self.assert_highlighted_chr("if answer >= 'yes'", "KK TTTTTT KK SSSSS", level=level, lang="en")
 
-    @parameterized.expand([
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-    ])
+    @parameterized.expand(
+        [
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+        ]
+    )
     def test_if_inf3(self, level):
-        self.assert_highlighted_chr(
-            "if answer >= 4242",
-            "KK TTTTTT KK NNNN",
-            level=level, lang="en")
+        self.assert_highlighted_chr("if answer >= 4242", "KK TTTTTT KK NNNN", level=level, lang="en")
 
-
-    @parameterized.expand([
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-    ])
+    @parameterized.expand(
+        [
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+        ]
+    )
     def test_if_in1(self, level):
-        self.assert_highlighted_chr(
-            "if answer in yes",
-            "KK TTTTTT KK TTT",
-            level=level, lang="en")
+        self.assert_highlighted_chr("if answer in yes", "KK TTTTTT KK TTT", level=level, lang="en")
 
-    @parameterized.expand([
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-    ])
+    @parameterized.expand(
+        [
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+        ]
+    )
     def test_if_in2(self, level):
-        self.assert_highlighted_chr(
-            "if answer in 'yes'",
-            "KK TTTTTT KK SSSSS",
-            level=level, lang="en")
+        self.assert_highlighted_chr("if answer in 'yes'", "KK TTTTTT KK SSSSS", level=level, lang="en")
 
-    @parameterized.expand([
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-    ])
+    @parameterized.expand(
+        [
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+        ]
+    )
     def test_if_in3(self, level):
-        self.assert_highlighted_chr(
-            "if answer in 4242",
-            "KK TTTTTT KK NNNN",
-            level=level, lang="en")
+        self.assert_highlighted_chr("if answer in 4242", "KK TTTTTT KK NNNN", level=level, lang="en")
 
-
-
-
-
-
-    @parameterized.expand([
-        ("level8"),
-        ("level9"),
-        ("level10"),
-        ("level11"),
-        ("level12"),
-        ("level13"),
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-    ])
+    @parameterized.expand(
+        [
+            ("level8"),
+            ("level9"),
+            ("level10"),
+            ("level11"),
+            ("level12"),
+            ("level13"),
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+        ]
+    )
     def test_else(self, level):
-        self.assert_highlighted_chr(
-            "else",
-            "KKKK",
-            level=level, lang="en")
+        self.assert_highlighted_chr("else", "KKKK", level=level, lang="en")
 
-
-
-
-
-
-
-
-
-    @parameterized.expand([
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-    ])
+    @parameterized.expand(
+        [
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+        ]
+    )
     def test_if_is1_or(self, level):
         self.assert_highlighted_chr(
-            "if answer is var or answer is 'yes'",
-            "KK TTTTTT KK TTT KK TTTTTT KK SSSSS",
-            level=level, lang="en")
+            "if answer is var or answer is 'yes'", "KK TTTTTT KK TTT KK TTTTTT KK SSSSS", level=level, lang="en"
+        )
 
-
-    @parameterized.expand([
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-    ])
+    @parameterized.expand(
+        [
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+        ]
+    )
     def test_if_is2_and(self, level):
         self.assert_highlighted_chr(
-            "if answer is 246 and answer is 'yes'",
-            "KK TTTTTT KK NNN KKK TTTTTT KK SSSSS",
-            level=level, lang="en")
+            "if answer is 246 and answer is 'yes'", "KK TTTTTT KK NNN KKK TTTTTT KK SSSSS", level=level, lang="en"
+        )
 
-
-    @parameterized.expand([
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-    ])
+    @parameterized.expand(
+        [
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+        ]
+    )
     def test_if_eq1_or(self, level):
         self.assert_highlighted_chr(
-            "if answer == var or answer != 'yes'",
-            "KK TTTTTT KK TTT KK TTTTTT KK SSSSS",
-            level=level, lang="en")
+            "if answer == var or answer != 'yes'", "KK TTTTTT KK TTT KK TTTTTT KK SSSSS", level=level, lang="en"
+        )
 
-
-    @parameterized.expand([
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-    ])
+    @parameterized.expand(
+        [
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+        ]
+    )
     def test_if_eq2_and(self, level):
         self.assert_highlighted_chr(
-            "if answer != 246 and answer == 'yes'",
-            "KK TTTTTT KK NNN KKK TTTTTT KK SSSSS",
-            level=level, lang="en")
-
-
+            "if answer != 246 and answer == 'yes'", "KK TTTTTT KK NNN KKK TTTTTT KK SSSSS", level=level, lang="en"
+        )

--- a/tests/test_highlighting/test_if_inline.py
+++ b/tests/test_highlighting/test_if_inline.py
@@ -1,113 +1,105 @@
 from tests.Highlighter import HighlightTester
 from parameterized import parameterized
 
-class HighlighterTestIfInline(HighlightTester):
 
-    @parameterized.expand([
-        ("level5"),
-        ("level6"),
-        ("level7"),
-    ])
+class HighlighterTestIfInline(HighlightTester):
+    @parameterized.expand(
+        [
+            ("level5"),
+            ("level6"),
+            ("level7"),
+        ]
+    )
     def test_if_print(self, level):
         self.assert_highlighted_chr(
             "if cat is chat print 'Terrific!' var at random",
             "KK TTT KK TTTT KKKKK SSSSSSSSSSS TTT KK KKKKKK",
-            level=level, lang="en")
-
+            level=level,
+            lang="en",
+        )
 
     def test_if_affectation1(self):
-        self.assert_highlighted_chr(
-            "if cat is 666 price is 5",
-            "KK TTT KK TTT TTTTT KK T",
-            level="level5", lang="en")
+        self.assert_highlighted_chr("if cat is 666 price is 5", "KK TTT KK TTT TTTTT KK T", level="level5", lang="en")
 
-    @parameterized.expand([
-        ("level6"),
-        ("level7"),
-    ])
+    @parameterized.expand(
+        [
+            ("level6"),
+            ("level7"),
+        ]
+    )
     def test_if_affectation2(self, level):
-        self.assert_highlighted_chr(
-            "if cat is 666 price is 5",
-            "KK TTT KK NNN TTTTT KK N",
-            level=level, lang="en")
+        self.assert_highlighted_chr("if cat is 666 price is 5", "KK TTT KK NNN TTTTT KK N", level=level, lang="en")
 
-    @parameterized.expand([
-        ("level6"),
-        ("level7"),
-    ])
+    @parameterized.expand(
+        [
+            ("level6"),
+            ("level7"),
+        ]
+    )
     def test_if_affectation3(self, level):
         self.assert_highlighted_chr(
-            "if cat is 666 price = 5 + 42",
-            "KK TTT KK NNN TTTTT K N K NN",
-            level=level, lang="en")
+            "if cat is 666 price = 5 + 42", "KK TTT KK NNN TTTTT K N K NN", level=level, lang="en"
+        )
 
-
-    @parameterized.expand([
-        ("level5"),
-        ("level6"),
-        ("level7"),
-    ])
+    @parameterized.expand(
+        [
+            ("level5"),
+            ("level6"),
+            ("level7"),
+        ]
+    )
     def test_if_else_print(self, level):
         self.assert_highlighted_chr(
             "if anything is no print 'Thats it!' goodanswer at random else print 'One ' anything at random",
             "KK TTTTTTTT KK TT KKKKK SSSSSSSSSSS TTTTTTTTTT KK KKKKKK KKKK KKKKK SSSSSS TTTTTTTT KK KKKKKK",
-            level=level, lang="en")
+            level=level,
+            lang="en",
+        )
 
-
-
-
-    @parameterized.expand([
-        ("level5"),
-        ("level6"),
-        ("level7"),
-    ])
+    @parameterized.expand(
+        [
+            ("level5"),
+            ("level6"),
+            ("level7"),
+        ]
+    )
     def test_if_else_is(self, level):
         self.assert_highlighted_chr(
             "if anything is no var is test else var is azerty",
             "KK TTTTTTTT KK TT TTT KK TTTT KKKK TTT KK TTTTTT",
-            level=level, lang="en")
+            level=level,
+            lang="en",
+        )
 
-
-
-
-
-
-    @parameterized.expand([
-        ("level5"),
-        ("level6"),
-        ("level7"),
-    ])
+    @parameterized.expand(
+        [
+            ("level5"),
+            ("level6"),
+            ("level7"),
+        ]
+    )
     def test_else_print(self, level):
         self.assert_highlighted_chr(
             "else print 'Oh no! You are being eaten by a...' monsters at random",
             "KKKK KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS TTTTTTTT KK KKKKKK",
-            level=level, lang="en")
+            level=level,
+            lang="en",
+        )
 
-
-    @parameterized.expand([
-        ("level6"),
-        ("level7"),
-    ])
+    @parameterized.expand(
+        [
+            ("level6"),
+            ("level7"),
+        ]
+    )
     def test_else_math(self, level):
-        self.assert_highlighted_chr(
-            "else price = 5 + 42",
-            "KKKK TTTTT K N K NN",
-            level=level, lang="en")
+        self.assert_highlighted_chr("else price = 5 + 42", "KKKK TTTTT K N K NN", level=level, lang="en")
 
-    @parameterized.expand([
-        ("level6"),
-        ("level7"),
-    ])
+    @parameterized.expand(
+        [
+            ("level6"),
+            ("level7"),
+        ]
+    )
     def test_else_is(self, level):
-        self.assert_highlighted_chr(
-            "else price is 5",
-            "KKKK TTTTT KK N",
-            level=level, lang="en")
-
-
-
-
-
-
-
-
+        self.assert_highlighted_chr("else price is 5", "KKKK TTTTT KK N", level=level, lang="en")

--- a/tests/test_highlighting/test_input.py
+++ b/tests/test_highlighting/test_input.py
@@ -1,60 +1,53 @@
 from tests.Highlighter import HighlightTester
 from parameterized import parameterized
 
+
 class HighlighterTestInput(HighlightTester):
-
-
-    @parameterized.expand([
-        ("level2"),
-        ("level3"),
-    ])
+    @parameterized.expand(
+        [
+            ("level2"),
+            ("level3"),
+        ]
+    )
     def test_is(self, level):
-        self.assert_highlighted_chr(
-            "sword is ask l ost",
-            "TTTTT KK KKK T TTT",
-            level=level, lang="en")
+        self.assert_highlighted_chr("sword is ask l ost", "TTTTT KK KKK T TTT", level=level, lang="en")
 
-
-    @parameterized.expand([
-        ("level4"),
-        ("level5"),
-        ("level6"),
-        ("level7"),
-        ("level8"),
-        ("level9"),
-        ("level10"),
-        ("level11"),
-        ("level12"),
-        ("level13"),
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-    ])
+    @parameterized.expand(
+        [
+            ("level4"),
+            ("level5"),
+            ("level6"),
+            ("level7"),
+            ("level8"),
+            ("level9"),
+            ("level10"),
+            ("level11"),
+            ("level12"),
+            ("level13"),
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+        ]
+    )
     def test_is_string(self, level):
-        self.assert_highlighted_chr(
-            "sword is ask 'lo R st'",
-            "TTTTT KK KKK SSSSSSSSS",
-            level=level, lang="en")
+        self.assert_highlighted_chr("sword is ask 'lo R st'", "TTTTT KK KKK SSSSSSSSS", level=level, lang="en")
 
-
-    @parameterized.expand([
-        ("level6"),
-        ("level7"),
-        ("level8"),
-        ("level9"),
-        ("level10"),
-        ("level11"),
-        ("level12"),
-        ("level13"),
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-    ])
+    @parameterized.expand(
+        [
+            ("level6"),
+            ("level7"),
+            ("level8"),
+            ("level9"),
+            ("level10"),
+            ("level11"),
+            ("level12"),
+            ("level13"),
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+        ]
+    )
     def test_is_string_equal(self, level):
-        self.assert_highlighted_chr(
-            "sword = ask 'lo st'",
-            "TTTTT K KKK SSSSSSS",
-            level=level, lang="en")
-
+        self.assert_highlighted_chr("sword = ask 'lo st'", "TTTTT K KKK SSSSSSS", level=level, lang="en")

--- a/tests/test_highlighting/test_list.py
+++ b/tests/test_highlighting/test_list.py
@@ -1,220 +1,220 @@
 from tests.Highlighter import HighlightTester
 from parameterized import parameterized
 
+
 class HighlighterTestList(HighlightTester):
-
-
-    @parameterized.expand([
-        ("level3"),
-        ("level4"),
-    ])
+    @parameterized.expand(
+        [
+            ("level3"),
+            ("level4"),
+        ]
+    )
     def test_list(self, level):
-        self.assert_highlighted_chr(
-            "sword is l ost, 12, aver i",
-            "TTTTT KK TTTTTK TTK TTTTTT",
-            level=level, lang="en")
+        self.assert_highlighted_chr("sword is l ost, 12, aver i", "TTTTT KK TTTTTK TTK TTTTTT", level=level, lang="en")
 
-
-    @parameterized.expand([
-        ("level5"),
-        ("level6"),
-        ("level7"),
-        ("level8"),
-        ("level9"),
-        ("level10"),
-        ("level11"),
-        ("level12"),
-        ("level13"),
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-    ])
+    @parameterized.expand(
+        [
+            ("level5"),
+            ("level6"),
+            ("level7"),
+            ("level8"),
+            ("level9"),
+            ("level10"),
+            ("level11"),
+            ("level12"),
+            ("level13"),
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+        ]
+    )
     def test_list_string(self, level):
         self.assert_highlighted_chr(
-            "sword is 'l ost', '12', 'aver i'",
-            "TTTTT KK SSSSSSSK SSSSK SSSSSSSS",
-            level=level, lang="en")
+            "sword is 'l ost', '12', 'aver i'", "TTTTT KK SSSSSSSK SSSSK SSSSSSSS", level=level, lang="en"
+        )
 
-    @parameterized.expand([
-        ("level4"),
-    ])
+    @parameterized.expand(
+        [
+            ("level4"),
+        ]
+    )
     def test_list_string_unquote(self, level):
         self.assert_highlighted_chr(
-            "sword is 'l ost', '12', 'aver i'",
-            "TTTTT KK TTTTTTTK TTTTK TTTTTTTT",
-            level=level, lang="en")
+            "sword is 'l ost', '12', 'aver i'", "TTTTT KK TTTTTTTK TTTTK TTTTTTTT", level=level, lang="en"
+        )
 
-
-    @parameterized.expand([
-        ("level5"),
-        ("level6"),
-        ("level7"),
-        ("level8"),
-        ("level9"),
-        ("level10"),
-        ("level11"),
-    ])
+    @parameterized.expand(
+        [
+            ("level5"),
+            ("level6"),
+            ("level7"),
+            ("level8"),
+            ("level9"),
+            ("level10"),
+            ("level11"),
+        ]
+    )
     def test_list_string_smiley(self, level):
-        self.assert_highlighted_chr(
-            "variable is 🦔, 🦉, 🐿, 🦇",
-            "TTTTTTTT KK TK TK TK T",
-            level=level, lang="en")
+        self.assert_highlighted_chr("variable is 🦔, 🦉, 🐿, 🦇", "TTTTTTTT KK TK TK TK T", level=level, lang="en")
 
-
-
-    @parameterized.expand([
-        ("level6"),
-        ("level7"),
-        ("level8"),
-        ("level9"),
-        ("level10"),
-        ("level11"),
-        ("level12"),
-        ("level13"),
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-    ])
+    @parameterized.expand(
+        [
+            ("level6"),
+            ("level7"),
+            ("level8"),
+            ("level9"),
+            ("level10"),
+            ("level11"),
+            ("level12"),
+            ("level13"),
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+        ]
+    )
     def test_list_string_equ(self, level):
         self.assert_highlighted_chr(
-            "sword = 'lost', '1 2', 'ave ri'",
-            "TTTTT K SSSSSSK SSSSSK SSSSSSSS",
-            level=level, lang="en")
+            "sword = 'lost', '1 2', 'ave ri'", "TTTTT K SSSSSSK SSSSSK SSSSSSSS", level=level, lang="en"
+        )
 
-
-    @parameterized.expand([
-        ("level6"),
-        ("level7"),
-        ("level8"),
-        ("level9"),
-        ("level10"),
-        ("level11"),
-    ])
+    @parameterized.expand(
+        [
+            ("level6"),
+            ("level7"),
+            ("level8"),
+            ("level9"),
+            ("level10"),
+            ("level11"),
+        ]
+    )
     def test_list_string_equ_smiley(self, level):
-        self.assert_highlighted_chr(
-            "variable = 🦔, 🦉, 🐿, 🦇",
-            "TTTTTTTT K TK TK TK T",
-            level=level, lang="en")
+        self.assert_highlighted_chr("variable = 🦔, 🦉, 🐿, 🦇", "TTTTTTTT K TK TK TK T", level=level, lang="en")
 
-
-
-    @parameterized.expand([
-        ("level6"),
-        ("level7"),
-        ("level8"),
-        ("level9"),
-        ("level10"),
-        ("level11"),
-        ("level12"),
-        ("level13"),
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-    ])
+    @parameterized.expand(
+        [
+            ("level6"),
+            ("level7"),
+            ("level8"),
+            ("level9"),
+            ("level10"),
+            ("level11"),
+            ("level12"),
+            ("level13"),
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+        ]
+    )
     def test_list_number(self, level):
         self.assert_highlighted_chr(
             "sword is 'l ost', 12, 'aver i', 1 , 3, 3",
             "TTTTT KK SSSSSSSK NNK SSSSSSSSK N K NK N",
-            level=level, lang="en")
+            level=level,
+            lang="en",
+        )
 
-    @parameterized.expand([
-        ("level6"),
-        ("level7"),
-        ("level8"),
-        ("level9"),
-        ("level10"),
-        ("level11"),
-        ("level12"),
-        ("level13"),
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-    ])
+    @parameterized.expand(
+        [
+            ("level6"),
+            ("level7"),
+            ("level8"),
+            ("level9"),
+            ("level10"),
+            ("level11"),
+            ("level12"),
+            ("level13"),
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+        ]
+    )
     def test_list_number_equ(self, level):
         self.assert_highlighted_chr(
-            "sword = 'l ost', 12, 'aver i', 1 , 3, 3",
-            "TTTTT K SSSSSSSK NNK SSSSSSSSK N K NK N",
-            level=level, lang="en")
+            "sword = 'l ost', 12, 'aver i', 1 , 3, 3", "TTTTT K SSSSSSSK NNK SSSSSSSSK N K NK N", level=level, lang="en"
+        )
 
-
-    @parameterized.expand([
-        ("level12"),
-        ("level13"),
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-    ])
+    @parameterized.expand(
+        [
+            ("level12"),
+            ("level13"),
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+        ]
+    )
     def test_list_number_float(self, level):
         self.assert_highlighted_chr(
             "sword is 'l ost', 12, 'aver i', 1.97 , 3.5, 3",
             "TTTTT KK SSSSSSSK NNK SSSSSSSSK NNNN K NNNK N",
-            level=level, lang="en")
+            level=level,
+            lang="en",
+        )
 
-    @parameterized.expand([
-        ("level12"),
-        ("level13"),
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-    ])
+    @parameterized.expand(
+        [
+            ("level12"),
+            ("level13"),
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+        ]
+    )
     def test_list_number_equ_float(self, level):
         self.assert_highlighted_chr(
             "sword = 'l ost', 12, 'aver i', 1.97 , 3.5, 3",
             "TTTTT K SSSSSSSK NNK SSSSSSSSK NNNN K NNNK N",
-            level=level, lang="en")
+            level=level,
+            lang="en",
+        )
 
-
-
-
-
-    @parameterized.expand([
-        ("level3"),
-        ("level4"),
-        ("level5"),
-        ("level6"),
-        ("level7"),
-        ("level8"),
-        ("level9"),
-        ("level10"),
-        ("level11"),
-        ("level12"),
-        ("level13"),
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-    ])
+    @parameterized.expand(
+        [
+            ("level3"),
+            ("level4"),
+            ("level5"),
+            ("level6"),
+            ("level7"),
+            ("level8"),
+            ("level9"),
+            ("level10"),
+            ("level11"),
+            ("level12"),
+            ("level13"),
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+        ]
+    )
     def test_list_add(self, level):
-        self.assert_highlighted_chr(
-            "add penguin to animals",
-            "KKK TTTTTTT KK TTTTTTT",
-            level=level, lang="en")
+        self.assert_highlighted_chr("add penguin to animals", "KKK TTTTTTT KK TTTTTTT", level=level, lang="en")
 
-    @parameterized.expand([
-        ("level3"),
-        ("level4"),
-        ("level5"),
-        ("level6"),
-        ("level7"),
-        ("level8"),
-        ("level9"),
-        ("level10"),
-        ("level11"),
-        ("level12"),
-        ("level13"),
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-    ])
+    @parameterized.expand(
+        [
+            ("level3"),
+            ("level4"),
+            ("level5"),
+            ("level6"),
+            ("level7"),
+            ("level8"),
+            ("level9"),
+            ("level10"),
+            ("level11"),
+            ("level12"),
+            ("level13"),
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+        ]
+    )
     def test_list_remove(self, level):
         self.assert_highlighted_chr(
-            "remove allergies from flavors",
-            "KKKKKK TTTTTTTTT KKKK TTTTTTT",
-            level=level, lang="en")
+            "remove allergies from flavors", "KKKKKK TTTTTTTTT KKKK TTTTTTT", level=level, lang="en"
+        )

--- a/tests/test_highlighting/test_numbers.py
+++ b/tests/test_highlighting/test_numbers.py
@@ -1,231 +1,209 @@
 from tests.Highlighter import HighlightTester
 from parameterized import parameterized
 
+
 class HighlighterTestNumbers(HighlightTester):
-
-
-    @parameterized.expand([
-        ("level6"),
-        ("level7"),
-        ("level8"),
-        ("level9"),
-        ("level10"),
-        ("level11"),
-        ("level12"),
-        ("level13"),
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-    ])
+    @parameterized.expand(
+        [
+            ("level6"),
+            ("level7"),
+            ("level8"),
+            ("level9"),
+            ("level10"),
+            ("level11"),
+            ("level12"),
+            ("level13"),
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+        ]
+    )
     def test_nb_is_number(self, level):
-        self.assert_highlighted_chr(
-            "sword is 12346",
-            "TTTTT KK NNNNN",
-            level=level, lang="en")
+        self.assert_highlighted_chr("sword is 12346", "TTTTT KK NNNNN", level=level, lang="en")
 
-    @parameterized.expand([
-        ("level6"),
-        ("level7"),
-        ("level8"),
-        ("level9"),
-        ("level10"),
-        ("level11"),
-        ("level12"),
-        ("level13"),
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-    ])
+    @parameterized.expand(
+        [
+            ("level6"),
+            ("level7"),
+            ("level8"),
+            ("level9"),
+            ("level10"),
+            ("level11"),
+            ("level12"),
+            ("level13"),
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+        ]
+    )
     def test_nb_is_number_equal(self, level):
-        self.assert_highlighted_chr(
-            "sword = 12346",
-            "TTTTT K NNNNN",
-            level=level, lang="en")
+        self.assert_highlighted_chr("sword = 12346", "TTTTT K NNNNN", level=level, lang="en")
 
-    @parameterized.expand([
-        ("level12"),
-        ("level13"),
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-    ])
+    @parameterized.expand(
+        [
+            ("level12"),
+            ("level13"),
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+        ]
+    )
     def test_nb_is_number_float(self, level):
-        self.assert_highlighted_chr(
-            "sword = 123.46",
-            "TTTTT K NNNNNN",
-            level=level, lang="en")
+        self.assert_highlighted_chr("sword = 123.46", "TTTTT K NNNNNN", level=level, lang="en")
 
-    @parameterized.expand([
-        ("level12"),
-        ("level13"),
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-    ])
+    @parameterized.expand(
+        [
+            ("level12"),
+            ("level13"),
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+        ]
+    )
     def test_nb_is_number_equal_float(self, level):
-        self.assert_highlighted_chr(
-            "sword is 123.46",
-            "TTTTT KK NNNNNN",
-            level=level, lang="en")
+        self.assert_highlighted_chr("sword is 123.46", "TTTTT KK NNNNNN", level=level, lang="en")
 
-    @parameterized.expand([
-        ("level6"),
-        ("level7"),
-        ("level8"),
-        ("level9"),
-        ("level10"),
-        ("level11"),
-    ])
+    @parameterized.expand(
+        [
+            ("level6"),
+            ("level7"),
+            ("level8"),
+            ("level9"),
+            ("level10"),
+            ("level11"),
+        ]
+    )
     def test_nb_is_number_equal_float_unknow(self, level):
-        self.assert_highlighted_chr(
-            "sword = 123.46",
-            "TTTTT K NNNTTT",
-            level=level, lang="en")
+        self.assert_highlighted_chr("sword = 123.46", "TTTTT K NNNTTT", level=level, lang="en")
 
-
-    @parameterized.expand([
-        ("level6"),
-        ("level7"),
-        ("level8"),
-        ("level9"),
-        ("level10"),
-        ("level11"),
-        ("level12"),
-        ("level13"),
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-    ])
+    @parameterized.expand(
+        [
+            ("level6"),
+            ("level7"),
+            ("level8"),
+            ("level9"),
+            ("level10"),
+            ("level11"),
+            ("level12"),
+            ("level13"),
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+        ]
+    )
     def test_nb_is_number_equal_plus(self, level):
-        self.assert_highlighted_chr(
-            "sword = 12346 + 78564",
-            "TTTTT K NNNNN K NNNNN",
-            level=level, lang="en")
+        self.assert_highlighted_chr("sword = 12346 + 78564", "TTTTT K NNNNN K NNNNN", level=level, lang="en")
 
-
-    @parameterized.expand([
-        ("level12"),
-        ("level13"),
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-    ])
+    @parameterized.expand(
+        [
+            ("level12"),
+            ("level13"),
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+        ]
+    )
     def test_nb_is_number_equal_float_plus(self, level):
-        self.assert_highlighted_chr(
-            "sword = 123.46 + 7949.8",
-            "TTTTT K NNNNNN K NNNNNN",
-            level=level, lang="en")
+        self.assert_highlighted_chr("sword = 123.46 + 7949.8", "TTTTT K NNNNNN K NNNNNN", level=level, lang="en")
 
-
-    @parameterized.expand([
-        ("level6"),
-        ("level7"),
-        ("level8"),
-        ("level9"),
-        ("level10"),
-        ("level11"),
-        ("level12"),
-        ("level13"),
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-    ])
+    @parameterized.expand(
+        [
+            ("level6"),
+            ("level7"),
+            ("level8"),
+            ("level9"),
+            ("level10"),
+            ("level11"),
+            ("level12"),
+            ("level13"),
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+        ]
+    )
     def test_nb_is_number_equal_minus(self, level):
-        self.assert_highlighted_chr(
-            "sword = 12346 - 78564",
-            "TTTTT K NNNNN K NNNNN",
-            level=level, lang="en")
+        self.assert_highlighted_chr("sword = 12346 - 78564", "TTTTT K NNNNN K NNNNN", level=level, lang="en")
 
-
-    @parameterized.expand([
-        ("level12"),
-        ("level13"),
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-    ])
+    @parameterized.expand(
+        [
+            ("level12"),
+            ("level13"),
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+        ]
+    )
     def test_nb_is_number_equal_float_minus(self, level):
-        self.assert_highlighted_chr(
-            "sword = 123.46 - 7949.8",
-            "TTTTT K NNNNNN K NNNNNN",
-            level=level, lang="en")
+        self.assert_highlighted_chr("sword = 123.46 - 7949.8", "TTTTT K NNNNNN K NNNNNN", level=level, lang="en")
 
-
-
-    @parameterized.expand([
-        ("level6"),
-        ("level7"),
-        ("level8"),
-        ("level9"),
-        ("level10"),
-        ("level11"),
-        ("level12"),
-        ("level13"),
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-    ])
+    @parameterized.expand(
+        [
+            ("level6"),
+            ("level7"),
+            ("level8"),
+            ("level9"),
+            ("level10"),
+            ("level11"),
+            ("level12"),
+            ("level13"),
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+        ]
+    )
     def test_nb_is_number_equal_multi(self, level):
-        self.assert_highlighted_chr(
-            "sword = 12346 * 78564",
-            "TTTTT K NNNNN K NNNNN",
-            level=level, lang="en")
+        self.assert_highlighted_chr("sword = 12346 * 78564", "TTTTT K NNNNN K NNNNN", level=level, lang="en")
 
-
-    @parameterized.expand([
-        ("level12"),
-        ("level13"),
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-    ])
+    @parameterized.expand(
+        [
+            ("level12"),
+            ("level13"),
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+        ]
+    )
     def test_nb_is_number_equal_float_multi(self, level):
-        self.assert_highlighted_chr(
-            "sword = 123.46 * 7949.8",
-            "TTTTT K NNNNNN K NNNNNN",
-            level=level, lang="en")
+        self.assert_highlighted_chr("sword = 123.46 * 7949.8", "TTTTT K NNNNNN K NNNNNN", level=level, lang="en")
 
-    @parameterized.expand([
-        ("level6"),
-        ("level7"),
-        ("level8"),
-        ("level9"),
-        ("level10"),
-        ("level11"),
-        ("level12"),
-        ("level13"),
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-    ])
+    @parameterized.expand(
+        [
+            ("level6"),
+            ("level7"),
+            ("level8"),
+            ("level9"),
+            ("level10"),
+            ("level11"),
+            ("level12"),
+            ("level13"),
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+        ]
+    )
     def test_nb_is_number_equal_div(self, level):
-        self.assert_highlighted_chr(
-            "sword = 12346 / 78564",
-            "TTTTT K NNNNN K NNNNN",
-            level=level, lang="en")
+        self.assert_highlighted_chr("sword = 12346 / 78564", "TTTTT K NNNNN K NNNNN", level=level, lang="en")
 
-
-    @parameterized.expand([
-        ("level12"),
-        ("level13"),
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-    ])
+    @parameterized.expand(
+        [
+            ("level12"),
+            ("level13"),
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+        ]
+    )
     def test_nb_is_number_equal_float_div(self, level):
-        self.assert_highlighted_chr(
-            "sword = 123.46 / 7949.8",
-            "TTTTT K NNNNNN K NNNNNN",
-            level=level, lang="en")
+        self.assert_highlighted_chr("sword = 123.46 / 7949.8", "TTTTT K NNNNNN K NNNNNN", level=level, lang="en")

--- a/tests/test_highlighting/test_over_coloration.py
+++ b/tests/test_highlighting/test_over_coloration.py
@@ -1,182 +1,165 @@
 from tests.Highlighter import HighlightTester
 from parameterized import parameterized
 
+
 class HighlighterTestOverCol(HighlightTester):
-
-    @parameterized.expand([
-        ("level2"),
-        ("level3"),
-        ("level4"),
-        ("level5"),
-        ("level6"),
-        ("level7"),
-        ("level8"),
-        ("level9"),
-        ("level10"),
-        ("level11"),
-    ])
+    @parameterized.expand(
+        [
+            ("level2"),
+            ("level3"),
+            ("level4"),
+            ("level5"),
+            ("level6"),
+            ("level7"),
+            ("level8"),
+            ("level9"),
+            ("level10"),
+            ("level11"),
+        ]
+    )
     def test_is1(self, level):
-        self.assert_highlighted_chr(
-            "ask is lost",
-            "TTT KK TTTT",
-            level=level, lang="en")
+        self.assert_highlighted_chr("ask is lost", "TTT KK TTTT", level=level, lang="en")
 
-
-
-    @parameterized.expand([
-        ("level12"),
-        ("level13"),
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-    ])
+    @parameterized.expand(
+        [
+            ("level12"),
+            ("level13"),
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+        ]
+    )
     def test_is2(self, level):
-        self.assert_highlighted_chr(
-            "ask is 'lost'",
-            "TTT KK SSSSSS",
-            level=level, lang="en")
+        self.assert_highlighted_chr("ask is 'lost'", "TTT KK SSSSSS", level=level, lang="en")
 
-
-    @parameterized.expand([
-        ("level6"),
-        ("level7"),
-        ("level8"),
-        ("level9"),
-        ("level10"),
-        ("level11"),
-    ])
+    @parameterized.expand(
+        [
+            ("level6"),
+            ("level7"),
+            ("level8"),
+            ("level9"),
+            ("level10"),
+            ("level11"),
+        ]
+    )
     def test_Eq1(self, level):
-        self.assert_highlighted_chr(
-            "ask = lost",
-            "TTT K TTTT",
-            level=level, lang="en")
+        self.assert_highlighted_chr("ask = lost", "TTT K TTTT", level=level, lang="en")
 
-    @parameterized.expand([
-        ("level12"),
-        ("level13"),
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-    ])
+    @parameterized.expand(
+        [
+            ("level12"),
+            ("level13"),
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+        ]
+    )
     def test_Eq2(self, level):
-        self.assert_highlighted_chr(
-            "ask = 'lost'",
-            "TTT K SSSSSS",
-            level=level, lang="en")
+        self.assert_highlighted_chr("ask = 'lost'", "TTT K SSSSSS", level=level, lang="en")
 
-
-    @parameterized.expand([
-        ("level2"),
-        ("level3"),
-    ])
+    @parameterized.expand(
+        [
+            ("level2"),
+            ("level3"),
+        ]
+    )
     def test_print1(self, level):
-        self.assert_highlighted_chr(
-            "print hello world! ask",
-            "KKKKK TTTTTTTTTTTTTTTT",
-            level=level, lang="en")
+        self.assert_highlighted_chr("print hello world! ask", "KKKKK TTTTTTTTTTTTTTTT", level=level, lang="en")
 
-
-    @parameterized.expand([
-        ("level4"),
-        ("level5"),
-        ("level6"),
-        ("level7"),
-        ("level8"),
-        ("level9"),
-        ("level10"),
-        ("level11"),
-        ("level12"),
-        ("level13"),
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-    ])
+    @parameterized.expand(
+        [
+            ("level4"),
+            ("level5"),
+            ("level6"),
+            ("level7"),
+            ("level8"),
+            ("level9"),
+            ("level10"),
+            ("level11"),
+            ("level12"),
+            ("level13"),
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+        ]
+    )
     def test_print2(self, level):
-        self.assert_highlighted_chr(
-            "print 'hello world!' ask",
-            "KKKKK SSSSSSSSSSSSSS TTT",
-            level=level, lang="en")
+        self.assert_highlighted_chr("print 'hello world!' ask", "KKKKK SSSSSSSSSSSSSS TTT", level=level, lang="en")
 
-
-    @parameterized.expand([
-        ("level3"),
-        ("level4"),
-        ("level5"),
-        ("level6"),
-        ("level7"),
-        ("level8"),
-        ("level9"),
-        ("level10"),
-        ("level11"),
-        ("level12"),
-        ("level13"),
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-    ])
+    @parameterized.expand(
+        [
+            ("level3"),
+            ("level4"),
+            ("level5"),
+            ("level6"),
+            ("level7"),
+            ("level8"),
+            ("level9"),
+            ("level10"),
+            ("level11"),
+            ("level12"),
+            ("level13"),
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+        ]
+    )
     def test_at_prefix(self, level):
-        self.assert_highlighted_chr(
-            "print atoptis at random",
-            "KKKKK TTTTTTT KK KKKKKK",
-            level=level, lang='en')
+        self.assert_highlighted_chr("print atoptis at random", "KKKKK TTTTTTT KK KKKKKK", level=level, lang="en")
 
-
-    @parameterized.expand([
-        ("level3"),
-        ("level4"),
-        ("level5"),
-        ("level6"),
-        ("level7"),
-        ("level8"),
-        ("level9"),
-        ("level10"),
-        ("level11"),
-        ("level12"),
-        ("level13"),
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-    ])
+    @parameterized.expand(
+        [
+            ("level3"),
+            ("level4"),
+            ("level5"),
+            ("level6"),
+            ("level7"),
+            ("level8"),
+            ("level9"),
+            ("level10"),
+            ("level11"),
+            ("level12"),
+            ("level13"),
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+        ]
+    )
     def test_at_prefix_nl(self, level):
-        self.assert_highlighted_chr(
-            "print optis at random",
-            "KKKKK TTTTT KK KKKKKK",
-            level=level, lang='nl')
+        self.assert_highlighted_chr("print optis at random", "KKKKK TTTTT KK KKKKKK", level=level, lang="nl")
 
-
-    @parameterized.expand([
-        ("level3"),
-        ("level4"),
-    ])
+    @parameterized.expand(
+        [
+            ("level3"),
+            ("level4"),
+        ]
+    )
     def test_from_prefix(self, level):
         self.assert_highlighted_chr(
-            "remove fromyour_name from people",
-            "KKKKKK TTTTTTTTTTTTT KKKK TTTTTT",
-            level=level, lang='en')
+            "remove fromyour_name from people", "KKKKKK TTTTTTTTTTTTT KKKK TTTTTT", level=level, lang="en"
+        )
 
-
-    @parameterized.expand([
-        ("level3"),
-        ("level4"),
-    ])
+    @parameterized.expand(
+        [
+            ("level3"),
+            ("level4"),
+        ]
+    )
     def test_from_prefix_nl(self, level):
         self.assert_highlighted_chr(
-            "remove uitfromyour_name from people",
-            "KKKKKK TTTTTTTTTTTTTTTT KKKK TTTTTT",
-            level=level, lang='nl')
+            "remove uitfromyour_name from people", "KKKKKK TTTTTTTTTTTTTTTT KKKK TTTTTT", level=level, lang="nl"
+        )
 
-    @parameterized.expand([
-        ("level3"),
-        ("level4"),
-    ])
+    @parameterized.expand(
+        [
+            ("level3"),
+            ("level4"),
+        ]
+    )
     def test_to_prefix(self, level):
-        self.assert_highlighted_chr(
-            "add toanimal to animals",
-            "KKK TTTTTTTT KK TTTTTTT",
-            level=level, lang='en')
-
+        self.assert_highlighted_chr("add toanimal to animals", "KKK TTTTTTTT KK TTTTTTT", level=level, lang="en")

--- a/tests/test_highlighting/test_print.py
+++ b/tests/test_highlighting/test_print.py
@@ -1,330 +1,335 @@
 from tests.Highlighter import HighlightTester
 from parameterized import parameterized
 
+
 class HighlighterTestPrint(HighlightTester):
-
-    @parameterized.expand([
-        ("level1"),
-        ("level2"),
-        ("level3"),
-    ])
+    @parameterized.expand(
+        [
+            ("level1"),
+            ("level2"),
+            ("level3"),
+        ]
+    )
     def test_print1(self, level):
-        self.assert_highlighted_chr(
-            "print hello world!",
-            "KKKKK TTTTTTTTTTTT",
-            level=level, lang='en')
+        self.assert_highlighted_chr("print hello world!", "KKKKK TTTTTTTTTTTT", level=level, lang="en")
 
-    @parameterized.expand([
-        ("level4"),
-        ("level5"),
-        ("level6"),
-        ("level7"),
-        ("level8"),
-        ("level9"),
-        ("level10"),
-        ("level11"),
-        ("level12"),
-        ("level13"),
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-    ])
+    @parameterized.expand(
+        [
+            ("level4"),
+            ("level5"),
+            ("level6"),
+            ("level7"),
+            ("level8"),
+            ("level9"),
+            ("level10"),
+            ("level11"),
+            ("level12"),
+            ("level13"),
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+        ]
+    )
     def test_print2(self, level):
-        self.assert_highlighted_chr(
-            "print 'hello world!'",
-            "KKKKK SSSSSSSSSSSSSS",
-            level=level, lang='en')
+        self.assert_highlighted_chr("print 'hello world!'", "KKKKK SSSSSSSSSSSSSS", level=level, lang="en")
 
-
-    @parameterized.expand([
-        ("level4"),
-        ("level5"),
-        ("level6"),
-        ("level7"),
-        ("level8"),
-        ("level9"),
-        ("level10"),
-        ("level11"),
-        ("level12"),
-        ("level13"),
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-    ])
+    @parameterized.expand(
+        [
+            ("level4"),
+            ("level5"),
+            ("level6"),
+            ("level7"),
+            ("level8"),
+            ("level9"),
+            ("level10"),
+            ("level11"),
+            ("level12"),
+            ("level13"),
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+        ]
+    )
     def test_print_incomplete1(self, level):
         self.assert_highlighted_chr(
-            "print 'hello world!' var at random",
-            "KKKKK SSSSSSSSSSSSSS TTT KK KKKKKK",
-            level=level, lang='en')
+            "print 'hello world!' var at random", "KKKKK SSSSSSSSSSSSSS TTT KK KKKKKK", level=level, lang="en"
+        )
 
-    @parameterized.expand([
-        ("level4"),
-        ("level5"),
-        ("level6"),
-        ("level7"),
-        ("level8"),
-        ("level9"),
-        ("level10"),
-        ("level11"),
-        ("level12"),
-        ("level13"),
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-    ])
+    @parameterized.expand(
+        [
+            ("level4"),
+            ("level5"),
+            ("level6"),
+            ("level7"),
+            ("level8"),
+            ("level9"),
+            ("level10"),
+            ("level11"),
+            ("level12"),
+            ("level13"),
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+        ]
+    )
     def test_print_incomplete2(self, level):
         self.assert_highlighted_chr(
-            "print 'hello world! var at random",
-            "KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSSS",
-            level=level, lang='en')
+            "print 'hello world! var at random", "KKKKK SSSSSSSSSSSSSSSSSSSSSSSSSSS", level=level, lang="en"
+        )
 
-
-
-    @parameterized.expand([
-        ("level3"),
-        ("level4"),
-        ("level5"),
-        ("level6"),
-        ("level7"),
-        ("level8"),
-        ("level9"),
-        ("level10"),
-        ("level11"),
-        ("level12"),
-        ("level13"),
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-    ])
+    @parameterized.expand(
+        [
+            ("level3"),
+            ("level4"),
+            ("level5"),
+            ("level6"),
+            ("level7"),
+            ("level8"),
+            ("level9"),
+            ("level10"),
+            ("level11"),
+            ("level12"),
+            ("level13"),
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+        ]
+    )
     def test_print_random_alone(self, level):
-        self.assert_highlighted_chr(
-            "print animals at random",
-            "KKKKK TTTTTTT KK KKKKKK",
-            level=level, lang='en')
-
-
+        self.assert_highlighted_chr("print animals at random", "KKKKK TTTTTTT KK KKKKKK", level=level, lang="en")
 
     def test_print_random1(self):
         self.assert_highlighted_chr(
             "print people at random does the dishes",
             "KKKKK TTTTTT KK KKKKKK TTTTTTTTTTTTTTT",
-            level="level3", lang='en')
+            level="level3",
+            lang="en",
+        )
 
-    @parameterized.expand([
-        ("level4"),
-        ("level5"),
-        ("level6"),
-        ("level7"),
-        ("level8"),
-        ("level9"),
-        ("level10"),
-        ("level11"),
-        ("level12"),
-        ("level13"),
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-    ])
+    @parameterized.expand(
+        [
+            ("level4"),
+            ("level5"),
+            ("level6"),
+            ("level7"),
+            ("level8"),
+            ("level9"),
+            ("level10"),
+            ("level11"),
+            ("level12"),
+            ("level13"),
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+        ]
+    )
     def test_print_random2(self, level):
         self.assert_highlighted_chr(
             "print 'The' people at random 'does the dishes'",
             "KKKKK SSSSS TTTTTT KK KKKKKK SSSSSSSSSSSSSSSSS",
-            level=level, lang='en')
-
+            level=level,
+            lang="en",
+        )
 
     def test_print_at1(self):
         self.assert_highlighted_chr(
-            "print people at 3 does the dishes",
-            "KKKKK TTTTTT KK T TTTTTTTTTTTTTTT",
-            level="level3", lang='en')
+            "print people at 3 does the dishes", "KKKKK TTTTTT KK T TTTTTTTTTTTTTTT", level="level3", lang="en"
+        )
 
-    @parameterized.expand([
-        ("level4"),
-        ("level5"),
-    ])
+    @parameterized.expand(
+        [
+            ("level4"),
+            ("level5"),
+        ]
+    )
     def test_print_at2(self, level):
         self.assert_highlighted_chr(
             "print 'The' people at 3 'does the dishes'",
             "KKKKK SSSSS TTTTTT KK T SSSSSSSSSSSSSSSSS",
-            level=level, lang='en')
+            level=level,
+            lang="en",
+        )
 
-    @parameterized.expand([
-        ("level6"),
-        ("level7"),
-        ("level8"),
-        ("level9"),
-        ("level10"),
-        ("level11"),
-        ("level12"),
-        ("level13"),
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-    ])
+    @parameterized.expand(
+        [
+            ("level6"),
+            ("level7"),
+            ("level8"),
+            ("level9"),
+            ("level10"),
+            ("level11"),
+            ("level12"),
+            ("level13"),
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+        ]
+    )
     def test_print_at3(self, level):
         self.assert_highlighted_chr(
             "print 'The' people at 3 'does the dishes'",
             "KKKKK SSSSS TTTTTT KK N SSSSSSSSSSSSSSSSS",
-            level=level, lang='en')
-
+            level=level,
+            lang="en",
+        )
 
     def test_print_18_1(self):
-        self.assert_highlighted_chr(
-            "print ('Great job!!!')",
-            "KKKKK KSSSSSSSSSSSSSSK",
-            level="level18", lang='en')
+        self.assert_highlighted_chr("print ('Great job!!!')", "KKKKK KSSSSSSSSSSSSSSK", level="level18", lang="en")
 
     def test_print_18_2(self):
         self.assert_highlighted_chr(
             "print('my name is ', name, 'my name is ')",
             "KKKKKKSSSSSSSSSSSSSK TTTTK SSSSSSSSSSSSSK",
-            level="level18", lang='en')
+            level="level18",
+            lang="en",
+        )
 
-    @parameterized.expand([
-        ("level6"),
-        ("level7"),
-        ("level8"),
-        ("level9"),
-        ("level10"),
-        ("level11"),
-        ("level12"),
-        ("level13"),
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-    ])
+    @parameterized.expand(
+        [
+            ("level6"),
+            ("level7"),
+            ("level8"),
+            ("level9"),
+            ("level10"),
+            ("level11"),
+            ("level12"),
+            ("level13"),
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+        ]
+    )
     def test_print_number_equal_plus(self, level):
         self.assert_highlighted_chr(
-            "print 'answer is' 12346 + 78564",
-            "KKKKK SSSSSSSSSSS NNNNN K NNNNN",
-            level=level, lang="en")
+            "print 'answer is' 12346 + 78564", "KKKKK SSSSSSSSSSS NNNNN K NNNNN", level=level, lang="en"
+        )
 
-
-    @parameterized.expand([
-        ("level12"),
-        ("level13"),
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-    ])
+    @parameterized.expand(
+        [
+            ("level12"),
+            ("level13"),
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+        ]
+    )
     def test_print_number_equal_float_plus(self, level):
         self.assert_highlighted_chr(
-            "print 'answer is' 123.46 + 7949.8",
-            "KKKKK SSSSSSSSSSS NNNNNN K NNNNNN",
-            level=level, lang="en")
+            "print 'answer is' 123.46 + 7949.8", "KKKKK SSSSSSSSSSS NNNNNN K NNNNNN", level=level, lang="en"
+        )
 
-
-    @parameterized.expand([
-        ("level6"),
-        ("level7"),
-        ("level8"),
-        ("level9"),
-        ("level10"),
-        ("level11"),
-        ("level12"),
-        ("level13"),
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-    ])
+    @parameterized.expand(
+        [
+            ("level6"),
+            ("level7"),
+            ("level8"),
+            ("level9"),
+            ("level10"),
+            ("level11"),
+            ("level12"),
+            ("level13"),
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+        ]
+    )
     def test_print_number_equal_minus(self, level):
         self.assert_highlighted_chr(
-            "print 'answer is' 12346 - 78564",
-            "KKKKK SSSSSSSSSSS NNNNN K NNNNN",
-            level=level, lang="en")
+            "print 'answer is' 12346 - 78564", "KKKKK SSSSSSSSSSS NNNNN K NNNNN", level=level, lang="en"
+        )
 
-
-    @parameterized.expand([
-        ("level12"),
-        ("level13"),
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-    ])
+    @parameterized.expand(
+        [
+            ("level12"),
+            ("level13"),
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+        ]
+    )
     def test_print_number_equal_float_minus(self, level):
         self.assert_highlighted_chr(
-            "print 'answer is' 123.46 - 7949.8",
-            "KKKKK SSSSSSSSSSS NNNNNN K NNNNNN",
-            level=level, lang="en")
+            "print 'answer is' 123.46 - 7949.8", "KKKKK SSSSSSSSSSS NNNNNN K NNNNNN", level=level, lang="en"
+        )
 
-
-
-    @parameterized.expand([
-        ("level6"),
-        ("level7"),
-        ("level8"),
-        ("level9"),
-        ("level10"),
-        ("level11"),
-        ("level12"),
-        ("level13"),
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-    ])
+    @parameterized.expand(
+        [
+            ("level6"),
+            ("level7"),
+            ("level8"),
+            ("level9"),
+            ("level10"),
+            ("level11"),
+            ("level12"),
+            ("level13"),
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+        ]
+    )
     def test_print_number_equal_multi(self, level):
         self.assert_highlighted_chr(
-            "print 'answer is' 12346 * 78564",
-            "KKKKK SSSSSSSSSSS NNNNN K NNNNN",
-            level=level, lang="en")
+            "print 'answer is' 12346 * 78564", "KKKKK SSSSSSSSSSS NNNNN K NNNNN", level=level, lang="en"
+        )
 
-
-    @parameterized.expand([
-        ("level12"),
-        ("level13"),
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-    ])
+    @parameterized.expand(
+        [
+            ("level12"),
+            ("level13"),
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+        ]
+    )
     def test_print_number_equal_float_multi(self, level):
         self.assert_highlighted_chr(
-            "print 'answer is' 123.46 * 7949.8",
-            "KKKKK SSSSSSSSSSS NNNNNN K NNNNNN",
-            level=level, lang="en")
+            "print 'answer is' 123.46 * 7949.8", "KKKKK SSSSSSSSSSS NNNNNN K NNNNNN", level=level, lang="en"
+        )
 
-    @parameterized.expand([
-        ("level6"),
-        ("level7"),
-        ("level8"),
-        ("level9"),
-        ("level10"),
-        ("level11"),
-        ("level12"),
-        ("level13"),
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-    ])
+    @parameterized.expand(
+        [
+            ("level6"),
+            ("level7"),
+            ("level8"),
+            ("level9"),
+            ("level10"),
+            ("level11"),
+            ("level12"),
+            ("level13"),
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+        ]
+    )
     def test_print_number_equal_div(self, level):
         self.assert_highlighted_chr(
-            "print 'answer is' 12346 / 78564",
-            "KKKKK SSSSSSSSSSS NNNNN K NNNNN",
-            level=level, lang="en")
+            "print 'answer is' 12346 / 78564", "KKKKK SSSSSSSSSSS NNNNN K NNNNN", level=level, lang="en"
+        )
 
-
-    @parameterized.expand([
-        ("level12"),
-        ("level13"),
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-    ])
+    @parameterized.expand(
+        [
+            ("level12"),
+            ("level13"),
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+        ]
+    )
     def test_print_number_equal_float_div(self, level):
         self.assert_highlighted_chr(
-            "print 'answer is' 123.46 / 7949.8",
-            "KKKKK SSSSSSSSSSS NNNNNN K NNNNNN",
-            level=level, lang="en")
+            "print 'answer is' 123.46 / 7949.8", "KKKKK SSSSSSSSSSS NNNNNN K NNNNNN", level=level, lang="en"
+        )

--- a/tests/test_highlighting/test_repeat.py
+++ b/tests/test_highlighting/test_repeat.py
@@ -1,85 +1,85 @@
 from tests.Highlighter import HighlightTester
 from parameterized import parameterized
 
+
 class HighlighterTestRepeat(HighlightTester):
-
-
-    @parameterized.expand([
-        ("level7"),
-        ("level8"),
-        ("level9"),
-        ("level10"),
-        ("level11"),
-        ("level12"),
-        ("level13"),
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-        ("level18"),
-    ])
+    @parameterized.expand(
+        [
+            ("level7"),
+            ("level8"),
+            ("level9"),
+            ("level10"),
+            ("level11"),
+            ("level12"),
+            ("level13"),
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+            ("level18"),
+        ]
+    )
     def test_repeat_print(self, lang):
         self.assert_highlighted_chr(
-            "repeat 3 times print 'Hedy is fun!'",
-            'KKKKKK N KKKKK KKKKK SSSSSSSSSSSSSS',
-            level=lang, lang="en")
+            "repeat 3 times print 'Hedy is fun!'", "KKKKKK N KKKKK KKKKK SSSSSSSSSSSSSS", level=lang, lang="en"
+        )
 
-    @parameterized.expand([
-        ("level7"),
-        ("level8"),
-        ("level9"),
-        ("level10"),
-        ("level11"),
-        ("level12"),
-        ("level13"),
-        ("level14"),
-        ("level15"),
-        ("level16"),
-    ])
+    @parameterized.expand(
+        [
+            ("level7"),
+            ("level8"),
+            ("level9"),
+            ("level10"),
+            ("level11"),
+            ("level12"),
+            ("level13"),
+            ("level14"),
+            ("level15"),
+            ("level16"),
+        ]
+    )
     def test_repeat_ask(self, lang):
         self.assert_highlighted_chr(
             "repeat 3 times question is ask 'What do you want to know?'",
-            'KKKKKK N KKKKK TTTTTTTT KK KKK SSSSSSSSSSSSSSSSSSSSSSSSSSS',
-            level=lang, lang="en")
+            "KKKKKK N KKKKK TTTTTTTT KK KKK SSSSSSSSSSSSSSSSSSSSSSSSSSS",
+            level=lang,
+            lang="en",
+        )
 
-
-
-    @parameterized.expand([
-        ("level7"),
-        ("level8"),
-        ("level9"),
-        ("level10"),
-        ("level11"),
-        ("level12"),
-        ("level13"),
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-        ("level18"),
-    ])
+    @parameterized.expand(
+        [
+            ("level7"),
+            ("level8"),
+            ("level9"),
+            ("level10"),
+            ("level11"),
+            ("level12"),
+            ("level13"),
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+            ("level18"),
+        ]
+    )
     def test_repeat_alone(self, lang):
-        self.assert_highlighted_chr(
-            "repeat people times",
-            'KKKKKK TTTTTT KKKKK',
-            level=lang, lang="en")
+        self.assert_highlighted_chr("repeat people times", "KKKKKK TTTTTT KKKKK", level=lang, lang="en")
 
-    @parameterized.expand([
-        ("level7"),
-        ("level8"),
-        ("level9"),
-        ("level10"),
-        ("level11"),
-        ("level12"),
-        ("level13"),
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-        ("level18"),
-    ])
+    @parameterized.expand(
+        [
+            ("level7"),
+            ("level8"),
+            ("level9"),
+            ("level10"),
+            ("level11"),
+            ("level12"),
+            ("level13"),
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+            ("level18"),
+        ]
+    )
     def test_repeat_number(self, lang):
-        self.assert_highlighted_chr(
-            "repeat 99 times",
-            'KKKKKK NN KKKKK',
-            level=lang, lang="en")
+        self.assert_highlighted_chr("repeat 99 times", "KKKKKK NN KKKKK", level=lang, lang="en")

--- a/tests/test_highlighting/test_sleep.py
+++ b/tests/test_highlighting/test_sleep.py
@@ -1,87 +1,78 @@
 from tests.Highlighter import HighlightTester
 from parameterized import parameterized
 
+
 class HighlighterTestSleep(HighlightTester):
-
-
-    @parameterized.expand([
-        ("level2"),
-        ("level3"),
-        ("level4"),
-        ("level5"),
-        ("level6"),
-        ("level7"),
-        ("level8"),
-        ("level9"),
-        ("level10"),
-        ("level11"),
-        ("level12"),
-        ("level13"),
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-    ])
+    @parameterized.expand(
+        [
+            ("level2"),
+            ("level3"),
+            ("level4"),
+            ("level5"),
+            ("level6"),
+            ("level7"),
+            ("level8"),
+            ("level9"),
+            ("level10"),
+            ("level11"),
+            ("level12"),
+            ("level13"),
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+        ]
+    )
     def test_sleep_alone(self, level):
-        self.assert_highlighted_chr(
-            "sleep",
-            "KKKKK",
-            level=level, lang="en")
+        self.assert_highlighted_chr("sleep", "KKKKK", level=level, lang="en")
 
-
-
-    @parameterized.expand([
-        ("level2"),
-        ("level3"),
-        ("level4"),
-        ("level5"),
-    ])
+    @parameterized.expand(
+        [
+            ("level2"),
+            ("level3"),
+            ("level4"),
+            ("level5"),
+        ]
+    )
     def test_sleep(self, level):
-        self.assert_highlighted_chr(
-            "sleep 12",
-            "KKKKK TT",
-            level=level, lang="en")
+        self.assert_highlighted_chr("sleep 12", "KKKKK TT", level=level, lang="en")
 
-
-    @parameterized.expand([
-        ("level7"),
-        ("level8"),
-        ("level9"),
-        ("level10"),
-        ("level11"),
-        ("level12"),
-        ("level13"),
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-    ])
+    @parameterized.expand(
+        [
+            ("level7"),
+            ("level8"),
+            ("level9"),
+            ("level10"),
+            ("level11"),
+            ("level12"),
+            ("level13"),
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+        ]
+    )
     def test_sleep_number(self, level):
-        self.assert_highlighted_chr(
-            "sleep 12",
-            "KKKKK NN",
-            level=level, lang="en")
+        self.assert_highlighted_chr("sleep 12", "KKKKK NN", level=level, lang="en")
 
-
-    @parameterized.expand([
-        ("level2"),
-        ("level3"),
-        ("level4"),
-        ("level5"),
-        ("level7"),
-        ("level8"),
-        ("level9"),
-        ("level10"),
-        ("level11"),
-        ("level12"),
-        ("level13"),
-        ("level14"),
-        ("level15"),
-        ("level16"),
-        ("level17"),
-    ])
+    @parameterized.expand(
+        [
+            ("level2"),
+            ("level3"),
+            ("level4"),
+            ("level5"),
+            ("level7"),
+            ("level8"),
+            ("level9"),
+            ("level10"),
+            ("level11"),
+            ("level12"),
+            ("level13"),
+            ("level14"),
+            ("level15"),
+            ("level16"),
+            ("level17"),
+        ]
+    )
     def test_sleep_var(self, level):
-        self.assert_highlighted_chr(
-            "sleep var",
-            "KKKKK TTT",
-            level=level, lang="en")
+        self.assert_highlighted_chr("sleep var", "KKKKK TTT", level=level, lang="en")

--- a/tests/test_highlighting/test_turtle.py
+++ b/tests/test_highlighting/test_turtle.py
@@ -1,314 +1,271 @@
 from tests.Highlighter import HighlightTester
 from parameterized import parameterized
 
+
 class HighlighterTestTurtle(HighlightTester):
-
-    @parameterized.expand([
-        ("level1"),
-        ("level2"),
-        ("level3"),
-        ("level4"),
-        ("level5"),
-    ])
+    @parameterized.expand(
+        [
+            ("level1"),
+            ("level2"),
+            ("level3"),
+            ("level4"),
+            ("level5"),
+        ]
+    )
     def test_forward(self, level):
-        self.assert_highlighted_chr(
-            "forward 25",
-            "KKKKKKK TT",
-            level=level, lang="en")
+        self.assert_highlighted_chr("forward 25", "KKKKKKK TT", level=level, lang="en")
 
-    @parameterized.expand([
-        ("level6"),
-        ("level7"),
-        ("level8"),
-    ])
+    @parameterized.expand(
+        [
+            ("level6"),
+            ("level7"),
+            ("level8"),
+        ]
+    )
     def test_forward_number(self, level):
-        self.assert_highlighted_chr(
-            "forward 25",
-            "KKKKKKK NN",
-            level=level, lang="en")
+        self.assert_highlighted_chr("forward 25", "KKKKKKK NN", level=level, lang="en")
 
-    @parameterized.expand([
-        ("level1"),
-        ("level2"),
-        ("level3"),
-        ("level4"),
-        ("level5"),
-        ("level6"),
-        ("level7"),
-        ("level8"),
-    ])
+    @parameterized.expand(
+        [
+            ("level1"),
+            ("level2"),
+            ("level3"),
+            ("level4"),
+            ("level5"),
+            ("level6"),
+            ("level7"),
+            ("level8"),
+        ]
+    )
     def test_forward_alone(self, level):
-        self.assert_highlighted_chr(
-            "forward",
-            "KKKKKKK",
-            level=level, lang="en")
-
-
-
-
+        self.assert_highlighted_chr("forward", "KKKKKKK", level=level, lang="en")
 
     def test_turn_left(self):
-        self.assert_highlighted_chr(
-            "turn left",
-            "KKKK TTTT",
-            level="level1", lang="en")
+        self.assert_highlighted_chr("turn left", "KKKK TTTT", level="level1", lang="en")
 
     def test_turn_right(self):
-        self.assert_highlighted_chr(
-            "turn right",
-            "KKKK TTTTT",
-            level="level1", lang="en")
+        self.assert_highlighted_chr("turn right", "KKKK TTTTT", level="level1", lang="en")
 
-
-    @parameterized.expand([
-        ("level1"),
-        ("level2"),
-        ("level3"),
-        ("level4"),
-        ("level5"),
-        ("level6"),
-        ("level7"),
-        ("level8"),
-    ])
+    @parameterized.expand(
+        [
+            ("level1"),
+            ("level2"),
+            ("level3"),
+            ("level4"),
+            ("level5"),
+            ("level6"),
+            ("level7"),
+            ("level8"),
+        ]
+    )
     def test_turn_alone(self, level):
-        self.assert_highlighted_chr(
-            "turn",
-            "KKKK",
-            level=level, lang="en")
+        self.assert_highlighted_chr("turn", "KKKK", level=level, lang="en")
 
-
-
-    @parameterized.expand([
-        ("level1"),
-        ("level2"),
-        ("level3"),
-        ("level4"),
-        ("level5"),
-    ])
+    @parameterized.expand(
+        [
+            ("level1"),
+            ("level2"),
+            ("level3"),
+            ("level4"),
+            ("level5"),
+        ]
+    )
     def test_turn(self, level):
-        self.assert_highlighted_chr(
-            "turn 25",
-            "KKKK TT",
-            level=level, lang="en")
+        self.assert_highlighted_chr("turn 25", "KKKK TT", level=level, lang="en")
 
-    @parameterized.expand([
-        ("level6"),
-        ("level7"),
-        ("level8"),
-    ])
+    @parameterized.expand(
+        [
+            ("level6"),
+            ("level7"),
+            ("level8"),
+        ]
+    )
     def test_turn_number(self, level):
-        self.assert_highlighted_chr(
-            "turn 25",
-            "KKKK NN",
-            level=level, lang="en")
+        self.assert_highlighted_chr("turn 25", "KKKK NN", level=level, lang="en")
 
-
-
-
-    @parameterized.expand([
-        ("level1"),
-        ("level2"),
-        ("level3"),
-        ("level4"),
-        ("level5"),
-        ("level6"),
-        ("level7"),
-        ("level8"),
-        ("level9"),
-        ("level10"),
-    ])
+    @parameterized.expand(
+        [
+            ("level1"),
+            ("level2"),
+            ("level3"),
+            ("level4"),
+            ("level5"),
+            ("level6"),
+            ("level7"),
+            ("level8"),
+            ("level9"),
+            ("level10"),
+        ]
+    )
     def test_color_black(self, level):
-        self.assert_highlighted_chr(
-            "color black",
-            "KKKKK TTTTT",
-            level=level, lang="en")
+        self.assert_highlighted_chr("color black", "KKKKK TTTTT", level=level, lang="en")
 
-
-    @parameterized.expand([
-        ("level1"),
-        ("level2"),
-        ("level3"),
-        ("level4"),
-        ("level5"),
-        ("level6"),
-        ("level7"),
-        ("level8"),
-        ("level9"),
-        ("level10"),
-    ])
+    @parameterized.expand(
+        [
+            ("level1"),
+            ("level2"),
+            ("level3"),
+            ("level4"),
+            ("level5"),
+            ("level6"),
+            ("level7"),
+            ("level8"),
+            ("level9"),
+            ("level10"),
+        ]
+    )
     def test_color_blue(self, level):
-        self.assert_highlighted_chr(
-            "color blue",
-            "KKKKK TTTT",
-            level=level, lang="en")
+        self.assert_highlighted_chr("color blue", "KKKKK TTTT", level=level, lang="en")
 
-
-    @parameterized.expand([
-        ("level1"),
-        ("level2"),
-        ("level3"),
-        ("level4"),
-        ("level5"),
-        ("level6"),
-        ("level7"),
-        ("level8"),
-        ("level9"),
-        ("level10"),
-    ])
+    @parameterized.expand(
+        [
+            ("level1"),
+            ("level2"),
+            ("level3"),
+            ("level4"),
+            ("level5"),
+            ("level6"),
+            ("level7"),
+            ("level8"),
+            ("level9"),
+            ("level10"),
+        ]
+    )
     def test_color_brown(self, level):
-        self.assert_highlighted_chr(
-            "color brown",
-            "KKKKK TTTTT",
-            level=level, lang="en")
+        self.assert_highlighted_chr("color brown", "KKKKK TTTTT", level=level, lang="en")
 
-
-    @parameterized.expand([
-        ("level1"),
-        ("level2"),
-        ("level3"),
-        ("level4"),
-        ("level5"),
-        ("level6"),
-        ("level7"),
-        ("level8"),
-        ("level9"),
-        ("level10"),
-    ])
+    @parameterized.expand(
+        [
+            ("level1"),
+            ("level2"),
+            ("level3"),
+            ("level4"),
+            ("level5"),
+            ("level6"),
+            ("level7"),
+            ("level8"),
+            ("level9"),
+            ("level10"),
+        ]
+    )
     def test_color_gray(self, level):
-        self.assert_highlighted_chr(
-            "color gray",
-            "KKKKK TTTT",
-            level=level, lang="en")
+        self.assert_highlighted_chr("color gray", "KKKKK TTTT", level=level, lang="en")
 
-
-    @parameterized.expand([
-        ("level1"),
-        ("level2"),
-        ("level3"),
-        ("level4"),
-        ("level5"),
-        ("level6"),
-        ("level7"),
-        ("level8"),
-        ("level9"),
-        ("level10"),
-    ])
+    @parameterized.expand(
+        [
+            ("level1"),
+            ("level2"),
+            ("level3"),
+            ("level4"),
+            ("level5"),
+            ("level6"),
+            ("level7"),
+            ("level8"),
+            ("level9"),
+            ("level10"),
+        ]
+    )
     def test_color_green(self, level):
-        self.assert_highlighted_chr(
-            "color green",
-            "KKKKK TTTTT",
-            level=level, lang="en")
+        self.assert_highlighted_chr("color green", "KKKKK TTTTT", level=level, lang="en")
 
-
-    @parameterized.expand([
-        ("level1"),
-        ("level2"),
-        ("level3"),
-        ("level4"),
-        ("level5"),
-        ("level6"),
-        ("level7"),
-        ("level8"),
-        ("level9"),
-        ("level10"),
-    ])
+    @parameterized.expand(
+        [
+            ("level1"),
+            ("level2"),
+            ("level3"),
+            ("level4"),
+            ("level5"),
+            ("level6"),
+            ("level7"),
+            ("level8"),
+            ("level9"),
+            ("level10"),
+        ]
+    )
     def test_color_orange(self, level):
-        self.assert_highlighted_chr(
-            "color orange",
-            "KKKKK TTTTTT",
-            level=level, lang="en")
+        self.assert_highlighted_chr("color orange", "KKKKK TTTTTT", level=level, lang="en")
 
-
-    @parameterized.expand([
-        ("level1"),
-        ("level2"),
-        ("level3"),
-        ("level4"),
-        ("level5"),
-        ("level6"),
-        ("level7"),
-        ("level8"),
-        ("level9"),
-        ("level10"),
-    ])
+    @parameterized.expand(
+        [
+            ("level1"),
+            ("level2"),
+            ("level3"),
+            ("level4"),
+            ("level5"),
+            ("level6"),
+            ("level7"),
+            ("level8"),
+            ("level9"),
+            ("level10"),
+        ]
+    )
     def test_color_pink(self, level):
-        self.assert_highlighted_chr(
-            "color pink",
-            "KKKKK TTTT",
-            level=level, lang="en")
+        self.assert_highlighted_chr("color pink", "KKKKK TTTT", level=level, lang="en")
 
-
-    @parameterized.expand([
-        ("level1"),
-        ("level2"),
-        ("level3"),
-        ("level4"),
-        ("level5"),
-        ("level6"),
-        ("level7"),
-        ("level8"),
-        ("level9"),
-        ("level10"),
-    ])
+    @parameterized.expand(
+        [
+            ("level1"),
+            ("level2"),
+            ("level3"),
+            ("level4"),
+            ("level5"),
+            ("level6"),
+            ("level7"),
+            ("level8"),
+            ("level9"),
+            ("level10"),
+        ]
+    )
     def test_color_purple(self, level):
-        self.assert_highlighted_chr(
-            "color purple",
-            "KKKKK TTTTTT",
-            level=level, lang="en")
+        self.assert_highlighted_chr("color purple", "KKKKK TTTTTT", level=level, lang="en")
 
-
-    @parameterized.expand([
-        ("level1"),
-        ("level2"),
-        ("level3"),
-        ("level4"),
-        ("level5"),
-        ("level6"),
-        ("level7"),
-        ("level8"),
-        ("level9"),
-        ("level10"),
-    ])
+    @parameterized.expand(
+        [
+            ("level1"),
+            ("level2"),
+            ("level3"),
+            ("level4"),
+            ("level5"),
+            ("level6"),
+            ("level7"),
+            ("level8"),
+            ("level9"),
+            ("level10"),
+        ]
+    )
     def test_color_red(self, level):
-        self.assert_highlighted_chr(
-            "color red",
-            "KKKKK TTT",
-            level=level, lang="en")
+        self.assert_highlighted_chr("color red", "KKKKK TTT", level=level, lang="en")
 
-
-    @parameterized.expand([
-        ("level1"),
-        ("level2"),
-        ("level3"),
-        ("level4"),
-        ("level5"),
-        ("level6"),
-        ("level7"),
-        ("level8"),
-        ("level9"),
-        ("level10"),
-    ])
+    @parameterized.expand(
+        [
+            ("level1"),
+            ("level2"),
+            ("level3"),
+            ("level4"),
+            ("level5"),
+            ("level6"),
+            ("level7"),
+            ("level8"),
+            ("level9"),
+            ("level10"),
+        ]
+    )
     def test_color_white(self, level):
-        self.assert_highlighted_chr(
-            "color white",
-            "KKKKK TTTTT",
-            level=level, lang="en")
+        self.assert_highlighted_chr("color white", "KKKKK TTTTT", level=level, lang="en")
 
-
-    @parameterized.expand([
-        ("level1"),
-        ("level2"),
-        ("level3"),
-        ("level4"),
-        ("level5"),
-        ("level6"),
-        ("level7"),
-        ("level8"),
-        ("level9"),
-        ("level10"),
-    ])
+    @parameterized.expand(
+        [
+            ("level1"),
+            ("level2"),
+            ("level3"),
+            ("level4"),
+            ("level5"),
+            ("level6"),
+            ("level7"),
+            ("level8"),
+            ("level9"),
+            ("level10"),
+        ]
+    )
     def test_color_yellow(self, level):
-        self.assert_highlighted_chr(
-            "color yellow",
-            "KKKKK TTTTTT",
-            level=level, lang="en")
+        self.assert_highlighted_chr("color yellow", "KKKKK TTTTTT", level=level, lang="en")

--- a/tests/test_highlighting/test_while.py
+++ b/tests/test_highlighting/test_while.py
@@ -1,77 +1,70 @@
 from tests.Highlighter import HighlightTester
 from parameterized import parameterized
 
+
 class HighlighterTestWhile(HighlightTester):
-
-    @parameterized.expand([
-        ("level15"),
-        ("level16"),
-        ("level17"),
-        ("level18"),
-    ])
+    @parameterized.expand(
+        [
+            ("level15"),
+            ("level16"),
+            ("level17"),
+            ("level18"),
+        ]
+    )
     def test_while_str(self, level):
-        self.assert_highlighted_chr(
-            "while keys == 'lost'",
-            "KKKKK TTTT KK SSSSSS",
-            level=level, lang="en")
+        self.assert_highlighted_chr("while keys == 'lost'", "KKKKK TTTT KK SSSSSS", level=level, lang="en")
 
-    @parameterized.expand([
-        ("level15"),
-        ("level16"),
-        ("level17"),
-        ("level18"),
-    ])
+    @parameterized.expand(
+        [
+            ("level15"),
+            ("level16"),
+            ("level17"),
+            ("level18"),
+        ]
+    )
     def test_while_diff_str(self, level):
-        self.assert_highlighted_chr(
-            "while keys != 'lost'",
-            "KKKKK TTTT KK SSSSSS",
-            level=level, lang="en")
+        self.assert_highlighted_chr("while keys != 'lost'", "KKKKK TTTT KK SSSSSS", level=level, lang="en")
 
-
-    @parameterized.expand([
-        ("level15"),
-        ("level16"),
-        ("level17"),
-        ("level18"),
-    ])
+    @parameterized.expand(
+        [
+            ("level15"),
+            ("level16"),
+            ("level17"),
+            ("level18"),
+        ]
+    )
     def test_while_number(self, level):
-        self.assert_highlighted_chr(
-            "while keys == 123",
-            "KKKKK TTTT KK NNN",
-            level=level, lang="en")
+        self.assert_highlighted_chr("while keys == 123", "KKKKK TTTT KK NNN", level=level, lang="en")
 
-    @parameterized.expand([
-        ("level15"),
-        ("level16"),
-        ("level17"),
-        ("level18"),
-    ])
+    @parameterized.expand(
+        [
+            ("level15"),
+            ("level16"),
+            ("level17"),
+            ("level18"),
+        ]
+    )
     def test_while_diff_number(self, level):
-        self.assert_highlighted_chr(
-            "while keys != 123",
-            "KKKKK TTTT KK NNN",
-            level=level, lang="en")
+        self.assert_highlighted_chr("while keys != 123", "KKKKK TTTT KK NNN", level=level, lang="en")
 
-    @parameterized.expand([
-        ("level15"),
-        ("level16"),
-        ("level17"),
-        ("level18"),
-    ])
+    @parameterized.expand(
+        [
+            ("level15"),
+            ("level16"),
+            ("level17"),
+            ("level18"),
+        ]
+    )
     def test_while_var(self, level):
-        self.assert_highlighted_chr(
-            "while keys == var",
-            "KKKKK TTTT KK TTT",
-            level=level, lang="en")
+        self.assert_highlighted_chr("while keys == var", "KKKKK TTTT KK TTT", level=level, lang="en")
 
-    @parameterized.expand([
-        ("level15"),
-        ("level16"),
-        ("level17"),
-        ("level18"),
-    ])
+    @parameterized.expand(
+        [
+            ("level15"),
+            ("level16"),
+            ("level17"),
+            ("level18"),
+        ]
+    )
     def test_while_diff_var(self, level):
-        self.assert_highlighted_chr(
-            "while keys != var",
-            "KKKKK TTTT KK TTT",
-            level=level, lang="en")
+        self.assert_highlighted_chr("while keys != var", "KKKKK TTTT KK TTT", level=level, lang="en")

--- a/tests/test_level/test_level_01.py
+++ b/tests/test_level/test_level_01.py
@@ -6,7 +6,7 @@ from tests.Tester import HedyTester
 
 class TestsLevel1(HedyTester):
     level = 1
-    '''
+    """
     Tests should be ordered as follows:
      * commands in the order of hedy.py e.g. for level 1: ['print', 'ask', 'echo', 'turn', 'forward']
      * combined tests
@@ -17,7 +17,7 @@ class TestsLevel1(HedyTester):
      * single keyword positive tests are just keyword or keyword_special_case
      * multi keyword positive tests are keyword1_keywords_2
      * negative tests should be situation_gives_exception
-    '''
+    """
 
     #
     # print tests
@@ -25,29 +25,19 @@ class TestsLevel1(HedyTester):
     def test_print(self):
         code = "print Hallo welkom bij Hedy!"
         expected = "print('Hallo welkom bij Hedy!')"
-        output = 'Hallo welkom bij Hedy!'
+        output = "Hallo welkom bij Hedy!"
         expected_commands = [Command.print]
 
-        self.single_level_tester(
-            code=code,
-            expected=expected,
-            output=output,
-            expected_commands=expected_commands
-        )
+        self.single_level_tester(code=code, expected=expected, output=output, expected_commands=expected_commands)
         self.assertEqual([output], hedy.all_print_arguments(code, self.level))
 
     def test_print_no_space(self):
         code = "printHallo welkom bij Hedy!"
         expected = "print('Hallo welkom bij Hedy!')"
-        output = 'Hallo welkom bij Hedy!'
+        output = "Hallo welkom bij Hedy!"
         expected_commands = [Command.print]
 
-        self.single_level_tester(
-            code=code,
-            expected=expected,
-            output=output,
-            expected_commands=expected_commands
-        )
+        self.single_level_tester(code=code, expected=expected, output=output, expected_commands=expected_commands)
         self.assertEqual([output], hedy.all_print_arguments(code, self.level))
 
     def test_print_comma(self):
@@ -58,20 +48,26 @@ class TestsLevel1(HedyTester):
         self.single_level_tester(code=code, expected=expected, expected_commands=expected_commands)
 
     def test_print_multiple_lines(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         print Hallo welkom bij Hedy
-        print Mooi hoor""")
+        print Mooi hoor"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         print('Hallo welkom bij Hedy')
-        print('Mooi hoor')""")
+        print('Mooi hoor')"""
+        )
 
-        output = textwrap.dedent("""\
+        output = textwrap.dedent(
+            """\
         Hallo welkom bij Hedy
-        Mooi hoor""")
+        Mooi hoor"""
+        )
 
         self.single_level_tester(code=code, expected=expected, output=output)
-        self.assertEqual(['Hallo welkom bij Hedy', 'Mooi hoor'], hedy.all_print_arguments(code, self.level))
+        self.assertEqual(["Hallo welkom bij Hedy", "Mooi hoor"], hedy.all_print_arguments(code, self.level))
 
     def test_print_single_quoted_text(self):
         code = "print 'Welcome to OceanView!'"
@@ -129,28 +125,29 @@ class TestsLevel1(HedyTester):
     def test_print_nl(self):
         code = "print Hallo welkom bij Hedy!"
         expected = "print('Hallo welkom bij Hedy!')"
-        output = 'Hallo welkom bij Hedy!'
+        output = "Hallo welkom bij Hedy!"
 
-        self.single_level_tester(code=code, expected=expected, output=output, lang='nl')
+        self.single_level_tester(code=code, expected=expected, output=output, lang="nl")
 
     def test_print_ar(self):
         code = "قول أهلا ومرحبا بكم في هيدي!"
         expected = "print('أهلا ومرحبا بكم في هيدي!')"
-        output = 'أهلا ومرحبا بكم في هيدي!'
+        output = "أهلا ومرحبا بكم في هيدي!"
 
-        self.single_level_tester(code=code, expected=expected, output=output, lang='ar')
+        self.single_level_tester(code=code, expected=expected, output=output, lang="ar")
 
     def test_print_ar_tatweel_all_places(self):
         code = "ـــقــولـ أ"
         expected = "print('أ')"
-        output = 'أ'
+        output = "أ"
 
         self.single_level_tester(
             code=code,
             expected=expected,
             output=output,
-            translate=False, #translation will remove the tatweels, we will deal with that later
-            lang='ar')
+            translate=False,  # translation will remove the tatweels, we will deal with that later
+            lang="ar",
+        )
 
     def test_ask_ar_tatweel_all_places(self):
         code = "اســأل أ"
@@ -159,8 +156,9 @@ class TestsLevel1(HedyTester):
         self.single_level_tester(
             code=code,
             expected=expected,
-            translate=False, #translation will remove the tatweels, we will deal with that later
-            lang='ar')
+            translate=False,  # translation will remove the tatweels, we will deal with that later
+            lang="ar",
+        )
 
     # def test_print_ar_tatweel_itself(self):
     # FH, May 2022, sadly beginning a string with tatweel does not work
@@ -180,45 +178,48 @@ class TestsLevel1(HedyTester):
     def test_print_ar_tatweel_printing(self):
         code = "قول لــــ"
         expected = "print('لــــ')"
-        output = 'لــــ'
+        output = "لــــ"
 
         self.single_level_tester(
             code=code,
             expected=expected,
             output=output,
-            translate=False, #translation will remove the tatweels, we will deal with that later
-            lang='ar')
+            translate=False,  # translation will remove the tatweels, we will deal with that later
+            lang="ar",
+        )
 
     def test_print_ar_tatweel_begin(self):
         code = "ـــقول أ"
         expected = "print('أ')"
-        output = 'أ'
+        output = "أ"
 
         self.single_level_tester(
             code=code,
             expected=expected,
             output=output,
-            translate=False, #translation will remove the tatweels, we will deal with that later
-            lang='ar')
+            translate=False,  # translation will remove the tatweels, we will deal with that later
+            lang="ar",
+        )
 
     def test_print_ar_tatweel_multiple_end(self):
         code = "ـــقــوـلــــ أ"
         expected = "print('أ')"
-        output = 'أ'
+        output = "أ"
 
         self.single_level_tester(
             code=code,
             expected=expected,
             output=output,
-            translate=False, #translation will remove the tatweels, we will deal with that later
-            lang='ar')
+            translate=False,  # translation will remove the tatweels, we will deal with that later
+            lang="ar",
+        )
 
     def test_print_ar_2(self):
         code = "قول مرحبا أيها العالم!"
         expected = "print('مرحبا أيها العالم!')"
-        output = 'مرحبا أيها العالم!'
+        output = "مرحبا أيها العالم!"
 
-        self.single_level_tester(code=code, expected=expected, output=output, lang='ar')
+        self.single_level_tester(code=code, expected=expected, output=output, lang="ar")
 
     #
     # ask tests
@@ -263,7 +264,7 @@ class TestsLevel1(HedyTester):
         code = "vraag Heb je er zin in?"
         expected = "answer = input('Heb je er zin in?')"
 
-        self.single_level_tester(code=code, expected=expected, lang='nl')
+        self.single_level_tester(code=code, expected=expected, lang="nl")
 
     def test_ask_en_code_transpiled_in_nl(self):
         code = "ask Heb je er zin in?"
@@ -272,29 +273,33 @@ class TestsLevel1(HedyTester):
         self.single_level_tester(
             code=code,
             expected=expected,
-            lang='nl',
-            translate=False  # we are trying a Dutch keyword in en, can't be translated
+            lang="nl",
+            translate=False,  # we are trying a Dutch keyword in en, can't be translated
         )
 
     def test_mixes_languages_nl_en(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         vraag Heb je er zin in?
         echo
         ask are you sure?
-        print mooizo!""")
+        print mooizo!"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         answer = input('Heb je er zin in?')
         print(answer)
         answer = input('are you sure?')
-        print('mooizo!')""")
+        print('mooizo!')"""
+        )
 
         self.single_level_tester(
             code=code,
             expected=expected,
-            expected_commands=['ask', 'echo', 'ask', 'print'],
-            lang='nl',
-            translate=False  # mixed codes will not translate back to their original form, sadly
+            expected_commands=["ask", "echo", "ask", "print"],
+            lang="nl",
+            translate=False,  # mixed codes will not translate back to their original form, sadly
         )
 
     #
@@ -307,13 +312,17 @@ class TestsLevel1(HedyTester):
         self.single_level_tester(code=code, expected=expected)
 
     def test_echo_with_quotes(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         ask waar?
-        echo oma's aan de""")
+        echo oma's aan de"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         answer = input('waar?')
-        print('oma\\'s aan de '+answer)""")
+        print('oma\\'s aan de '+answer)"""
+        )
 
         self.single_level_tester(code=code, expected=expected)
 
@@ -325,10 +334,7 @@ class TestsLevel1(HedyTester):
         expected = HedyTester.dedent(HedyTester.forward_transpiled(50))
 
         self.multi_level_tester(
-            code=code,
-            expected=expected,
-            extra_check_function=self.is_turtle(),
-            max_level=self.max_turtle_level
+            code=code, expected=expected, extra_check_function=self.is_turtle(), max_level=self.max_turtle_level
         )
 
     def test_forward_arabic_numeral(self):
@@ -336,10 +342,7 @@ class TestsLevel1(HedyTester):
         expected = HedyTester.forward_transpiled(1111111)
 
         self.multi_level_tester(
-            code=code,
-            expected=expected,
-            extra_check_function=self.is_turtle(),
-            max_level=self.max_turtle_level
+            code=code, expected=expected, extra_check_function=self.is_turtle(), max_level=self.max_turtle_level
         )
 
     def test_forward_hindi_numeral(self):
@@ -347,49 +350,44 @@ class TestsLevel1(HedyTester):
         expected = HedyTester.forward_transpiled(555)
 
         self.multi_level_tester(
-            code=code,
-            expected=expected,
-            extra_check_function=self.is_turtle(),
-            max_level=self.max_turtle_level
+            code=code, expected=expected, extra_check_function=self.is_turtle(), max_level=self.max_turtle_level
         )
 
     def test_forward_without_argument(self):
-        code = 'forward'
-        expected = textwrap.dedent("""\
+        code = "forward"
+        expected = textwrap.dedent(
+            """\
         t.forward(50)
-        time.sleep(0.1)""")
+        time.sleep(0.1)"""
+        )
 
         self.multi_level_tester(
-            code=code,
-            expected=expected,
-            extra_check_function=self.is_turtle(),
-            max_level=self.max_turtle_level
+            code=code, expected=expected, extra_check_function=self.is_turtle(), max_level=self.max_turtle_level
         )
 
     def test_forward_with_text_gives_type_error(self):
         code = "forward lalalala"
 
         self.multi_level_tester(
-            code=code,
-            exception=hedy.exceptions.InvalidArgumentTypeException,
-            max_level=self.max_turtle_level
+            code=code, exception=hedy.exceptions.InvalidArgumentTypeException, max_level=self.max_turtle_level
         )
 
     def test_multiple_forward_without_arguments(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         forward
-        forward""")
-        expected = textwrap.dedent("""\
+        forward"""
+        )
+        expected = textwrap.dedent(
+            """\
         t.forward(50)
         time.sleep(0.1)
         t.forward(50)
-        time.sleep(0.1)""")
+        time.sleep(0.1)"""
+        )
 
         self.multi_level_tester(
-            code=code,
-            expected=expected,
-            max_level=self.max_turtle_level,
-            extra_check_function=self.is_turtle()
+            code=code, expected=expected, max_level=self.max_turtle_level, extra_check_function=self.is_turtle()
         )
 
     #
@@ -399,31 +397,26 @@ class TestsLevel1(HedyTester):
         code = "color"
         expected = "t.pencolor('black')"
         self.multi_level_tester(
-            code=code,
-            expected=expected,
-            extra_check_function=self.is_turtle(),
-            max_level=self.max_turtle_level)
+            code=code, expected=expected, extra_check_function=self.is_turtle(), max_level=self.max_turtle_level
+        )
 
     def test_one_color_red(self):
         code = "color red"
         expected = "t.pencolor('red')"
 
-        self.single_level_tester(code=code, expected=expected,
-                                 extra_check_function=self.is_turtle())
+        self.single_level_tester(code=code, expected=expected, extra_check_function=self.is_turtle())
 
     def test_one_color_purple(self):
         code = "color purple"
         expected = "t.pencolor('purple')"
 
-        self.single_level_tester(code=code, expected=expected,
-                                 extra_check_function=self.is_turtle())
+        self.single_level_tester(code=code, expected=expected, extra_check_function=self.is_turtle())
 
     def test_one_color_purple_nl(self):
         code = "kleur paars"
         expected = "t.pencolor('purple')"
 
-        self.single_level_tester(code=code, expected=expected,
-                                 extra_check_function=self.is_turtle(), lang='nl')
+        self.single_level_tester(code=code, expected=expected, extra_check_function=self.is_turtle(), lang="nl")
 
     #
     # turn tests
@@ -433,42 +426,26 @@ class TestsLevel1(HedyTester):
         expected = "t.right(90)"
 
         self.multi_level_tester(
-            code=code,
-            expected=expected,
-            extra_check_function=self.is_turtle(),
-            max_level=self.max_turtle_level
+            code=code, expected=expected, extra_check_function=self.is_turtle(), max_level=self.max_turtle_level
         )
 
     def test_turn_right(self):
         code = "turn right"
         expected = "t.right(90)"
 
-        self.single_level_tester(
-            code=code,
-            expected=expected,
-            extra_check_function=self.is_turtle()
-        )
+        self.single_level_tester(code=code, expected=expected, extra_check_function=self.is_turtle())
 
     def test_turn_left(self):
         code = "turn left"
         expected = "t.left(90)"
 
-        self.single_level_tester(
-            code=code,
-            expected=expected,
-            extra_check_function=self.is_turtle()
-        )
+        self.single_level_tester(code=code, expected=expected, extra_check_function=self.is_turtle())
 
     def test_turn_left_nl(self):
         code = "draai links"
         expected = "t.left(90)"
 
-        self.single_level_tester(
-            code=code,
-            expected=expected,
-            extra_check_function=self.is_turtle(),
-            lang='nl'
-        )
+        self.single_level_tester(code=code, expected=expected, extra_check_function=self.is_turtle(), lang="nl")
 
     def test_turn_with_text_gives_error(self):
         code = "turn koekoek"
@@ -486,53 +463,52 @@ class TestsLevel1(HedyTester):
     def test_print_comment(self):
         code = "print Hallo welkom bij Hedy! # This is a print"
         expected = "print('Hallo welkom bij Hedy! ')"
-        output = 'Hallo welkom bij Hedy!'
+        output = "Hallo welkom bij Hedy!"
 
-        self.single_level_tester(
-            code=code,
-            expected=expected,
-            output=output,
-            expected_commands=[Command.print]
-        )
+        self.single_level_tester(code=code, expected=expected, output=output, expected_commands=[Command.print])
 
-        self.assertEqual(['Hallo welkom bij Hedy! '], hedy.all_print_arguments(code, self.level))
+        self.assertEqual(["Hallo welkom bij Hedy! "], hedy.all_print_arguments(code, self.level))
 
     #
     # combined commands tests
     #
     def test_print_ask_echo(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         print Hallo
         ask Wat is je lievelingskleur
-        echo je lievelingskleur is""")
+        echo je lievelingskleur is"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         print('Hallo')
         answer = input('Wat is je lievelingskleur')
-        print('je lievelingskleur is '+answer)""")
+        print('je lievelingskleur is '+answer)"""
+        )
 
         self.single_level_tester(
-            code=code,
-            expected=expected,
-            expected_commands=[Command.print, Command.ask, Command.echo])
+            code=code, expected=expected, expected_commands=[Command.print, Command.ask, Command.echo]
+        )
 
     def test_forward_turn_combined(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
             forward 50
             turn
-            forward 100""")
+            forward 100"""
+        )
 
         expected = HedyTester.dedent(
-            HedyTester.forward_transpiled(50),
-            't.right(90)',
-            HedyTester.forward_transpiled(100))
+            HedyTester.forward_transpiled(50), "t.right(90)", HedyTester.forward_transpiled(100)
+        )
 
         self.multi_level_tester(
             max_level=self.max_turtle_level,
             code=code,
             expected=expected,
             extra_check_function=self.is_turtle(),
-            expected_commands=[Command.forward, Command.turn, Command.forward]
+            expected_commands=[Command.forward, Command.turn, Command.forward],
         )
 
     #
@@ -541,7 +517,7 @@ class TestsLevel1(HedyTester):
     def test_lines_may_end_in_spaces(self):
         code = "print Hallo welkom bij Hedy! "
         expected = "print('Hallo welkom bij Hedy! ')"
-        output = 'Hallo welkom bij Hedy!'
+        output = "Hallo welkom bij Hedy!"
 
         self.single_level_tester(code=code, expected=expected, output=output)
 
@@ -551,26 +527,17 @@ class TestsLevel1(HedyTester):
     def test_print_with_space_gives_invalid(self):
         code = " print Hallo welkom bij Hedy!"
 
-        self.multi_level_tester(
-            code=code,
-            exception=hedy.exceptions.InvalidSpaceException,
-            max_level=3)
+        self.multi_level_tester(code=code, exception=hedy.exceptions.InvalidSpaceException, max_level=3)
 
     def test_ask_with_space_gives_invalid(self):
         code = " ask Hallo welkom bij Hedy?"
 
-        self.multi_level_tester(
-            code=code,
-            exception=hedy.exceptions.InvalidSpaceException,
-            max_level=1)
+        self.multi_level_tester(code=code, exception=hedy.exceptions.InvalidSpaceException, max_level=1)
 
     def test_lines_with_spaces_gives_invalid(self):
         code = " print Hallo welkom bij Hedy!\n print Hallo welkom bij Hedy!"
 
-        self.multi_level_tester(
-            code=code,
-            exception=hedy.exceptions.InvalidSpaceException,
-            max_level=3)
+        self.multi_level_tester(code=code, exception=hedy.exceptions.InvalidSpaceException, max_level=3)
 
     def test_word_plus_period_gives_invalid(self):
         code = "word."
@@ -585,23 +552,25 @@ class TestsLevel1(HedyTester):
         self.single_level_tester(code, exception=hedy.exceptions.LonelyEchoException)
 
     def test_echo_before_ask_gives_lonely_echo(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         echo what can't we do?
-        ask time travel """)
+        ask time travel """
+        )
         self.single_level_tester(code, exception=hedy.exceptions.LonelyEchoException)
 
     def test_print_without_argument_gives_incomplete(self):
         self.multi_level_tester(
             code="print",
             exception=hedy.exceptions.IncompleteCommandException,
-            extra_check_function=lambda c: c.exception.arguments['incomplete_command'] == 'print'
+            extra_check_function=lambda c: c.exception.arguments["incomplete_command"] == "print",
         )
 
     def test_print_without_argument_gives_incomplete_2(self):
         self.multi_level_tester(
             code="print lalalala\nprint",
             exception=hedy.exceptions.IncompleteCommandException,
-            extra_check_function=lambda c: c.exception.arguments['incomplete_command'] == 'print',
+            extra_check_function=lambda c: c.exception.arguments["incomplete_command"] == "print",
             max_level=17,
         )
 
@@ -609,6 +578,6 @@ class TestsLevel1(HedyTester):
         self.multi_level_tester(
             code="aks felienne 123",
             exception=hedy.exceptions.InvalidCommandException,
-            extra_check_function=lambda c: c.exception.arguments['invalid_command'] == 'aks',
+            extra_check_function=lambda c: c.exception.arguments["invalid_command"] == "aks",
             max_level=17,
         )

--- a/tests/test_level/test_level_02.py
+++ b/tests/test_level/test_level_02.py
@@ -6,7 +6,7 @@ from tests.Tester import HedyTester
 
 class TestsLevel2(HedyTester):
     level = 2
-    '''
+    """
     Tests should be ordered as follows:
      * commands in the order of hedy.py e.g. for level 1: ['print', 'ask', 'echo', 'turn', 'forward']
      * combined tests
@@ -17,7 +17,7 @@ class TestsLevel2(HedyTester):
      * single keyword positive tests are just keyword or keyword_special_case
      * multi keyword positive tests are keyword1_keywords_2
      * negative tests should be situation_gives_exception
-    '''
+    """
 
     #
     # print tests
@@ -25,19 +25,14 @@ class TestsLevel2(HedyTester):
     def test_print(self):
         code = "print Hallo welkom bij Hedy!"
         expected = "print(f'Hallo welkom bij Hedy!')"
-        output = 'Hallo welkom bij Hedy!'
+        output = "Hallo welkom bij Hedy!"
 
-        self.multi_level_tester(
-            code=code,
-            expected=expected,
-            output=output,
-            max_level=3
-        )
+        self.multi_level_tester(code=code, expected=expected, output=output, max_level=3)
 
     def test_print_no_space(self):
         code = "printHallo welkom bij Hedy!"
         expected = "print(f'Hallo welkom bij Hedy!')"
-        output = 'Hallo welkom bij Hedy!'
+        output = "Hallo welkom bij Hedy!"
 
         self.multi_level_tester(code=code, expected=expected, output=output, max_level=3)
 
@@ -49,32 +44,44 @@ class TestsLevel2(HedyTester):
         self.multi_level_tester(code=code, expected=expected, output=output, max_level=3)
 
     def test_print_multiple_lines(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         print Hallo welkom bij Hedy!
-        print Mooi hoor""")
+        print Mooi hoor"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         print(f'Hallo welkom bij Hedy!')
-        print(f'Mooi hoor')""")
+        print(f'Mooi hoor')"""
+        )
 
-        output = textwrap.dedent("""\
+        output = textwrap.dedent(
+            """\
         Hallo welkom bij Hedy!
-        Mooi hoor""")
+        Mooi hoor"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, output=output, max_level=3)
 
     def test_print_var_with_comma(self):
-        #test for issue 2549
-        code = textwrap.dedent("""\
+        # test for issue 2549
+        code = textwrap.dedent(
+            """\
         name is test
-        print name, heya!""")
+        print name, heya!"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         name = 'test'
-        print(f'{name}, heya!')""")
+        print(f'{name}, heya!')"""
+        )
 
-        output = textwrap.dedent("""\
-        test, heya!""")
+        output = textwrap.dedent(
+            """\
+        test, heya!"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, output=output, max_level=3)
 
@@ -89,13 +96,9 @@ class TestsLevel2(HedyTester):
         # test for issue 279
         code = "print hello world!'"
         expected = "print(f'hello world!\\'')"
-        output = "hello world!\'"
+        output = "hello world!'"
 
-        self.multi_level_tester\
-            (code=code,
-             expected=expected,
-             output=output,
-             max_level=3)
+        self.multi_level_tester(code=code, expected=expected, output=output, max_level=3)
 
     def test_print_double_quoted_text(self):
         code = 'print "Welcome to OceanView"'
@@ -182,13 +185,17 @@ class TestsLevel2(HedyTester):
         self.multi_level_tester(code=code, expected=expected, max_level=3)
 
     def test_ask_with_comma(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         dieren is ask hond, kat, kangoeroe
-        print dieren""")
+        print dieren"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         dieren = input('hond, kat, kangoeroe')
-        print(f'{dieren}')""")
+        print(f'{dieren}')"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=3)
 
@@ -199,13 +206,17 @@ class TestsLevel2(HedyTester):
         self.multi_level_tester(code=code, expected=expected, max_level=3)
 
     def test_ask_bengali_var(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         রং is ask আপনার প্রিয় রং কি?
-        print রং is আপনার প্রিয""")
+        print রং is আপনার প্রিয"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         রং = input('আপনার প্রিয় রং কি?')
-        print(f'{রং} is আপনার প্রিয')""")
+        print(f'{রং} is আপনার প্রিয')"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=3)
 
@@ -213,12 +224,12 @@ class TestsLevel2(HedyTester):
     # forward tests
     #
     def test_forward_with_integer_variable(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
             a is 50
-            forward a""")
-        expected = HedyTester.dedent(
-            "a = '50'",
-            HedyTester.forward_transpiled('a'))
+            forward a"""
+        )
+        expected = HedyTester.dedent("a = '50'", HedyTester.forward_transpiled("a"))
 
         self.multi_level_tester(
             code=code,
@@ -228,9 +239,11 @@ class TestsLevel2(HedyTester):
         )
 
     def test_forward_with_string_variable_gives_type_error(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
             a is test
-            forward a""")
+            forward a"""
+        )
 
         self.multi_level_tester(
             code=code,
@@ -264,12 +277,12 @@ class TestsLevel2(HedyTester):
         )
 
     def test_turn_with_number_var(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
             direction is 70
-            turn direction""")
-        expected = HedyTester.dedent(
-            "direction = '70'",
-            HedyTester.turn_transpiled('direction'))
+            turn direction"""
+        )
+        expected = HedyTester.dedent("direction = '70'", HedyTester.turn_transpiled("direction"))
 
         self.multi_level_tester(
             code=code,
@@ -279,11 +292,14 @@ class TestsLevel2(HedyTester):
         )
 
     def test_turn_with_non_latin_number_var(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         الزاوية هي ٩٠
         استدر الزاوية
-        تقدم ١٠٠""")
-        expected = textwrap.dedent("""\
+        تقدم ١٠٠"""
+        )
+        expected = textwrap.dedent(
+            """\
         الزاوية = '٩٠'
         trtl = الزاوية
         try:
@@ -297,11 +313,12 @@ class TestsLevel2(HedyTester):
         except ValueError:
           raise Exception(f'While running your program the command <span class="command-highlighted">forward</span> received the value <span class="command-highlighted">{trtl}</span> which is not allowed. Try changing the value to a number.')
         t.forward(min(600, trtl) if trtl > 0 else max(-600, trtl))
-        time.sleep(0.1)""")
+        time.sleep(0.1)"""
+        )
 
         self.multi_level_tester(
             code=code,
-            lang='ar',
+            lang="ar",
             expected=expected,
             extra_check_function=self.is_turtle(),
             max_level=self.max_turtle_level,
@@ -316,7 +333,7 @@ class TestsLevel2(HedyTester):
             max_level=self.max_turtle_level,
         )
 
-    @parameterized.expand(['left', 'right'])
+    @parameterized.expand(["left", "right"])
     def test_one_turn_with_left_or_right_gives_type_error(self, arg):
         code = f"turn {arg}"
         self.multi_level_tester(
@@ -326,16 +343,20 @@ class TestsLevel2(HedyTester):
         )
 
     def test_access_before_assign_not_allowed(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
             print the name program
-            name is Hedy""")
+            name is Hedy"""
+        )
         with self.assertRaises(hedy.exceptions.AccessBeforeAssign) as context:
             result = hedy.transpile(code, self.level)
 
     def test_turn_with_string_var_gives_type_error(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
             direction is ten
-            turn direction""")
+            turn direction"""
+        )
 
         self.multi_level_tester(
             code=code,
@@ -344,18 +365,18 @@ class TestsLevel2(HedyTester):
         )
 
     def test_turn_with_non_ascii_var(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
             ángulo is 90
-            turn ángulo""")
-        expected = HedyTester.dedent(
-            "ángulo = '90'",
-            HedyTester.turn_transpiled('ángulo'))
+            turn ángulo"""
+        )
+        expected = HedyTester.dedent("ángulo = '90'", HedyTester.turn_transpiled("ángulo"))
 
         self.multi_level_tester(
             code=code,
             expected=expected,
             extra_check_function=self.is_turtle(),
-            expected_commands=['is', 'turn'],
+            expected_commands=["is", "turn"],
             max_level=self.max_turtle_level,
         )
 
@@ -371,41 +392,34 @@ class TestsLevel2(HedyTester):
     # color tests
     def test_color_red(self):
         code = "color red"
-        expected = HedyTester.turtle_color_command_transpiled('red')
+        expected = HedyTester.turtle_color_command_transpiled("red")
 
         self.multi_level_tester(
-            code=code,
-            expected=expected,
-            extra_check_function=self.is_turtle(),
-            max_level=self.max_turtle_level
+            code=code, expected=expected, extra_check_function=self.is_turtle(), max_level=self.max_turtle_level
         )
 
     def test_color_with_var(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
             foo is white
-            color foo""")
-        expected = HedyTester.dedent(
-            "foo = 'white'",
-            HedyTester.turtle_color_command_transpiled('{foo}')
+            color foo"""
         )
+        expected = HedyTester.dedent("foo = 'white'", HedyTester.turtle_color_command_transpiled("{foo}"))
 
         self.multi_level_tester(
-            code=code,
-            expected=expected,
-            extra_check_function=self.is_turtle(),
-            max_level=self.max_turtle_level
+            code=code, expected=expected, extra_check_function=self.is_turtle(), max_level=self.max_turtle_level
         )
 
     def test_color_translated(self):
         code = "kleur blauw"
-        expected = HedyTester.turtle_color_command_transpiled('blue')
+        expected = HedyTester.turtle_color_command_transpiled("blue")
 
         self.multi_level_tester(
             code=code,
             expected=expected,
             extra_check_function=self.is_turtle(),
-            lang='nl',
-            max_level=self.max_turtle_level
+            lang="nl",
+            max_level=self.max_turtle_level,
         )
 
     def test_color_with_number_gives_type_error(self):
@@ -451,39 +465,41 @@ class TestsLevel2(HedyTester):
         self.multi_level_tester(code=code, expected=expected)
 
     def test_sleep_with_number_variable(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
             n is 2
-            sleep n""")
-        expected = HedyTester.dedent(
-            "n = '2'",
-            HedyTester.sleep_command_transpiled("n"))
+            sleep n"""
+        )
+        expected = HedyTester.dedent("n = '2'", HedyTester.sleep_command_transpiled("n"))
 
         self.multi_level_tester(max_level=11, code=code, expected=expected)
 
     def test_sleep_with_number_variable_hi(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
             n is २
-            sleep n""")
-        expected = HedyTester.dedent(
-            "n = '२'",
-            HedyTester.sleep_command_transpiled("n"))
+            sleep n"""
+        )
+        expected = HedyTester.dedent("n = '२'", HedyTester.sleep_command_transpiled("n"))
 
         self.multi_level_tester(max_level=11, code=code, expected=expected)
 
     def test_sleep_with_input_variable(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
             n is ask how long
-            sleep n""")
-        expected = HedyTester.dedent(
-            "n = input('how long')",
-            HedyTester.sleep_command_transpiled("n"))
+            sleep n"""
+        )
+        expected = HedyTester.dedent("n = input('how long')", HedyTester.sleep_command_transpiled("n"))
 
         self.multi_level_tester(max_level=3, code=code, expected=expected)
 
     def test_sleep_with_string_variable_gives_error(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
             n is test
-            sleep n""")
+            sleep n"""
+        )
 
         self.multi_level_tester(max_level=11, code=code, exception=hedy.exceptions.InvalidArgumentTypeException)
 
@@ -494,10 +510,7 @@ class TestsLevel2(HedyTester):
     def test_assign_with_space_gives_invalid(self):
         code = " naam is Hedy"
 
-        self.multi_level_tester(
-            code=code,
-            exception=hedy.exceptions.InvalidSpaceException,
-            max_level=7)
+        self.multi_level_tester(code=code, exception=hedy.exceptions.InvalidSpaceException, max_level=7)
 
     def test_assign(self):
         code = "naam is Felienne"
@@ -536,13 +549,17 @@ class TestsLevel2(HedyTester):
         self.multi_level_tester(code=code, expected=expected, max_level=11)
 
     def test_assign_text_to_hungarian_var(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         állatok is kutya
-        print állatok""")
+        print állatok"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         állatok = 'kutya'
-        print(f'{állatok}')""")
+        print(f'{állatok}')"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=11)
 
@@ -564,8 +581,10 @@ class TestsLevel2(HedyTester):
     #
     def test_spaces_in_arguments(self):
         code = "print hallo      wereld"
-        expected = textwrap.dedent("""\
-        print(f'hallo wereld')""")
+        expected = textwrap.dedent(
+            """\
+        print(f'hallo wereld')"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=3)
 
@@ -573,86 +592,100 @@ class TestsLevel2(HedyTester):
     # combined tests
     #
     def test_ask_print(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         kleur is ask wat is je lievelingskleur?
-        print kleur!""")
-        expected = textwrap.dedent("""\
+        print kleur!"""
+        )
+        expected = textwrap.dedent(
+            """\
         kleur = input('wat is je lievelingskleur?')
-        print(f'{kleur}!')""")
+        print(f'{kleur}!')"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=3)
 
     def test_assign_print(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         naam is Felienne
-        print naam""")
-        expected = textwrap.dedent("""\
+        print naam"""
+        )
+        expected = textwrap.dedent(
+            """\
         naam = 'Felienne'
-        print(f'{naam}')""")
+        print(f'{naam}')"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=3)
 
     def test_forward_ask(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
             afstand is ask hoe ver dan?
-            forward afstand""")
-        expected = HedyTester.dedent(
-            "afstand = input('hoe ver dan?')",
-            HedyTester.forward_transpiled('afstand'))
-
-        self.multi_level_tester(
-            code=code,
-            expected=expected,
-            extra_check_function=self.is_turtle(),
-            max_level=3
+            forward afstand"""
         )
+        expected = HedyTester.dedent("afstand = input('hoe ver dan?')", HedyTester.forward_transpiled("afstand"))
+
+        self.multi_level_tester(code=code, expected=expected, extra_check_function=self.is_turtle(), max_level=3)
 
     def test_ask_turn(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         print Turtle race
         direction is ask Where to turn?
-        turn direction""")
-
-        expected = HedyTester.dedent("""\
-        print(f'Turtle race')
-        direction = input('Where to turn?')""",
-                                     HedyTester.turn_transpiled('direction'))
-
-        self.multi_level_tester(
-            code=code,
-            expected=expected,
-            extra_check_function=self.is_turtle(),
-            max_level=3
+        turn direction"""
         )
 
-    def test_assign_print_punctuation(self):
-        code = textwrap.dedent("""\
-        naam is Hedy
-        print Hallo naam!""")
+        expected = HedyTester.dedent(
+            """\
+        print(f'Turtle race')
+        direction = input('Where to turn?')""",
+            HedyTester.turn_transpiled("direction"),
+        )
 
-        expected = textwrap.dedent("""\
+        self.multi_level_tester(code=code, expected=expected, extra_check_function=self.is_turtle(), max_level=3)
+
+    def test_assign_print_punctuation(self):
+        code = textwrap.dedent(
+            """\
+        naam is Hedy
+        print Hallo naam!"""
+        )
+
+        expected = textwrap.dedent(
+            """\
         naam = 'Hedy'
-        print(f'Hallo {naam}!')""")
+        print(f'Hallo {naam}!')"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=3)
 
     def test_assign_print_sentence(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         naam is Hedy
-        print naam is jouw voornaam""")
-        expected = textwrap.dedent("""\
+        print naam is jouw voornaam"""
+        )
+        expected = textwrap.dedent(
+            """\
         naam = 'Hedy'
-        print(f'{naam} is jouw voornaam')""")
+        print(f'{naam} is jouw voornaam')"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=3)
 
     def test_assign_print_something_else(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         naam is Felienne
-        print Hallo""")
-        expected = textwrap.dedent("""\
+        print Hallo"""
+        )
+        expected = textwrap.dedent(
+            """\
         naam = 'Felienne'
-        print(f'Hallo')""")
+        print(f'Hallo')"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=3)
 
@@ -660,29 +693,23 @@ class TestsLevel2(HedyTester):
     # negative tests
     #
     def test_echo_gives_error(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         ask what is jouw lievelingskleur?
-        echo Jouw lievelingskleur is dus...""")
+        echo Jouw lievelingskleur is dus..."""
+        )
 
         self.multi_level_tester(
             code=code,
             exception=hedy.exceptions.WrongLevelException,
-            extra_check_function=lambda c: c.exception.error_code == 'Wrong Level',
-            max_level=3
+            extra_check_function=lambda c: c.exception.error_code == "Wrong Level",
+            max_level=3,
         )
 
     def test_ask_without_var_gives_error(self):
         code = "ask is de papier goed?"
-        self.multi_level_tester(
-            code=code,
-            max_level=3,
-            exception=hedy.exceptions.WrongLevelException
-        )
+        self.multi_level_tester(code=code, max_level=3, exception=hedy.exceptions.WrongLevelException)
 
     def test_ask_without_argument_gives_error(self):
         code = "name is ask"
-        self.multi_level_tester(
-            max_level=17,
-            code=code,
-            exception=hedy.exceptions.IncompleteCommandException
-        )
+        self.multi_level_tester(max_level=17, code=code, exception=hedy.exceptions.IncompleteCommandException)

--- a/tests/test_level/test_level_03.py
+++ b/tests/test_level/test_level_03.py
@@ -5,7 +5,7 @@ from tests.Tester import HedyTester
 
 class TestsLevel3(HedyTester):
     level = 3
-    '''
+    """
     Tests should be ordered as follows:
      * commands in the order of hedy.py e.g. for level 1: ['print', 'ask', 'echo', 'turn', 'forward']
      * combined tests
@@ -16,7 +16,7 @@ class TestsLevel3(HedyTester):
      * single keyword positive tests are just keyword or keyword_special_case
      * multi keyword positive tests are keyword1_keywords_2
      * negative tests should be situation_gives_exception
-    '''
+    """
 
     #
     # print tests
@@ -24,114 +24,110 @@ class TestsLevel3(HedyTester):
 
     # issue #745
     def test_print_list_gives_type_error(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         plaatsen is een stad, een  dorp, een strand
-        print plaatsen""")
-
-        self.multi_level_tester(
-            code=code,
-            max_level=11,
-            exception=hedy.exceptions.InvalidArgumentTypeException
+        print plaatsen"""
         )
+
+        self.multi_level_tester(code=code, max_level=11, exception=hedy.exceptions.InvalidArgumentTypeException)
 
     def test_print_list_random(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         dieren is Hond, Kat, Kangoeroe
-        print dieren at random""")
+        print dieren at random"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         dieren = ['Hond', 'Kat', 'Kangoeroe']
-        print(f'{random.choice(dieren)}')""")
+        print(f'{random.choice(dieren)}')"""
+        )
 
         # check if result is in the expected list
-        check_in_list = (lambda x: HedyTester.run_code(x) in ['Hond', 'Kat', 'Kangoeroe'])
+        check_in_list = lambda x: HedyTester.run_code(x) in ["Hond", "Kat", "Kangoeroe"]
 
-        self.multi_level_tester(
-            max_level=11,
-            code=code,
-            expected=expected,
-            extra_check_function=check_in_list
-        )
+        self.multi_level_tester(max_level=11, code=code, expected=expected, extra_check_function=check_in_list)
 
     def test_print_list_access_index(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         dieren is Hond, Kat, Kangoeroe
-        print dieren at 1""")
-
-        expected = textwrap.dedent("""\
-        dieren = ['Hond', 'Kat', 'Kangoeroe']
-        print(f'{dieren[1-1]}')""")
-
-        check_in_list = (lambda x: HedyTester.run_code(x) == 'Hond')
-
-        self.multi_level_tester(
-            max_level=11,
-            code=code,
-            expected=expected,
-            extra_check_function=check_in_list
+        print dieren at 1"""
         )
 
-    def test_print_list_random_fr(self):
-        code = textwrap.dedent("""\
-        animaux est chien, chat, kangourou
-        affiche animaux au hasard""")
+        expected = textwrap.dedent(
+            """\
+        dieren = ['Hond', 'Kat', 'Kangoeroe']
+        print(f'{dieren[1-1]}')"""
+        )
 
-        expected = textwrap.dedent("""\
+        check_in_list = lambda x: HedyTester.run_code(x) == "Hond"
+
+        self.multi_level_tester(max_level=11, code=code, expected=expected, extra_check_function=check_in_list)
+
+    def test_print_list_random_fr(self):
+        code = textwrap.dedent(
+            """\
+        animaux est chien, chat, kangourou
+        affiche animaux au hasard"""
+        )
+
+        expected = textwrap.dedent(
+            """\
         animaux = ['chien', 'chat', 'kangourou']
-        print(f'{random.choice(animaux)}')""")
+        print(f'{random.choice(animaux)}')"""
+        )
 
         # check if result is in the expected list
-        check_in_list = (lambda x: HedyTester.run_code(x) in ['chien', 'chat', 'kangourou'])
+        check_in_list = lambda x: HedyTester.run_code(x) in ["chien", "chat", "kangourou"]
 
         self.multi_level_tester(
-            max_level=11,
-            code=code,
-            expected=expected,
-            extra_check_function=check_in_list,
-            lang='fr'
+            max_level=11, code=code, expected=expected, extra_check_function=check_in_list, lang="fr"
         )
 
     #
     # ask tests
     #
     def test_ask_list_gives_type_error(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         plaatsen is een stad, een  dorp, een strand
-        var is ask plaatsen""")
-
-        self.multi_level_tester(
-            code=code,
-            max_level=11,
-            exception=hedy.exceptions.InvalidArgumentTypeException
+        var is ask plaatsen"""
         )
+
+        self.multi_level_tester(code=code, max_level=11, exception=hedy.exceptions.InvalidArgumentTypeException)
 
     #
     # sleep tests
     #
     def test_sleep_with_list_access(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
             n is 1, 2, 3
-            sleep n at 1""")
-        expected = HedyTester.dedent(
-            "n = ['1', '2', '3']",
-            HedyTester.sleep_command_transpiled("n[1-1]"))
+            sleep n at 1"""
+        )
+        expected = HedyTester.dedent("n = ['1', '2', '3']", HedyTester.sleep_command_transpiled("n[1-1]"))
 
         self.multi_level_tester(max_level=11, code=code, expected=expected)
 
     def test_sleep_with_list_random(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
             n is 1, 2, 3
-            sleep n at random""")
-        expected = HedyTester.dedent(
-            "n = ['1', '2', '3']",
-            HedyTester.sleep_command_transpiled("random.choice(n)"))
+            sleep n at random"""
+        )
+        expected = HedyTester.dedent("n = ['1', '2', '3']", HedyTester.sleep_command_transpiled("random.choice(n)"))
 
         self.multi_level_tester(max_level=11, code=code, expected=expected)
 
     def test_sleep_with_list_gives_error(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
             n is 1, 2, 3
-            sleep n""")
+            sleep n"""
+        )
 
         self.multi_level_tester(max_level=11, code=code, exception=hedy.exceptions.InvalidArgumentTypeException)
 
@@ -139,15 +135,19 @@ class TestsLevel3(HedyTester):
     # assign tests
     #
     def test_assign_var_to_var(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         dier1 is hond
         dier2 is dier1
-        print dier2""")
+        print dier2"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         dier1 = 'hond'
         dier2 = dier1
-        print(f'{dier2}')""")
+        print(f'{dier2}')"""
+        )
 
         self.multi_level_tester(max_level=11, code=code, expected=expected)
 
@@ -158,13 +158,17 @@ class TestsLevel3(HedyTester):
         self.multi_level_tester(max_level=11, code=code, expected=expected)
 
     def test_assign_list_to_hungarian_var(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         állatok is kutya, macska, kenguru
-        print állatok at random""")
+        print állatok at random"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         állatok = ['kutya', 'macska', 'kenguru']
-        print(f'{random.choice(állatok)}')""")
+        print(f'{random.choice(állatok)}')"""
+        )
 
         self.multi_level_tester(max_level=11, code=code, expected=expected)
 
@@ -177,21 +181,25 @@ class TestsLevel3(HedyTester):
         self.multi_level_tester(max_level=11, code=code, expected=expected)
 
     def test_assign_random_value(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         dieren is hond, kat, kangoeroe
         dier is dieren at random
-        print dier""")
+        print dier"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         dieren = ['hond', 'kat', 'kangoeroe']
         dier = random.choice(dieren)
-        print(f'{dier}')""")
+        print(f'{dier}')"""
+        )
 
         self.multi_level_tester(
             max_level=11,
             code=code,
             expected=expected,
-            extra_check_function=self.result_in(['Hond', 'Kat', 'Kangoeroe'])
+            extra_check_function=self.result_in(["Hond", "Kat", "Kangoeroe"]),
         )
 
     def test_assign_list_with_dutch_comma_arabic_lang(self):
@@ -202,85 +210,95 @@ class TestsLevel3(HedyTester):
             max_level=11,
             code=code,
             expected=expected,
-            lang='ar',
+            lang="ar",
             # translation must be off because the Latin commas will be converted to arabic commas and this is correct
-            translate=False
+            translate=False,
         )
 
     def test_assign_list_with_arabic_comma_and_is(self):
         code = "animals هو cat، dog، platypus"
         expected = "animals = ['cat', 'dog', 'platypus']"
 
-        self.multi_level_tester(
-            max_level=11,
-            code=code,
-            expected=expected,
-            lang='ar'
-        )
+        self.multi_level_tester(max_level=11, code=code, expected=expected, lang="ar")
 
     def test_assign_list_with_arabic_comma(self):
         code = "صديقي هو احمد، خالد، حسن"
         expected = "صديقي = ['احمد', 'خالد', 'حسن']"
 
-        self.multi_level_tester(
-            max_level=11,
-            code=code,
-            expected=expected,
-            lang='ar'
-        )
+        self.multi_level_tester(max_level=11, code=code, expected=expected, lang="ar")
 
     def test_assign_list_exclamation_mark(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         antwoorden is ja, NEE!, misschien
-        print antwoorden at random""")
+        print antwoorden at random"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         antwoorden = ['ja', 'NEE!', 'misschien']
-        print(f'{random.choice(antwoorden)}')""")
+        print(f'{random.choice(antwoorden)}')"""
+        )
 
         self.multi_level_tester(max_level=11, code=code, expected=expected)
 
     def test_assign_list_values_with_inner_single_quotes(self):
-        code = textwrap.dedent(f"""\
+        code = textwrap.dedent(
+            f"""\
         taart is 'appeltaart, choladetaart, kwarktaart'
-        print 'we bakken een' taart at random""")
+        print 'we bakken een' taart at random"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         taart = ['\\'appeltaart', 'choladetaart', 'kwarktaart\\'']
-        print(f'\\'we bakken een\\' {random.choice(taart)}')""")
+        print(f'\\'we bakken een\\' {random.choice(taart)}')"""
+        )
 
         self.single_level_tester(code=code, expected=expected)
 
     def test_assign_list_values_with_inner_double_quotes(self):
-        code = textwrap.dedent(f"""\
+        code = textwrap.dedent(
+            f"""\
         taart is "appeltaart, choladetaart, kwarktaart"
-        print 'we bakken een' taart at random""")
+        print 'we bakken een' taart at random"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         taart = ['"appeltaart', 'choladetaart', 'kwarktaart"']
-        print(f'\\'we bakken een\\' {random.choice(taart)}')""")
+        print(f'\\'we bakken een\\' {random.choice(taart)}')"""
+        )
 
         self.single_level_tester(code=code, expected=expected)
 
     def test_assign_list_with_single_quoted_values(self):
-        code = textwrap.dedent(f"""\
+        code = textwrap.dedent(
+            f"""\
         taart is 'appeltaart', 'choladetaart', 'kwarktaart'
-        print 'we bakken een' taart at random""")
+        print 'we bakken een' taart at random"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         taart = ['\\'appeltaart\\'', '\\'choladetaart\\'', '\\'kwarktaart\\'']
-        print(f'\\'we bakken een\\' {random.choice(taart)}')""")
+        print(f'\\'we bakken een\\' {random.choice(taart)}')"""
+        )
 
         self.single_level_tester(code=code, expected=expected)
 
     def test_assign_list_with_double_quoted_values(self):
-        code = textwrap.dedent(f"""\
+        code = textwrap.dedent(
+            f"""\
         taart is "appeltaart", "choladetaart", "kwarktaart"
-        print "we bakken een" taart at random""")
+        print "we bakken een" taart at random"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         taart = ['"appeltaart"', '"choladetaart"', '"kwarktaart"']
-        print(f'"we bakken een" {random.choice(taart)}')""")
+        print(f'"we bakken een" {random.choice(taart)}')"""
+        )
 
         self.single_level_tester(code=code, expected=expected)
 
@@ -294,24 +312,28 @@ class TestsLevel3(HedyTester):
     # forward tests
     #
     def test_forward_with_list_variable_gives_error(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         a is 1, 2, 3
-        forward a""")
+        forward a"""
+        )
 
         self.multi_level_tester(
-            max_level=self.max_turtle_level,
-            code=code,
-            exception=hedy.exceptions.InvalidArgumentTypeException
+            max_level=self.max_turtle_level, code=code, exception=hedy.exceptions.InvalidArgumentTypeException
         )
 
     def test_forward_with_list_access_random(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         directions is 10, 100, 360
-        forward directions at random""")
+        forward directions at random"""
+        )
 
-        expected = HedyTester.dedent("""\
+        expected = HedyTester.dedent(
+            """\
         directions = ['10', '100', '360']""",
-        HedyTester.forward_transpiled('random.choice(directions)'))
+            HedyTester.forward_transpiled("random.choice(directions)"),
+        )
 
         self.multi_level_tester(
             max_level=self.max_turtle_level,
@@ -324,24 +346,28 @@ class TestsLevel3(HedyTester):
     # turn tests
     #
     def test_turn_with_list_variable_gives_error(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         a is 45, 90, 180
-        turn a""")
+        turn a"""
+        )
 
         self.multi_level_tester(
-            max_level=self.max_turtle_level,
-            code=code,
-            exception=hedy.exceptions.InvalidArgumentTypeException
+            max_level=self.max_turtle_level, code=code, exception=hedy.exceptions.InvalidArgumentTypeException
         )
 
     def test_turn_with_list_access_random(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         directions is 10, 100, 360
-        turn directions at random""")
+        turn directions at random"""
+        )
 
-        expected = HedyTester.dedent("""\
+        expected = HedyTester.dedent(
+            """\
         directions = ['10', '100', '360']""",
-        HedyTester.turn_transpiled('random.choice(directions)'))
+            HedyTester.turn_transpiled("random.choice(directions)"),
+        )
 
         self.multi_level_tester(
             max_level=self.max_turtle_level,
@@ -354,24 +380,28 @@ class TestsLevel3(HedyTester):
     # color tests
     #
     def test_color_with_list_variable_gives_error(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         c is red, green, blue
-        color c""")
+        color c"""
+        )
 
         self.multi_level_tester(
-            max_level=self.max_turtle_level,
-            code=code,
-            exception=hedy.exceptions.InvalidArgumentTypeException
+            max_level=self.max_turtle_level, code=code, exception=hedy.exceptions.InvalidArgumentTypeException
         )
 
     def test_color_with_list_access_random(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         colors is red, green, blue
-        color colors at random""")
+        color colors at random"""
+        )
 
-        expected = HedyTester.dedent("""\
+        expected = HedyTester.dedent(
+            """\
         colors = ['red', 'green', 'blue']""",
-        HedyTester.turtle_color_command_transpiled('{random.choice(colors)}'))
+            HedyTester.turtle_color_command_transpiled("{random.choice(colors)}"),
+        )
 
         self.multi_level_tester(
             max_level=self.max_turtle_level,
@@ -384,274 +414,292 @@ class TestsLevel3(HedyTester):
     # combined tests
     #
     def test_list_access_misspelled_at_gives_error(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         dieren is Hond, Kat, Kangoeroe
-        print dieren ad random""")
-
-        self.multi_level_tester(
-            max_level=11,
-            code=code,
-            exception=hedy.exceptions.InvalidArgumentTypeException
+        print dieren ad random"""
         )
+
+        self.multi_level_tester(max_level=11, code=code, exception=hedy.exceptions.InvalidArgumentTypeException)
 
     #
     # add/remove tests
     #
     def test_add_text_to_list(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         dieren is koe, kiep
         add muis to dieren
-        print dieren at random""")
+        print dieren at random"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         dieren = ['koe', 'kiep']
         dieren.append('muis')
-        print(f'{random.choice(dieren)}')""")
+        print(f'{random.choice(dieren)}')"""
+        )
 
         self.multi_level_tester(
             code=code,
             expected=expected,
             max_level=11,
-            extra_check_function=self.result_in(['koe', 'kiep', 'muis']),
+            extra_check_function=self.result_in(["koe", "kiep", "muis"]),
         )
 
     def test_add_text_with_inner_single_quote_to_list(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         dieren is koe, kiep
         add mui's to dieren
-        print dieren at random""")
+        print dieren at random"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         dieren = ['koe', 'kiep']
         dieren.append('mui\\\'s')
-        print(f'{random.choice(dieren)}')""")
+        print(f'{random.choice(dieren)}')"""
+        )
 
         self.multi_level_tester(
             code=code,
             expected=expected,
             max_level=11,
-            extra_check_function=self.result_in(['koe', 'kiep', 'mui\'s']),
+            extra_check_function=self.result_in(["koe", "kiep", "mui's"]),
         )
 
     def test_add_text_with_inner_double_quote_to_list(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         dieren is koe, kiep
         add mui"s to dieren
-        print dieren at random""")
+        print dieren at random"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         dieren = ['koe', 'kiep']
         dieren.append('mui"s')
-        print(f'{random.choice(dieren)}')""")
+        print(f'{random.choice(dieren)}')"""
+        )
 
         self.multi_level_tester(
             code=code,
             expected=expected,
             max_level=11,
-            extra_check_function=self.result_in(['koe', 'kiep', 'mui\"s']),
+            extra_check_function=self.result_in(["koe", "kiep", 'mui"s']),
         )
 
     def test_remove_text_from_list(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         dieren is koe, kiep
         remove kiep from dieren
-        print dieren at random""")
+        print dieren at random"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         dieren = ['koe', 'kiep']
         try:
           dieren.remove('kiep')
         except:
           pass
-        print(f'{random.choice(dieren)}')""")
+        print(f'{random.choice(dieren)}')"""
+        )
 
         self.multi_level_tester(
             code=code,
             expected=expected,
             max_level=11,
-            extra_check_function=self.result_in(['koe']),
+            extra_check_function=self.result_in(["koe"]),
         )
 
     def test_remove_text_with_single_quote_from_list(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         dieren is koe, kiep's
         remove kiep's from dieren
-        print dieren at random""")
+        print dieren at random"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         dieren = ['koe', 'kiep\\\'s']
         try:
           dieren.remove('kiep\\\'s')
         except:
           pass
-        print(f'{random.choice(dieren)}')""")
+        print(f'{random.choice(dieren)}')"""
+        )
 
         self.multi_level_tester(
             code=code,
             expected=expected,
             max_level=11,
-            extra_check_function=self.result_in(['koe', 'kiep', 'mui\'s']),
+            extra_check_function=self.result_in(["koe", "kiep", "mui's"]),
         )
 
     def test_remove_text_with_double_quote_from_list(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         dieren is koe, kiep"s
         remove kiep"s from dieren
-        print dieren at random""")
+        print dieren at random"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         dieren = ['koe', 'kiep"s']
         try:
           dieren.remove('kiep"s')
         except:
           pass
-        print(f'{random.choice(dieren)}')""")
+        print(f'{random.choice(dieren)}')"""
+        )
 
         self.multi_level_tester(
             code=code,
             expected=expected,
             max_level=11,
-            extra_check_function=self.result_in(['koe', 'kiep', 'mui\'s']),
+            extra_check_function=self.result_in(["koe", "kiep", "mui's"]),
         )
 
     def test_add_text_with_spaces_to_list(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         opties is zeker weten, misschien wel
         add absoluut niet to opties
-        print opties at random""")
-
-        expected = textwrap.dedent("""\
-        opties = ['zeker weten', 'misschien wel']
-        opties.append('absoluut niet')
-        print(f'{random.choice(opties)}')""")
-
-        self.multi_level_tester(
-            max_level=11,
-            code=code,
-            expected=expected
+        print opties at random"""
         )
 
+        expected = textwrap.dedent(
+            """\
+        opties = ['zeker weten', 'misschien wel']
+        opties.append('absoluut niet')
+        print(f'{random.choice(opties)}')"""
+        )
+
+        self.multi_level_tester(max_level=11, code=code, expected=expected)
+
     def test_acess_before_assign_with_random(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         print colors at random
-        colors is green, red, blue""")
+        colors is green, red, blue"""
+        )
 
         with self.assertRaises(hedy.exceptions.AccessBeforeAssign) as context:
             result = hedy.transpile(code, self.level)
 
     def test_add_ask_to_list(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         color is ask what is your favorite color?
         colors is green, red, blue
         add color to colors
-        print colors at random""")
+        print colors at random"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         color = input('what is your favorite color?')
         colors = ['green', 'red', 'blue']
         colors.append(color)
-        print(f'{random.choice(colors)}')""")
+        print(f'{random.choice(colors)}')"""
+        )
 
         self.single_level_tester(code=code, expected=expected)
 
     def test_remove_ask_from_list(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         colors is green, red, blue
         color is ask what color to remove?
         remove color from colors
-        print colors at random""")
+        print colors at random"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         colors = ['green', 'red', 'blue']
         color = input('what color to remove?')
         try:
           colors.remove(color)
         except:
           pass
-        print(f'{random.choice(colors)}')""")
+        print(f'{random.choice(colors)}')"""
+        )
 
         self.single_level_tester(code=code, expected=expected)
 
     def test_add_to_list_with_string_var_gives_error(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         color is yellow
         colors is green, red, blue
-        add colors to color""")
-
-        self.multi_level_tester(
-            max_level=11,
-            code=code,
-            exception=hedy.exceptions.InvalidArgumentTypeException
+        add colors to color"""
         )
+
+        self.multi_level_tester(max_level=11, code=code, exception=hedy.exceptions.InvalidArgumentTypeException)
 
     def test_add_to_list_with_input_var_gives_error(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         colors is ask 'What are the colors?'
         favorite is red
-        add favorite to colors""")
-
-        self.multi_level_tester(
-            max_level=11,
-            code=code,
-            exception=hedy.exceptions.InvalidArgumentTypeException
+        add favorite to colors"""
         )
+
+        self.multi_level_tester(max_level=11, code=code, exception=hedy.exceptions.InvalidArgumentTypeException)
 
     def test_remove_from_list_with_string_var_gives_error(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         color is yellow
         colors is green, red, blue
-        remove colors from color""")
-
-        self.multi_level_tester(
-            max_level=11,
-            code=code,
-            exception=hedy.exceptions.InvalidArgumentTypeException
+        remove colors from color"""
         )
+
+        self.multi_level_tester(max_level=11, code=code, exception=hedy.exceptions.InvalidArgumentTypeException)
 
     def test_remove_from_list_with_input_var_gives_error(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         colors is ask 'What are the colors?'
         favorite is red
-        remove favorite from colors""")
-
-        self.multi_level_tester(
-            max_level=11,
-            code=code,
-            exception=hedy.exceptions.InvalidArgumentTypeException
+        remove favorite from colors"""
         )
+
+        self.multi_level_tester(max_level=11, code=code, exception=hedy.exceptions.InvalidArgumentTypeException)
 
     #
     # negative tests
     #
     def test_random_from_string_gives_type_error(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         items is aap noot mies
-        print items at random""")
-
-        self.multi_level_tester(
-            code=code,
-            max_level=11,
-            exception=hedy.exceptions.InvalidArgumentTypeException
+        print items at random"""
         )
+
+        self.multi_level_tester(code=code, max_level=11, exception=hedy.exceptions.InvalidArgumentTypeException)
 
     def test_random_undefined_var_gives_error(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         dieren is hond, kat, kangoeroe
-        print dier at random""")
-
-        self.multi_level_tester(
-            code=code,
-            max_level=11,
-            exception=hedy.exceptions.UndefinedVarException
+        print dier at random"""
         )
+
+        self.multi_level_tester(code=code, max_level=11, exception=hedy.exceptions.UndefinedVarException)
 
     def test_list_access_with_type_input_gives_error(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         animals is ask 'What are the animals?'
-        print animals at random""")
-
-        self.multi_level_tester(
-            max_level=11,
-            code=code,
-            exception=hedy.exceptions.InvalidArgumentTypeException
+        print animals at random"""
         )
+
+        self.multi_level_tester(max_level=11, code=code, exception=hedy.exceptions.InvalidArgumentTypeException)

--- a/tests/test_level/test_level_04.py
+++ b/tests/test_level/test_level_04.py
@@ -6,7 +6,7 @@ from parameterized import parameterized
 
 class TestsLevel4(HedyTester):
     level = 4
-    '''
+    """
     Tests should be ordered as follows:
      * commands in the order of hedy.py e.g. for level 1: ['print', 'ask', 'echo', 'turn', 'forward']
      * combined tests
@@ -17,7 +17,7 @@ class TestsLevel4(HedyTester):
      * single keyword positive tests are just keyword or keyword_special_case
      * multi keyword positive tests are keyword1_keywords_2
      * negative tests should be situation_gives_exception
-    '''
+    """
 
     #
     # print tests
@@ -26,63 +26,41 @@ class TestsLevel4(HedyTester):
         code = "print 'hallo wereld!'"
         expected = "print(f'hallo wereld!')"
 
-        self.multi_level_tester(
-            code=code,
-            max_level=11,
-            expected=expected)
+        self.multi_level_tester(code=code, max_level=11, expected=expected)
 
     def test_print_double_quoted_text(self):
         code = 'print "hallo wereld!"'
         expected = "print(f'hallo wereld!')"
 
-        self.multi_level_tester(
-            code=code,
-            max_level=11,
-            expected=expected)
+        self.multi_level_tester(code=code, max_level=11, expected=expected)
 
     def test_print_single_quoted_text_with_inner_double_quote(self):
         code = """print 'quote is "'"""
         expected = """print(f'quote is "')"""
 
-        self.multi_level_tester(
-            code=code,
-            max_level=11,
-            expected=expected)
+        self.multi_level_tester(code=code, max_level=11, expected=expected)
 
     def test_print_double_quoted_text_with_inner_single_quote(self):
         code = '''print "It's me"'''
         expected = """print(f'It\\'s me')"""
 
-        self.multi_level_tester(
-            code=code,
-            max_level=11,
-            expected=expected)
+        self.multi_level_tester(code=code, max_level=11, expected=expected)
 
     def test_print_with_space_gives_invalid(self):
         code = " print 'Hallo welkom bij Hedy!'"
 
-        self.multi_level_tester(
-            code=code,
-            exception=hedy.exceptions.InvalidSpaceException,
-            max_level=7)
+        self.multi_level_tester(code=code, exception=hedy.exceptions.InvalidSpaceException, max_level=7)
 
     def test_print_no_space(self):
         code = "print'hallo wereld!'"
         expected = "print(f'hallo wereld!')"
 
-        self.multi_level_tester(
-            code=code,
-            max_level=11,
-            expected=expected)
+        self.multi_level_tester(code=code, max_level=11, expected=expected)
 
     def test_print_comma(self):
         code = "print 'Hi, I am Hedy'"
         expected = "print(f'Hi, I am Hedy')"
-        self.multi_level_tester(
-            code=code,
-            max_level=11,
-            expected=expected
-        )
+        self.multi_level_tester(code=code, max_level=11, expected=expected)
 
     def test_print_slash(self):
         code = "print 'Yes/No'"
@@ -95,33 +73,18 @@ class TestsLevel4(HedyTester):
         expected = "print(f'Yes\\\\No')"
         output = "Yes\\No"
 
-        self.multi_level_tester(
-            code=code,
-            expected=expected,
-            output=output,
-            max_level=11,
-            translate=True
-        )
+        self.multi_level_tester(code=code, expected=expected, output=output, max_level=11, translate=True)
 
     def test_print_with_backslash_at_end(self):
         code = "print 'Welcome to \\'"
         expected = "print(f'Welcome to \\\\')"
-        self.multi_level_tester(
-            code=code,
-            max_level=11,
-            expected=expected,
-            translate=True
-        )
+        self.multi_level_tester(code=code, max_level=11, expected=expected, translate=True)
 
     def test_print_with_spaces(self):
         code = "print        'hallo!'"
         expected = "print(f'hallo!')"
 
-        self.multi_level_tester(
-            code=code,
-            max_level=11,
-            expected=expected
-        )
+        self.multi_level_tester(code=code, max_level=11, expected=expected)
 
     def test_print_asterisk(self):
         code = "print '*Jouw* favoriet is dus kleur'"
@@ -135,11 +98,7 @@ class TestsLevel4(HedyTester):
 
         code = "print hedy 123"
 
-        self.multi_level_tester(
-            code=code,
-            max_level=5,
-            exception=hedy.exceptions.UnquotedTextException
-        )
+        self.multi_level_tester(code=code, max_level=5, exception=hedy.exceptions.UnquotedTextException)
 
     def test_print_without_quotes_gives_error_from_transpiler(self):
         # in other cases, there might be two different problems
@@ -160,11 +119,7 @@ class TestsLevel4(HedyTester):
         # same as print for level 4
         code = "pietje is ask hedy 123"
 
-        self.multi_level_tester(
-            code=code,
-            max_level=4,
-            exception=hedy.exceptions.UnquotedTextException
-        )
+        self.multi_level_tester(code=code, max_level=4, exception=hedy.exceptions.UnquotedTextException)
 
     def test_ask_without_quotes_gives_error_from_transpiler(self):
         # same as print
@@ -176,16 +131,17 @@ class TestsLevel4(HedyTester):
             exception=hedy.exceptions.UnquotedTextException,
         )
 
-
     def test_print_similar_var_gives_error(self):
         # continuing: is this unquoted? or did we forget an initialization of a variable?
 
         # a quick analysis of the logs shows that in most cases quotes are forgotten
         # so we will only raise var if there is a variable that is a bit similar (see next test)
 
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
             werld is ask 'tegen wie zeggen we hallo?'
-            print hallo wereld""")
+            print hallo wereld"""
+        )
 
         self.multi_level_tester(
             code=code,
@@ -196,62 +152,58 @@ class TestsLevel4(HedyTester):
     @parameterized.expand(HedyTester.quotes)
     def test_print_without_opening_quote_gives_error(self, q):
         code = f"print hedy 123{q}"
-        self.multi_level_tester(
-            code,
-            max_level=6,
-            exception=hedy.exceptions.UnquotedTextException
-        )
+        self.multi_level_tester(code, max_level=6, exception=hedy.exceptions.UnquotedTextException)
 
     @parameterized.expand(HedyTester.quotes)
     def test_print_without_closing_quote_gives_error(self, q):
         code = f"print {q}hedy 123"
-        self.multi_level_tester(
-            code,
-            max_level=6,
-            exception=hedy.exceptions.UnquotedTextException
-        )
+        self.multi_level_tester(code, max_level=6, exception=hedy.exceptions.UnquotedTextException)
 
     def test_print_single_quoted_text_var(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         naam is 'Hedy'
-        print 'ik heet ' naam""")
-
-        expected = textwrap.dedent("""\
-        naam = '\\'Hedy\\''
-        print(f'ik heet {naam}')""")
-
-        self.multi_level_tester(
-            max_level=11,
-            code=code,
-            expected=expected
+        print 'ik heet ' naam"""
         )
+
+        expected = textwrap.dedent(
+            """\
+        naam = '\\'Hedy\\''
+        print(f'ik heet {naam}')"""
+        )
+
+        self.multi_level_tester(max_level=11, code=code, expected=expected)
 
     def test_print_double_quoted_text_var(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         naam is "Hedy"
-        print 'ik heet ' naam""")
-
-        expected = textwrap.dedent("""\
-        naam = '"Hedy"'
-        print(f'ik heet {naam}')""")
-
-        self.multi_level_tester(
-            max_level=11,
-            code=code,
-            expected=expected
+        print 'ik heet ' naam"""
         )
+
+        expected = textwrap.dedent(
+            """\
+        naam = '"Hedy"'
+        print(f'ik heet {naam}')"""
+        )
+
+        self.multi_level_tester(max_level=11, code=code, expected=expected)
 
     # issue 1795
     def test_print_quoted_var_reference(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         naam is 'Daan'
         woord1 is zomerkamp
-        print 'naam' ' is naar het' 'woord1'""")
+        print 'naam' ' is naar het' 'woord1'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         naam = '\\'Daan\\''
         woord1 = 'zomerkamp'
-        print(f'naam is naar hetwoord1')""")
+        print(f'naam is naar hetwoord1')"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=11)
 
@@ -278,7 +230,7 @@ class TestsLevel4(HedyTester):
 
     def test_ask_double_quoted_text_with_inner_single_quote(self):
         code = f'''details is ask "say 'no'"'''
-        expected = '''details = input(f'say \\'no\\'')'''
+        expected = """details = input(f'say \\'no\\'')"""
 
         self.multi_level_tester(code=code, expected=expected, max_level=11)
 
@@ -306,13 +258,17 @@ class TestsLevel4(HedyTester):
         self.single_level_tester(code, exception=hedy.exceptions.UnquotedTextException)
 
     def test_ask_with_comma(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         dieren is ask 'hond, kat, kangoeroe'
-        print dieren""")
+        print dieren"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         dieren = input(f'hond, kat, kangoeroe')
-        print(f'{dieren}')""")
+        print(f'{dieren}')"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=11)
 
@@ -325,57 +281,77 @@ class TestsLevel4(HedyTester):
 
     @parameterized.expand(HedyTester.quotes)
     def test_ask_bengali_var(self, q):
-        code = textwrap.dedent(f"""\
+        code = textwrap.dedent(
+            f"""\
         রং is ask {q}আপনার প্রিয় রং কি?{q}
-        print রং {q} is আপনার প্রিয{q}""")
+        print রং {q} is আপনার প্রিয{q}"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         রং = input(f'আপনার প্রিয় রং কি?')
-        print(f'{রং} is আপনার প্রিয')""")
+        print(f'{রং} is আপনার প্রিয')"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=11)
 
     def test_ask_list_random(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         colors is orange, blue, green
-        favorite is ask 'Is your fav color ' colors at random""")
+        favorite is ask 'Is your fav color ' colors at random"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         colors = ['orange', 'blue', 'green']
-        favorite = input(f'Is your fav color {random.choice(colors)}')""")
+        favorite = input(f'Is your fav color {random.choice(colors)}')"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=11)
 
     def test_ask_list_access_index(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         colors is orange, blue, green
-        favorite is ask 'Is your fav color ' colors at 1""")
+        favorite is ask 'Is your fav color ' colors at 1"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         colors = ['orange', 'blue', 'green']
-        favorite = input(f'Is your fav color {colors[1-1]}')""")
+        favorite = input(f'Is your fav color {colors[1-1]}')"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=11)
 
     def test_ask_string_var(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         color is orange
-        favorite is ask 'Is your fav color ' color""")
+        favorite is ask 'Is your fav color ' color"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         color = 'orange'
-        favorite = input(f'Is your fav color {color}')""")
+        favorite = input(f'Is your fav color {color}')"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=11)
 
     def test_ask_integer_var(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         number is 10
-        favorite is ask 'Is your fav number' number""")
+        favorite is ask 'Is your fav number' number"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         number = '10'
-        favorite = input(f'Is your fav number{number}')""")
+        favorite = input(f'Is your fav number{number}')"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=11)
 
@@ -383,12 +359,12 @@ class TestsLevel4(HedyTester):
     # sleep tests
     #
     def test_sleep_with_input_variable(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
             n is ask "how long"
-            sleep n""")
-        expected = HedyTester.dedent(
-            "n = input(f'how long')",
-            HedyTester.sleep_command_transpiled("n"))
+            sleep n"""
+        )
+        expected = HedyTester.dedent("n = input(f'how long')", HedyTester.sleep_command_transpiled("n"))
 
         self.multi_level_tester(max_level=11, code=code, expected=expected)
 
@@ -396,24 +372,32 @@ class TestsLevel4(HedyTester):
     # assign tests
     #
     def test_assign_print(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         naam is Hedy
-        print 'ik heet' naam""")
+        print 'ik heet' naam"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         naam = 'Hedy'
-        print(f'ik heet{naam}')""")
+        print(f'ik heet{naam}')"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=11)
 
     def test_assign_underscore(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         voor_naam is Hedy
-        print 'ik heet ' voor_naam""")
+        print 'ik heet ' voor_naam"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         voor_naam = 'Hedy'
-        print(f'ik heet {voor_naam}')""")
+        print(f'ik heet {voor_naam}')"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=11)
 
@@ -424,46 +408,62 @@ class TestsLevel4(HedyTester):
         self.multi_level_tester(code=code, expected=expected, max_level=11)
 
     def test_assign_list_values_with_inner_single_quotes(self):
-        code = textwrap.dedent(f"""\
+        code = textwrap.dedent(
+            f"""\
           taart is 'appeltaart, choladetaart, kwarktaart'
-          print 'we bakken een ' taart at random""")
+          print 'we bakken een ' taart at random"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
           taart = ['\\'appeltaart', 'choladetaart', 'kwarktaart\\'']
-          print(f'we bakken een {random.choice(taart)}')""")
+          print(f'we bakken een {random.choice(taart)}')"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=11)
 
     def test_assign_list_values_with_inner_double_quotes(self):
-        code = textwrap.dedent(f"""\
+        code = textwrap.dedent(
+            f"""\
           taart is "appeltaart, choladetaart, kwarktaart"
-          print 'we bakken een ' taart at random""")
+          print 'we bakken een ' taart at random"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
           taart = ['"appeltaart', 'choladetaart', 'kwarktaart"']
-          print(f'we bakken een {random.choice(taart)}')""")
+          print(f'we bakken een {random.choice(taart)}')"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=11)
 
     def test_assign_list_with_single_quoted_values(self):
-        code = textwrap.dedent(f"""\
+        code = textwrap.dedent(
+            f"""\
         taart is 'appeltaart', 'choladetaart', 'kwarktaart'
-        print 'we bakken een' taart at random""")
+        print 'we bakken een' taart at random"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         taart = ['\\'appeltaart\\'', '\\'choladetaart\\'', '\\'kwarktaart\\'']
-        print(f'we bakken een{random.choice(taart)}')""")
+        print(f'we bakken een{random.choice(taart)}')"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=11)
 
     def test_assign_list_with_double_quoted_values(self):
-        code = textwrap.dedent(f"""\
+        code = textwrap.dedent(
+            f"""\
         taart is "appeltaart, choladetaart, kwarktaart"
-        print 'we bakken een' taart at random""")
+        print 'we bakken een' taart at random"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         taart = ['"appeltaart', 'choladetaart', 'kwarktaart"']
-        print(f'we bakken een{random.choice(taart)}')""")
+        print(f'we bakken een{random.choice(taart)}')"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=11)
 
@@ -481,35 +481,43 @@ class TestsLevel4(HedyTester):
     # add/remove tests
     #
     def test_add_ask_to_list(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         color is ask 'what is your favorite color?'
         colors is green, red, blue
         add color to colors
-        print colors at random""")
+        print colors at random"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         color = input(f'what is your favorite color?')
         colors = ['green', 'red', 'blue']
         colors.append(color)
-        print(f'{random.choice(colors)}')""")
+        print(f'{random.choice(colors)}')"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=11)
 
     def test_remove_ask_from_list(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         colors is green, red, blue
         color is ask 'what color to remove?'
         remove color from colors
-        print colors at random""")
+        print colors at random"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         colors = ['green', 'red', 'blue']
         color = input(f'what color to remove?')
         try:
           colors.remove(color)
         except:
           pass
-        print(f'{random.choice(colors)}')""")
+        print(f'{random.choice(colors)}')"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=11)
 
@@ -517,61 +525,62 @@ class TestsLevel4(HedyTester):
     # combined tests
     #
     def test_assign_print_chinese(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         你世界 is 你好世界
-        print 你世界""")
+        print 你世界"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         你世界 = '你好世界'
-        print(f'{你世界}')""")
+        print(f'{你世界}')"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=11)
 
     def test_ask_forward(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         afstand is ask 'hoe ver dan?'
-        forward afstand""")
+        forward afstand"""
+        )
 
-        expected = HedyTester.dedent(
-            "afstand = input(f'hoe ver dan?')",
-            HedyTester.forward_transpiled('afstand'))
+        expected = HedyTester.dedent("afstand = input(f'hoe ver dan?')", HedyTester.forward_transpiled("afstand"))
 
         self.multi_level_tester(
-            max_level=self.max_turtle_level,
-            code=code,
-            expected=expected,
-            extra_check_function=self.is_turtle()
+            max_level=self.max_turtle_level, code=code, expected=expected, extra_check_function=self.is_turtle()
         )
 
     #
     # negative tests
     #
     def test_var_undefined_error_message(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         naam is Hedy
-        print 'ik heet ' name""")
-
-        self.multi_level_tester(
-            code=code,
-            max_level=11,
-            exception=hedy.exceptions.UndefinedVarException
+        print 'ik heet ' name"""
         )
+
+        self.multi_level_tester(code=code, max_level=11, exception=hedy.exceptions.UndefinedVarException)
 
     # issue 375
     def test_program_gives_hedy_parse_exception(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         is Foobar
-        print welcome""")
+        print welcome"""
+        )
 
         self.multi_level_tester(
             code=code,
             max_level=11,
             exception=hedy.exceptions.ParseException,
-            extra_check_function=lambda c: c.exception.error_location[0] == 1 and c.exception.error_location[1] == 1
+            extra_check_function=lambda c: c.exception.error_location[0] == 1 and c.exception.error_location[1] == 1,
         )
 
     def test_quoted_text_gives_error(self):
-        code = 'competitie die gaan we winnen'
+        code = "competitie die gaan we winnen"
 
         self.multi_level_tester(code=code, exception=hedy.exceptions.MissingCommandException)
 
@@ -581,7 +590,7 @@ class TestsLevel4(HedyTester):
         self.multi_level_tester(
             code=code,
             exception=hedy.exceptions.ParseException,
-            extra_check_function=lambda c: c.exception.fixed_code == "print 'Hello'"
+            extra_check_function=lambda c: c.exception.fixed_code == "print 'Hello'",
         )
 
     #
@@ -589,9 +598,11 @@ class TestsLevel4(HedyTester):
     #
     @parameterized.expand(HedyTester.quotes)
     def test_meta_column_missing_closing_quote(self, q):
-        code = textwrap.dedent(f"""\
+        code = textwrap.dedent(
+            f"""\
         print {q}Hello{q}
-        print {q}World""")
+        print {q}World"""
+        )
 
         line, column = self.codeToInvalidInfo(code)
 
@@ -600,9 +611,11 @@ class TestsLevel4(HedyTester):
 
     @parameterized.expand(HedyTester.quotes)
     def test_meta_column_missing_opening_quote(self, q):
-        code = textwrap.dedent(f"""\
+        code = textwrap.dedent(
+            f"""\
         print {q}Hello{q}
-        print World{q}""")
+        print World{q}"""
+        )
 
         line, column = self.codeToInvalidInfo(code)
 

--- a/tests/test_level/test_level_05.py
+++ b/tests/test_level/test_level_05.py
@@ -6,7 +6,7 @@ from parameterized import parameterized
 
 class TestsLevel5(HedyTester):
     level = 5
-    '''
+    """
     Tests should be ordered as follows:
      * commands in the order of hedy.py e.g. for level 1: ['print', 'ask', 'echo', 'turn', 'forward']
      * combined tests
@@ -17,504 +17,613 @@ class TestsLevel5(HedyTester):
      * single keyword positive tests are just keyword or keyword_special_case
      * multi keyword positive tests are keyword1_keywords_2
      * negative tests should be situation_gives_exception
-    '''
+    """
 
     #
     # if tests
     #
     def test_if_equality_linebreak_print(self):
         # line breaks after if-condition are allowed
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         naam is Hedy
         if naam is Hedy
-        print 'leuk'""")
+        print 'leuk'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         naam = 'Hedy'
         if naam == 'Hedy':
-          print(f'leuk')""")
+          print(f'leuk')"""
+        )
 
         self.single_level_tester(code=code, expected=expected)
 
     def test_if_equality_trailing_space_linebreak_print(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         naam is James
         if naam is trailing_space 
-        print 'shaken'""")
+        print 'shaken'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         naam = 'James'
         if naam == 'trailing_space':
-          print(f'shaken')""")
+          print(f'shaken')"""
+        )
 
         self.single_level_tester(code=code, expected=expected)
 
     def test_if_equality_unquoted_rhs_with_space_linebreak_print(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         naam is James
         if naam is James Bond
-        print 'shaken'""")
+        print 'shaken'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         naam = 'James'
         if naam == 'James Bond':
-          print(f'shaken')""")
+          print(f'shaken')"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=7)
 
     def test_if_equality_unquoted_rhs_with_space_and_trailing_space_linebreak_print(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         naam is James
         if naam is trailing space  
-        print 'shaken'""")
+        print 'shaken'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         naam = 'James'
         if naam == 'trailing space':
-          print(f'shaken')""")
+          print(f'shaken')"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=7)
 
     def test_if_2_vars_equality_print(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         jouwkeuze is schaar
         computerkeuze is schaar
-        if computerkeuze is jouwkeuze print 'gelijkspel!'""")
+        if computerkeuze is jouwkeuze print 'gelijkspel!'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         jouwkeuze = 'schaar'
         computerkeuze = 'schaar'
         if computerkeuze == jouwkeuze:
-          print(f'gelijkspel!')""")
+          print(f'gelijkspel!')"""
+        )
 
-        self.single_level_tester(code=code, expected=expected, output='gelijkspel!')
+        self.single_level_tester(code=code, expected=expected, output="gelijkspel!")
 
     def test_if_in_list_print(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         items is red, green
         selected is red
-        if selected in items print 'found!'""")
+        if selected in items print 'found!'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         items = ['red', 'green']
         selected = 'red'
         if selected in items:
-          print(f'found!')""")
+          print(f'found!')"""
+        )
 
         self.multi_level_tester(
             max_level=7,
             code=code,
             expected=expected,
-            output='found!',
-            expected_commands=['is', 'is', 'if', 'in', 'print']
+            output="found!",
+            expected_commands=["is", "is", "if", "in", "print"],
         )
 
     def test_if_in_undefined_list(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         selected is red
-        if selected in items print 'found!'""")
+        if selected in items print 'found!'"""
+        )
 
         self.multi_level_tester(code=code, exception=hedy.exceptions.UndefinedVarException, max_level=7)
 
     def test_if_equality_unquoted_rhs_with_space_print_gives_error(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         naam is James
-        if naam is James Bond print 'shaken'""")
+        if naam is James Bond print 'shaken'"""
+        )
 
         self.multi_level_tester(code=code, exception=hedy.exceptions.UnquotedEqualityCheck, max_level=11)
 
     def test_if_equality_unquoted_rhs_with_space_assign_gives_error(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         naam is James
-        if naam is James Bond naam is 'Pietjansma'""")
+        if naam is James Bond naam is 'Pietjansma'"""
+        )
 
         self.multi_level_tester(code=code, exception=hedy.exceptions.UnquotedEqualityCheck, max_level=11)
 
     @parameterized.expand(HedyTester.quotes)
     def test_if_equality_quoted_rhs_with_space(self, q):
-        code = textwrap.dedent(f"""\
+        code = textwrap.dedent(
+            f"""\
         naam is James
-        if naam is {q}James Bond{q} print {q}shaken{q}""")
+        if naam is {q}James Bond{q} print {q}shaken{q}"""
+        )
 
-        expected = textwrap.dedent(f"""\
+        expected = textwrap.dedent(
+            f"""\
         naam = 'James'
         if naam == 'James Bond':
-          print(f'shaken')""")
+          print(f'shaken')"""
+        )
 
-        self.single_level_tester(
-            code=code,
-            expected_commands=['is', 'if', 'print'],
-            expected=expected)
+        self.single_level_tester(code=code, expected_commands=["is", "if", "print"], expected=expected)
 
     @parameterized.expand(HedyTester.quotes)
     def test_if_equality_quoted_rhs_with_spaces(self, q):
-        code = textwrap.dedent(f"""\
+        code = textwrap.dedent(
+            f"""\
         naam is James
-        if naam is {q}Bond James Bond{q} print 'shaken'""")
+        if naam is {q}Bond James Bond{q} print 'shaken'"""
+        )
 
-        expected = textwrap.dedent(f"""\
+        expected = textwrap.dedent(
+            f"""\
         naam = 'James'
         if naam == 'Bond James Bond':
-          print(f'shaken')""")
+          print(f'shaken')"""
+        )
 
         self.single_level_tester(code=code, expected=expected)
 
     def test_ask_if(self):
-        code = textwrap.dedent(f"""\
+        code = textwrap.dedent(
+            f"""\
         name is ask 'what is your name?'
-        if name is Hedy print 'nice' else print 'boo!'""")
+        if name is Hedy print 'nice' else print 'boo!'"""
+        )
 
-        expected = textwrap.dedent(f"""\
+        expected = textwrap.dedent(
+            f"""\
         name = input(f'what is your name?')
         if name == 'Hedy':
           print(f'nice')
         else:
-          print(f'boo!')""")
+          print(f'boo!')"""
+        )
 
         self.single_level_tester(
-            code=code,
-            expected_commands=['ask', 'if', 'else', 'print', 'print'],
-            expected=expected)
+            code=code, expected_commands=["ask", "if", "else", "print", "print"], expected=expected
+        )
 
     def test_if_equality_single_quoted_rhs_with_inner_double_quote(self):
-        code = textwrap.dedent(f"""\
+        code = textwrap.dedent(
+            f"""\
         answer is no
-        if answer is 'He said "no"' print 'no'""")
+        if answer is 'He said "no"' print 'no'"""
+        )
 
-        expected = textwrap.dedent(f"""\
+        expected = textwrap.dedent(
+            f"""\
         answer = 'no'
         if answer == 'He said "no"':
-          print(f'no')""")
+          print(f'no')"""
+        )
 
-        self.single_level_tester(
-            code=code,
-            expected_commands=['is', 'if', 'print'],
-            expected=expected)
+        self.single_level_tester(code=code, expected_commands=["is", "if", "print"], expected=expected)
 
     def test_if_equality_double_quoted_rhs_with_inner_single_quote(self):
-        code = textwrap.dedent(f"""\
+        code = textwrap.dedent(
+            f"""\
         answer is no
-        if answer is "He said 'no'" print 'no'""")
+        if answer is "He said 'no'" print 'no'"""
+        )
 
-        expected = textwrap.dedent(f"""\
+        expected = textwrap.dedent(
+            f"""\
         answer = 'no'
         if answer == 'He said \\'no\\'':
-          print(f'no')""")
+          print(f'no')"""
+        )
 
         self.single_level_tester(code=code, expected=expected)
 
     def test_equality_promotes_int_to_string(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         a is test
         b is 15
-        if a is b c is 1""")
-        expected = textwrap.dedent("""\
+        if a is b c is 1"""
+        )
+        expected = textwrap.dedent(
+            """\
         a = 'test'
         b = '15'
         if a == b:
-          c = '1'""")
+          c = '1'"""
+        )
 
         self.single_level_tester(code=code, expected=expected)
 
     def test_equality_with_lists_gives_error(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         n is 1, 2
         m is 1, 2
-        if n is m print 'success!'""")
-
-        self.multi_level_tester(
-            max_level=7,
-            code=code,
-            exception=hedy.exceptions.InvalidArgumentTypeException
+        if n is m print 'success!'"""
         )
+
+        self.multi_level_tester(max_level=7, code=code, exception=hedy.exceptions.InvalidArgumentTypeException)
 
     def test_if_in_list_with_string_var_gives_type_error(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         items is red
-        if red in items print 'found!'""")
-        self.multi_level_tester(
-            max_level=7,
-            code=code,
-            exception=hedy.exceptions.InvalidArgumentTypeException
+        if red in items print 'found!'"""
         )
+        self.multi_level_tester(max_level=7, code=code, exception=hedy.exceptions.InvalidArgumentTypeException)
 
     def test_if_in_list_with_input_gives_type_error(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         items is ask 'What are the items?'
-        if red in items print 'found!'""")
-        self.multi_level_tester(
-            max_level=7,
-            code=code,
-            exception=hedy.exceptions.InvalidArgumentTypeException
+        if red in items print 'found!'"""
         )
+        self.multi_level_tester(max_level=7, code=code, exception=hedy.exceptions.InvalidArgumentTypeException)
 
     #
     # if else tests
     #
     def test_if_equality_print_else_print(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         naam is Hedy
-        if naam is Hedy print 'leuk' else print 'minder leuk'""")
+        if naam is Hedy print 'leuk' else print 'minder leuk'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         naam = 'Hedy'
         if naam == 'Hedy':
           print(f'leuk')
         else:
-          print(f'minder leuk')""")
+          print(f'minder leuk')"""
+        )
 
         self.single_level_tester(code=code, expected=expected)
 
     def test_if_ask_equality_print_else_print(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         kleur is ask 'Wat is je lievelingskleur?'
-        if kleur is groen print 'mooi!' else print 'niet zo mooi'""")
+        if kleur is groen print 'mooi!' else print 'niet zo mooi'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         kleur = input(f'Wat is je lievelingskleur?')
         if kleur == 'groen':
           print(f'mooi!')
         else:
-          print(f'niet zo mooi')""")
+          print(f'niet zo mooi')"""
+        )
 
         self.single_level_tester(code=code, expected=expected)
 
     def test_if_else_followed_by_print(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         kleur is geel
         if kleur is groen antwoord is ok else antwoord is stom
-        print antwoord""")
+        print antwoord"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         kleur = 'geel'
         if kleur == 'groen':
           antwoord = 'ok'
         else:
           antwoord = 'stom'
-        print(f'{antwoord}')""")
+        print(f'{antwoord}')"""
+        )
 
         self.single_level_tester(code=code, expected=expected)
 
     def test_if_equality_trailing_space_linebreak_print_else(self):
         # this code has a space at the end of line 2
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         naam is James
         if naam is trailing space  
-        print 'shaken' else print 'biertje!'""")
+        print 'shaken' else print 'biertje!'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         naam = 'James'
         if naam == 'trailing space':
           print(f'shaken')
         else:
-          print(f'biertje!')""")
+          print(f'biertje!')"""
+        )
 
         self.multi_level_tester(max_level=7, code=code, expected=expected)
 
     def test_if_equality_print_linebreak_else_print(self):
         # line break before else is allowed
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         naam is Hedy
         if naam is Hedy print 'leuk'
-        else print 'minder leuk'""")
+        else print 'minder leuk'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         naam = 'Hedy'
         if naam == 'Hedy':
           print(f'leuk')
         else:
-          print(f'minder leuk')""")
+          print(f'minder leuk')"""
+        )
 
         self.single_level_tester(code=code, expected=expected)
 
     def test_if_equality_linebreak_print_else_print(self):
         # line break after if-condition is allowed
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         naam is Hedy
         if naam is Hedy
-        print 'leuk' else print 'minder leuk'""")
+        print 'leuk' else print 'minder leuk'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         naam = 'Hedy'
         if naam == 'Hedy':
           print(f'leuk')
         else:
-          print(f'minder leuk')""")
+          print(f'minder leuk')"""
+        )
 
         self.single_level_tester(code=code, expected=expected)
 
     def test_if_equality_unquoted_with_space_linebreak_print_else_print(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         naam is James
         if naam is James Bond
-        print 'shaken' else print 'biertje!'""")
+        print 'shaken' else print 'biertje!'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         naam = 'James'
         if naam == 'James Bond':
           print(f'shaken')
         else:
-          print(f'biertje!')""")
+          print(f'biertje!')"""
+        )
 
         self.multi_level_tester(max_level=7, code=code, expected=expected)
 
     def test_if_equality_print_else_linebreak_print(self):
         # line break after else is allowed
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         naam is Hedy
         if naam is Hedy print 'leuk' else
-        print 'minder leuk'""")
+        print 'minder leuk'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         naam = 'Hedy'
         if naam == 'Hedy':
           print(f'leuk')
         else:
-          print(f'minder leuk')""")
+          print(f'minder leuk')"""
+        )
 
         self.single_level_tester(code=code, expected=expected)
-      
+
     def test_if_with_negative_number(self):
-      code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
       antwoord is -10
-      if antwoord is -10 print 'Nice' else print 'Oh no'""")
-      
-      expected = textwrap.dedent("""\
+      if antwoord is -10 print 'Nice' else print 'Oh no'"""
+        )
+
+        expected = textwrap.dedent(
+            """\
       antwoord = '-10'
       if antwoord == '-10':
         print(f'Nice')
       else:
-        print(f'Oh no')""")
-      
-      self.single_level_tester(code=code, expected=expected, output='Nice')
+        print(f'Oh no')"""
+        )
+
+        self.single_level_tester(code=code, expected=expected, output="Nice")
 
     def test_if_equality_linebreak_print_linebreak_else_print(self):
         # line breaks after if-condition and before else are allowed
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         naam is Hedy
         if naam is Hedy
         print 'leuk'
-        else print 'minder leuk'""")
+        else print 'minder leuk'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         naam = 'Hedy'
         if naam == 'Hedy':
           print(f'leuk')
         else:
-          print(f'minder leuk')""")
+          print(f'minder leuk')"""
+        )
 
         self.single_level_tester(code=code, expected=expected)
 
     def test_if_equality_linebreak_print_linebreak_else_linebreak_print(self):
         # line breaks after if-condition, before else and after else are allowed
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         naam is Hedy
         if naam is Hedy
         print 'leuk'
         else
-        print 'minder leuk'""")
+        print 'minder leuk'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         naam = 'Hedy'
         if naam == 'Hedy':
           print(f'leuk')
         else:
-          print(f'minder leuk')""")
+          print(f'minder leuk')"""
+        )
 
         self.single_level_tester(code=code, expected=expected)
 
     def test_if_equality_linebreak_print_else_linebreak_print(self):
         # line breaks after if-condition and after else are allowed
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         naam is Hedy
         if naam is Hedy
         print 'leuk' else
-        print 'minder leuk'""")
+        print 'minder leuk'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         naam = 'Hedy'
         if naam == 'Hedy':
           print(f'leuk')
         else:
-          print(f'minder leuk')""")
+          print(f'minder leuk')"""
+        )
 
         self.single_level_tester(code=code, expected=expected)
 
     def test_if_list_assignment_else_print(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         people is mom, dad, Emma, Sophie
         dishwasher is people at random
         if dishwasher is Sophie
         print 'too bad I have to do the dishes'
         else
-        print 'luckily no dishes because' dishwasher 'is already washing up'""")
+        print 'luckily no dishes because' dishwasher 'is already washing up'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         people = ['mom', 'dad', 'Emma', 'Sophie']
         dishwasher = random.choice(people)
         if dishwasher == 'Sophie':
           print(f'too bad I have to do the dishes')
         else:
-          print(f'luckily no dishes because{dishwasher}is already washing up')""")
+          print(f'luckily no dishes because{dishwasher}is already washing up')"""
+        )
 
         self.single_level_tester(code=code, expected=expected)
 
     @parameterized.expand(HedyTester.quotes)
     def test_if_equality_quoted_rhs_with_space_else(self, q):
-        code = textwrap.dedent(f"""\
+        code = textwrap.dedent(
+            f"""\
         naam is James
-        if naam is {q}James Bond{q} print {q}shaken{q} else print {q}biertje!{q}""")
+        if naam is {q}James Bond{q} print {q}shaken{q} else print {q}biertje!{q}"""
+        )
 
-        expected = textwrap.dedent(f"""\
+        expected = textwrap.dedent(
+            f"""\
         naam = 'James'
         if naam == 'James Bond':
           print(f'shaken')
         else:
-          print(f'biertje!')""")
+          print(f'biertje!')"""
+        )
 
         self.single_level_tester(code=code, expected=expected)
 
     def test_if_equality_text_with_spaces_and_single_quotes_linebreak_print_else_print(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         naam is James
         if naam is James 'Bond'
-        print 'shaken' else print 'biertje!'""")
+        print 'shaken' else print 'biertje!'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         naam = 'James'
         if naam == 'James \\'Bond\\'':
           print(f'shaken')
         else:
-          print(f'biertje!')""")
+          print(f'biertje!')"""
+        )
 
         self.multi_level_tester(max_level=7, code=code, expected=expected)
 
     def test_if_equality_text_with_spaces_and_double_quotes_linebreak_print_else_print(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         naam is James
         if naam is James "Bond"
-        print 'shaken' else print 'biertje!'""")
+        print 'shaken' else print 'biertje!'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         naam = 'James'
         if naam == 'James "Bond"':
           print(f'shaken')
         else:
-          print(f'biertje!')""")
+          print(f'biertje!')"""
+        )
 
         self.multi_level_tester(max_level=7, code=code, expected=expected)
 
     def test_if_equality_print_else_print_bengali(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         নাম is ask 'আপনার নাম কি?'
-        if নাম is হেডি print 'ভালো!' else print 'মন্দ'""")
+        if নাম is হেডি print 'ভালো!' else print 'মন্দ'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         নাম = input(f'আপনার নাম কি?')
         if নাম == 'হেডি':
           print(f'ভালো!')
         else:
-          print(f'মন্দ')""")
+          print(f'মন্দ')"""
+        )
 
         self.single_level_tester(code=code, expected=expected)
 
@@ -522,48 +631,59 @@ class TestsLevel5(HedyTester):
     # combined tests
     #
     def test_consecutive_if_statements(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         names is Hedy, Lamar
         name is ask 'What is a name you like?'
         if name is Hedy print 'nice!'
-        if name in names print 'nice!'""")
+        if name in names print 'nice!'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         names = ['Hedy', 'Lamar']
         name = input(f'What is a name you like?')
         if name == 'Hedy':
           print(f'nice!')
         if name in names:
-          print(f'nice!')""")
+          print(f'nice!')"""
+        )
 
         self.single_level_tester(code=code, expected=expected)
 
     def test_consecutive_if_and_if_else_statements(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         naam is ask 'hoe heet jij?'
         if naam is Hedy print 'leuk'
         if naam is Python print 'ook leuk'
-        else print 'minder leuk!'""")
+        else print 'minder leuk!'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         naam = input(f'hoe heet jij?')
         if naam == 'Hedy':
           print(f'leuk')
         if naam == 'Python':
           print(f'ook leuk')
         else:
-          print(f'minder leuk!')""")
+          print(f'minder leuk!')"""
+        )
 
         self.single_level_tester(code=code, expected=expected)
 
     def test_consecutive_if_else_statements(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         names is Hedy, Lamar
         name is ask 'What is a name you like?'
         if name is Hedy print 'nice!' else print 'meh'
-        if name in names print 'nice!' else print 'meh'""")
+        if name in names print 'nice!' else print 'meh'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         names = ['Hedy', 'Lamar']
         name = input(f'What is a name you like?')
         if name == 'Hedy':
@@ -573,82 +693,95 @@ class TestsLevel5(HedyTester):
         if name in names:
           print(f'nice!')
         else:
-          print(f'meh')""")
+          print(f'meh')"""
+        )
 
         self.single_level_tester(code=code, expected=expected)
 
     def test_turn_if_forward(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         angle is 90, 180, 270
         direction is angle at random
         turn direction
-        if direction is 180 forward 100""")
+        if direction is 180 forward 100"""
+        )
 
         expected = HedyTester.dedent(
             """\
             angle = ['90', '180', '270']
             direction = random.choice(angle)""",
-            HedyTester.turn_transpiled('direction'),
+            HedyTester.turn_transpiled("direction"),
             "if direction == '180':",
-            (HedyTester.forward_transpiled(100), '  '))
+            (HedyTester.forward_transpiled(100), "  "),
+        )
 
         self.single_level_tester(code=code, expected=expected)
 
     def test_turn_if_forward_else_forward(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         angle is 90, 180, 270
         direction is angle at random
         if direction is 180 forward direction
-        else turn direction""")
+        else turn direction"""
+        )
 
         expected = HedyTester.dedent(
             """\
             angle = ['90', '180', '270']
             direction = random.choice(angle)
             if direction == '180':""",
-            (HedyTester.forward_transpiled('direction'), '  '),
+            (HedyTester.forward_transpiled("direction"), "  "),
             "else:",
-            (HedyTester.turn_transpiled('direction'), '  '))
+            (HedyTester.turn_transpiled("direction"), "  "),
+        )
 
         self.single_level_tester(code=code, expected=expected)
 
     def test_list_access_index(self):
-      code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
       friends is Hedy, Lola, Frida
       friend is friends at 2
-      print friend""")
-      
-      expected = textwrap.dedent("""\
+      print friend"""
+        )
+
+        expected = textwrap.dedent(
+            """\
       friends = ['Hedy', 'Lola', 'Frida']
       friend = friends[2-1]
-      print(f'{friend}')""")
-      
-      self.multi_level_tester(code=code, expected=expected, max_level=11)
+      print(f'{friend}')"""
+        )
+
+        self.multi_level_tester(code=code, expected=expected, max_level=11)
+
     #
     # negative tests
     #
     def test_if_indent_gives_parse_error(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         option is ask 'Rock Paper or Scissors?'
         if option is Scissors
-            print 'Its a tie!'""")
+            print 'Its a tie!'"""
+        )
 
         self.multi_level_tester(
             max_level=7,
             code=code,
             exception=hedy.exceptions.ParseException,
-            extra_check_function=lambda c: c.exception.error_location[0] == 3 and c.exception.error_location[1] == 1
+            extra_check_function=lambda c: c.exception.error_location[0] == 3 and c.exception.error_location[1] == 1,
         )
 
     def test_line_with_if_with_space_gives_invalid(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         name is Hedy
-         if name is 3 print 'leuk' else print 'stom'""")
+         if name is 3 print 'leuk' else print 'stom'"""
+        )
 
-        self.multi_level_tester(
-            code=code,
-            exception=hedy.exceptions.InvalidSpaceException,
-            max_level=7)
+        self.multi_level_tester(code=code, exception=hedy.exceptions.InvalidSpaceException, max_level=7)
 
     def test_pront_should_suggest_print(self):
         code = "pront 'Hedy is leuk!'"
@@ -656,23 +789,21 @@ class TestsLevel5(HedyTester):
         self.multi_level_tester(
             code=code,
             exception=hedy.exceptions.InvalidCommandException,
-            extra_check_function=lambda c: str(c.exception.arguments['guessed_command']) == 'print'
+            extra_check_function=lambda c: str(c.exception.arguments["guessed_command"]) == "print",
         )
 
     def test_if_equality_print_backtick_text_gives_error(self):
         code = "if 1 is 1 print `yay!` else print `nay`"
 
-        self.multi_level_tester(
-            max_level=6,
-            code=code,
-            exception=hedy.exceptions.UnquotedTextException
-        )
+        self.multi_level_tester(max_level=6, code=code, exception=hedy.exceptions.UnquotedTextException)
 
     @parameterized.expand(HedyTester.quotes)
     def test_meta_column_missing_quote(self, q):
-        code = textwrap.dedent(f"""\
+        code = textwrap.dedent(
+            f"""\
         name is ask 'what is your name?'
-        if name is Hedy print nice{q} else print {q}boo!{q}""")
+        if name is Hedy print nice{q} else print {q}boo!{q}"""
+        )
 
         line, column = self.codeToInvalidInfo(code)
 

--- a/tests/test_level/test_level_06.py
+++ b/tests/test_level/test_level_06.py
@@ -6,7 +6,7 @@ from tests.Tester import HedyTester
 
 class TestsLevel6(HedyTester):
     level = 6
-    '''
+    """
     Tests should be ordered as follows:
      * commands in the order of hedy.py e.g. for level 1: ['print', 'ask', 'echo', 'turn', 'forward']
      * combined tests
@@ -17,7 +17,7 @@ class TestsLevel6(HedyTester):
      * single keyword positive tests are just keyword or keyword_special_case
      * multi keyword positive tests are keyword1_keywords_2
      * negative tests should be situation_gives_exception
-    '''
+    """
 
     #
     # ask tests
@@ -29,15 +29,19 @@ class TestsLevel6(HedyTester):
         self.multi_level_tester(code=code, expected=expected, max_level=11)
 
     def test_ask_chained(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         a is ask 'What is a?'
         b is ask 'Are you sure a is ' a '?'
-        print a b""")
+        print a b"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         a = input(f'What is a?')
         b = input(f'Are you sure a is {a}?')
-        print(f'{a}{b}')""")
+        print(f'{a}{b}')"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=11)
 
@@ -45,12 +49,12 @@ class TestsLevel6(HedyTester):
     # sleep tests
     #
     def test_sleep_with_calc(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
             n is 1 * 2 + 3
-            sleep n""")
-        expected = HedyTester.dedent(
-            "n = int(1) * int(2) + int(3)",
-            HedyTester.sleep_command_transpiled("n"))
+            sleep n"""
+        )
+        expected = HedyTester.dedent("n = int(1) * int(2) + int(3)", HedyTester.sleep_command_transpiled("n"))
 
         self.multi_level_tester(max_level=11, code=code, expected=expected)
 
@@ -61,34 +65,23 @@ class TestsLevel6(HedyTester):
         code = "name = Hedy"
         expected = "name = 'Hedy'"
 
-        self.multi_level_tester(
-            max_level=11,
-            code=code,
-            expected=expected
-        )
+        self.multi_level_tester(max_level=11, code=code, expected=expected)
 
     def test_assign_with_equals_no_space(self):
         code = "name=Hedy"
         expected = "name = 'Hedy'"
 
-        self.multi_level_tester(
-            max_level=11,
-            code=code,
-            expected=expected
-        )
+        self.multi_level_tester(max_level=11, code=code, expected=expected)
 
     def test_assign_list_with_equals(self):
         code = "name = Hedy, Lamar"
         expected = "name = ['Hedy', 'Lamar']"
 
-        self.multi_level_tester(
-            max_level=11,
-            code=code,
-            expected=expected
-        )
+        self.multi_level_tester(max_level=11, code=code, expected=expected)
 
     def test_assign_text_with_space(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         a is 'Hello World'
         print a
 
@@ -99,199 +92,246 @@ class TestsLevel6(HedyTester):
         print a
 
         a = Hello World
-        print a""")
-
-        expected = textwrap.dedent("""\
-        a = '\\'Hello World\\''
-        print(f'{a}')
-        a = '\\'Hello World\\''
-        print(f'{a}')
-        a = 'Hello World'
-        print(f'{a}')
-        a = 'Hello World'
-        print(f'{a}')""")
-
-        self.multi_level_tester(
-            max_level=11,
-            code=code,
-            expected=expected
+        print a"""
         )
-    
-    def test_assign_substract_negative_number(self):
-      
-      code = textwrap.dedent("""\
-      n = -3-4
-      print n""")
-      
-      expected = textwrap.dedent("""\
-      n = int(-3) - int(4)
-      print(f'{n}')""")
 
-      self.multi_level_tester(
-        max_level=11,
-        code=code,
-        expected=expected
-      )
+        expected = textwrap.dedent(
+            """\
+        a = '\\'Hello World\\''
+        print(f'{a}')
+        a = '\\'Hello World\\''
+        print(f'{a}')
+        a = 'Hello World'
+        print(f'{a}')
+        a = 'Hello World'
+        print(f'{a}')"""
+        )
+
+        self.multi_level_tester(max_level=11, code=code, expected=expected)
+
+    def test_assign_substract_negative_number(self):
+
+        code = textwrap.dedent(
+            """\
+      n = -3-4
+      print n"""
+        )
+
+        expected = textwrap.dedent(
+            """\
+      n = int(-3) - int(4)
+      print(f'{n}')"""
+        )
+
+        self.multi_level_tester(max_level=11, code=code, expected=expected)
 
     #
     # if tests
     #
     def test_if_equality_linebreak_print(self):
         # line breaks after if-condition are allowed
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         naam is Hedy
         if naam is Hedy
-        print 'leuk'""")
+        print 'leuk'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         naam = 'Hedy'
         if convert_numerals('Latin', naam) == convert_numerals('Latin', 'Hedy'):
-          print(f'leuk')""")
+          print(f'leuk')"""
+        )
 
         self.multi_level_tester(max_level=7, code=code, expected=expected)
 
     def test_if_equality_trailing_space_linebreak_print(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         naam is James
         if naam is trailing_space 
-        print 'shaken'""")
+        print 'shaken'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         naam = 'James'
         if convert_numerals('Latin', naam) == convert_numerals('Latin', 'trailing_space'):
-          print(f'shaken')""")
+          print(f'shaken')"""
+        )
 
         self.multi_level_tester(max_level=7, code=code, expected=expected)
 
     def test_if_2_vars_equality_print(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         jouwkeuze is schaar
         computerkeuze is schaar
-        if computerkeuze is jouwkeuze print 'gelijkspel!'""")
+        if computerkeuze is jouwkeuze print 'gelijkspel!'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         jouwkeuze = 'schaar'
         computerkeuze = 'schaar'
         if convert_numerals('Latin', computerkeuze) == convert_numerals('Latin', jouwkeuze):
-          print(f'gelijkspel!')""")
+          print(f'gelijkspel!')"""
+        )
 
-        self.multi_level_tester(max_level=7, code=code, expected=expected, output='gelijkspel!')
+        self.multi_level_tester(max_level=7, code=code, expected=expected, output="gelijkspel!")
 
     def test_equality_arabic(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         nummer1 is ٢
         nummer2 is 2
-        if nummer1 is nummer2 print 'jahoor!'""")
+        if nummer1 is nummer2 print 'jahoor!'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         nummer1 = '٢'
         nummer2 = '2'
         if convert_numerals('Latin', nummer1) == convert_numerals('Latin', nummer2):
-          print(f'jahoor!')""")
+          print(f'jahoor!')"""
+        )
 
-        self.multi_level_tester(max_level=7, code=code, expected=expected, output='jahoor!')
+        self.multi_level_tester(max_level=7, code=code, expected=expected, output="jahoor!")
 
     @parameterized.expand(HedyTester.quotes)
     def test_if_equality_quoted_rhs_with_space(self, q):
-        code = textwrap.dedent(f"""\
+        code = textwrap.dedent(
+            f"""\
         naam is James
-        if naam is {q}James Bond{q} print {q}shaken{q}""")
+        if naam is {q}James Bond{q} print {q}shaken{q}"""
+        )
 
-        expected = textwrap.dedent(f"""\
+        expected = textwrap.dedent(
+            f"""\
         naam = 'James'
         if convert_numerals('Latin', naam) == convert_numerals('Latin', 'James Bond'):
-          print(f'shaken')""")
+          print(f'shaken')"""
+        )
 
         self.multi_level_tester(max_level=7, code=code, expected=expected)
 
     @parameterized.expand(HedyTester.quotes)
     def test_if_equality_quoted_rhs_with_spaces(self, q):
-        code = textwrap.dedent(f"""\
+        code = textwrap.dedent(
+            f"""\
         naam is James
-        if naam is {q}Bond James Bond{q} print 'shaken'""")
+        if naam is {q}Bond James Bond{q} print 'shaken'"""
+        )
 
-        expected = textwrap.dedent(f"""\
+        expected = textwrap.dedent(
+            f"""\
         naam = 'James'
         if convert_numerals('Latin', naam) == convert_numerals('Latin', 'Bond James Bond'):
-          print(f'shaken')""")
+          print(f'shaken')"""
+        )
 
         self.multi_level_tester(max_level=7, code=code, expected=expected)
 
     def test_if_equality_single_quoted_rhs_with_inner_double_quote(self):
-        code = textwrap.dedent(f"""\
+        code = textwrap.dedent(
+            f"""\
         answer is no
-        if answer is 'He said "no"' print 'no'""")
+        if answer is 'He said "no"' print 'no'"""
+        )
 
-        expected = textwrap.dedent(f"""\
+        expected = textwrap.dedent(
+            f"""\
         answer = 'no'
         if convert_numerals('Latin', answer) == convert_numerals('Latin', 'He said "no"'):
-          print(f'no')""")
+          print(f'no')"""
+        )
 
         self.multi_level_tester(max_level=7, code=code, expected=expected)
 
     def test_equality_double_quoted_rhs_with_inner_single_quote(self):
-        code = textwrap.dedent(f"""\
+        code = textwrap.dedent(
+            f"""\
         answer is no
-        if answer is "He said 'no'" print 'no'""")
+        if answer is "He said 'no'" print 'no'"""
+        )
 
-        expected = textwrap.dedent(f"""\
+        expected = textwrap.dedent(
+            f"""\
         answer = 'no'
         if convert_numerals('Latin', answer) == convert_numerals('Latin', 'He said \\'no\\''):
-          print(f'no')""")
+          print(f'no')"""
+        )
 
         self.multi_level_tester(max_level=7, code=code, expected=expected)
 
     def test_equality_promotes_int_to_string(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         a is test
         b is 15
-        if a is b c is 1""")
+        if a is b c is 1"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         a = 'test'
         b = '15'
         if convert_numerals('Latin', a) == convert_numerals('Latin', b):
-          c = '1'""")
+          c = '1'"""
+        )
 
         self.multi_level_tester(max_level=7, code=code, expected=expected)
 
     def test_if_equality_assign_calc(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         cmp is 1
         test is 2
         acu is 0
-        if test is cmp acu is acu + 1""")
+        if test is cmp acu is acu + 1"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         cmp = '1'
         test = '2'
         acu = '0'
         if convert_numerals('Latin', test) == convert_numerals('Latin', cmp):
-          acu = int(acu) + int(1)""")
+          acu = int(acu) + int(1)"""
+        )
 
         self.multi_level_tester(max_level=7, code=code, expected=expected)
 
     def test_if_equality_with_is(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         naam is Hedy
-        if naam is Hedy print 'leuk'""")
+        if naam is Hedy print 'leuk'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         naam = 'Hedy'
         if convert_numerals('Latin', naam) == convert_numerals('Latin', 'Hedy'):
-          print(f'leuk')""")
+          print(f'leuk')"""
+        )
 
         self.multi_level_tester(max_level=7, code=code, expected=expected)
 
     def test_if_equality_with_equals_sign(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         naam is Hedy
-        if naam = Hedy print 'leuk'""")
+        if naam = Hedy print 'leuk'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         naam = 'Hedy'
         if convert_numerals('Latin', naam) == convert_numerals('Latin', 'Hedy'):
-          print(f'leuk')""")
+          print(f'leuk')"""
+        )
 
         self.multi_level_tester(max_level=7, code=code, expected=expected)
 
@@ -299,83 +339,103 @@ class TestsLevel6(HedyTester):
     # if else tests
     #
     def test_if_equality_print_else_print(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         naam is Hedy
-        if naam is Hedy print 'leuk' else print 'minder leuk'""")
+        if naam is Hedy print 'leuk' else print 'minder leuk'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         naam = 'Hedy'
         if convert_numerals('Latin', naam) == convert_numerals('Latin', 'Hedy'):
           print(f'leuk')
         else:
-          print(f'minder leuk')""")
+          print(f'minder leuk')"""
+        )
 
         self.multi_level_tester(max_level=7, code=code, expected=expected)
 
     def test_if_ask_equality_print_else_print(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         kleur is ask 'Wat is je lievelingskleur?'
-        if kleur is groen print 'mooi!' else print 'niet zo mooi'""")
+        if kleur is groen print 'mooi!' else print 'niet zo mooi'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         kleur = input(f'Wat is je lievelingskleur?')
         if convert_numerals('Latin', kleur) == convert_numerals('Latin', 'groen'):
           print(f'mooi!')
         else:
-          print(f'niet zo mooi')""")
+          print(f'niet zo mooi')"""
+        )
 
         self.multi_level_tester(max_level=7, code=code, expected=expected)
 
     def test_if_else_followed_by_print(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         kleur is geel
         if kleur is groen antwoord is ok else antwoord is stom
-        print antwoord""")
+        print antwoord"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         kleur = 'geel'
         if convert_numerals('Latin', kleur) == convert_numerals('Latin', 'groen'):
           antwoord = 'ok'
         else:
           antwoord = 'stom'
-        print(f'{antwoord}')""")
+        print(f'{antwoord}')"""
+        )
 
         self.multi_level_tester(max_level=7, code=code, expected=expected)
 
     def test_if_equality_assign_else_assign(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         cmp is 1
         test is 2
         acu is 0
         if test is cmp
         acu is acu + 1
         else
-        acu is acu + 5""")
+        acu is acu + 5"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         cmp = '1'
         test = '2'
         acu = '0'
         if convert_numerals('Latin', test) == convert_numerals('Latin', cmp):
           acu = int(acu) + int(1)
         else:
-          acu = int(acu) + int(5)""")
+          acu = int(acu) + int(5)"""
+        )
 
         self.multi_level_tester(max_level=7, code=code, expected=expected)
-      
+
     def test_if_with_negative_number(self):
-      code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
       antwoord is -10
-      if antwoord is -10 print 'Nice' else print 'Oh no'""")
-      
-      expected = textwrap.dedent("""\
+      if antwoord is -10 print 'Nice' else print 'Oh no'"""
+        )
+
+        expected = textwrap.dedent(
+            """\
       antwoord = '-10'
       if convert_numerals('Latin', antwoord) == convert_numerals('Latin', '-10'):
         print(f'Nice')
       else:
-        print(f'Oh no')""")
-      
-      self.multi_level_tester(code=code, expected=expected, output='Nice', max_level=7)
+        print(f'Oh no')"""
+        )
+
+        self.multi_level_tester(code=code, expected=expected, output="Nice", max_level=7)
 
     # Legal syntax:
     #
@@ -391,121 +451,146 @@ class TestsLevel6(HedyTester):
 
     def test_if_equality_print_linebreak_else_print(self):
         # line break before else is allowed
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         naam is Hedy
         if naam is Hedy print 'leuk'
-        else print 'minder leuk'""")
+        else print 'minder leuk'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         naam = 'Hedy'
         if convert_numerals('Latin', naam) == convert_numerals('Latin', 'Hedy'):
           print(f'leuk')
         else:
-          print(f'minder leuk')""")
+          print(f'minder leuk')"""
+        )
 
         self.multi_level_tester(
-            max_level=7,
-            code=code,
-            expected=expected,
-            expected_commands=['is', 'if', 'else', 'print', 'print']
+            max_level=7, code=code, expected=expected, expected_commands=["is", "if", "else", "print", "print"]
         )
 
     def test_if_equality_linebreak_print_else_print(self):
         # line break after if-condition is allowed
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         naam is Hedy
         if naam is Hedy
-        print 'leuk' else print 'minder leuk'""")
+        print 'leuk' else print 'minder leuk'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         naam = 'Hedy'
         if convert_numerals('Latin', naam) == convert_numerals('Latin', 'Hedy'):
           print(f'leuk')
         else:
-          print(f'minder leuk')""")
+          print(f'minder leuk')"""
+        )
 
         self.multi_level_tester(max_level=7, code=code, expected=expected)
 
     def test_if_equality_print_else_linebreak_print(self):
         # line break after else is allowed
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         naam is Hedy
         if naam is Hedy print 'leuk' else
-        print 'minder leuk'""")
+        print 'minder leuk'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         naam = 'Hedy'
         if convert_numerals('Latin', naam) == convert_numerals('Latin', 'Hedy'):
           print(f'leuk')
         else:
-          print(f'minder leuk')""")
+          print(f'minder leuk')"""
+        )
 
         self.multi_level_tester(max_level=7, code=code, expected=expected)
 
     def test_if_equality_linebreak_print_linebreak_else_print(self):
         # line breaks after if-condition and before else are allowed
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         naam is Hedy
         if naam is Hedy
         print 'leuk'
-        else print 'minder leuk'""")
+        else print 'minder leuk'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         naam = 'Hedy'
         if convert_numerals('Latin', naam) == convert_numerals('Latin', 'Hedy'):
           print(f'leuk')
         else:
-          print(f'minder leuk')""")
+          print(f'minder leuk')"""
+        )
 
         self.multi_level_tester(max_level=7, code=code, expected=expected)
 
     def test_if_equality_linebreak_print_linebreak_else_linebreak_print(self):
         # line breaks after if-condition, before else and after else are allowed
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         naam is Hedy
         if naam is Hedy
         print 'leuk'
         else
-        print 'minder leuk'""")
+        print 'minder leuk'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         naam = 'Hedy'
         if convert_numerals('Latin', naam) == convert_numerals('Latin', 'Hedy'):
           print(f'leuk')
         else:
-          print(f'minder leuk')""")
+          print(f'minder leuk')"""
+        )
 
         self.multi_level_tester(max_level=7, code=code, expected=expected)
 
     def test_if_equality_linebreak_print_else_linebreak_print(self):
         # line breaks after if-condition and after else are allowed
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         naam is Hedy
         if naam is Hedy
         print 'leuk' else
-        print 'minder leuk'""")
+        print 'minder leuk'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         naam = 'Hedy'
         if convert_numerals('Latin', naam) == convert_numerals('Latin', 'Hedy'):
           print(f'leuk')
         else:
-          print(f'minder leuk')""")
+          print(f'minder leuk')"""
+        )
 
         self.multi_level_tester(max_level=7, code=code, expected=expected)
 
     @parameterized.expand(HedyTester.quotes)
     def test_if_equality_quoted_rhs_with_space_else(self, q):
-        code = textwrap.dedent(f"""\
+        code = textwrap.dedent(
+            f"""\
         naam is James
-        if naam is {q}James Bond{q} print {q}shaken{q} else print {q}biertje!{q}""")
+        if naam is {q}James Bond{q} print {q}shaken{q} else print {q}biertje!{q}"""
+        )
 
-        expected = textwrap.dedent(f"""\
+        expected = textwrap.dedent(
+            f"""\
         naam = 'James'
         if convert_numerals('Latin', naam) == convert_numerals('Latin', 'James Bond'):
           print(f'shaken')
         else:
-          print(f'biertje!')""")
+          print(f'biertje!')"""
+        )
 
         self.multi_level_tester(max_level=7, code=code, expected=expected)
 
@@ -515,27 +600,31 @@ class TestsLevel6(HedyTester):
     def test_print_calc(self):
         code = "print 5 * 5"
         expected = "print(f'{int(5) * int(5)}')"
-        output = '25'
+        output = "25"
 
         self.multi_level_tester(max_level=11, code=code, expected=expected, output=output)
 
     def test_print_nested_calcs(self):
         code = "print 5 * 5 * 5"
         expected = "print(f'{int(5) * int(5) * int(5)}')"
-        output = '125'
+        output = "125"
 
         self.multi_level_tester(max_level=11, code=code, expected=expected, output=output)
 
     def test_assign_calc_print_var(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         nummer is 4 + 5
-        print nummer""")
+        print nummer"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         nummer = int(4) + int(5)
-        print(f'{nummer}')""")
+        print(f'{nummer}')"""
+        )
 
-        self.multi_level_tester(max_level=11, code=code, expected=expected, output='9')
+        self.multi_level_tester(max_level=11, code=code, expected=expected, output="9")
 
     def test_assign_calc_no_space(self):
         code = "nummer is 4+5"
@@ -544,12 +633,16 @@ class TestsLevel6(HedyTester):
         self.multi_level_tester(max_level=11, code=code, expected=expected)
 
     def test_print_calc_with_var(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         var is 5
-        print var + 5""")
-        expected = textwrap.dedent("""\
+        print var + 5"""
+        )
+        expected = textwrap.dedent(
+            """\
         var = '5'
-        print(f'{int(var) + int(5)}')""")
+        print(f'{int(var) + int(5)}')"""
+        )
 
         self.multi_level_tester(max_level=11, code=code, expected=expected)
 
@@ -558,219 +651,209 @@ class TestsLevel6(HedyTester):
     def test_assign_calc_precedes_quoted_string(self, operation):
         code = f"a is '3{operation}10'"  # gets parsed to arithmetic operation of '3 and 10'
 
-        self.multi_level_tester(
-            max_level=11,
-            code=code,
-            exception=hedy.exceptions.InvalidArgumentTypeException
-        )
+        self.multi_level_tester(max_level=11, code=code, exception=hedy.exceptions.InvalidArgumentTypeException)
 
-    @parameterized.expand([
-        ('*', '*', '16'),
-        ('/', '//', '4'),
-        ('+', '+', '10'),
-        ('-', '-', '6')
-    ])
+    @parameterized.expand([("*", "*", "16"), ("/", "//", "4"), ("+", "+", "10"), ("-", "-", "6")])
     def test_assign_calc_with_vars(self, op, transpiled_op, output):
-        code = textwrap.dedent(f"""\
+        code = textwrap.dedent(
+            f"""\
         nummer is 8
         nummertwee is 2
         getal is nummer {op} nummertwee
-        print getal""")
+        print getal"""
+        )
 
-        expected = textwrap.dedent(f"""\
+        expected = textwrap.dedent(
+            f"""\
         nummer = '8'
         nummertwee = '2'
         getal = int(nummer) {transpiled_op} int(nummertwee)
-        print(f'{{getal}}')""")
+        print(f'{{getal}}')"""
+        )
 
         self.multi_level_tester(max_level=11, code=code, expected=expected, output=output)
 
-    @parameterized.expand([
-        ('*', '*', '16'),
-        ('/', '//', '4'),
-        ('+', '+', '10'),
-        ('-', '-', '6')
-    ])
+    @parameterized.expand([("*", "*", "16"), ("/", "//", "4"), ("+", "+", "10"), ("-", "-", "6")])
     def test_print_calc_with_vars(self, op, transpiled_op, output):
-        code = textwrap.dedent(f"""\
+        code = textwrap.dedent(
+            f"""\
         nummer is 8
         nummertwee is 2
-        print nummer {op} nummertwee""")
+        print nummer {op} nummertwee"""
+        )
 
-        expected = textwrap.dedent(f"""\
+        expected = textwrap.dedent(
+            f"""\
         nummer = '8'
         nummertwee = '2'
-        print(f'{{int(nummer) {transpiled_op} int(nummertwee)}}')""")
+        print(f'{{int(nummer) {transpiled_op} int(nummertwee)}}')"""
+        )
 
         self.multi_level_tester(max_level=11, code=code, expected=expected, output=output)
 
-    @parameterized.expand([
-        ('*', '*', '16'),
-        ('/', '//', '4'),
-        ('+', '+', '10'),
-        ('-', '-', '6')
-    ])
+    @parameterized.expand([("*", "*", "16"), ("/", "//", "4"), ("+", "+", "10"), ("-", "-", "6")])
     def test_print_calc_with_vars_arabic(self, op, transpiled_op, output):
-        code = textwrap.dedent(f"""\
+        code = textwrap.dedent(
+            f"""\
             nummer is ٨
             nummertwee is ٢
-            print nummer {op} nummertwee""")
+            print nummer {op} nummertwee"""
+        )
 
-        expected = textwrap.dedent(f"""\
+        expected = textwrap.dedent(
+            f"""\
             nummer = '٨'
             nummertwee = '٢'
-            print(f'{{int(nummer) {transpiled_op} int(nummertwee)}}')""")
+            print(f'{{int(nummer) {transpiled_op} int(nummertwee)}}')"""
+        )
 
         self.multi_level_tester(max_level=11, code=code, expected=expected, output=output)
 
     def test_print_calc_arabic_directly(self):
         # TODO: can also be generalized for other ops
-        code = textwrap.dedent(f"""\
-            قول "٥ ضرب ٥ يساوي " ٥*٥""")
+        code = textwrap.dedent(
+            f"""\
+            قول "٥ ضرب ٥ يساوي " ٥*٥"""
+        )
 
-        expected = textwrap.dedent("""\
-            print(f'٥ ضرب ٥ يساوي {convert_numerals("Arabic",int(5) * int(5))}')""")
+        expected = textwrap.dedent(
+            """\
+            print(f'٥ ضرب ٥ يساوي {convert_numerals("Arabic",int(5) * int(5))}')"""
+        )
 
-        output = '٥ ضرب ٥ يساوي ٢٥'
+        output = "٥ ضرب ٥ يساوي ٢٥"
 
-        self.multi_level_tester(
-            max_level=11,
-            code=code,
-            expected=expected,
-            output=output,
-            lang='ar')
+        self.multi_level_tester(max_level=11, code=code, expected=expected, output=output, lang="ar")
 
     def test_print_calc_arabic_directly_in_en(self):
         # TODO: can also be generalized for other ops
-        code = textwrap.dedent(f"""\
-            print "nummers" ٥*٥""")
+        code = textwrap.dedent(
+            f"""\
+            print "nummers" ٥*٥"""
+        )
 
-        expected = textwrap.dedent("""\
-            print(f'nummers{int(5) * int(5)}')""")
+        expected = textwrap.dedent(
+            """\
+            print(f'nummers{int(5) * int(5)}')"""
+        )
 
-        self.multi_level_tester(
-            max_level=11,
-            code=code,
-            expected=expected,
-            translate=False)
+        self.multi_level_tester(max_level=11, code=code, expected=expected, translate=False)
 
     @parameterized.expand(HedyTester.arithmetic_operations)
     def test_calc_with_text_var_gives_type_error(self, operation):
-        code = textwrap.dedent(f"""\
+        code = textwrap.dedent(
+            f"""\
         a is test
-        print a {operation} 2""")
-
-        self.multi_level_tester(
-            max_level=11,
-            code=code,
-            exception=hedy.exceptions.InvalidArgumentTypeException
+        print a {operation} 2"""
         )
+
+        self.multi_level_tester(max_level=11, code=code, exception=hedy.exceptions.InvalidArgumentTypeException)
 
     @parameterized.expand(HedyTester.arithmetic_operations)
     def test_calc_with_quoted_string_gives_type_error(self, operation):
-        code = textwrap.dedent(f"""\
+        code = textwrap.dedent(
+            f"""\
         a is 1
-        print a {operation} 'Test'""")
-
-        self.multi_level_tester(
-            max_level=11,
-            code=code,
-            exception=hedy.exceptions.InvalidArgumentTypeException
+        print a {operation} 'Test'"""
         )
+
+        self.multi_level_tester(max_level=11, code=code, exception=hedy.exceptions.InvalidArgumentTypeException)
 
     @parameterized.expand(HedyTester.arithmetic_operations)
     def test_calc_with_list_var_gives_type_error(self, operation):
-        code = textwrap.dedent(f"""\
+        code = textwrap.dedent(
+            f"""\
         a is one, two
-        print a {operation} 2""")
-
-        self.multi_level_tester(
-            max_level=11,
-            code=code,
-            exception=hedy.exceptions.InvalidArgumentTypeException
+        print a {operation} 2"""
         )
 
-    @parameterized.expand(['1.5', '1,5'])
+        self.multi_level_tester(max_level=11, code=code, exception=hedy.exceptions.InvalidArgumentTypeException)
+
+    @parameterized.expand(["1.5", "1,5"])
     def test_calculation_with_unsupported_float_gives_error(self, number):
         self.multi_level_tester(
-            max_level=11,
-            code=f"print {number} + 1",
-            exception=hedy.exceptions.UnsupportedFloatException
+            max_level=11, code=f"print {number} + 1", exception=hedy.exceptions.UnsupportedFloatException
         )
 
     def test_print_calc_chained_vars(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         a is 5
         b is a + 1
-        print a + b""")
+        print a + b"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         a = '5'
         b = int(a) + int(1)
-        print(f'{int(a) + int(b)}')""")
+        print(f'{int(a) + int(b)}')"""
+        )
 
         self.multi_level_tester(
             code=code,
             max_level=11,
             expected=expected,
-            expected_commands=['is', 'is', 'addition', 'print', 'addition'],
-            extra_check_function=lambda x: self.run_code(x) == "11"
+            expected_commands=["is", "is", "addition", "print", "addition"],
+            extra_check_function=lambda x: self.run_code(x) == "11",
         )
 
     def test_type_reassignment_to_proper_type_valid(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         a is Hello
         a is 5
         b is a + 1
-        print a + b""")
+        print a + b"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         a = 'Hello'
         a = '5'
         b = int(a) + int(1)
-        print(f'{int(a) + int(b)}')""")
+        print(f'{int(a) + int(b)}')"""
+        )
 
         self.multi_level_tester(
             code=code,
             max_level=11,
             expected=expected,
-            expected_commands=['is', 'is', 'is', 'addition', 'print', 'addition'],
-            extra_check_function=lambda x: self.run_code(x) == "11"
+            expected_commands=["is", "is", "is", "addition", "print", "addition"],
+            extra_check_function=lambda x: self.run_code(x) == "11",
         )
 
     def test_type_reassignment_to_wrong_type_raises_error(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         a is 5
         a is test
-        print a + 2""")
-
-        self.multi_level_tester(
-            max_level=11,
-            code=code,
-            exception=hedy.exceptions.InvalidArgumentTypeException
+        print a + 2"""
         )
+
+        self.multi_level_tester(max_level=11, code=code, exception=hedy.exceptions.InvalidArgumentTypeException)
 
     def test_cyclic_var_definition_gives_error(self):
         code = "b is b + 1"
 
-        self.multi_level_tester(
-            code=code,
-            exception=hedy.exceptions.CyclicVariableDefinitionException
-        )
+        self.multi_level_tester(code=code, exception=hedy.exceptions.CyclicVariableDefinitionException)
 
     #
     # combined tests
     #
     def test_if_calc_else_calc_print(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         keuzes is 1, 2, 3, 4, 5, regenworm
         punten is 0
         worp is keuzes at random
         if worp is regenworm punten is punten + 5
         else punten is punten + worp
-        print 'dat zijn dan ' punten""")
+        print 'dat zijn dan ' punten"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         keuzes = ['1', '2', '3', '4', '5', 'regenworm']
         punten = '0'
         worp = random.choice(keuzes)
@@ -778,53 +861,65 @@ class TestsLevel6(HedyTester):
           punten = int(punten) + int(5)
         else:
           punten = int(punten) + int(worp)
-        print(f'dat zijn dan {punten}')""")
+        print(f'dat zijn dan {punten}')"""
+        )
 
         self.multi_level_tester(max_level=7, code=code, expected=expected)
 
     def test_consecutive_if_statements(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         names is Hedy, Lamar
         name is ask 'What is a name you like?'
         if name is Hedy print 'nice!'
-        if name in names print 'nice!'""")
+        if name in names print 'nice!'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         names = ['Hedy', 'Lamar']
         name = input(f'What is a name you like?')
         if convert_numerals('Latin', name) == convert_numerals('Latin', 'Hedy'):
           print(f'nice!')
         if name in names:
-          print(f'nice!')""")
+          print(f'nice!')"""
+        )
 
         self.multi_level_tester(max_level=7, code=code, expected=expected)
 
     def test_consecutive_if_and_if_else_statements(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         naam is ask 'hoe heet jij?'
         if naam is Hedy print 'leuk'
         if naam is Python print 'ook leuk'
-        else print 'minder leuk!'""")
+        else print 'minder leuk!'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         naam = input(f'hoe heet jij?')
         if convert_numerals('Latin', naam) == convert_numerals('Latin', 'Hedy'):
           print(f'leuk')
         if convert_numerals('Latin', naam) == convert_numerals('Latin', 'Python'):
           print(f'ook leuk')
         else:
-          print(f'minder leuk!')""")
+          print(f'minder leuk!')"""
+        )
 
         self.multi_level_tester(max_level=7, code=code, expected=expected)
 
     def test_consecutive_if_else_statements(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         names is Hedy, Lamar
         name is ask 'What is a name you like?'
         if name is Hedy print 'nice!' else print 'meh'
-        if name in names print 'nice!' else print 'meh'""")
+        if name in names print 'nice!' else print 'meh'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         names = ['Hedy', 'Lamar']
         name = input(f'What is a name you like?')
         if convert_numerals('Latin', name) == convert_numerals('Latin', 'Hedy'):
@@ -834,26 +929,35 @@ class TestsLevel6(HedyTester):
         if name in names:
           print(f'nice!')
         else:
-          print(f'meh')""")
+          print(f'meh')"""
+        )
 
         self.multi_level_tester(max_level=7, code=code, expected=expected)
 
     def test_print_single_number(self):
-        code = textwrap.dedent("""\
-                print 5""")
+        code = textwrap.dedent(
+            """\
+                print 5"""
+        )
 
-        expected = textwrap.dedent("""\
-                print(f'5')""")
+        expected = textwrap.dedent(
+            """\
+                print(f'5')"""
+        )
 
         self.multi_level_tester(max_level=6, code=code, expected=expected)
 
     def test_negative_variable(self):
-      code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         a = -3
         b = a + 3
-        print b""")
-      expected = textwrap.dedent("""\
+        print b"""
+        )
+        expected = textwrap.dedent(
+            """\
         a = '-3'
         b = int(a) + int(3)
-        print(f'{b}')""")
-      self.multi_level_tester(code=code, expected=expected, output='0', max_level=11)
+        print(f'{b}')"""
+        )
+        self.multi_level_tester(code=code, expected=expected, output="0", max_level=11)

--- a/tests/test_level/test_level_07.py
+++ b/tests/test_level/test_level_07.py
@@ -6,7 +6,7 @@ from tests.Tester import HedyTester
 
 class TestsLevel7(HedyTester):
     level = 7
-    '''
+    """
     Tests should be ordered as follows:
      * commands in the order of hedy.py e.g. for level 1: ['print', 'ask', 'echo', 'turn', 'forward']
      * combined tests
@@ -17,7 +17,7 @@ class TestsLevel7(HedyTester):
      * single keyword positive tests are just keyword or keyword_special_case
      * multi keyword positive tests are keyword1_keywords_2
      * negative tests should be situation_gives_exception
-    '''
+    """
 
     #
     # repeat tests
@@ -25,46 +25,54 @@ class TestsLevel7(HedyTester):
     def test_repeat_turtle(self):
         code = "repeat 3 times forward 100"
 
-        expected = HedyTester.dedent(
-            "for i in range(int('3')):",
-            (HedyTester.forward_transpiled(100), '  '))
+        expected = HedyTester.dedent("for i in range(int('3')):", (HedyTester.forward_transpiled(100), "  "))
 
         self.single_level_tester(code=code, expected=expected, extra_check_function=self.is_turtle())
 
     def test_repeat_print(self):
         code = "repeat 5 times print 'me wants a cookie!'"
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         for i in range(int('5')):
           print(f'me wants a cookie!')
-          time.sleep(0.1)""")
+          time.sleep(0.1)"""
+        )
 
-        output = textwrap.dedent("""\
+        output = textwrap.dedent(
+            """\
         me wants a cookie!
         me wants a cookie!
         me wants a cookie!
         me wants a cookie!
-        me wants a cookie!""")
+        me wants a cookie!"""
+        )
 
         self.single_level_tester(code=code, expected=expected, output=output)
 
     def test_repeat_print_variable(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         n is 5
-        repeat n times print 'me wants a cookie!'""")
+        repeat n times print 'me wants a cookie!'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         n = '5'
         for i in range(int(n)):
           print(f'me wants a cookie!')
-          time.sleep(0.1)""")
+          time.sleep(0.1)"""
+        )
 
-        output = textwrap.dedent("""\
+        output = textwrap.dedent(
+            """\
         me wants a cookie!
         me wants a cookie!
         me wants a cookie!
         me wants a cookie!
-        me wants a cookie!""")
+        me wants a cookie!"""
+        )
 
         self.single_level_tester(code=code, expected=expected, output=output)
 
@@ -74,72 +82,95 @@ class TestsLevel7(HedyTester):
         self.single_level_tester(code=code, exception=hedy.exceptions.UndefinedVarException)
 
     def test_repeat_with_string_variable_gives_type_error(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         n is 'test'
-        repeat n times print 'n'""")
+        repeat n times print 'n'"""
+        )
 
         self.single_level_tester(code=code, exception=hedy.exceptions.InvalidArgumentTypeException)
 
     def test_repeat_with_list_variable_gives_type_error(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         n is 1, 2, 3
-        repeat n times print 'n'""")
+        repeat n times print 'n'"""
+        )
 
         self.single_level_tester(code=code, exception=hedy.exceptions.InvalidArgumentTypeException)
 
     def test_repeat_with_missing_print_gives_error(self):
-        code = textwrap.dedent("""\
-        repeat 3 times 'n'""")
+        code = textwrap.dedent(
+            """\
+        repeat 3 times 'n'"""
+        )
 
         self.single_level_tester(code=code, exception=hedy.exceptions.IncompleteRepeatException)
 
     def test_repeat_with_missing_times_gives_error(self):
-        code = textwrap.dedent("""\
-        repeat 3 print 'n'""")
+        code = textwrap.dedent(
+            """\
+        repeat 3 print 'n'"""
+        )
 
         self.single_level_tester(code=code, exception=hedy.exceptions.IncompleteRepeatException)
 
     def test_repeat_ask(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         n is ask 'How many times?'
-        repeat n times print 'n'""")
+        repeat n times print 'n'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         n = input(f'How many times?')
         for i in range(int(n)):
           print(f'n')
-          time.sleep(0.1)""")
+          time.sleep(0.1)"""
+        )
 
         self.single_level_tester(code=code, expected=expected)
 
-    @parameterized.expand(['5', '𑁫', '५', '૫', '੫', '৫', '೫', '୫', '൫', '௫', '౫', '၅', '༥', '᠕', '៥', '๕', '໕', '꧕', '٥', '۵'])
+    @parameterized.expand(
+        ["5", "𑁫", "५", "૫", "੫", "৫", "೫", "୫", "൫", "௫", "౫", "၅", "༥", "᠕", "៥", "๕", "໕", "꧕", "٥", "۵"]
+    )
     def test_repeat_with_all_numerals(self, number):
         code = textwrap.dedent(f"repeat {number} times print 'me wants a cookie!'")
 
-        expected = textwrap.dedent(f"""\
+        expected = textwrap.dedent(
+            f"""\
         for i in range(int('{int(number)}')):
           print(f'me wants a cookie!')
-          time.sleep(0.1)""")
+          time.sleep(0.1)"""
+        )
 
-        output = textwrap.dedent("""\
+        output = textwrap.dedent(
+            """\
         me wants a cookie!
         me wants a cookie!
         me wants a cookie!
         me wants a cookie!
-        me wants a cookie!""")
+        me wants a cookie!"""
+        )
 
         self.single_level_tester(code=code, expected=expected, output=output)
 
     def test_repeat_over_9_times(self):
-        code = textwrap.dedent("""\
-        repeat 10 times print 'me wants a cookie!'""")
+        code = textwrap.dedent(
+            """\
+        repeat 10 times print 'me wants a cookie!'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         for i in range(int('10')):
           print(f'me wants a cookie!')
-          time.sleep(0.1)""")
+          time.sleep(0.1)"""
+        )
 
-        output = textwrap.dedent("""\
+        output = textwrap.dedent(
+            """\
         me wants a cookie!
         me wants a cookie!
         me wants a cookie!
@@ -149,53 +180,56 @@ class TestsLevel7(HedyTester):
         me wants a cookie!
         me wants a cookie!
         me wants a cookie!
-        me wants a cookie!""")
+        me wants a cookie!"""
+        )
 
-        self.single_level_tester(
-            code=code,
-            expected=expected,
-            expected_commands=['repeat','print'],
-            output=output)
+        self.single_level_tester(code=code, expected=expected, expected_commands=["repeat", "print"], output=output)
 
     def test_repeat_with_variable_name_collision(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         i is hallo!
         repeat 5 times print 'me wants a cookie!'
-        print i""")
+        print i"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         i = 'hallo!'
         for _i in range(int('5')):
           print(f'me wants a cookie!')
           time.sleep(0.1)
-        print(f'{i}')""")
+        print(f'{i}')"""
+        )
 
-        output = textwrap.dedent("""\
+        output = textwrap.dedent(
+            """\
         me wants a cookie!
         me wants a cookie!
         me wants a cookie!
         me wants a cookie!
         me wants a cookie!
-        hallo!""")
+        hallo!"""
+        )
 
         self.single_level_tester(
-            code=code,
-            expected=expected,
-            expected_commands=['is', 'repeat', 'print', 'print'],
-            output=output)
+            code=code, expected=expected, expected_commands=["is", "repeat", "print", "print"], output=output
+        )
 
     def test_repeat_if(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         naam is Hedy
-        if naam is Hedy repeat 3 times print 'Hallo Hedy!'""")
+        if naam is Hedy repeat 3 times print 'Hallo Hedy!'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         naam = 'Hedy'
         if convert_numerals('Latin', naam) == convert_numerals('Latin', 'Hedy'):
           for i in range(int('3')):
             print(f'Hallo Hedy!')
-            time.sleep(0.1)""")
+            time.sleep(0.1)"""
+        )
 
-        self.single_level_tester(
-            code=code,
-            expected=expected)
+        self.single_level_tester(code=code, expected=expected)

--- a/tests/test_level/test_level_08.py
+++ b/tests/test_level/test_level_08.py
@@ -6,7 +6,7 @@ from parameterized import parameterized
 
 class TestsLevel8(HedyTester):
     level = 8
-    '''
+    """
     Tests should be ordered as follows:
      * commands in the order of hedy.py e.g. for level 1: ['print', 'ask', 'echo', 'turn', 'forward']
      * combined tests
@@ -17,415 +17,496 @@ class TestsLevel8(HedyTester):
      * single keyword positive tests are just keyword or keyword_special_case
      * multi keyword positive tests are keyword1_keywords_2
      * negative tests should be situation_gives_exception
-    '''
+    """
 
     #
     # if command
     #
     def test_if_no_indentation(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         antwoord is ask Hoeveel is 10 keer tien?
         if antwoord is 100
-        print 'goed zo'""")
+        print 'goed zo'"""
+        )
 
         # gives the right exception for all levels even though it misses brackets
         # because the indent check happens before parsing
         self.multi_level_tester(code=code, exception=hedy.exceptions.NoIndentationException)
 
     def test_if_equality_with_is(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         naam is Hedy
         if naam is Hedy
-            print 'leuk'""")
+            print 'leuk'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         naam = 'Hedy'
         if convert_numerals('Latin', naam) == convert_numerals('Latin', 'Hedy'):
-          print(f'leuk')""")
+          print(f'leuk')"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=11)
 
     def test_if_equality_with_equals_sign(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         naam is Hedy
         if naam = Hedy
-            print 'leuk'""")
+            print 'leuk'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         naam = 'Hedy'
         if convert_numerals('Latin', naam) == convert_numerals('Latin', 'Hedy'):
-          print(f'leuk')""")
+          print(f'leuk')"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=11)
 
     def test_if_equality_trailing_space_linebreak_print(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         naam is James
         if naam is trailing_space 
-            print 'shaken'""")
+            print 'shaken'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         naam = 'James'
         if convert_numerals('Latin', naam) == convert_numerals('Latin', 'trailing_space'):
-          print(f'shaken')""")
+          print(f'shaken')"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=11)
 
     def test_if_equality_unquoted_rhs_with_space(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         naam is James
         if naam is James Bond
-            print 'shaken'""")
+            print 'shaken'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         naam = 'James'
         if convert_numerals('Latin', naam) == convert_numerals('Latin', 'James Bond'):
-          print(f'shaken')""")
+          print(f'shaken')"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=11)
 
     def test_if_equality_unquoted_rhs_with_space_and_trailing_space_linebreak_print(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         naam is James
         if naam is trailing space  
-            print 'shaken'""")
+            print 'shaken'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         naam = 'James'
         if convert_numerals('Latin', naam) == convert_numerals('Latin', 'trailing space'):
-          print(f'shaken')""")
+          print(f'shaken')"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=11)
 
     @parameterized.expand(HedyTester.quotes)
     def test_if_equality_quoted_rhs_with_space(self, q):
-        code = textwrap.dedent(f"""\
+        code = textwrap.dedent(
+            f"""\
         naam is James
         if naam is {q}James Bond{q}
-            print {q}shaken{q}""")
+            print {q}shaken{q}"""
+        )
 
-        expected = textwrap.dedent(f"""\
+        expected = textwrap.dedent(
+            f"""\
         naam = 'James'
         if convert_numerals('Latin', naam) == convert_numerals('Latin', 'James Bond'):
-          print(f'shaken')""")
+          print(f'shaken')"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=11)
 
     @parameterized.expand(HedyTester.quotes)
     def test_if_equality_quoted_rhs_with_spaces(self, q):
-        code = textwrap.dedent(f"""\
+        code = textwrap.dedent(
+            f"""\
         naam is James
         if naam is {q}Bond James Bond{q}
-            print 'shaken'""")
+            print 'shaken'"""
+        )
 
-        expected = textwrap.dedent(f"""\
+        expected = textwrap.dedent(
+            f"""\
         naam = 'James'
         if convert_numerals('Latin', naam) == convert_numerals('Latin', 'Bond James Bond'):
-          print(f'shaken')""")
+          print(f'shaken')"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=11)
 
     def test_if_equality_single_quoted_rhs_with_inner_double_quote(self):
-        code = textwrap.dedent(f"""\
+        code = textwrap.dedent(
+            f"""\
         answer is no
         if answer is 'He said "no"'
-          print 'no'""")
+          print 'no'"""
+        )
 
-        expected = textwrap.dedent(f"""\
+        expected = textwrap.dedent(
+            f"""\
         answer = 'no'
         if convert_numerals('Latin', answer) == convert_numerals('Latin', 'He said "no"'):
-          print(f'no')""")
+          print(f'no')"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=11)
 
     def test_if_equality_double_quoted_rhs_with_inner_single_quote(self):
-        code = textwrap.dedent(f"""\
+        code = textwrap.dedent(
+            f"""\
         answer is no
         if answer is "He said 'no'"
-          print 'no'""")
+          print 'no'"""
+        )
 
-        expected = textwrap.dedent(f"""\
+        expected = textwrap.dedent(
+            f"""\
         answer = 'no'
         if convert_numerals('Latin', answer) == convert_numerals('Latin', 'He said \\'no\\''):
-          print(f'no')""")
+          print(f'no')"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=11)
 
     def test_if_2_vars_equality_print(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         jouwkeuze is schaar
         computerkeuze is schaar
         if computerkeuze is jouwkeuze
-            print 'gelijkspel!'""")
+            print 'gelijkspel!'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         jouwkeuze = 'schaar'
         computerkeuze = 'schaar'
         if convert_numerals('Latin', computerkeuze) == convert_numerals('Latin', jouwkeuze):
-          print(f'gelijkspel!')""")
+          print(f'gelijkspel!')"""
+        )
 
-        self.multi_level_tester(max_level=11, code=code, expected=expected, output='gelijkspel!')
+        self.multi_level_tester(max_level=11, code=code, expected=expected, output="gelijkspel!")
 
     def test_if_in_list_print(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         items is red, green
         selected is red
         if selected in items
-            print 'found!'""")
+            print 'found!'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         items = ['red', 'green']
         selected = 'red'
         if selected in items:
-          print(f'found!')""")
+          print(f'found!')"""
+        )
 
         self.multi_level_tester(
             max_level=11,
             code=code,
             expected=expected,
-            output='found!',
-            expected_commands=['is', 'is', 'if', 'in', 'print']
+            output="found!",
+            expected_commands=["is", "is", "if", "in", "print"],
         )
 
     def test_if_equality_assign_calc(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         cmp is 1
         test is 2
         acu is 0
         if test is cmp
-            acu is acu + 1""")
+            acu is acu + 1"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         cmp = '1'
         test = '2'
         acu = '0'
         if convert_numerals('Latin', test) == convert_numerals('Latin', cmp):
-          acu = int(acu) + int(1)""")
+          acu = int(acu) + int(1)"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=11)
 
     def test_if_in_undefined_list_gives_error(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         selected is 5
         if selected in items
-            print 'found!'""")
+            print 'found!'"""
+        )
 
         self.multi_level_tester(code=code, exception=hedy.exceptions.UndefinedVarException, max_level=16)
 
     def test_equality_promotes_int_to_string(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         a is test
         b is 15
         if a is b
-            c is 1""")
+            c is 1"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         a = 'test'
         b = '15'
         if convert_numerals('Latin', a) == convert_numerals('Latin', b):
-          c = '1'""")
+          c = '1'"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=11)
 
     def test_equality_with_lists_gives_error(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         m is 1, 2
         n is 1, 2
         if m is n
-          print 'success!'""")
-
-        self.multi_level_tester(
-            max_level=11,
-            code=code,
-            exception=hedy.exceptions.InvalidArgumentTypeException
+          print 'success!'"""
         )
+
+        self.multi_level_tester(max_level=11, code=code, exception=hedy.exceptions.InvalidArgumentTypeException)
 
     def test_if_in_list_with_string_var_gives_type_error(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         items is red
         if red in items
-            print 'found!'""")
-
-        self.multi_level_tester(
-            max_level=11,
-            code=code,
-            exception=hedy.exceptions.InvalidArgumentTypeException
+            print 'found!'"""
         )
+
+        self.multi_level_tester(max_level=11, code=code, exception=hedy.exceptions.InvalidArgumentTypeException)
 
     def test_if_in_list_with_input_gives_type_error(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         items is ask 'What are the items?'
         if red in items
-            print 'found!'""")
-        self.multi_level_tester(
-            max_level=16,
-            code=code,
-            exception=hedy.exceptions.InvalidArgumentTypeException
+            print 'found!'"""
         )
+        self.multi_level_tester(max_level=16, code=code, exception=hedy.exceptions.InvalidArgumentTypeException)
 
     def test_equality_with_list_gives_error(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         color is 5, 6, 7
         if red is color
-            print 'success!'""")
-
-        self.multi_level_tester(
-            max_level=11,
-            code=code,
-            exception=hedy.exceptions.InvalidArgumentTypeException
+            print 'success!'"""
         )
 
+        self.multi_level_tester(max_level=11, code=code, exception=hedy.exceptions.InvalidArgumentTypeException)
+
     def test_if_with_negative_number(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         antwoord = -10
         if antwoord is -10
-            print 'Nice'""")
-        
-        expected = textwrap.dedent("""\
+            print 'Nice'"""
+        )
+
+        expected = textwrap.dedent(
+            """\
         antwoord = '-10'
         if convert_numerals('Latin', antwoord) == convert_numerals('Latin', '-10'):
-          print(f'Nice')""")
+          print(f'Nice')"""
+        )
 
-        self.multi_level_tester(code=code, expected=expected, output='Nice', max_level=11)
+        self.multi_level_tester(code=code, expected=expected, output="Nice", max_level=11)
 
-    
     #
     # if else tests
     #
     def test_if_else_no_indentation(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         antwoord is ask Hoeveel is 10 keer tien?
         if antwoord is 100
         print 'goed zo'
         else
-        print 'bah slecht'""")
+        print 'bah slecht'"""
+        )
 
         # gives the right exception for all levels even though it misses brackets
         # because the indent check happens before parsing
         self.multi_level_tester(code=code, exception=hedy.exceptions.NoIndentationException)
 
     def test_if_equality_print_else_print(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         naam is Hedy
         if naam is Hedy
             print 'leuk'
         else
-            print 'minder leuk'""")
+            print 'minder leuk'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         naam = 'Hedy'
         if convert_numerals('Latin', naam) == convert_numerals('Latin', 'Hedy'):
           print(f'leuk')
         else:
-          print(f'minder leuk')""")
+          print(f'minder leuk')"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=11)
 
     def test_if_equality_assign_else_assign(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         a is 5
         if a is 1
             x is 2
         else
-            x is 222""")
-        expected = textwrap.dedent("""\
+            x is 222"""
+        )
+        expected = textwrap.dedent(
+            """\
         a = '5'
         if convert_numerals('Latin', a) == convert_numerals('Latin', '1'):
           x = '2'
         else:
-          x = '222'""")
+          x = '222'"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=11)
 
     def test_if_else_followed_by_print(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         kleur is geel
         if kleur is groen
             antwoord is ok
         else
             antwoord is stom
-        print antwoord""")
+        print antwoord"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         kleur = 'geel'
         if convert_numerals('Latin', kleur) == convert_numerals('Latin', 'groen'):
           antwoord = 'ok'
         else:
           antwoord = 'stom'
-        print(f'{antwoord}')""")
+        print(f'{antwoord}')"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=11)
 
     def test_if_else_trailing_space_after_else(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         a is 1
         if a is 1
             print a
         else    
-            print 'nee'""")
+            print 'nee'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         a = '1'
         if convert_numerals('Latin', a) == convert_numerals('Latin', '1'):
           print(f'{a}')
         else:
-          print(f'nee')""")
+          print(f'nee')"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=11)
 
     def test_if_list_assignment_else_print(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         people is mom, dad, Emma, Sophie
         dishwasher is people at random
         if dishwasher is Sophie
             print 'too bad I have to do the dishes'
         else
-            print 'luckily no dishes because' dishwasher 'is already washing up'""")
+            print 'luckily no dishes because' dishwasher 'is already washing up'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         people = ['mom', 'dad', 'Emma', 'Sophie']
         dishwasher = random.choice(people)
         if convert_numerals('Latin', dishwasher) == convert_numerals('Latin', 'Sophie'):
           print(f'too bad I have to do the dishes')
         else:
-          print(f'luckily no dishes because{dishwasher}is already washing up')""")
+          print(f'luckily no dishes because{dishwasher}is already washing up')"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=11)
 
     def test_if_empty_line_with_whitespace_else_print(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         if 1 is 2
             print 'nice!'
                
         else
-            print 'pizza is better'""")
+            print 'pizza is better'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         if convert_numerals('Latin', '1') == convert_numerals('Latin', '2'):
           print(f'nice!')
         else:
-          print(f'pizza is better')""")
+          print(f'pizza is better')"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=11)
 
     def test_if_else_with_multiple_lines(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         antwoord is ask 'Hoeveel is 10 plus 10?'
         if antwoord is 20
             print 'Goedzo!'
             print 'Het antwoord was inderdaad ' antwoord
         else
             print 'Foutje'
-            print 'Het antwoord moest zijn ' antwoord""")
+            print 'Het antwoord moest zijn ' antwoord"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         antwoord = input(f'Hoeveel is 10 plus 10?')
         if convert_numerals('Latin', antwoord) == convert_numerals('Latin', '20'):
           print(f'Goedzo!')
           print(f'Het antwoord was inderdaad {antwoord}')
         else:
           print(f'Foutje')
-          print(f'Het antwoord moest zijn {antwoord}')""")
+          print(f'Het antwoord moest zijn {antwoord}')"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=11)
 
@@ -433,250 +514,311 @@ class TestsLevel8(HedyTester):
     # repeat command
     #
     def test_repeat_no_indentation(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
           repeat 3 times
-          print 'hooray!'""")
+          print 'hooray!'"""
+        )
 
         self.multi_level_tester(code=code, exception=hedy.exceptions.NoIndentationException)
 
     def test_repeat_repair_too_few_indents(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         repeat 5 times
              print('repair')
-          print('me')""")
+          print('me')"""
+        )
 
-        fixed_code = textwrap.dedent("""\
+        fixed_code = textwrap.dedent(
+            """\
         repeat 5 times
              print('repair')
-             print('me')""")
+             print('me')"""
+        )
 
         self.multi_level_tester(
             code=code,
             exception=hedy.exceptions.NoIndentationException,
-            extra_check_function=(lambda x: x.exception.fixed_code == fixed_code)
+            extra_check_function=(lambda x: x.exception.fixed_code == fixed_code),
         )
 
     def test_repeat_repair_too_many_indents(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         repeat 5 times
           print('repair')
-             print('me')""")
-        fixed_code = textwrap.dedent("""\
+             print('me')"""
+        )
+        fixed_code = textwrap.dedent(
+            """\
         repeat 5 times
           print('repair')
-          print('me')""")
+          print('me')"""
+        )
 
         self.multi_level_tester(
             code=code,
             exception=hedy.exceptions.IndentationException,
-            extra_check_function=(lambda x: x.exception.fixed_code == fixed_code)
+            extra_check_function=(lambda x: x.exception.fixed_code == fixed_code),
         )
 
     def test_repeat_turtle(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
             repeat 3 times
-                forward 100""")
+                forward 100"""
+        )
 
-        expected = HedyTester.dedent(
-            "for i in range(int('3')):",
-            (HedyTester.forward_transpiled(100), '  '))
+        expected = HedyTester.dedent("for i in range(int('3')):", (HedyTester.forward_transpiled(100), "  "))
 
         self.multi_level_tester(
-            max_level=self.max_turtle_level,
-            code=code,
-            expected=expected,
-            extra_check_function=self.is_turtle()
+            max_level=self.max_turtle_level, code=code, expected=expected, extra_check_function=self.is_turtle()
         )
 
     def test_repeat_print(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         repeat 5 times
-            print 'koekoek'""")
+            print 'koekoek'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         for i in range(int('5')):
           print(f'koekoek')
-          time.sleep(0.1)""")
+          time.sleep(0.1)"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=11)
 
     def test_repeat_print_variable(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         n is 5
         repeat n times
-            print 'me wants a cookie!'""")
+            print 'me wants a cookie!'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         n = '5'
         for i in range(int(n)):
           print(f'me wants a cookie!')
-          time.sleep(0.1)""")
+          time.sleep(0.1)"""
+        )
 
-        output = textwrap.dedent("""\
+        output = textwrap.dedent(
+            """\
         me wants a cookie!
         me wants a cookie!
         me wants a cookie!
         me wants a cookie!
-        me wants a cookie!""")
+        me wants a cookie!"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, output=output, max_level=11)
 
     def test_repeat_arabic(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         repeat ٥ times
-            print 'koekoek'""")
+            print 'koekoek'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         for i in range(int('5')):
           print(f'koekoek')
-          time.sleep(0.1)""")
+          time.sleep(0.1)"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=11)
 
     def test_repeat_with_arabic_variable_print(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         n is ٥
         repeat ٥ times
-            print 'me wants a cookie!'""")
+            print 'me wants a cookie!'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         n = '٥'
         for i in range(int('5')):
           print(f'me wants a cookie!')
-          time.sleep(0.1)""")
+          time.sleep(0.1)"""
+        )
 
-        output = textwrap.dedent("""\
+        output = textwrap.dedent(
+            """\
         me wants a cookie!
         me wants a cookie!
         me wants a cookie!
         me wants a cookie!
-        me wants a cookie!""")
+        me wants a cookie!"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, output=output, max_level=11)
 
     def test_repeat_with_non_latin_variable_print(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         állatok is 5
         repeat állatok times
-            print 'me wants a cookie!'""")
+            print 'me wants a cookie!'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         állatok = '5'
         for i in range(int(állatok)):
           print(f'me wants a cookie!')
-          time.sleep(0.1)""")
+          time.sleep(0.1)"""
+        )
 
-        output = textwrap.dedent("""\
+        output = textwrap.dedent(
+            """\
         me wants a cookie!
         me wants a cookie!
         me wants a cookie!
         me wants a cookie!
-        me wants a cookie!""")
+        me wants a cookie!"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, output=output, max_level=11)
 
     def test_repeat_undefined_variable_gives_error(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         repeat n times
-            print 'me wants a cookie!'""")
+            print 'me wants a cookie!'"""
+        )
 
-        self.multi_level_tester(
-            code=code,
-            exception=hedy.exceptions.UndefinedVarException,
-            max_level=17)
+        self.multi_level_tester(code=code, exception=hedy.exceptions.UndefinedVarException, max_level=17)
 
     # issue 297
     def test_repeat_print_assign_addition(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         count is 1
         repeat 12 times
             print count ' times 12 is ' count * 12
-            count is count + 1""")
+            count is count + 1"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         count = '1'
         for i in range(int('12')):
           print(f'{count} times 12 is {int(count) * int(12)}')
           count = int(count) + int(1)
-          time.sleep(0.1)""")
+          time.sleep(0.1)"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=11)
 
     def test_repeat_with_comment(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         repeat 5 times #This should be ignored
             print 'koekoek'
-            print 'koekoek'""")
+            print 'koekoek'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         for i in range(int('5')):
           print(f'koekoek')
           print(f'koekoek')
-          time.sleep(0.1)""")
+          time.sleep(0.1)"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=11)
 
     def test_repeat_with_string_variable_gives_type_error(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         n is 'test'
         repeat n times
-            print 'n'""")
+            print 'n'"""
+        )
 
         self.multi_level_tester(code=code, exception=hedy.exceptions.InvalidArgumentTypeException, max_level=17)
 
     def test_repeat_with_list_variable_gives_type_error(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         n is 1, 2, 3
         repeat n times
-            print 'n'""")
+            print 'n'"""
+        )
 
         self.multi_level_tester(code=code, exception=hedy.exceptions.InvalidArgumentTypeException, max_level=15)
 
     def test_repeat_ask(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         n is ask 'How many times?'
         repeat n times
-            print 'n'""")
+            print 'n'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         n = input(f'How many times?')
         for i in range(int(n)):
           print(f'n')
-          time.sleep(0.1)""")
+          time.sleep(0.1)"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=11)
 
-    @parameterized.expand(['5', '𑁫', '५', '૫', '੫', '৫', '೫', '୫', '൫', '௫', '౫', '၅', '༥', '᠕', '៥', '๕', '໕', '꧕', '٥', '۵'])
+    @parameterized.expand(
+        ["5", "𑁫", "५", "૫", "੫", "৫", "೫", "୫", "൫", "௫", "౫", "၅", "༥", "᠕", "៥", "๕", "໕", "꧕", "٥", "۵"]
+    )
     def test_repeat_with_all_numerals(self, number):
-        code = textwrap.dedent(f"""\
+        code = textwrap.dedent(
+            f"""\
         repeat {number} times
-            print 'me wants a cookie!'""")
+            print 'me wants a cookie!'"""
+        )
 
-        expected = textwrap.dedent(f"""\
+        expected = textwrap.dedent(
+            f"""\
         for i in range(int('{int(number)}')):
           print(f'me wants a cookie!')
-          time.sleep(0.1)""")
+          time.sleep(0.1)"""
+        )
 
-        output = textwrap.dedent("""\
+        output = textwrap.dedent(
+            """\
         me wants a cookie!
         me wants a cookie!
         me wants a cookie!
         me wants a cookie!
-        me wants a cookie!""")
+        me wants a cookie!"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, output=output, max_level=11)
 
     def test_repeat_over_9_times(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         repeat 10 times
-            print 'me wants a cookie!'""")
+            print 'me wants a cookie!'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         for i in range(int('10')):
           print(f'me wants a cookie!')
-          time.sleep(0.1)""")
+          time.sleep(0.1)"""
+        )
 
-        output = textwrap.dedent("""\
+        output = textwrap.dedent(
+            """\
         me wants a cookie!
         me wants a cookie!
         me wants a cookie!
@@ -686,44 +828,47 @@ class TestsLevel8(HedyTester):
         me wants a cookie!
         me wants a cookie!
         me wants a cookie!
-        me wants a cookie!""")
+        me wants a cookie!"""
+        )
 
         self.multi_level_tester(
-            code=code,
-            expected=expected,
-            expected_commands=['repeat', 'print'],
-            output=output,
-            max_level=11
+            code=code, expected=expected, expected_commands=["repeat", "print"], output=output, max_level=11
         )
 
     def test_repeat_with_variable_name_collision(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         i is hallo!
         repeat 5 times
             print 'me wants a cookie!'
-        print i""")
+        print i"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         i = 'hallo!'
         for _i in range(int('5')):
           print(f'me wants a cookie!')
           time.sleep(0.1)
-        print(f'{i}')""")
+        print(f'{i}')"""
+        )
 
-        output = textwrap.dedent("""\
+        output = textwrap.dedent(
+            """\
         me wants a cookie!
         me wants a cookie!
         me wants a cookie!
         me wants a cookie!
         me wants a cookie!
-        hallo!""")
+        hallo!"""
+        )
 
         self.multi_level_tester(
             code=code,
             expected=expected,
-            expected_commands=['is', 'repeat', 'print', 'print'],
+            expected_commands=["is", "repeat", "print", "print"],
             output=output,
-            max_level=11
+            max_level=11,
         )
 
     #
@@ -732,22 +877,26 @@ class TestsLevel8(HedyTester):
 
     # issue 902
     def test_repeat_if_gives_error(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
            print 'kassabon'
            prijs is 0
            repeat 7 times # TEST
                ingredient is ask 'wat wil je kopen?'
                if ingredient is appel
                    prijs is prijs + 1
-           print 'Dat is in totaal ' prijs ' euro.'""")
+           print 'Dat is in totaal ' prijs ' euro.'"""
+        )
 
         self.single_level_tester(code=code, exception=hedy.exceptions.LockedLanguageFeatureException)
 
     def test_if_repeat_gives_error(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         kleur is groen
         if kleur is groen
             repeat 3 times
-                print 'mooi'""")
+                print 'mooi'"""
+        )
 
         self.single_level_tester(code=code, exception=hedy.exceptions.LockedLanguageFeatureException)

--- a/tests/test_level/test_level_09.py
+++ b/tests/test_level/test_level_09.py
@@ -4,7 +4,7 @@ from tests.Tester import HedyTester
 
 class TestsLevel9(HedyTester):
     level = 9
-    '''
+    """
     Tests should be ordered as follows:
      * commands in the order of hedy.py e.g. for level 1: ['print', 'ask', 'echo', 'turn', 'forward']
      * combined tests
@@ -15,30 +15,35 @@ class TestsLevel9(HedyTester):
      * single keyword positive tests are just keyword or keyword_special_case
      * multi keyword positive tests are keyword1_keywords_2
      * negative tests should be situation_gives_exception
-    '''
+    """
 
     #
     # if nesting
     #
     def test_if_nested_in_if(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         n is 1
         m is 2
         if n is 1
             if m is 2
-                print 'great!'""")
+                print 'great!'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         n = '1'
         m = '2'
         if convert_numerals('Latin', n) == convert_numerals('Latin', '1'):
           if convert_numerals('Latin', m) == convert_numerals('Latin', '2'):
-            print(f'great!')""")
+            print(f'great!')"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=11)
 
     def test_ifs_nested_in_if_else(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         n is 1
         m is 2
         if n is 1
@@ -46,9 +51,11 @@ class TestsLevel9(HedyTester):
                 print 'great!'
         else
             if m is 3
-                print 'awesome'""")
+                print 'awesome'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         n = '1'
         m = '2'
         if convert_numerals('Latin', n) == convert_numerals('Latin', '1'):
@@ -56,33 +63,39 @@ class TestsLevel9(HedyTester):
             print(f'great!')
         else:
           if convert_numerals('Latin', m) == convert_numerals('Latin', '3'):
-            print(f'awesome')""")
+            print(f'awesome')"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=11)
 
     def test_if_else_nested_in_if(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         n is 1
         m is 2
         if n is 1
             if m is 2
                 print 'great!'
             else
-                print 'awesome'""")
+                print 'awesome'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         n = '1'
         m = '2'
         if convert_numerals('Latin', n) == convert_numerals('Latin', '1'):
           if convert_numerals('Latin', m) == convert_numerals('Latin', '2'):
             print(f'great!')
           else:
-            print(f'awesome')""")
+            print(f'awesome')"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=11)
 
     def test_if_else_statements_nested_in_if_else(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
          n is 1
          m is 2
          if n is 1
@@ -94,9 +107,11 @@ class TestsLevel9(HedyTester):
              if m is 3
                  print 'awesome!'
              else
-                 print 'amazing!'""")
+                 print 'amazing!'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
          n = '1'
          m = '2'
          if convert_numerals('Latin', n) == convert_numerals('Latin', '1'):
@@ -108,7 +123,8 @@ class TestsLevel9(HedyTester):
            if convert_numerals('Latin', m) == convert_numerals('Latin', '3'):
              print(f'awesome!')
            else:
-             print(f'amazing!')""")
+             print(f'amazing!')"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=11)
 
@@ -116,16 +132,20 @@ class TestsLevel9(HedyTester):
     # repeat nesting
     #
     def test_repeat_nested_in_repeat(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         repeat 2 times
             repeat 3 times
-                print 'hello'""")
+                print 'hello'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
            for i in range(int('2')):
              for i in range(int('3')):
                print(f'hello')
-               time.sleep(0.1)""")
+               time.sleep(0.1)"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=11)
 
@@ -133,79 +153,93 @@ class TestsLevel9(HedyTester):
     # if and repeat nesting
     #
     def test_if_nested_in_repeat(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         prijs is 0
         repeat 7 times
             ingredient is ask 'wat wil je kopen?'
             if ingredient is appel
                 prijs is prijs + 1
-        print 'Dat is in totaal ' prijs ' euro.'""")
+        print 'Dat is in totaal ' prijs ' euro.'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         prijs = '0'
         for i in range(int('7')):
           ingredient = input(f'wat wil je kopen?')
           if convert_numerals('Latin', ingredient) == convert_numerals('Latin', 'appel'):
             prijs = int(prijs) + int(1)
           time.sleep(0.1)
-        print(f'Dat is in totaal {prijs} euro.')""")
+        print(f'Dat is in totaal {prijs} euro.')"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=11)
 
     def test_if_nested_in_repeat_with_comment(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         prijs is 0
         repeat 7 times # comment
             ingredient is ask 'wat wil je kopen?'
             if ingredient is appel # another comment
                 prijs is prijs + 1
-        print 'Dat is in totaal ' prijs ' euro.'""")
+        print 'Dat is in totaal ' prijs ' euro.'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         prijs = '0'
         for i in range(int('7')):
           ingredient = input(f'wat wil je kopen?')
           if convert_numerals('Latin', ingredient) == convert_numerals('Latin', 'appel'):
             prijs = int(prijs) + int(1)
           time.sleep(0.1)
-        print(f'Dat is in totaal {prijs} euro.')""")
+        print(f'Dat is in totaal {prijs} euro.')"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=11)
 
     def test_repeat_nested_in_if(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         kleur is groen
         if kleur is groen
             repeat 3 times
-                print 'mooi'""")
+                print 'mooi'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         kleur = 'groen'
         if convert_numerals('Latin', kleur) == convert_numerals('Latin', 'groen'):
           for i in range(int('3')):
             print(f'mooi')
-            time.sleep(0.1)""")
+            time.sleep(0.1)"""
+        )
 
         self.multi_level_tester(
-            code=code,
-            expected=expected,
-            max_level=11,
-            expected_commands=['is', 'if', 'repeat', 'print'])
+            code=code, expected=expected, max_level=11, expected_commands=["is", "if", "repeat", "print"]
+        )
 
     def test_if_else_nested_in_repeat(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         repeat 5 times
             if antwoord2 is 10
                 print 'Goedzo'
             else
-                print 'lalala'""")
+                print 'lalala'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         for i in range(int('5')):
           if convert_numerals('Latin', 'antwoord2') == convert_numerals('Latin', '10'):
             print(f'Goedzo')
           else:
             print(f'lalala')
-          time.sleep(0.1)""")
+          time.sleep(0.1)"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=11)

--- a/tests/test_level/test_level_10.py
+++ b/tests/test_level/test_level_10.py
@@ -5,7 +5,7 @@ from tests.Tester import HedyTester
 
 class TestsLevel10(HedyTester):
     level = 10
-    '''
+    """
     Tests should be ordered as follows:
      * commands in the order of hedy.py e.g. for level 1: ['print', 'ask', 'echo', 'turn', 'forward']
      * combined tests
@@ -16,87 +16,87 @@ class TestsLevel10(HedyTester):
      * single keyword positive tests are just keyword or keyword_special_case
      * multi keyword positive tests are keyword1_keywords_2
      * negative tests should be situation_gives_exception
-    '''
+    """
 
     #
     # for list command
     #
     def test_for_list(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         dieren is hond, kat, papegaai
         for dier in dieren
-            print dier""")
+            print dier"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         dieren = ['hond', 'kat', 'papegaai']
         for dier in dieren:
           print(f'{dier}')
-          time.sleep(0.1)""")
-
-        self.multi_level_tester(
-            code=code,
-            expected=expected,
-            expected_commands=['is', 'for', 'print'],
-            max_level=11
+          time.sleep(0.1)"""
         )
 
+        self.multi_level_tester(code=code, expected=expected, expected_commands=["is", "for", "print"], max_level=11)
+
     def test_for_list_hindi(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         क is hond, kat, papegaai
         for काउंटर in क
-            print काउंटर""")
+            print काउंटर"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         क = ['hond', 'kat', 'papegaai']
         for काउंटर in क:
           print(f'{काउंटर}')
-          time.sleep(0.1)""")
-
-        self.multi_level_tester(
-            code=code,
-            expected=expected,
-            expected_commands=['is', 'for', 'print'],
-            max_level=11
+          time.sleep(0.1)"""
         )
 
+        self.multi_level_tester(code=code, expected=expected, expected_commands=["is", "for", "print"], max_level=11)
+
     def test_for_list_multiline_body(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         familie is baby, mommy, daddy, grandpa, grandma
         for shark in familie
             print shark ' shark tudutudutudu'
             print shark ' shark tudutudutudu'
             print shark ' shark tudutudutudu'
-            print shark ' shark'""")
+            print shark ' shark'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         familie = ['baby', 'mommy', 'daddy', 'grandpa', 'grandma']
         for shark in familie:
           print(f'{shark} shark tudutudutudu')
           print(f'{shark} shark tudutudutudu')
           print(f'{shark} shark tudutudutudu')
           print(f'{shark} shark')
-          time.sleep(0.1)""")
+          time.sleep(0.1)"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=11)
 
     def test_for_list_with_string_gives_type_error(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         dieren is 'text'
         for dier in dieren
-            print dier""")
+            print dier"""
+        )
 
-        self.multi_level_tester(
-            code=code,
-            max_level=16,
-            exception=hedy.exceptions.InvalidArgumentTypeException)
+        self.multi_level_tester(code=code, max_level=16, exception=hedy.exceptions.InvalidArgumentTypeException)
 
     def test_for_list_with_int_gives_type_error(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         dieren is 5
         for dier in dieren
-            print dier""")
+            print dier"""
+        )
 
-        self.multi_level_tester(
-            code=code,
-            max_level=16,
-            exception=hedy.exceptions.InvalidArgumentTypeException)
+        self.multi_level_tester(code=code, max_level=16, exception=hedy.exceptions.InvalidArgumentTypeException)

--- a/tests/test_level/test_level_11.py
+++ b/tests/test_level/test_level_11.py
@@ -5,7 +5,7 @@ from tests.Tester import HedyTester
 
 class TestsLevel11(HedyTester):
     level = 11
-    '''
+    """
     Tests should be ordered as follows:
      * commands in the order of hedy.py e.g. for level 1: ['print', 'ask', 'echo', 'turn', 'forward']
      * combined tests
@@ -16,100 +16,112 @@ class TestsLevel11(HedyTester):
      * single keyword positive tests are just keyword or keyword_special_case
      * multi keyword positive tests are keyword1_keywords_2
      * negative tests should be situation_gives_exception
-    '''
+    """
 
     #
     # for loop
     #
     def test_for_loop(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         for i in range 1 to 10
-            a is i + 1""")
-        expected = textwrap.dedent("""\
+            a is i + 1"""
+        )
+        expected = textwrap.dedent(
+            """\
         step = 1 if int(1) < int(10) else -1
         for i in range(int(1), int(10) + step, step):
           a = int(i) + int(1)
-          time.sleep(0.1)""")
+          time.sleep(0.1)"""
+        )
 
-        self.single_level_tester(
-            code=code,
-            expected=expected,
-            expected_commands=['for', 'is', 'addition'])
+        self.single_level_tester(code=code, expected=expected, expected_commands=["for", "is", "addition"])
 
     def test_for_loop_with_int_vars(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         begin = 1
         end = 10
         for i in range begin to end
-            print i""")
+            print i"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         begin = '1'
         end = '10'
         step = 1 if int(begin) < int(end) else -1
         for i in range(int(begin), int(end) + step, step):
           print(f'{i}')
-          time.sleep(0.1)""")
+          time.sleep(0.1)"""
+        )
 
         self.single_level_tester(code=code, expected=expected)
 
     def test_for_loop_with_list_var_gives_type_error(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         begin = 1, 2
         end = 3, 4
         for i in range begin to end
-            print i""")
+            print i"""
+        )
 
-        self.multi_level_tester(
-            code=code,
-            max_level=15,
-            exception=hedy.exceptions.InvalidArgumentTypeException)
+        self.multi_level_tester(code=code, max_level=15, exception=hedy.exceptions.InvalidArgumentTypeException)
 
     def test_for_loop_with_string_var_gives_type_error(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         begin = 'one'
         end = 'ten'
         for i in range begin to end
-            print i""")
+            print i"""
+        )
 
-        self.multi_level_tester(
-            code=code,
-            max_level=16,
-            exception=hedy.exceptions.InvalidArgumentTypeException)
+        self.multi_level_tester(code=code, max_level=16, exception=hedy.exceptions.InvalidArgumentTypeException)
 
     def test_for_loop_multiline_body(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         a is 2
         b is 3
         for a in range 2 to 4
             a is a + 2
-            b is b + 2""")
+            b is b + 2"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         a = '2'
         b = '3'
         step = 1 if int(2) < int(4) else -1
         for a in range(int(2), int(4) + step, step):
           a = int(a) + int(2)
           b = int(b) + int(2)
-          time.sleep(0.1)""")
+          time.sleep(0.1)"""
+        )
 
         self.single_level_tester(code=code, expected=expected)
 
     def test_for_loop_followed_by_print(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         for i in range 1 to 10
             print i
-        print 'wie niet weg is is gezien'""")
+        print 'wie niet weg is is gezien'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         step = 1 if int(1) < int(10) else -1
         for i in range(int(1), int(10) + step, step):
           print(f'{i}')
           time.sleep(0.1)
-        print(f'wie niet weg is is gezien')""")
+        print(f'wie niet weg is is gezien')"""
+        )
 
-        output = textwrap.dedent("""\
+        output = textwrap.dedent(
+            """\
         1
         2
         3
@@ -120,100 +132,106 @@ class TestsLevel11(HedyTester):
         8
         9
         10
-        wie niet weg is is gezien""")
+        wie niet weg is is gezien"""
+        )
 
         self.single_level_tester(
-            code=code,
-            expected=expected,
-            expected_commands=['for', 'print', 'print'],
-            output=output)
+            code=code, expected=expected, expected_commands=["for", "print", "print"], output=output
+        )
 
     def test_for_loop_hindi_variable(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         for काउंटर in range 1 to 5
-            print काउंटर""")
+            print काउंटर"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         step = 1 if int(1) < int(5) else -1
         for काउंटर in range(int(1), int(5) + step, step):
           print(f'{काउंटर}')
-          time.sleep(0.1)""")
+          time.sleep(0.1)"""
+        )
 
-        self.single_level_tester(
-            code=code,
-            expected=expected,
-            expected_commands=['for', 'print'])
+        self.single_level_tester(code=code, expected=expected, expected_commands=["for", "print"])
 
     def test_for_loop_arabic_range_latin_output(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         for دورة in range ١ to ٥
-            print دورة""")
+            print دورة"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         step = 1 if int(1) < int(5) else -1
         for دورة in range(int(1), int(5) + step, step):
           print(f'{دورة}')
-          time.sleep(0.1)""")
+          time.sleep(0.1)"""
+        )
 
-        output = textwrap.dedent("""\
+        output = textwrap.dedent(
+            """\
         1
         2
         3
         4
-        5""")
+        5"""
+        )
 
-        self.single_level_tester(
-            code=code,
-            output=output,
-            expected=expected,
-            expected_commands=['for', 'print'])
+        self.single_level_tester(code=code, output=output, expected=expected, expected_commands=["for", "print"])
 
     def test_for_loop_arabic_range_arabic_output(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         for دورة in range ١ to ٥
-            print دورة""")
+            print دورة"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         step = 1 if int(1) < int(5) else -1
         for دورة in range(int(1), int(5) + step, step):
           print(f'{convert_numerals("Arabic",دورة)}')
-          time.sleep(0.1)""")
+          time.sleep(0.1)"""
+        )
 
-        output = textwrap.dedent("""\
+        output = textwrap.dedent(
+            """\
         ١
         ٢
         ٣
         ٤
-        ٥""")
+        ٥"""
+        )
 
         self.single_level_tester(
-            code=code,
-            output=output,
-            lang='ar',
-            translate=False,
-            expected=expected,
-            expected_commands=['for', 'print'])
+            code=code, output=output, lang="ar", translate=False, expected=expected, expected_commands=["for", "print"]
+        )
 
     def test_for_loop_reversed_range(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         for i in range 10 to 1
             print i
-        print 'wie niet weg is is gezien'""")
+        print 'wie niet weg is is gezien'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         step = 1 if int(10) < int(1) else -1
         for i in range(int(10), int(1) + step, step):
           print(f'{i}')
           time.sleep(0.1)
-        print(f'wie niet weg is is gezien')""")
+        print(f'wie niet weg is is gezien')"""
+        )
 
-        self.single_level_tester(
-            code=code,
-            expected=expected,
-            expected_commands=['for', 'print', 'print'])
+        self.single_level_tester(code=code, expected=expected, expected_commands=["for", "print", "print"])
 
     def test_for_loop_with_if_else_body(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         for i in range 0 to 10
             antwoord is ask 'Wat is 5*5'
             if antwoord is 24
@@ -221,9 +239,11 @@ class TestsLevel11(HedyTester):
             else
                 print 'Dat is goed!'
             if antwoord is 25
-                i is 10""")
+                i is 10"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         step = 1 if int(0) < int(10) else -1
         for i in range(int(0), int(10) + step, step):
           antwoord = input(f'Wat is 5*5')
@@ -233,70 +253,85 @@ class TestsLevel11(HedyTester):
             print(f'Dat is goed!')
           if convert_numerals('Latin', antwoord) == convert_numerals('Latin', '25'):
             i = '10'
-          time.sleep(0.1)""")
+          time.sleep(0.1)"""
+        )
 
         self.single_level_tester(code=code, expected=expected)
 
     # issue 363
     def test_for_loop_if_followed_by_print(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         for i in range 0 to 10
             antwoord is ask 'Wat is 5*5'
             if antwoord is 24
                 print 'fout'
-        print 'klaar met for loop'""")
+        print 'klaar met for loop'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         step = 1 if int(0) < int(10) else -1
         for i in range(int(0), int(10) + step, step):
           antwoord = input(f'Wat is 5*5')
           if convert_numerals('Latin', antwoord) == convert_numerals('Latin', '24'):
             print(f'fout')
           time.sleep(0.1)
-        print(f'klaar met for loop')""")
+        print(f'klaar met for loop')"""
+        )
 
         self.single_level_tester(code=code, expected=expected)
 
     # issue 599
     def test_for_loop_if(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         for i in range 0 to 10
             if i is 2
-                print '2'""")
+                print '2'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         step = 1 if int(0) < int(10) else -1
         for i in range(int(0), int(10) + step, step):
           if convert_numerals('Latin', i) == convert_numerals('Latin', '2'):
             print(f'2')
-          time.sleep(0.1)""")
+          time.sleep(0.1)"""
+        )
 
         self.single_level_tester(code=code, expected=expected)
 
     # issue 1209
     def test_for_loop_unindented_nested_for_loop(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         for x in range 1 to 10
          for y in range 1 to 10
-         print 'x*y'""")
+         print 'x*y'"""
+        )
 
         self.multi_level_tester(code, exception=hedy.exceptions.NoIndentationException)
 
     # issue 1209
     def test_for_loop_dedented_nested_loop(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         for x in range 1 to 10
          for y in range 1 to 10
-        print 'x*y'""")
+        print 'x*y'"""
+        )
 
         self.multi_level_tester(code, exception=hedy.exceptions.NoIndentationException)
 
     # issue 1209
     def test_nested_for_loop_with_zigzag_body(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         for x in range 1 to 10
           for y in range 1 to 10
              print 'this number is'
-            print x*y""")
+            print x*y"""
+        )
 
         self.multi_level_tester(code, exception=hedy.exceptions.IndentationException)

--- a/tests/test_level/test_level_12.py
+++ b/tests/test_level/test_level_12.py
@@ -6,7 +6,7 @@ from tests.Tester import HedyTester
 
 class TestsLevel12(HedyTester):
     level = 12
-    '''
+    """
     Tests should be ordered as follows:
      * commands in the order of hedy.py e.g. for level 1: ['print', 'ask', 'echo', 'turn', 'forward']
      * combined tests
@@ -17,24 +17,24 @@ class TestsLevel12(HedyTester):
      * single keyword positive tests are just keyword or keyword_special_case
      * multi keyword positive tests are keyword1_keywords_2
      * negative tests should be situation_gives_exception
-    '''
+    """
 
     #
     # print tests
     #
     def test_print_float(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
             pi is 3.14
-            print pi""")
-        expected = textwrap.dedent("""\
-            pi = 3.14
-            print(f'''{pi}''')""")
-
-        self.multi_level_tester(
-            code=code,
-            max_level=17,
-            expected=expected
+            print pi"""
         )
+        expected = textwrap.dedent(
+            """\
+            pi = 3.14
+            print(f'''{pi}''')"""
+        )
+
+        self.multi_level_tester(code=code, max_level=17, expected=expected)
 
     def test_print_literal_strings(self):
         code = """print "It's " '"Hedy"!'"""
@@ -47,115 +47,90 @@ class TestsLevel12(HedyTester):
         )
 
     def test_print_string_with_triple_quotes_gives_error(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
             var = " is not allowed"
-            print "'''" + var """)
-
-        self.multi_level_tester(
-            code=code,
-            max_level=17,
-            exception=hedy.exceptions.UnsupportedStringValue
+            print "'''" + var """
         )
+
+        self.multi_level_tester(code=code, max_level=17, exception=hedy.exceptions.UnsupportedStringValue)
 
     # issue #745
     def test_print_list_gives_type_error(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
             plaatsen is 1, 2, 3
-            print plaatsen""")
-
-        self.multi_level_tester(
-            code=code,
-            max_level=15,
-            exception=hedy.exceptions.InvalidArgumentTypeException
+            print plaatsen"""
         )
+
+        self.multi_level_tester(code=code, max_level=15, exception=hedy.exceptions.InvalidArgumentTypeException)
 
     def test_print_list_random(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
             numbers is 1, 2, 4
-            print numbers at random""")
-
-        expected = textwrap.dedent("""\
-            numbers = [1, 2, 4]
-            print(f'''{random.choice(numbers)}''')""")
-
-        self.multi_level_tester(
-            code=code,
-            max_level=15,
-            expected=expected,
-            expected_commands=['is', 'print', 'random']
+            print numbers at random"""
         )
+
+        expected = textwrap.dedent(
+            """\
+            numbers = [1, 2, 4]
+            print(f'''{random.choice(numbers)}''')"""
+        )
+
+        self.multi_level_tester(code=code, max_level=15, expected=expected, expected_commands=["is", "print", "random"])
 
     def test_print_list_access_index(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         numbers is 5, 4, 3
-        print numbers at 1""")
-
-        expected = textwrap.dedent("""\
-        numbers = [5, 4, 3]
-        print(f'''{numbers[1-1]}''')""")
-
-        check_in_list = (lambda x: HedyTester.run_code(x) == '5')
-
-        self.multi_level_tester(
-            max_level=15,
-            code=code,
-            expected=expected,
-            extra_check_function=check_in_list
+        print numbers at 1"""
         )
+
+        expected = textwrap.dedent(
+            """\
+        numbers = [5, 4, 3]
+        print(f'''{numbers[1-1]}''')"""
+        )
+
+        check_in_list = lambda x: HedyTester.run_code(x) == "5"
+
+        self.multi_level_tester(max_level=15, code=code, expected=expected, extra_check_function=check_in_list)
 
     def test_print_single_quoted_text(self):
         code = "print 'hallo wereld!'"
         expected = "print(f'''hallo wereld!''')"
 
-        self.multi_level_tester(
-            code=code,
-            max_level=17,
-            expected=expected)
+        self.multi_level_tester(code=code, max_level=17, expected=expected)
 
     def test_print_double_quoted_text(self):
         code = 'print "hallo wereld!"'
         expected = "print(f'''hallo wereld!''')"
 
-        self.multi_level_tester(
-            code=code,
-            max_level=17,
-            expected=expected)
+        self.multi_level_tester(code=code, max_level=17, expected=expected)
 
     def test_print_single_quoted_text_with_inner_double_quote(self):
         code = """print 'quote is "'"""
         expected = """print(f'''quote is "''')"""
 
-        self.multi_level_tester(
-            code=code,
-            max_level=17,
-            expected=expected)
+        self.multi_level_tester(code=code, max_level=17, expected=expected)
 
     def test_print_double_quoted_text_with_inner_single_quote(self):
         code = '''print "It's me"'''
         expected = """print(f'''It\\'s me''')"""
 
-        self.multi_level_tester(
-            code=code,
-            max_level=17,
-            expected=expected)
+        self.multi_level_tester(code=code, max_level=17, expected=expected)
 
     def test_print_no_space(self):
         code = "print'hallo wereld!'"
         expected = "print(f'''hallo wereld!''')"
 
-        self.multi_level_tester(
-            code=code,
-            max_level=17,
-            expected=expected)
+        self.multi_level_tester(code=code, max_level=17, expected=expected)
 
     def test_print_comma(self):
         code = "print 'Hi, I am Hedy'"
         expected = "print(f'''Hi, I am Hedy''')"
-        self.multi_level_tester(
-            code=code,
-            max_level=17,
-            expected=expected
-        )
+        self.multi_level_tester(code=code, max_level=17, expected=expected)
 
     def test_print_slash(self):
         code = "print 'Yes/No'"
@@ -168,23 +143,12 @@ class TestsLevel12(HedyTester):
         expected = "print(f'''Yes\\\\No''')"
         output = "Yes\\No"
 
-        self.multi_level_tester(
-            code=code,
-            expected=expected,
-            output=output,
-            max_level=17,
-            translate=True
-        )
+        self.multi_level_tester(code=code, expected=expected, output=output, max_level=17, translate=True)
 
     def test_print_with_backslash_at_end(self):
         code = "print 'Welcome to \\'"
         expected = "print(f'''Welcome to \\\\''')"
-        self.multi_level_tester(
-            code=code,
-            max_level=17,
-            expected=expected,
-            translate=True
-        )
+        self.multi_level_tester(code=code, max_level=17, expected=expected, translate=True)
 
     def test_print_with_spaces(self):
         code = "print        'hallo!'"
@@ -199,38 +163,50 @@ class TestsLevel12(HedyTester):
         self.multi_level_tester(code=code, expected=expected, max_level=17)
 
     def test_print_single_quoted_text_var(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         naam is "'Hedy'"
-        print 'ik heet ' naam""")
+        print 'ik heet ' naam"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         naam = "'Hedy'"
-        print(f'''ik heet {naam}''')""")
+        print(f'''ik heet {naam}''')"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=17)
 
     def test_print_double_quoted_text_var(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         naam is '"Hedy"'
-        print 'ik heet ' naam""")
+        print 'ik heet ' naam"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         naam = '"Hedy"'
-        print(f'''ik heet {naam}''')""")
+        print(f'''ik heet {naam}''')"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=17)
 
     # issue 1795
     def test_print_quoted_var_reference(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         naam is "'Daan'"
         woord1 is 'zomerkamp'
-        print 'naam' ' is naar het' 'woord1'""")
+        print 'naam' ' is naar het' 'woord1'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         naam = "'Daan'"
         woord1 = 'zomerkamp'
-        print(f'''naam is naar hetwoord1''')""")
+        print(f'''naam is naar hetwoord1''')"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=17)
 
@@ -249,36 +225,48 @@ class TestsLevel12(HedyTester):
 
     @parameterized.expand(HedyTester.quotes)
     def test_print_concat_var_and_literal_string(self, q):
-        code = textwrap.dedent(f"""\
+        code = textwrap.dedent(
+            f"""\
         hi = {q}Hi{q}
-        print hi + {q} there{q}""")
-        expected = textwrap.dedent("""\
+        print hi + {q} there{q}"""
+        )
+        expected = textwrap.dedent(
+            """\
         hi = 'Hi'
-        print(f'''{hi + ' there'}''')""")
+        print(f'''{hi + ' there'}''')"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=17)
 
     def test_print_chained_assignments(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
             x is 1 + 2
             y is x + 3
-            print y + 4""")
+            print y + 4"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
             x = 1 + 2
             y = x + 3
-            print(f'''{y + 4}''')""")
+            print(f'''{y + 4}''')"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=17)
 
     def test_print_calc(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
             var is 5
-            print var + 5""")
+            print var + 5"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
             var = 5
-            print(f'''{var + 5}''')""")
+            print(f'''{var + 5}''')"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=17)
 
@@ -286,11 +274,14 @@ class TestsLevel12(HedyTester):
     # ask tests
     #
     def test_ask_number_answer(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         prijs is ask 'hoeveel?'
         gespaard is 7
-        sparen is prijs - gespaard""")
-        expected = textwrap.dedent("""\
+        sparen is prijs - gespaard"""
+        )
+        expected = textwrap.dedent(
+            """\
         prijs = input(f'''hoeveel?''')
         try:
           prijs = int(prijs)
@@ -300,16 +291,20 @@ class TestsLevel12(HedyTester):
           except ValueError:
             pass
         gespaard = 7
-        sparen = prijs - gespaard""")
+        sparen = prijs - gespaard"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=17)
 
     def test_ask_with_list_var(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         colors is 'orange', 'blue', 'green'
-        favorite is ask 'Is your fav color' colors at 1""")
+        favorite is ask 'Is your fav color' colors at 1"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         colors = ['orange', 'blue', 'green']
         favorite = input(f'''Is your fav color{colors[1-1]}''')
         try:
@@ -318,13 +313,15 @@ class TestsLevel12(HedyTester):
           try:
             favorite = float(favorite)
           except ValueError:
-            pass""")
+            pass"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=14)
 
     def test_ask_literal_strings(self):
         code = """var is ask "It's " '"Hedy"!'"""
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         var = input(f'''It\\'s "Hedy"!''')
         try:
           var = int(var)
@@ -332,17 +329,21 @@ class TestsLevel12(HedyTester):
           try:
             var = float(var)
           except ValueError:
-            pass""")
+            pass"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=17)
 
     @parameterized.expand(HedyTester.quotes)
     def test_ask_with_string_var(self, q):
-        code = textwrap.dedent(f"""\
+        code = textwrap.dedent(
+            f"""\
         color is {q}orange{q}
-        favorite is ask {q}Is your fav color{q} color""")
+        favorite is ask {q}Is your fav color{q} color"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         color = 'orange'
         favorite = input(f'''Is your fav color{color}''')
         try:
@@ -351,17 +352,21 @@ class TestsLevel12(HedyTester):
           try:
             favorite = float(favorite)
           except ValueError:
-            pass""")
+            pass"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=17)
 
-    @parameterized.expand(['10', '10.0'])
+    @parameterized.expand(["10", "10.0"])
     def test_ask_with_number_var(self, number):
-        code = textwrap.dedent(f"""\
+        code = textwrap.dedent(
+            f"""\
         number is {number}
-        favorite is ask 'Is your fav number' number""")
+        favorite is ask 'Is your fav number' number"""
+        )
 
-        expected = textwrap.dedent(f"""\
+        expected = textwrap.dedent(
+            f"""\
         number = {number}
         favorite = input(f'''Is your fav number{{number}}''')
         try:
@@ -370,102 +375,110 @@ class TestsLevel12(HedyTester):
           try:
             favorite = float(favorite)
           except ValueError:
-            pass""")
+            pass"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=17)
 
     def test_ask_list_gives_type_error(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         numbers is 1, 2, 3
-        favorite is ask 'Is your fav number' numbers""")
-
-        self.multi_level_tester(
-            max_level=15,
-            code=code,
-            exception=hedy.exceptions.InvalidArgumentTypeException
+        favorite is ask 'Is your fav number' numbers"""
         )
+
+        self.multi_level_tester(max_level=15, code=code, exception=hedy.exceptions.InvalidArgumentTypeException)
 
     def test_ask_single_quoted_text(self):
         code = "details is ask 'tell me more'"
-        expected = HedyTester.input_transpiled('details', 'tell me more')
+        expected = HedyTester.input_transpiled("details", "tell me more")
 
         self.multi_level_tester(code=code, expected=expected, max_level=17)
 
     def test_ask_double_quoted_text(self):
         code = 'details is ask "tell me more"'
-        expected = HedyTester.input_transpiled('details', 'tell me more')
+        expected = HedyTester.input_transpiled("details", "tell me more")
 
         self.multi_level_tester(code=code, expected=expected, max_level=17)
 
     def test_ask_single_quoted_text_with_inner_double_quote(self):
         code = """details is ask 'say "no"'"""
-        expected = HedyTester.input_transpiled('details', 'say "no"')
+        expected = HedyTester.input_transpiled("details", 'say "no"')
 
         self.multi_level_tester(code=code, expected=expected, max_level=17)
 
     def test_ask_double_quoted_text_with_inner_single_quote(self):
         code = f'''details is ask "say 'no'"'''
-        expected = HedyTester.input_transpiled('details', "say \\'no\\'")
+        expected = HedyTester.input_transpiled("details", "say \\'no\\'")
 
         self.multi_level_tester(code=code, expected=expected, max_level=17)
 
     def test_ask_with_comma(self):
         code = "dieren is ask 'hond, kat, kangoeroe'"
-        expected = HedyTester.input_transpiled('dieren', 'hond, kat, kangoeroe')
+        expected = HedyTester.input_transpiled("dieren", "hond, kat, kangoeroe")
 
         self.multi_level_tester(code=code, expected=expected, max_level=17)
 
     @parameterized.expand(HedyTester.quotes)
     def test_ask_es(self, q):
         code = f"""color is ask {q}Cuál es tu color favorito?{q}"""
-        expected = HedyTester.input_transpiled('color', 'Cuál es tu color favorito?')
+        expected = HedyTester.input_transpiled("color", "Cuál es tu color favorito?")
 
         self.multi_level_tester(code=code, expected=expected, max_level=17)
 
     @parameterized.expand(HedyTester.quotes)
     def test_ask_bengali_var(self, q):
         code = f"""রং is ask {q}আপনার প্রিয় রং কি?{q}"""
-        expected = HedyTester.input_transpiled('রং', 'আপনার প্রিয় রং কি?')
+        expected = HedyTester.input_transpiled("রং", "আপনার প্রিয় রং কি?")
 
         self.multi_level_tester(code=code, expected=expected, max_level=17)
 
     def test_ask_list_random(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
             numbers is 1, 2, 3
-            favorite is ask 'Is your fav number ' numbers at random""")
+            favorite is ask 'Is your fav number ' numbers at random"""
+        )
         expected = HedyTester.dedent(
             "numbers = [1, 2, 3]",
-            HedyTester.input_transpiled('favorite', 'Is your fav number {random.choice(numbers)}'))
+            HedyTester.input_transpiled("favorite", "Is your fav number {random.choice(numbers)}"),
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=15)
 
     def test_ask_list_access_index(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
             numbers is 1, 2, 3
-            favorite is ask 'Is your fav number ' numbers at 2""")
+            favorite is ask 'Is your fav number ' numbers at 2"""
+        )
         expected = HedyTester.dedent(
-            "numbers = [1, 2, 3]",
-            HedyTester.input_transpiled('favorite', 'Is your fav number {numbers[2-1]}'))
+            "numbers = [1, 2, 3]", HedyTester.input_transpiled("favorite", "Is your fav number {numbers[2-1]}")
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=15)
 
     def test_ask_string_var(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
             color is "orange"
-            favorite is ask 'Is your fav color ' color""")
+            favorite is ask 'Is your fav color ' color"""
+        )
         expected = HedyTester.dedent(
-            "color = 'orange'",
-            HedyTester.input_transpiled('favorite', 'Is your fav color {color}'))
+            "color = 'orange'", HedyTester.input_transpiled("favorite", "Is your fav color {color}")
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=17)
 
     def test_ask_integer_var(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
             number is 10
-            favorite is ask 'Is your fav number ' number""")
+            favorite is ask 'Is your fav number ' number"""
+        )
         expected = HedyTester.dedent(
-            "number = 10",
-            HedyTester.input_transpiled('favorite', 'Is your fav number {number}'))
+            "number = 10", HedyTester.input_transpiled("favorite", "Is your fav number {number}")
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=17)
 
@@ -473,54 +486,61 @@ class TestsLevel12(HedyTester):
     # sleep tests
     #
     def test_sleep_with_number_variable(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
             n is 2
-            sleep n""")
-        expected = HedyTester.dedent(
-            "n = 2",
-            HedyTester.sleep_command_transpiled("n"))
+            sleep n"""
+        )
+        expected = HedyTester.dedent("n = 2", HedyTester.sleep_command_transpiled("n"))
 
         self.multi_level_tester(code=code, expected=expected)
 
     def test_sleep_with_string_variable_gives_error(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
             n is "test"
-            sleep n""")
+            sleep n"""
+        )
 
         self.multi_level_tester(code=code, exception=hedy.exceptions.InvalidArgumentTypeException)
 
     def test_sleep_with_list_access(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
             n is 1, 2, 3
-            sleep n at 1""")
-        expected = HedyTester.dedent(
-            "n = [1, 2, 3]",
-            HedyTester.sleep_command_transpiled("n[1-1]"))
+            sleep n at 1"""
+        )
+        expected = HedyTester.dedent("n = [1, 2, 3]", HedyTester.sleep_command_transpiled("n[1-1]"))
 
         self.multi_level_tester(max_level=15, code=code, expected=expected)
 
     def test_sleep_with_list_random(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
             n is 1, 2, 3
-            sleep n at random""")
-        expected = HedyTester.dedent(
-            "n = [1, 2, 3]",
-            HedyTester.sleep_command_transpiled("random.choice(n)"))
+            sleep n at random"""
+        )
+        expected = HedyTester.dedent("n = [1, 2, 3]", HedyTester.sleep_command_transpiled("random.choice(n)"))
 
         self.multi_level_tester(max_level=15, code=code, expected=expected)
 
     def test_sleep_with_list_gives_error(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
             n is 1, 2, 3
-            sleep n""")
+            sleep n"""
+        )
 
         self.multi_level_tester(max_level=15, code=code, exception=hedy.exceptions.InvalidArgumentTypeException)
 
     def test_sleep_with_input_variable(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
             n is ask "how long"
-            sleep n""")
-        expected = HedyTester.dedent("""\
+            sleep n"""
+        )
+        expected = HedyTester.dedent(
+            """\
             n = input(f'''how long''')
             try:
               n = int(n)
@@ -529,24 +549,27 @@ class TestsLevel12(HedyTester):
                 n = float(n)
               except ValueError:
                 pass""",
-                                     HedyTester.sleep_command_transpiled("n"))
+            HedyTester.sleep_command_transpiled("n"),
+        )
 
         self.multi_level_tester(max_level=17, code=code, expected=expected)
 
     def test_sleep_with_calc(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
             n is 1 * 2 + 3
-            sleep n""")
-        expected = HedyTester.dedent(
-            "n = 1 * 2 + 3",
-            HedyTester.sleep_command_transpiled("n"))
+            sleep n"""
+        )
+        expected = HedyTester.dedent("n = 1 * 2 + 3", HedyTester.sleep_command_transpiled("n"))
 
         self.multi_level_tester(code=code, expected=expected)
 
     def test_sleep_with_float_gives_error(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
             n is 1.5
-            sleep n""")
+            sleep n"""
+        )
 
         self.multi_level_tester(code=code, exception=hedy.exceptions.InvalidArgumentTypeException)
 
@@ -566,18 +589,19 @@ class TestsLevel12(HedyTester):
         self.multi_level_tester(code=code, expected=expected, max_level=15)
 
     def test_assign_list_random(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         dieren is 'hond', 'kat', 'kangoeroe'
-        dier is dieren at random""")
+        dier is dieren at random"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         dieren = ['hond', 'kat', 'kangoeroe']
-        dier = random.choice(dieren)""")
+        dier = random.choice(dieren)"""
+        )
 
-        self.multi_level_tester(
-            code=code,
-            expected=expected,
-            max_level=15)
+        self.multi_level_tester(code=code, expected=expected, max_level=15)
 
     def test_assign_list_with_dutch_comma_arabic_lang(self):
         code = "صديقي هو 'احمد', 'خالد', 'حسن'"
@@ -586,42 +610,28 @@ class TestsLevel12(HedyTester):
         self.multi_level_tester(
             code=code,
             expected=expected,
-            lang='ar',
+            lang="ar",
             max_level=15,
             # translation must be off because the Latin commas will be converted to arabic commas and this is correct
-            translate=False
+            translate=False,
         )
 
     def test_assign_list_with_arabic_comma_and_is(self):
         code = "animals هو 'cat'، 'dog'، 'platypus'"
         expected = "animals = ['cat', 'dog', 'platypus']"
 
-        self.multi_level_tester(
-            max_level=15,
-            code=code,
-            expected=expected,
-            lang='ar'
-        )
+        self.multi_level_tester(max_level=15, code=code, expected=expected, lang="ar")
 
     def test_assign_list_with_arabic_comma(self):
         code = "صديقي هو 'احمد'، 'خالد'، 'حسن'"
         expected = "صديقي = ['احمد', 'خالد', 'حسن']"
 
-        self.multi_level_tester(
-            max_level=15,
-            code=code,
-            expected=expected,
-            lang='ar'
-        )
+        self.multi_level_tester(max_level=15, code=code, expected=expected, lang="ar")
 
     def test_assign_string_without_quotes(self):
         code = "name is felienne"
 
-        self.multi_level_tester(
-            code=code,
-            max_level=17,
-            exception=hedy.exceptions.UnquotedAssignTextException
-        )
+        self.multi_level_tester(code=code, max_level=17, exception=hedy.exceptions.UnquotedAssignTextException)
 
     @parameterized.expand(HedyTester.quotes)
     def test_assign_string(self, q):
@@ -671,86 +681,88 @@ class TestsLevel12(HedyTester):
     # add/remove tests
     #
     def test_add_ask_to_list(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
             color is ask 'what is your favorite color?'
             colors is 'green', 'red', 'blue'
-            add color to colors""")
+            add color to colors"""
+        )
 
         expected = HedyTester.dedent(
-            HedyTester.input_transpiled('color', 'what is your favorite color?'),
+            HedyTester.input_transpiled("color", "what is your favorite color?"),
             "colors = ['green', 'red', 'blue']",
-            "colors.append(color)")
+            "colors.append(color)",
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=15)
 
     def test_remove_ask_from_list(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
             colors is 'green', 'red', 'blue'
             color is ask 'what color to remove?'
-            remove color from colors""")
+            remove color from colors"""
+        )
 
         expected = HedyTester.dedent(
             "colors = ['green', 'red', 'blue']",
-            HedyTester.input_transpiled('color', 'what color to remove?'),
-            HedyTester.remove_transpiled('colors', 'color'))
+            HedyTester.input_transpiled("color", "what color to remove?"),
+            HedyTester.remove_transpiled("colors", "color"),
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=15)
 
     def test_add_to_list_with_string_var_gives_error(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         color is 'yellow'
         colors is 'green', 'red', 'blue'
-        add colors to color""")
-
-        self.multi_level_tester(
-            max_level=15,
-            code=code,
-            exception=hedy.exceptions.InvalidArgumentTypeException
+        add colors to color"""
         )
+
+        self.multi_level_tester(max_level=15, code=code, exception=hedy.exceptions.InvalidArgumentTypeException)
 
     def test_add_to_list_with_input_var_gives_error(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         colors is ask 'What are the colors?'
         favorite is 'red'
-        add favorite to colors""")
-
-        self.multi_level_tester(
-            max_level=15,
-            code=code,
-            exception=hedy.exceptions.InvalidArgumentTypeException
+        add favorite to colors"""
         )
+
+        self.multi_level_tester(max_level=15, code=code, exception=hedy.exceptions.InvalidArgumentTypeException)
 
     def test_remove_from_list_with_string_var_gives_error(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         color is 'yellow'
         colors is 'green', 'red', 'blue'
-        remove colors from color""")
-
-        self.multi_level_tester(
-            max_level=15,
-            code=code,
-            exception=hedy.exceptions.InvalidArgumentTypeException
+        remove colors from color"""
         )
+
+        self.multi_level_tester(max_level=15, code=code, exception=hedy.exceptions.InvalidArgumentTypeException)
 
     def test_remove_from_list_with_input_var_gives_error(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         colors is ask 'What are the colors?'
         favorite is 'red'
-        remove favorite from colors""")
-
-        self.multi_level_tester(
-            max_level=15,
-            code=code,
-            exception=hedy.exceptions.InvalidArgumentTypeException
+        remove favorite from colors"""
         )
 
+        self.multi_level_tester(max_level=15, code=code, exception=hedy.exceptions.InvalidArgumentTypeException)
+
     def test_list_creation_with_numbers(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         getallen is 1, 2, 3, 4, 5, 6, 7, 8, 9, 10
-        getal is getallen at random""")
-        expected = textwrap.dedent("""\
+        getal is getallen at random"""
+        )
+        expected = textwrap.dedent(
+            """\
         getallen = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-        getal = random.choice(getallen)""")
+        getal = random.choice(getallen)"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=15)
 
@@ -758,21 +770,21 @@ class TestsLevel12(HedyTester):
     # for loop tests
     #
     def test_for_loop_arabic(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         for دورة in range ١ to ٥
-            print دورة""")
+            print دورة"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         step = 1 if 1 < 5 else -1
         for دورة in range(1, 5 + step, step):
           print(f'''{دورة}''')
-          time.sleep(0.1)""")
+          time.sleep(0.1)"""
+        )
 
-        self.multi_level_tester(
-            max_level=16,
-            code=code,
-            expected=expected,
-            expected_commands=['for', 'print'])
+        self.multi_level_tester(max_level=16, code=code, expected=expected, expected_commands=["for", "print"])
 
     def test_assign_list_with_spaces(self):
         code = "voorspellingen = 'je wordt rijk' , 'je wordt verliefd' , 'je glijdt uit over een bananenschil'"
@@ -785,105 +797,127 @@ class TestsLevel12(HedyTester):
     #
     @parameterized.expand(HedyTester.equality_comparison_with_is)
     def test_if_equality_print(self, eq):
-        code = textwrap.dedent(f"""\
+        code = textwrap.dedent(
+            f"""\
         naam = 'Hedy'
         if naam {eq} 'Hedy'
-            print 'koekoek'""")
+            print 'koekoek'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         naam = 'Hedy'
         if convert_numerals('Latin', naam) == convert_numerals('Latin', 'Hedy'):
-          print(f'''koekoek''')""")
+          print(f'''koekoek''')"""
+        )
 
-        self.multi_level_tester(
-            code=code,
-            expected=expected,
-            expected_commands=['is', 'if', 'print'],
-            max_level=16)
+        self.multi_level_tester(code=code, expected=expected, expected_commands=["is", "if", "print"], max_level=16)
 
     def test_if_equality_no_spaces_print(self):
-        code = textwrap.dedent(f"""\
+        code = textwrap.dedent(
+            f"""\
         naam = 'Hedy'
         if naam='Hedy'
-            print 'koekoek'""")
+            print 'koekoek'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         naam = 'Hedy'
         if convert_numerals('Latin', naam) == convert_numerals('Latin', 'Hedy'):
-          print(f'''koekoek''')""")
+          print(f'''koekoek''')"""
+        )
 
         self.multi_level_tester(
-            code=code,
-            expected=expected,
-            expected_commands=['is', 'if', 'print'],
-            max_level=16)  # space between = is not preserved (but is needed for the test)
+            code=code, expected=expected, expected_commands=["is", "if", "print"], max_level=16
+        )  # space between = is not preserved (but is needed for the test)
 
     def test_if_equality_rhs_with_space(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
            naam is 'James'
            if naam is 'James Bond'
-               print 'shaken'""")
+               print 'shaken'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
            naam = 'James'
            if convert_numerals('Latin', naam) == convert_numerals('Latin', 'James Bond'):
-             print(f'''shaken''')""")
+             print(f'''shaken''')"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=16)
 
     def test_if_equality_single_quoted_rhs_with_inner_double_quote(self):
-        code = textwrap.dedent(f"""\
+        code = textwrap.dedent(
+            f"""\
         answer is 'no'
         if answer is 'He said "no"'
-          print 'no'""")
+          print 'no'"""
+        )
 
-        expected = textwrap.dedent(f"""\
+        expected = textwrap.dedent(
+            f"""\
         answer = 'no'
         if convert_numerals('Latin', answer) == convert_numerals('Latin', 'He said "no"'):
-          print(f'''no''')""")
+          print(f'''no''')"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=16)
 
     def test_if_equality_double_quoted_rhs_with_inner_single_quote(self):
-        code = textwrap.dedent(f"""\
+        code = textwrap.dedent(
+            f"""\
         answer is 'no'
         if answer is "He said 'no'"
-          print 'no'""")
+          print 'no'"""
+        )
 
-        expected = textwrap.dedent(f"""\
+        expected = textwrap.dedent(
+            f"""\
         answer = 'no'
         if convert_numerals('Latin', answer) == convert_numerals('Latin', 'He said \\'no\\''):
-          print(f'''no''')""")
+          print(f'''no''')"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=16)
 
     def test_if_equality_negative_number(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         antwoord = -10
         if antwoord is -10
-            print 'Nice'""")
+            print 'Nice'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         antwoord = -10
         if convert_numerals('Latin', antwoord) == convert_numerals('Latin', '-10'):
-          print(f'''Nice''')""")
+          print(f'''Nice''')"""
+        )
 
-        self.multi_level_tester(code=code, expected=expected, output='Nice', max_level=16)
+        self.multi_level_tester(code=code, expected=expected, output="Nice", max_level=16)
 
     def test_if_2_vars_equality_print(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         jouwkeuze is 'schaar'
         computerkeuze is 'schaar'
         if computerkeuze is jouwkeuze
-            print 'gelijkspel!'""")
+            print 'gelijkspel!'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         jouwkeuze = 'schaar'
         computerkeuze = 'schaar'
         if convert_numerals('Latin', computerkeuze) == convert_numerals('Latin', jouwkeuze):
-          print(f'''gelijkspel!''')""")
+          print(f'''gelijkspel!''')"""
+        )
 
-        self.multi_level_tester(max_level=16, code=code, expected=expected, output='gelijkspel!')
+        self.multi_level_tester(max_level=16, code=code, expected=expected, output="gelijkspel!")
 
     # def test_if_equality_trailing_space_linebreak_print(self):
     #     code = textwrap.dedent("""\
@@ -899,158 +933,175 @@ class TestsLevel12(HedyTester):
     #     self.multi_level_tester(max_level=18, code=code, expected=expected)
 
     def test_if_equality_lists(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         m is 1, 2
         n is 1, 2
         if m is n
-            print 'success!'""")
+            print 'success!'"""
+        )
 
-        self.multi_level_tester(
-            max_level=13,
-            code=code,
-            exception=hedy.exceptions.InvalidArgumentTypeException)
+        self.multi_level_tester(max_level=13, code=code, exception=hedy.exceptions.InvalidArgumentTypeException)
 
     @parameterized.expand(HedyTester.quotes)
     def test_if_in_list_with_string_var_gives_type_error(self, q):
-        code = textwrap.dedent(f"""\
+        code = textwrap.dedent(
+            f"""\
         items is {q}red{q}
         if {q}red{q} in items
-            print {q}found!{q}""")
-        self.multi_level_tester(
-            max_level=16,
-            code=code,
-            exception=hedy.exceptions.InvalidArgumentTypeException
+            print {q}found!{q}"""
         )
+        self.multi_level_tester(max_level=16, code=code, exception=hedy.exceptions.InvalidArgumentTypeException)
 
     def test_if_equality_with_list_gives_error(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         color is 5, 6, 7
         if 1 is color
-            print 'success!'""")
-        self.multi_level_tester(
-            max_level=13,
-            code=code,
-            exception=hedy.exceptions.InvalidArgumentTypeException
+            print 'success!'"""
         )
+        self.multi_level_tester(max_level=13, code=code, exception=hedy.exceptions.InvalidArgumentTypeException)
 
     def test_if_equality_with_incompatible_types_gives_error(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         a is 'test'
         b is 15
         if a is b
-          c is 1""")
-        self.multi_level_tester(
-            max_level=16,
-            code=code,
-            exception=hedy.exceptions.InvalidTypeCombinationException
+          c is 1"""
         )
+        self.multi_level_tester(max_level=16, code=code, exception=hedy.exceptions.InvalidTypeCombinationException)
 
     #
     # if else tests
     #
     def test_if_equality_print_else_print(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         naam is 'Hedy'
         if naam is 'Hedy'
             print 'leuk'
         else
-            print 'minder leuk'""")
+            print 'minder leuk'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         naam = 'Hedy'
         if convert_numerals('Latin', naam) == convert_numerals('Latin', 'Hedy'):
           print(f'''leuk''')
         else:
-          print(f'''minder leuk''')""")
+          print(f'''minder leuk''')"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=16)
 
     def test_if_equality_assign_else_assign(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
          a is 5
          if a is 1
              x is 2
          else
-             x is 222""")
-        expected = textwrap.dedent("""\
+             x is 222"""
+        )
+        expected = textwrap.dedent(
+            """\
          a = 5
          if convert_numerals('Latin', a) == convert_numerals('Latin', '1'):
            x = 2
          else:
-           x = 222""")
+           x = 222"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=16)
 
     def test_if_else_followed_by_print(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         kleur is 'geel'
         if kleur is 'groen'
             antwoord is 'ok'
         else
             antwoord is 'stom'
-        print antwoord""")
+        print antwoord"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         kleur = 'geel'
         if convert_numerals('Latin', kleur) == convert_numerals('Latin', 'groen'):
           antwoord = 'ok'
         else:
           antwoord = 'stom'
-        print(f'''{antwoord}''')""")
+        print(f'''{antwoord}''')"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=16)
 
     def test_if_else_trailing_space_after_else(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         a is 1
         if a is 1
             print a
         else    
-            print 'nee'""")
+            print 'nee'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         a = 1
         if convert_numerals('Latin', a) == convert_numerals('Latin', '1'):
           print(f'''{a}''')
         else:
-          print(f'''nee''')""")
+          print(f'''nee''')"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=16)
 
     def test_if_empty_line_with_whitespace_else_print(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         if 1 is 2
             sleep
 
         else
-            sleep""")
+            sleep"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         if convert_numerals('Latin', '1') == convert_numerals('Latin', '2'):
           time.sleep(1)
         else:
-          time.sleep(1)""")
+          time.sleep(1)"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=16)
 
     def test_if_else_with_multiple_lines(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
             antwoord is ask 'Hoeveel is 10 plus 10?'
             if antwoord is 20
                 print 'Goedzo!'
                 print 'Het antwoord was inderdaad ' antwoord
             else
                 print 'Foutje'
-                print 'Het antwoord moest zijn ' antwoord""")
+                print 'Het antwoord moest zijn ' antwoord"""
+        )
 
         expected = HedyTester.dedent(
-            HedyTester.input_transpiled('antwoord', 'Hoeveel is 10 plus 10?'), """\
+            HedyTester.input_transpiled("antwoord", "Hoeveel is 10 plus 10?"),
+            """\
             if convert_numerals('Latin', antwoord) == convert_numerals('Latin', '20'):
               print(f'''Goedzo!''')
               print(f'''Het antwoord was inderdaad {antwoord}''')
             else:
               print(f'''Foutje''')
-              print(f'''Het antwoord moest zijn {antwoord}''')""")
+              print(f'''Het antwoord moest zijn {antwoord}''')""",
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=16)
 
@@ -1058,128 +1109,164 @@ class TestsLevel12(HedyTester):
     # repeat tests
     #
     def test_repeat_print(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         repeat 5 times
-            print 'koekoek'""")
+            print 'koekoek'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         for i in range(int('5')):
           print(f'''koekoek''')
-          time.sleep(0.1)""")
+          time.sleep(0.1)"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=17)
 
     def test_repeat_print_variable(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         n is 5
         repeat n times
-            print 'me wants a cookie!'""")
+            print 'me wants a cookie!'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         n = 5
         for i in range(int(n)):
           print(f'''me wants a cookie!''')
-          time.sleep(0.1)""")
+          time.sleep(0.1)"""
+        )
 
-        output = textwrap.dedent("""\
+        output = textwrap.dedent(
+            """\
         me wants a cookie!
         me wants a cookie!
         me wants a cookie!
         me wants a cookie!
-        me wants a cookie!""")
+        me wants a cookie!"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, output=output, max_level=17)
 
     # issue 297
     def test_repeat_print_assign_addition(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         count is 1
         repeat 12 times
             print count ' times 12 is ' count * 12
-            count is count + 1""")
+            count is count + 1"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         count = 1
         for i in range(int('12')):
           print(f'''{count} times 12 is {count * 12}''')
           count = count + 1
-          time.sleep(0.1)""")
+          time.sleep(0.1)"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=17)
 
     def test_repeat_with_comment(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         repeat 5 times #This should be ignored
-            sleep""")
+            sleep"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         for i in range(int('5')):
           time.sleep(1)
-          time.sleep(0.1)""")
+          time.sleep(0.1)"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=17)
 
-    @parameterized.expand(['5', '𑁫', '५', '૫', '੫', '৫', '೫', '୫', '൫', '௫', '౫', '၅', '༥', '᠕', '៥', '๕', '໕', '꧕', '٥', '۵'])
+    @parameterized.expand(
+        ["5", "𑁫", "५", "૫", "੫", "৫", "೫", "୫", "൫", "௫", "౫", "၅", "༥", "᠕", "៥", "๕", "໕", "꧕", "٥", "۵"]
+    )
     def test_repeat_with_all_numerals(self, number):
-        code = textwrap.dedent(f"""\
+        code = textwrap.dedent(
+            f"""\
         repeat {number} times
-            print 'me wants a cookie!'""")
+            print 'me wants a cookie!'"""
+        )
 
-        expected = textwrap.dedent(f"""\
+        expected = textwrap.dedent(
+            f"""\
         for i in range(int('{int(number)}')):
           print(f'''me wants a cookie!''')
-          time.sleep(0.1)""")
+          time.sleep(0.1)"""
+        )
 
-        output = textwrap.dedent("""\
+        output = textwrap.dedent(
+            """\
         me wants a cookie!
         me wants a cookie!
         me wants a cookie!
         me wants a cookie!
-        me wants a cookie!""")
+        me wants a cookie!"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, output=output, max_level=17)
 
     def test_repeat_with_variable_name_collision(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         i is 'hallo!'
         repeat 5 times
             print 'me wants a cookie!'
-        print i""")
+        print i"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         i = 'hallo!'
         for _i in range(int('5')):
           print(f'''me wants a cookie!''')
           time.sleep(0.1)
-        print(f'''{i}''')""")
+        print(f'''{i}''')"""
+        )
 
-        output = textwrap.dedent("""\
+        output = textwrap.dedent(
+            """\
         me wants a cookie!
         me wants a cookie!
         me wants a cookie!
         me wants a cookie!
         me wants a cookie!
-        hallo!""")
+        hallo!"""
+        )
 
         self.multi_level_tester(
             code=code,
             expected=expected,
-            expected_commands=['is', 'repeat', 'print', 'print'],
+            expected_commands=["is", "repeat", "print", "print"],
             output=output,
-            max_level=17
+            max_level=17,
         )
 
     def test_repeat_nested_in_repeat(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         repeat 2 times
             repeat 3 times
-                print 'hello'""")
+                print 'hello'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
            for i in range(int('2')):
              for i in range(int('3')):
                print(f'''hello''')
-               time.sleep(0.1)""")
+               time.sleep(0.1)"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=17)
 
@@ -1187,41 +1274,44 @@ class TestsLevel12(HedyTester):
     # for list command
     #
     def test_for_list(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
          dieren is 'hond', 'kat', 'papegaai'
          for dier in dieren
-             print dier""")
+             print dier"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
          dieren = ['hond', 'kat', 'papegaai']
          for dier in dieren:
            print(f'''{dier}''')
-           time.sleep(0.1)""")
-
-        self.multi_level_tester(
-            code=code,
-            expected=expected,
-            expected_commands=['is', 'for', 'print'],
-            max_level=15
+           time.sleep(0.1)"""
         )
 
+        self.multi_level_tester(code=code, expected=expected, expected_commands=["is", "for", "print"], max_level=15)
+
     def test_for_list_multiline_body(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         familie is 'baby', 'mommy', 'daddy', 'grandpa', 'grandma'
         for shark in familie
             print shark ' shark tudutudutudu'
             print shark ' shark tudutudutudu'
             print shark ' shark tudutudutudu'
-            print shark ' shark'""")
+            print shark ' shark'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         familie = ['baby', 'mommy', 'daddy', 'grandpa', 'grandma']
         for shark in familie:
           print(f'''{shark} shark tudutudutudu''')
           print(f'''{shark} shark tudutudutudu''')
           print(f'''{shark} shark tudutudutudu''')
           print(f'''{shark} shark''')
-          time.sleep(0.1)""")
+          time.sleep(0.1)"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=15)
 
@@ -1229,71 +1319,84 @@ class TestsLevel12(HedyTester):
     # for loop
     #
     def test_for_loop(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
          for i in range 1 to 10
-             a is i + 1""")
-        expected = textwrap.dedent("""\
+             a is i + 1"""
+        )
+        expected = textwrap.dedent(
+            """\
          step = 1 if 1 < 10 else -1
          for i in range(1, 10 + step, step):
            a = i + 1
-           time.sleep(0.1)""")
+           time.sleep(0.1)"""
+        )
 
-        self.multi_level_tester(
-            code=code,
-            expected=expected,
-            max_level=16,
-            expected_commands=['for', 'is', 'addition'])
+        self.multi_level_tester(code=code, expected=expected, max_level=16, expected_commands=["for", "is", "addition"])
 
     def test_for_loop_with_int_vars(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         begin = 1
         end = 10
         for i in range begin to end
-            print i""")
+            print i"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         begin = 1
         end = 10
         step = 1 if begin < end else -1
         for i in range(begin, end + step, step):
           print(f'''{i}''')
-          time.sleep(0.1)""")
+          time.sleep(0.1)"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=16)
 
     def test_for_loop_multiline_body(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         a is 2
         b is 3
         for a in range 2 to 4
             a is a + 2
-            b is b + 2""")
+            b is b + 2"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         a = 2
         b = 3
         step = 1 if 2 < 4 else -1
         for a in range(2, 4 + step, step):
           a = a + 2
           b = b + 2
-          time.sleep(0.1)""")
+          time.sleep(0.1)"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=16)
 
     def test_for_loop_followed_by_print(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         for i in range 1 to 10
             print i
-        print 'wie niet weg is is gezien'""")
+        print 'wie niet weg is is gezien'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         step = 1 if 1 < 10 else -1
         for i in range(1, 10 + step, step):
           print(f'''{i}''')
           time.sleep(0.1)
-        print(f'''wie niet weg is is gezien''')""")
+        print(f'''wie niet weg is is gezien''')"""
+        )
 
-        output = textwrap.dedent("""\
+        output = textwrap.dedent(
+            """\
         1
         2
         3
@@ -1304,70 +1407,69 @@ class TestsLevel12(HedyTester):
         8
         9
         10
-        wie niet weg is is gezien""")
+        wie niet weg is is gezien"""
+        )
 
         self.multi_level_tester(
-            code=code,
-            expected=expected,
-            max_level=16,
-            expected_commands=['for', 'print', 'print'],
-            output=output)
+            code=code, expected=expected, max_level=16, expected_commands=["for", "print", "print"], output=output
+        )
 
     # issue 363
     def test_for_loop_if_followed_by_print(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         for i in range 0 to 10
             antwoord is ask 'Wat is 5*5'
             if antwoord is 24
                 print 'fout'
-        print 'klaar met for loop'""")
+        print 'klaar met for loop'"""
+        )
 
-        expected = HedyTester.dedent("""\
+        expected = HedyTester.dedent(
+            """\
         step = 1 if 0 < 10 else -1
         for i in range(0, 10 + step, step):""",
-          (HedyTester.input_transpiled('antwoord', 'Wat is 5*5'), '  '), """\
+            (HedyTester.input_transpiled("antwoord", "Wat is 5*5"), "  "),
+            """\
           if convert_numerals('Latin', antwoord) == convert_numerals('Latin', '24'):
             print(f'''fout''')
           time.sleep(0.1)
-        print(f'''klaar met for loop''')""")
+        print(f'''klaar met for loop''')""",
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=16)
 
     # issue 599
     def test_for_loop_if(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         for i in range 0 to 10
             if i is 2
-                print '2'""")
+                print '2'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         step = 1 if 0 < 10 else -1
         for i in range(0, 10 + step, step):
           if convert_numerals('Latin', i) == convert_numerals('Latin', '2'):
             print(f'''2''')
-          time.sleep(0.1)""")
+          time.sleep(0.1)"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=16)
 
     #
     # arithmetic expressions tests
     #
-    @parameterized.expand([
-        ('*', '*', '12'),
-        ('/', '//', '3'),
-        ('+', '+', '8'),
-        ('-', '-', '4')])
+    @parameterized.expand([("*", "*", "12"), ("/", "//", "3"), ("+", "+", "8"), ("-", "-", "4")])
     def test_int_calc(self, op, transpiled_op, output):
         code = f"print 6 {op} 2"
         expected = f"print(f'''{{6 {transpiled_op} 2}}''')"
 
         self.multi_level_tester(code=code, expected=expected, output=output, max_level=17)
 
-    @parameterized.expand([
-        ('*', '*', '100'),
-        ('/', '//', '1'),
-        ('+', '+', '17'),
-        ('-', '-', '3')])
+    @parameterized.expand([("*", "*", "100"), ("/", "//", "1"), ("+", "+", "17"), ("-", "-", "3")])
     def test_nested_int_calc(self, op, transpiled_op, output):
         code = f"print 10 {op} 5 {op} 2"
         expected = f"print(f'''{{10 {transpiled_op} 5 {transpiled_op} 2}}''')"
@@ -1396,113 +1498,123 @@ class TestsLevel12(HedyTester):
         self.multi_level_tester(code=code, expected=expected, max_level=17)
 
     def test_print_add_negative_number(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         n = -4 +3
-        print n""")
-        expected = textwrap.dedent("""\
+        print n"""
+        )
+        expected = textwrap.dedent(
+            """\
         n = -4 + 3
-        print(f'''{n}''')""")
+        print(f'''{n}''')"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=17)
 
     @parameterized.expand(HedyTester.arithmetic_transpiled_operators)
     def test_float_calc_with_var(self, op, transpiled_op):
-        code = textwrap.dedent(f"""\
+        code = textwrap.dedent(
+            f"""\
         getal1 is 5
         getal2 is 4.3
-        print 'dat is dan: ' getal1 {op} getal2""")
-        expected = textwrap.dedent(f"""\
+        print 'dat is dan: ' getal1 {op} getal2"""
+        )
+        expected = textwrap.dedent(
+            f"""\
         getal1 = 5
         getal2 = 4.3
-        print(f'''dat is dan: {{getal1 {transpiled_op} getal2}}''')""")
+        print(f'''dat is dan: {{getal1 {transpiled_op} getal2}}''')"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=17)
 
     @parameterized.expand(HedyTester.arithmetic_transpiled_operators)
     def test_int_calc_with_var(self, op, transpiled_op):
-        code = textwrap.dedent(f"""\
+        code = textwrap.dedent(
+            f"""\
         a is 1
         b is 2
-        c is a {op} b""")
-        expected = textwrap.dedent(f"""\
+        c is a {op} b"""
+        )
+        expected = textwrap.dedent(
+            f"""\
         a = 1
         b = 2
-        c = a {transpiled_op} b""")
+        c = a {transpiled_op} b"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=17)
 
     def test_concat_calc_with_var(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         getal1 is '5'
         getal2 is '6'
         getal3 is '7'
-        print 'dat is dan: ' getal1 + getal2 + getal3""")
-        expected = textwrap.dedent("""\
+        print 'dat is dan: ' getal1 + getal2 + getal3"""
+        )
+        expected = textwrap.dedent(
+            """\
         getal1 = '5'
         getal2 = '6'
         getal3 = '7'
-        print(f'''dat is dan: {getal1 + getal2 + getal3}''')""")
-
-        check_output = (lambda x: HedyTester.run_code(x) == 'dat is dan: 567')
-
-        self.multi_level_tester(
-            code=code,
-            max_level=17,
-            expected=expected,
-            extra_check_function=check_output
+        print(f'''dat is dan: {getal1 + getal2 + getal3}''')"""
         )
 
+        check_output = lambda x: HedyTester.run_code(x) == "dat is dan: 567"
+
+        self.multi_level_tester(code=code, max_level=17, expected=expected, extra_check_function=check_output)
+
     def test_int_calc_chained_vars(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         a is 5
         b is a + 1
-        print a + b""")
+        print a + b"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         a = 5
         b = a + 1
-        print(f'''{a + b}''')""")
+        print(f'''{a + b}''')"""
+        )
 
         self.multi_level_tester(
-            code=code,
-            max_level=17,
-            expected=expected,
-            extra_check_function=lambda x: self.run_code(x) == "11"
+            code=code, max_level=17, expected=expected, extra_check_function=lambda x: self.run_code(x) == "11"
         )
 
     def test_calc_string_and_int_gives_type_error(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         x is 'test1'
-        y is x + 1""")
+        y is x + 1"""
+        )
 
-        self.multi_level_tester(
-            code=code,
-            exception=hedy.exceptions.InvalidTypeCombinationException)
+        self.multi_level_tester(code=code, exception=hedy.exceptions.InvalidTypeCombinationException)
 
     def test_concat_quoted_string_and_int_gives_type_error(self):
         code = """y is 'test1' + 1"""
 
-        self.multi_level_tester(
-            code=code,
-            exception=hedy.exceptions.InvalidTypeCombinationException)
+        self.multi_level_tester(code=code, exception=hedy.exceptions.InvalidTypeCombinationException)
 
-    @parameterized.expand(['-', '*', '/'])
+    @parameterized.expand(["-", "*", "/"])
     def test_calc_with_single_quoted_strings_gives_type_error(self, operation):
-        code = textwrap.dedent(f"""\
-        a is 1 {operation} 'Test'""")
+        code = textwrap.dedent(
+            f"""\
+        a is 1 {operation} 'Test'"""
+        )
 
-        self.multi_level_tester(
-            code=code,
-            exception=hedy.exceptions.InvalidArgumentTypeException)
+        self.multi_level_tester(code=code, exception=hedy.exceptions.InvalidArgumentTypeException)
 
-    @parameterized.expand(['-', '*', '/'])
+    @parameterized.expand(["-", "*", "/"])
     def test_calc_with_double_quoted_strings_gives_type_error(self, operation):
-        code = textwrap.dedent(f"""\
-        a is 1 {operation} "Test\"""")
+        code = textwrap.dedent(
+            f"""\
+        a is 1 {operation} "Test\""""
+        )
 
-        self.multi_level_tester(
-            code=code,
-            exception=hedy.exceptions.InvalidArgumentTypeException)
+        self.multi_level_tester(code=code, exception=hedy.exceptions.InvalidArgumentTypeException)
 
     # def test_access_variable_before_definition(self):
     #   code = textwrap.dedent("""\
@@ -1528,7 +1640,8 @@ class TestsLevel12(HedyTester):
     #
 
     def test_list_with_spaces_nested_for_loop(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         actions is 'clap your hands', 'stomp your feet', 'shout Hurray'
         for action in actions
             for i in range 1 to 2
@@ -1536,8 +1649,10 @@ class TestsLevel12(HedyTester):
                 print action
             print 'if youre happy and you know it and you really want to show it'
             print 'if youre happy and you know it'
-            print action""")
-        expected = textwrap.dedent("""\
+            print action"""
+        )
+        expected = textwrap.dedent(
+            """\
         actions = ['clap your hands', 'stomp your feet', 'shout Hurray']
         for action in actions:
           step = 1 if 1 < 2 else -1
@@ -1548,6 +1663,7 @@ class TestsLevel12(HedyTester):
           print(f'''if youre happy and you know it and you really want to show it''')
           print(f'''if youre happy and you know it''')
           print(f'''{action}''')
-          time.sleep(0.1)""")
+          time.sleep(0.1)"""
+        )
 
         self.multi_level_tester(code=code, expected=expected, max_level=15)

--- a/tests/test_level/test_level_13.py
+++ b/tests/test_level/test_level_13.py
@@ -1,18 +1,21 @@
-
 import hedy
 import textwrap
 from tests.Tester import HedyTester
 
-class TestsLevel13(HedyTester):
-  level = 13
 
-  def test_and(self):
-    code = textwrap.dedent("""\
+class TestsLevel13(HedyTester):
+    level = 13
+
+    def test_and(self):
+        code = textwrap.dedent(
+            """\
       naam is ask 'hoe heet jij?'
       leeftijd is ask 'hoe oud ben jij?'
       if naam is 'Felienne' and leeftijd is 37
-          print 'hallo jij!'""")
-    expected = textwrap.dedent("""\
+          print 'hallo jij!'"""
+        )
+        expected = textwrap.dedent(
+            """\
       naam = input(f'''hoe heet jij?''')
       try:
         naam = int(naam)
@@ -30,22 +33,22 @@ class TestsLevel13(HedyTester):
         except ValueError:
           pass
       if convert_numerals('Latin', naam) == convert_numerals('Latin', 'Felienne') and convert_numerals('Latin', leeftijd) == convert_numerals('Latin', '37'):
-        print(f'''hallo jij!''')""")
+        print(f'''hallo jij!''')"""
+        )
 
-    self.multi_level_tester(
-      max_level=16,
-      code=code,
-      expected=expected
-    )
+        self.multi_level_tester(max_level=16, code=code, expected=expected)
 
-  def test_equals(self):
-    code = textwrap.dedent("""\
+    def test_equals(self):
+        code = textwrap.dedent(
+            """\
     name = ask 'what is your name?'
     age = ask 'what is your age?'
     if name is 'Hedy' and age is 2
-        print 'You are the real Hedy!'""")
+        print 'You are the real Hedy!'"""
+        )
 
-    expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
       name = input(f'''what is your name?''')
       try:
         name = int(name)
@@ -63,30 +66,23 @@ class TestsLevel13(HedyTester):
         except ValueError:
           pass
       if convert_numerals('Latin', name) == convert_numerals('Latin', 'Hedy') and convert_numerals('Latin', age) == convert_numerals('Latin', '2'):
-        print(f'''You are the real Hedy!''')""")
+        print(f'''You are the real Hedy!''')"""
+        )
 
-    self.multi_level_tester(
-      code=code,
-      max_level=16,
-      expected=expected,
-      expected_commands=['ask', 'ask', 'if', 'and', 'print']
-    )
+        self.multi_level_tester(
+            code=code, max_level=16, expected=expected, expected_commands=["ask", "ask", "if", "and", "print"]
+        )
 
-
-  def test_or(self):
-    code = textwrap.dedent("""\
+    def test_or(self):
+        code = textwrap.dedent(
+            """\
       if 5 is 5 or 4 is 4
-          print 'hallo'""")
-    expected = textwrap.dedent("""\
+          print 'hallo'"""
+        )
+        expected = textwrap.dedent(
+            """\
       if convert_numerals('Latin', '5') == convert_numerals('Latin', '5') or convert_numerals('Latin', '4') == convert_numerals('Latin', '4'):
-        print(f'''hallo''')""")
+        print(f'''hallo''')"""
+        )
 
-    self.multi_level_tester(
-      code=code,
-      max_level=16,
-      expected=expected,
-      expected_commands=['if', 'or', 'print']
-    )
-
-
-
+        self.multi_level_tester(code=code, max_level=16, expected=expected, expected_commands=["if", "or", "print"])

--- a/tests/test_level/test_level_14.py
+++ b/tests/test_level/test_level_14.py
@@ -4,17 +4,20 @@ import textwrap
 from parameterized import parameterized
 from tests.Tester import HedyTester
 
+
 class TestsLevel14(HedyTester):
-  level = 14
+    level = 14
 
-
-  @parameterized.expand(HedyTester.comparison_commands)
-  def test_comparisons_with_int(self, comparison):
-    code = textwrap.dedent(f"""\
+    @parameterized.expand(HedyTester.comparison_commands)
+    def test_comparisons_with_int(self, comparison):
+        code = textwrap.dedent(
+            f"""\
       leeftijd is ask 'Hoe oud ben jij?'
       if leeftijd {comparison} 12
-          print 'Dan ben je jonger dan ik!'""")
-    expected = textwrap.dedent(f"""\
+          print 'Dan ben je jonger dan ik!'"""
+        )
+        expected = textwrap.dedent(
+            f"""\
       leeftijd = input(f'''Hoe oud ben jij?''')
       try:
         leeftijd = int(leeftijd)
@@ -24,43 +27,47 @@ class TestsLevel14(HedyTester):
         except ValueError:
           pass
       if convert_numerals('Latin', leeftijd).zfill(100){comparison}convert_numerals('Latin', 12).zfill(100):
-        print(f'''Dan ben je jonger dan ik!''')""")
+        print(f'''Dan ben je jonger dan ik!''')"""
+        )
 
-    self.multi_level_tester(
-      code=code,
-      max_level=16,
-      expected=expected,
-    )
+        self.multi_level_tester(
+            code=code,
+            max_level=16,
+            expected=expected,
+        )
 
-  def test_equality_arabic(self):
-      code = textwrap.dedent("""\
+    def test_equality_arabic(self):
+        code = textwrap.dedent(
+            """\
       nummer1 is ٢
       nummer2 is 2
       if nummer1 != nummer2
           print 'jahoor!'
       else
-          print 'neejoh!'""")
+          print 'neejoh!'"""
+        )
 
-      expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
       nummer1 = 2
       nummer2 = 2
       if convert_numerals('Latin', nummer1).zfill(100)!=convert_numerals('Latin', nummer2).zfill(100):
         print(f'''jahoor!''')
       else:
-        print(f'''neejoh!''')""")
+        print(f'''neejoh!''')"""
+        )
 
-      self.multi_level_tester(
-        max_level=16,
-        code=code,
-        expected=expected,
-        output='neejoh!')
+        self.multi_level_tester(max_level=16, code=code, expected=expected, output="neejoh!")
 
-  def test_inequality_with_string(self):
-    code = textwrap.dedent(f"""\
+    def test_inequality_with_string(self):
+        code = textwrap.dedent(
+            f"""\
       name is ask 'What is your name?'
       if name != 'Hedy'
-          print 'meh'""")
-    expected = textwrap.dedent(f"""\
+          print 'meh'"""
+        )
+        expected = textwrap.dedent(
+            f"""\
       name = input(f'''What is your name?''')
       try:
         name = int(name)
@@ -70,22 +77,26 @@ class TestsLevel14(HedyTester):
         except ValueError:
           pass
       if convert_numerals('Latin', name).zfill(100)!='Hedy'.zfill(100):
-        print(f'''meh''')""")
+        print(f'''meh''')"""
+        )
 
-    self.multi_level_tester(
-      code=code,
-      max_level=16,
-      expected=expected,
-    )
+        self.multi_level_tester(
+            code=code,
+            max_level=16,
+            expected=expected,
+        )
 
-  def test_inequality_Hindi(self):
-    code = textwrap.dedent(f"""\
+    def test_inequality_Hindi(self):
+        code = textwrap.dedent(
+            f"""\
     उम्र is ask 'आप कितने साल के हैं?'
     if उम्र > 12
         print 'आप मुझसे छोटे हैं!'
     else
-        print 'आप मुझसे बड़े हैं!'""")
-    expected = textwrap.dedent(f"""\
+        print 'आप मुझसे बड़े हैं!'"""
+        )
+        expected = textwrap.dedent(
+            f"""\
       उम्र = input(f'''आप कितने साल के हैं?''')
       try:
         उम्र = int(उम्र)
@@ -97,23 +108,25 @@ class TestsLevel14(HedyTester):
       if convert_numerals('Latin', उम्र).zfill(100)>convert_numerals('Latin', 12).zfill(100):
         print(f'''आप मुझसे छोटे हैं!''')
       else:
-        print(f'''आप मुझसे बड़े हैं!''')""")
+        print(f'''आप मुझसे बड़े हैं!''')"""
+        )
 
-    self.multi_level_tester(
-      code=code,
-      max_level=16,
-      expected=expected,
-    )
+        self.multi_level_tester(
+            code=code,
+            max_level=16,
+            expected=expected,
+        )
 
-
-
-  @parameterized.expand(HedyTester.equality_comparison_commands)
-  def test_equality_with_string(self, comparison):
-    code = textwrap.dedent(f"""\
+    @parameterized.expand(HedyTester.equality_comparison_commands)
+    def test_equality_with_string(self, comparison):
+        code = textwrap.dedent(
+            f"""\
       name is ask 'What is your name?'
       if name {comparison} 'Hedy'
-          print 'meh'""")
-    expected = textwrap.dedent(f"""\
+          print 'meh'"""
+        )
+        expected = textwrap.dedent(
+            f"""\
       name = input(f'''What is your name?''')
       try:
         name = int(name)
@@ -123,23 +136,27 @@ class TestsLevel14(HedyTester):
         except ValueError:
           pass
       if convert_numerals('Latin', name) == convert_numerals('Latin', 'Hedy'):
-        print(f'''meh''')""")
+        print(f'''meh''')"""
+        )
 
-    self.multi_level_tester(
-      code=code,
-      max_level=16,
-      expected=expected,
-    )
+        self.multi_level_tester(
+            code=code,
+            max_level=16,
+            expected=expected,
+        )
 
-  @parameterized.expand(HedyTester.comparison_commands)
-  def test_comparisons_else(self, comparison):
-    code = textwrap.dedent(f"""\
+    @parameterized.expand(HedyTester.comparison_commands)
+    def test_comparisons_else(self, comparison):
+        code = textwrap.dedent(
+            f"""\
       leeftijd is ask 'Hoe oud ben jij?'
       if leeftijd {comparison} 12
           print 'Dan ben je jonger dan ik!'
       else
-          print 'Dan ben je ouder dan ik!'""")
-    expected = textwrap.dedent(f"""\
+          print 'Dan ben je ouder dan ik!'"""
+        )
+        expected = textwrap.dedent(
+            f"""\
       leeftijd = input(f'''Hoe oud ben jij?''')
       try:
         leeftijd = int(leeftijd)
@@ -151,21 +168,21 @@ class TestsLevel14(HedyTester):
       if convert_numerals('Latin', leeftijd).zfill(100){comparison}convert_numerals('Latin', 12).zfill(100):
         print(f'''Dan ben je jonger dan ik!''')
       else:
-        print(f'''Dan ben je ouder dan ik!''')""")
+        print(f'''Dan ben je ouder dan ik!''')"""
+        )
 
-    self.multi_level_tester(
-      code=code,
-      max_level=16,
-      expected=expected
-    )
+        self.multi_level_tester(code=code, max_level=16, expected=expected)
 
-  @parameterized.expand(HedyTester.comparison_commands)
-  def tests_smaller_no_spaces(self, comparison):
-    code = textwrap.dedent(f"""\
+    @parameterized.expand(HedyTester.comparison_commands)
+    def tests_smaller_no_spaces(self, comparison):
+        code = textwrap.dedent(
+            f"""\
     leeftijd is ask 'Hoe oud ben jij?'
     if leeftijd {comparison} 12
-        print 'Dan ben je jonger dan ik!'""")
-    expected = textwrap.dedent(f"""\
+        print 'Dan ben je jonger dan ik!'"""
+        )
+        expected = textwrap.dedent(
+            f"""\
     leeftijd = input(f'''Hoe oud ben jij?''')
     try:
       leeftijd = int(leeftijd)
@@ -175,148 +192,141 @@ class TestsLevel14(HedyTester):
       except ValueError:
         pass
     if convert_numerals('Latin', leeftijd).zfill(100){comparison}convert_numerals('Latin', 12).zfill(100):
-      print(f'''Dan ben je jonger dan ik!''')""")
+      print(f'''Dan ben je jonger dan ik!''')"""
+        )
 
-    self.multi_level_tester(
-      code=code,
-      max_level=16,
-      expected=expected
-    )
+        self.multi_level_tester(code=code, max_level=16, expected=expected)
 
-  @parameterized.expand(HedyTester.number_comparison_commands)
-  def test_comparison_with_string_gives_type_error(self, comparison):
-    code = textwrap.dedent(f"""\
+    @parameterized.expand(HedyTester.number_comparison_commands)
+    def test_comparison_with_string_gives_type_error(self, comparison):
+        code = textwrap.dedent(
+            f"""\
       a is 'text'
       if a {comparison} 12
-          b is 1""")
+          b is 1"""
+        )
 
-    self.multi_level_tester(
-      code=code,
-      max_level=16,
-      exception=hedy.exceptions.InvalidArgumentTypeException
-    )
+        self.multi_level_tester(code=code, max_level=16, exception=hedy.exceptions.InvalidArgumentTypeException)
 
-
-  @parameterized.expand(HedyTester.number_comparison_commands)
-  def test_comparison_with_list_gives_type_error(self, comparison):
-    code = textwrap.dedent(f"""\
+    @parameterized.expand(HedyTester.number_comparison_commands)
+    def test_comparison_with_list_gives_type_error(self, comparison):
+        code = textwrap.dedent(
+            f"""\
       a is 1, 2, 3
       if a {comparison} 12
-          b is 1""")
+          b is 1"""
+        )
 
-    self.multi_level_tester(
-      code=code,
-      max_level=15,
-      exception=hedy.exceptions.InvalidArgumentTypeException
-    )
+        self.multi_level_tester(code=code, max_level=15, exception=hedy.exceptions.InvalidArgumentTypeException)
 
-  def test_not_equal_promotes_int_to_float(self):
-    code = textwrap.dedent(f"""\
+    def test_not_equal_promotes_int_to_float(self):
+        code = textwrap.dedent(
+            f"""\
       a is 1
       b is 1.2
       if a != b
-          b is 1""")
+          b is 1"""
+        )
 
-    expected = textwrap.dedent(f"""\
+        expected = textwrap.dedent(
+            f"""\
       a = 1
       b = 1.2
       if convert_numerals('Latin', a).zfill(100)!=convert_numerals('Latin', b).zfill(100):
-        b = 1""")
+        b = 1"""
+        )
 
-    self.multi_level_tester(
-      code=code,
-      max_level=16,
-      expected=expected
-    )
+        self.multi_level_tester(code=code, max_level=16, expected=expected)
 
-  @parameterized.expand([
-    ('"text"', "'text'"),
-    ("'text'", "'text'"),
-    ('1', '1'),
-    ('1.3', '1.3'),
-    ('1, 2', '[1, 2]')])
-  def test_not_equal(self, arg, exp):
-    code = textwrap.dedent(f"""\
+    @parameterized.expand([('"text"', "'text'"), ("'text'", "'text'"), ("1", "1"), ("1.3", "1.3"), ("1, 2", "[1, 2]")])
+    def test_not_equal(self, arg, exp):
+        code = textwrap.dedent(
+            f"""\
       a is {arg}
       b is {arg}
       if a != b
-          b is 1""")
+          b is 1"""
+        )
 
-    expected = textwrap.dedent(f"""\
+        expected = textwrap.dedent(
+            f"""\
       a = {exp}
       b = {exp}
       if convert_numerals('Latin', a).zfill(100)!=convert_numerals('Latin', b).zfill(100):
-        b = 1""")
+        b = 1"""
+        )
 
-    self.multi_level_tester(
-      code=code,
-      max_level=15,
-      expected=expected
-    )
+        self.multi_level_tester(code=code, max_level=15, expected=expected)
 
-  def test_if_with_double_equals(self):
-    code = textwrap.dedent("""\
+    def test_if_with_double_equals(self):
+        code = textwrap.dedent(
+            """\
     naam = 'Hedy'
     if naam == Hedy
-        print 'koekoek'""")
+        print 'koekoek'"""
+        )
 
-    expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
     naam = 'Hedy'
     if convert_numerals('Latin', naam) == convert_numerals('Latin', 'Hedy'):
-      print(f'''koekoek''')""")
+      print(f'''koekoek''')"""
+        )
 
-    self.multi_level_tester(
-      code=code,
-      expected=expected,
-      max_level=16)
+        self.multi_level_tester(code=code, expected=expected, max_level=16)
 
-  @parameterized.expand(HedyTester.equality_comparison_commands)
-  def test_equality_with_lists(self, comparison):
-    code = textwrap.dedent(f"""\
+    @parameterized.expand(HedyTester.equality_comparison_commands)
+    def test_equality_with_lists(self, comparison):
+        code = textwrap.dedent(
+            f"""\
     a = 1, 2
     b = 1, 2
     if a {comparison} b
-        sleep""")
+        sleep"""
+        )
 
-    expected = textwrap.dedent(f"""\
+        expected = textwrap.dedent(
+            f"""\
     a = [1, 2]
     b = [1, 2]
     if convert_numerals('Latin', a) == convert_numerals('Latin', b):
-      time.sleep(1)""")
+      time.sleep(1)"""
+        )
 
-    self.multi_level_tester(
-      code=code,
-      expected=expected,
-      max_level=15)
+        self.multi_level_tester(code=code, expected=expected, max_level=15)
 
-  def test_inequality_with_lists(self):
-    code = textwrap.dedent("""\
+    def test_inequality_with_lists(self):
+        code = textwrap.dedent(
+            """\
     a = 1, 2
     b = 1, 2
     if a != b
-        sleep""")
+        sleep"""
+        )
 
-    expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
     a = [1, 2]
     b = [1, 2]
     if convert_numerals('Latin', a).zfill(100)!=convert_numerals('Latin', b).zfill(100):
-      time.sleep(1)""")
+      time.sleep(1)"""
+        )
 
-    self.multi_level_tester(
-      code=code,
-      expected=expected,
-      max_level=15)
+        self.multi_level_tester(code=code, expected=expected, max_level=15)
 
-  @parameterized.expand(HedyTester.comparison_commands)
-  def test_comparisons_with_boolean(self, comparison):
-    code = textwrap.dedent(f"""\
+    @parameterized.expand(HedyTester.comparison_commands)
+    def test_comparisons_with_boolean(self, comparison):
+        code = textwrap.dedent(
+            f"""\
       leeftijd is ask 'Hoe oud ben jij?'
       if leeftijd {comparison} 12 or leeftijd {comparison} 15
           print 'Dan ben je jonger dan ik!'
       if leeftijd {comparison} 12 and leeftijd {comparison} 15
-          print 'Some other string!'""")
-      
-    expected = textwrap.dedent(f"""\
+          print 'Some other string!'"""
+        )
+
+        expected = textwrap.dedent(
+            f"""\
       leeftijd = input(f'''Hoe oud ben jij?''')
       try:
         leeftijd = int(leeftijd)
@@ -328,45 +338,43 @@ class TestsLevel14(HedyTester):
       if convert_numerals('Latin', leeftijd).zfill(100){comparison}convert_numerals('Latin', 12).zfill(100) or convert_numerals('Latin', leeftijd).zfill(100){comparison}convert_numerals('Latin', 15).zfill(100):
         print(f'''Dan ben je jonger dan ik!''')
       if convert_numerals('Latin', leeftijd).zfill(100){comparison}convert_numerals('Latin', 12).zfill(100) and convert_numerals('Latin', leeftijd).zfill(100){comparison}convert_numerals('Latin', 15).zfill(100):
-        print(f'''Some other string!''')""")
+        print(f'''Some other string!''')"""
+        )
 
-    self.multi_level_tester(
-      code=code,
-      max_level=16,
-      expected=expected,
-    )
+        self.multi_level_tester(
+            code=code,
+            max_level=16,
+            expected=expected,
+        )
 
-  @parameterized.expand([
-    ('"text"', '1'),      # double-quoted text and number
-    ("'text'", '1'),      # single-quoted text and number
-    ('1, 2', '1'),        # list and number
-    ('1, 2', "'text'"),   # list and single-quoted text
-    ('1, 2', '"text"')])  # list and double-quoted text
-
-  def test_not_equal_with_diff_types_gives_error(self, left, right):
-    code = textwrap.dedent(f"""\
+    @parameterized.expand(
+        [
+            ('"text"', "1"),  # double-quoted text and number
+            ("'text'", "1"),  # single-quoted text and number
+            ("1, 2", "1"),  # list and number
+            ("1, 2", "'text'"),  # list and single-quoted text
+            ("1, 2", '"text"'),
+        ]
+    )  # list and double-quoted text
+    def test_not_equal_with_diff_types_gives_error(self, left, right):
+        code = textwrap.dedent(
+            f"""\
       a is {left}
       b is {right}
       if a != b
-          b is 1""")
+          b is 1"""
+        )
 
-    self.multi_level_tester(
-      code=code,
-      max_level=15,
-      exception=exceptions.InvalidTypeCombinationException
-    )
+        self.multi_level_tester(code=code, max_level=15, exception=exceptions.InvalidTypeCombinationException)
 
-  def test_missing_indent_else(self):
-    code = textwrap.dedent(f"""\
+    def test_missing_indent_else(self):
+        code = textwrap.dedent(
+            f"""\
       age = ask 'How old are you?'
       if age < 13
           print 'You are younger than me!'
       else
-      print 'You are older than me!'""")
+      print 'You are older than me!'"""
+        )
 
-    self.multi_level_tester(
-      code=code,
-      max_level=15,
-      exception=exceptions.NoIndentationException
-    )
-
+        self.multi_level_tester(code=code, max_level=15, exception=exceptions.NoIndentationException)

--- a/tests/test_level/test_level_15.py
+++ b/tests/test_level/test_level_15.py
@@ -3,17 +3,21 @@ import exceptions
 import textwrap
 from tests.Tester import HedyTester
 from parameterized import parameterized
+
+
 class TestsLevel15(HedyTester):
-  level = 15
+    level = 15
 
-
-  def test_while_equals(self):
-    code = textwrap.dedent("""\
+    def test_while_equals(self):
+        code = textwrap.dedent(
+            """\
       antwoord is 0
       while antwoord != 25
           antwoord is ask 'Wat is 5 keer 5?'
-      print 'Goed gedaan!'""")
-    expected = textwrap.dedent("""\
+      print 'Goed gedaan!'"""
+        )
+        expected = textwrap.dedent(
+            """\
     antwoord = 0
     while convert_numerals('Latin', antwoord).zfill(100)!=convert_numerals('Latin', 25).zfill(100):
       antwoord = input(f'''Wat is 5 keer 5?''')
@@ -25,24 +29,25 @@ class TestsLevel15(HedyTester):
         except ValueError:
           pass
       time.sleep(0.1)
-    print(f'''Goed gedaan!''')""")
+    print(f'''Goed gedaan!''')"""
+        )
 
-    self.multi_level_tester(
-      code=code,
-      max_level=16,
-      expected=expected,
-      expected_commands=['is', 'while', 'ask', 'print']
-    )
-  
-  @parameterized.expand(['and', 'or'])
-  def test_while_and_or(self, op):
-    code = textwrap.dedent(f"""\
+        self.multi_level_tester(
+            code=code, max_level=16, expected=expected, expected_commands=["is", "while", "ask", "print"]
+        )
+
+    @parameterized.expand(["and", "or"])
+    def test_while_and_or(self, op):
+        code = textwrap.dedent(
+            f"""\
       answer = 7
       while answer > 5 {op} answer < 10
         answer = ask 'What is 5 times 5?'
-      print 'A correct answer has been given'""")
-    
-    expected = textwrap.dedent(f"""\
+      print 'A correct answer has been given'"""
+        )
+
+        expected = textwrap.dedent(
+            f"""\
         answer = 7
         while convert_numerals('Latin', answer).zfill(100)>convert_numerals('Latin', 5).zfill(100) {op} convert_numerals('Latin', answer).zfill(100)<convert_numerals('Latin', 10).zfill(100):
           answer = input(f'''What is 5 times 5?''')
@@ -54,22 +59,23 @@ class TestsLevel15(HedyTester):
             except ValueError:
               pass
           time.sleep(0.1)
-        print(f'''A correct answer has been given''')""")
+        print(f'''A correct answer has been given''')"""
+        )
 
-    self.multi_level_tester(
-      code=code,
-      max_level=16,
-      expected=expected,
-      expected_commands=['is', 'while', op,'ask', 'print']
-    )
+        self.multi_level_tester(
+            code=code, max_level=16, expected=expected, expected_commands=["is", "while", op, "ask", "print"]
+        )
 
-  def test_while_fr_equals(self):
-    code = textwrap.dedent("""\
+    def test_while_fr_equals(self):
+        code = textwrap.dedent(
+            """\
       antwoord est 0
       tant que antwoord != 25
           antwoord est demande 'Wat is 5 keer 5?'
-      affiche 'Goed gedaan!'""")
-    expected = textwrap.dedent("""\
+      affiche 'Goed gedaan!'"""
+        )
+        expected = textwrap.dedent(
+            """\
     antwoord = 0
     while convert_numerals('Latin', antwoord).zfill(100)!=convert_numerals('Latin', 25).zfill(100):
       antwoord = input(f'''Wat is 5 keer 5?''')
@@ -81,34 +87,36 @@ class TestsLevel15(HedyTester):
         except ValueError:
           pass
       time.sleep(0.1)
-    print(f'''Goed gedaan!''')""")
+    print(f'''Goed gedaan!''')"""
+        )
 
-    self.multi_level_tester(
-      code=code,
-      max_level=16,
-      expected=expected,
-      expected_commands=['is', 'while', 'ask', 'print'],
-      lang='fr'
-    )
+        self.multi_level_tester(
+            code=code, max_level=16, expected=expected, expected_commands=["is", "while", "ask", "print"], lang="fr"
+        )
 
-  def test_while_undefined_var(self):
-    code = textwrap.dedent("""\
+    def test_while_undefined_var(self):
+        code = textwrap.dedent(
+            """\
       while antwoord != 25
-          print 'hoera'""")
+          print 'hoera'"""
+        )
 
-    self.multi_level_tester(
-      code=code,
-      exception=hedy.exceptions.UndefinedVarException,
-      max_level=16,
-    )
+        self.multi_level_tester(
+            code=code,
+            exception=hedy.exceptions.UndefinedVarException,
+            max_level=16,
+        )
 
-  def test_while_smaller(self):
-    code = textwrap.dedent("""\
+    def test_while_smaller(self):
+        code = textwrap.dedent(
+            """\
       getal is 0
       while getal < 100000
           getal is ask 'HOGER!!!!!'
-      print 'Hoog he?'""")
-    expected = textwrap.dedent("""\
+      print 'Hoog he?'"""
+        )
+        expected = textwrap.dedent(
+            """\
     getal = 0
     while convert_numerals('Latin', getal).zfill(100)<convert_numerals('Latin', 100000).zfill(100):
       getal = input(f'''HOGER!!!!!''')
@@ -120,23 +128,18 @@ class TestsLevel15(HedyTester):
         except ValueError:
           pass
       time.sleep(0.1)
-    print(f'''Hoog he?''')""")
+    print(f'''Hoog he?''')"""
+        )
 
-    self.multi_level_tester(
-      code=code,
-      max_level=16,
-      expected=expected
-    )
+        self.multi_level_tester(code=code, max_level=16, expected=expected)
 
-  def test_missing_indent_while(self):
-    code = textwrap.dedent(f"""\
+    def test_missing_indent_while(self):
+        code = textwrap.dedent(
+            f"""\
     answer = 0
     while answer != 25
     answer = ask 'What is 5 times 5?'
-    print 'A correct answer has been given'""")
+    print 'A correct answer has been given'"""
+        )
 
-    self.multi_level_tester(
-      code=code,
-      max_level=15,
-      exception=exceptions.NoIndentationException
-    )
+        self.multi_level_tester(code=code, max_level=15, exception=exceptions.NoIndentationException)

--- a/tests/test_level/test_level_16.py
+++ b/tests/test_level/test_level_16.py
@@ -9,256 +9,241 @@ class TestsLevel16(HedyTester):
     level = 16
 
     def test_print_list_var(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
             dieren is ['Hond', 'Kat', 'Kangoeroe']
-            print dieren[1]""")
-
-        expected = textwrap.dedent("""\
-            dieren = ['Hond', 'Kat', 'Kangoeroe']
-            print(f'''{dieren[1-1]}''')""")
-
-        check_in_list = (lambda x: HedyTester.run_code(x) == 'Hond')
-
-        self.multi_level_tester(
-            code=code,
-            max_level=17,
-            expected=expected,
-            extra_check_function=check_in_list
+            print dieren[1]"""
         )
-    
+
+        expected = textwrap.dedent(
+            """\
+            dieren = ['Hond', 'Kat', 'Kangoeroe']
+            print(f'''{dieren[1-1]}''')"""
+        )
+
+        check_in_list = lambda x: HedyTester.run_code(x) == "Hond"
+
+        self.multi_level_tester(code=code, max_level=17, expected=expected, extra_check_function=check_in_list)
+
     def test_create_empty_list(self):
         code = "friends = []"
         expected = "friends = []"
 
-        self.multi_level_tester(
-            code=code,
-            max_level=17,
-            expected=expected
-        )
-    
+        self.multi_level_tester(code=code, max_level=17, expected=expected)
+
     def test_create_with_single_item(self):
         code = "friends = ['Ashli']"
         expected = "friends = ['Ashli']"
 
-        check_in_list = (lambda x: HedyTester.run_code(x) == 'Ashli')
+        check_in_list = lambda x: HedyTester.run_code(x) == "Ashli"
 
-        self.multi_level_tester(
-            code=code,
-            max_level=17,
-            expected=expected,
-            extra_check_function=check_in_list
-        )
-    
+        self.multi_level_tester(code=code, max_level=17, expected=expected, extra_check_function=check_in_list)
+
     def test_add_to_empty_list(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
                 friends = []
                 add 'Ashli' to friends
-                print friends[1]""")
-        
-        expected = textwrap.dedent("""\
+                print friends[1]"""
+        )
+
+        expected = textwrap.dedent(
+            """\
                 friends = []
                 friends.append('Ashli')
-                print(f'''{friends[1-1]}''')""")
-        
-        check_in_list = (lambda x: HedyTester.run_code(x) == 'Ashli')
-
-        self.multi_level_tester(
-            code=code,
-            max_level=17,
-            expected=expected,
-            extra_check_function=check_in_list
+                print(f'''{friends[1-1]}''')"""
         )
+
+        check_in_list = lambda x: HedyTester.run_code(x) == "Ashli"
+
+        self.multi_level_tester(code=code, max_level=17, expected=expected, extra_check_function=check_in_list)
 
     def test_print_list_var_arabic_number(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
             dieren is ['Hond', 'Kat', 'Kangoeroe']
-            print dieren[١]""")
-
-        expected = textwrap.dedent("""\
-            dieren = ['Hond', 'Kat', 'Kangoeroe']
-            print(f'''{dieren[1-1]}''')""")
-
-        check_in_list = (lambda x: HedyTester.run_code(x) == 'Hond')
-
-        self.multi_level_tester(
-            code=code,
-            max_level=17,
-            expected=expected,
-            extra_check_function=check_in_list
+            print dieren[١]"""
         )
+
+        expected = textwrap.dedent(
+            """\
+            dieren = ['Hond', 'Kat', 'Kangoeroe']
+            print(f'''{dieren[1-1]}''')"""
+        )
+
+        check_in_list = lambda x: HedyTester.run_code(x) == "Hond"
+
+        self.multi_level_tester(code=code, max_level=17, expected=expected, extra_check_function=check_in_list)
 
     def test_print_list_commas(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
             szamok1 = ['1' , '2' , '3' , '4' , '5']
             szamok2 = ['6' , '7' , '8' , '9']
-            print szamok1[random]""")
+            print szamok1[random]"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
             szamok1 = ['1', '2', '3', '4', '5']
             szamok2 = ['6', '7', '8', '9']
-            print(f'''{random.choice(szamok1)}''')""")
-
-        szamok1 = ['1', '2', '3', '4', '5']
-        check_in_list = (lambda x: HedyTester.run_code(x) in szamok1)
-
-        self.multi_level_tester(
-            code=code,
-            max_level=17,
-            expected=expected,
-            extra_check_function=check_in_list
+            print(f'''{random.choice(szamok1)}''')"""
         )
-    
+
+        szamok1 = ["1", "2", "3", "4", "5"]
+        check_in_list = lambda x: HedyTester.run_code(x) in szamok1
+
+        self.multi_level_tester(code=code, max_level=17, expected=expected, extra_check_function=check_in_list)
+
     def test_list_access_space(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
             szamok1 = [ '1' , '2' , '3' , '4' , '5' ]
-            print szamok1 [random]""")
-        
-        expected = textwrap.dedent("""\
-            szamok1 = ['1', '2', '3', '4', '5']
-            print(f'''{random.choice(szamok1)}''')""")
-        self.multi_level_tester(
-            code=code,
-            max_level=17,
-            expected=expected
+            print szamok1 [random]"""
         )
+
+        expected = textwrap.dedent(
+            """\
+            szamok1 = ['1', '2', '3', '4', '5']
+            print(f'''{random.choice(szamok1)}''')"""
+        )
+        self.multi_level_tester(code=code, max_level=17, expected=expected)
 
     def test_print_list_access(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
             fruit is ['banaan', 'appel', 'kers']
-            print fruit[1]""")
-        expected = textwrap.dedent("""\
+            print fruit[1]"""
+        )
+        expected = textwrap.dedent(
+            """\
             fruit = ['banaan', 'appel', 'kers']
-            print(f'''{fruit[1-1]}''')""")
-
-        self.multi_level_tester(
-            code=code,
-            max_level=17,
-            expected=expected,
-            extra_check_function=self.is_not_turtle()
+            print(f'''{fruit[1-1]}''')"""
         )
 
+        self.multi_level_tester(code=code, max_level=17, expected=expected, extra_check_function=self.is_not_turtle())
+
     def test_print_list_access_non_latin(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
             vrienden = ['Ahmed', 'Ben', 'Cayden']
             geluksgetallen = [15, 18, 6]
             voor म in bereik 1 tot 3
                print 'het geluksgetal van ' vrienden[म]
-               print 'is ' geluksgetallen[म]""")
-        expected = textwrap.dedent("""\
+               print 'is ' geluksgetallen[म]"""
+        )
+        expected = textwrap.dedent(
+            """\
         vrienden = ['Ahmed', 'Ben', 'Cayden']
         geluksgetallen = [15, 18, 6]
         step = 1 if 1 < 3 else -1
         for म in range(1, 3 + step, step):
           print(f'''het geluksgetal van {vrienden[म-1]}''')
           print(f'''is {geluksgetallen[म-1]}''')
-          time.sleep(0.1)""")
-
-        self.single_level_tester(
-            code=code,
-            expected=expected,
-            lang='nl',
-            extra_check_function=self.is_not_turtle()
+          time.sleep(0.1)"""
         )
+
+        self.single_level_tester(code=code, expected=expected, lang="nl", extra_check_function=self.is_not_turtle())
 
     def test_list_access_var(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
             fruit = ['banaan', 'appel', 'kers']
             eerstefruit = fruit[1]
-            print eerstefruit""")
-        expected = textwrap.dedent("""\
+            print eerstefruit"""
+        )
+        expected = textwrap.dedent(
+            """\
             fruit = ['banaan', 'appel', 'kers']
             eerstefruit = fruit[1-1]
-            print(f'''{eerstefruit}''')""")
-
-        self.multi_level_tester(
-            code=code,
-            max_level=17,
-            expected=expected,
-            extra_check_function=self.is_not_turtle()
+            print(f'''{eerstefruit}''')"""
         )
 
+        self.multi_level_tester(code=code, max_level=17, expected=expected, extra_check_function=self.is_not_turtle())
+
     def test_access_plus(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
             lijst is [1, 2, 3]
             optellen is lijst[1] + lijst[2]
             optellen is optellen + lijst[3]
-            print optellen""")
-        expected = textwrap.dedent("""\
+            print optellen"""
+        )
+        expected = textwrap.dedent(
+            """\
             lijst = [1, 2, 3]
             optellen = lijst[1-1] + lijst[2-1]
             optellen = optellen + lijst[3-1]
-            print(f'''{optellen}''')""")
-
-        self.multi_level_tester(
-            code=code,
-            max_level=17,
-            expected=expected,
-            extra_check_function=self.is_not_turtle()
+            print(f'''{optellen}''')"""
         )
+
+        self.multi_level_tester(code=code, max_level=17, expected=expected, extra_check_function=self.is_not_turtle())
 
     def test_list_access_random(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
             fruit is ['banaan', 'appel', 'kers']
             randomfruit is fruit[random]
-            print randomfruit""")
-        expected = textwrap.dedent("""\
+            print randomfruit"""
+        )
+        expected = textwrap.dedent(
+            """\
             fruit = ['banaan', 'appel', 'kers']
             randomfruit = random.choice(fruit)
-            print(f'''{randomfruit}''')""")
-
-        self.multi_level_tester(
-            code=code,
-            max_level=17,
-            expected=expected,
-            extra_check_function=self.is_not_turtle()
+            print(f'''{randomfruit}''')"""
         )
 
+        self.multi_level_tester(code=code, max_level=17, expected=expected, extra_check_function=self.is_not_turtle())
+
     def test_access_in_equality_check(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
             luiaard = 'luiaard'
             dieren is ['aap', 'goat', 'fish']
             if luiaard is dieren[1]
-                print 'ja'""")
+                print 'ja'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
             luiaard = 'luiaard'
             dieren = ['aap', 'goat', 'fish']
             if convert_numerals('Latin', luiaard) == convert_numerals('Latin', dieren[1-1]):
-              print(f'''ja''')""")
-
-        self.single_level_tester(
-            code=code,
-            expected=expected,
-            extra_check_function=self.is_not_turtle()
+              print(f'''ja''')"""
         )
 
+        self.single_level_tester(code=code, expected=expected, extra_check_function=self.is_not_turtle())
+
     @parameterized.expand(HedyTester.comparison_commands)
-    def test_access_smaller_check(self,comparison):
-        code = textwrap.dedent(f"""\
+    def test_access_smaller_check(self, comparison):
+        code = textwrap.dedent(
+            f"""\
             balletje = 0
             bingo_getallen is [11, 17, 21]
             if balletje {comparison} bingo_getallen[1]
-                print 'ja'""")
+                print 'ja'"""
+        )
 
-        expected = textwrap.dedent(f"""\
+        expected = textwrap.dedent(
+            f"""\
             balletje = 0
             bingo_getallen = [11, 17, 21]
             if convert_numerals('Latin', balletje).zfill(100){comparison}convert_numerals('Latin', bingo_getallen[1-1]).zfill(100):
-              print(f'''ja''')""")
-
-        self.single_level_tester(
-            code=code,
-            expected=expected,
-            extra_check_function=self.is_not_turtle()
+              print(f'''ja''')"""
         )
+
+        self.single_level_tester(code=code, expected=expected, extra_check_function=self.is_not_turtle())
 
     # ask tests
     def test_ask_with_list_var(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         colors is ['orange', 'blue', 'green']
-        favorite is ask 'Is your fav color' colors[1]""")
+        favorite is ask 'Is your fav color' colors[1]"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         colors = ['orange', 'blue', 'green']
         favorite = input(f'''Is your fav color{colors[1-1]}''')
         try:
@@ -267,21 +252,20 @@ class TestsLevel16(HedyTester):
           try:
             favorite = float(favorite)
           except ValueError:
-            pass""")
-
-        self.multi_level_tester(
-            code=code,
-            max_level=17,
-            expected=expected,
-            extra_check_function=self.is_not_turtle()
+            pass"""
         )
 
-    def test_ask_with_list(self):
-        code = textwrap.dedent("""\
-        colors is ['orange', 'blue', 'green']
-        favorite is ask 'Is your fav color' colors""")
+        self.multi_level_tester(code=code, max_level=17, expected=expected, extra_check_function=self.is_not_turtle())
 
-        expected = textwrap.dedent("""\
+    def test_ask_with_list(self):
+        code = textwrap.dedent(
+            """\
+        colors is ['orange', 'blue', 'green']
+        favorite is ask 'Is your fav color' colors"""
+        )
+
+        expected = textwrap.dedent(
+            """\
         colors = ['orange', 'blue', 'green']
         favorite = input(f'''Is your fav color{colors}''')
         try:
@@ -290,23 +274,23 @@ class TestsLevel16(HedyTester):
           try:
             favorite = float(favorite)
           except ValueError:
-            pass""")
-
-        self.multi_level_tester(
-            code=code,
-            max_level=17,
-            expected=expected
+            pass"""
         )
 
-    #add/remove tests
+        self.multi_level_tester(code=code, max_level=17, expected=expected)
+
+    # add/remove tests
     def test_add_to_list(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         color is ask 'what is your favorite color? '
         colors is ['green', 'red', 'blue']
         add color to colors
-        print colors[random]""")
+        print colors[random]"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         color = input(f'''what is your favorite color? ''')
         try:
           color = int(color)
@@ -317,22 +301,22 @@ class TestsLevel16(HedyTester):
             pass
         colors = ['green', 'red', 'blue']
         colors.append(color)
-        print(f'''{random.choice(colors)}''')""")
-
-        self.multi_level_tester(
-          code=code,
-          max_level=17,
-          expected=expected
+        print(f'''{random.choice(colors)}''')"""
         )
 
+        self.multi_level_tester(code=code, max_level=17, expected=expected)
+
     def test_remove_from_list(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         colors is ['green', 'red', 'blue']
         color is ask 'what color to remove?'
         remove color from colors
-        print colors[random]""")
+        print colors[random]"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         colors = ['green', 'red', 'blue']
         color = input(f'''what color to remove?''')
         try:
@@ -346,64 +330,76 @@ class TestsLevel16(HedyTester):
           colors.remove(color)
         except:
           pass
-        print(f'''{random.choice(colors)}''')""")
-
-        self.multi_level_tester(
-          code=code,
-          max_level=17,
-          expected=expected
+        print(f'''{random.choice(colors)}''')"""
         )
 
+        self.multi_level_tester(code=code, max_level=17, expected=expected)
+
     def test_equality_with_lists(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         m is [1, 2]
         n is [1, 2]
         if m is n
-            print 'success!'""")
+            print 'success!'"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         m = [1, 2]
         n = [1, 2]
         if convert_numerals('Latin', m) == convert_numerals('Latin', n):
-          print(f'''success!''')""")
+          print(f'''success!''')"""
+        )
 
         self.single_level_tester(code=code, expected=expected)
 
     def test_equality_with_number_and_list_gives_error(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         color is [5, 6, 7]
         if 1 is color
-            print 'success!'""")
+            print 'success!'"""
+        )
 
         with self.assertRaises(hedy.exceptions.InvalidTypeCombinationException):
             hedy.transpile(code, self.level)
 
-    @parameterized.expand(["'text'", '1', '1.3', '[1, 2]'])
+    @parameterized.expand(["'text'", "1", "1.3", "[1, 2]"])
     def test_not_equal(self, arg):
-        code = textwrap.dedent(f"""\
+        code = textwrap.dedent(
+            f"""\
             a = {arg}
             b = {arg}
             if a != b
-                b = 1""")
+                b = 1"""
+        )
 
-        expected = textwrap.dedent(f"""\
+        expected = textwrap.dedent(
+            f"""\
             a = {arg}
             b = {arg}
             if convert_numerals('Latin', a).zfill(100)!=convert_numerals('Latin', b).zfill(100):
-              b = 1""")
+              b = 1"""
+        )
 
         self.single_level_tester(code, expected=expected)
 
-    @parameterized.expand([
-        ('"text"', '1'),        # double-quoted text and number
-        ("'text'", '1'),        # single-quoted text and number
-        ('[1, 2]', '1'),        # list and number
-        ('[1, 2]', "'text'")])  # list and text
+    @parameterized.expand(
+        [
+            ('"text"', "1"),  # double-quoted text and number
+            ("'text'", "1"),  # single-quoted text and number
+            ("[1, 2]", "1"),  # list and number
+            ("[1, 2]", "'text'"),
+        ]
+    )  # list and text
     def test_not_equal_with_diff_types_gives_error(self, left, right):
-        code = textwrap.dedent(f"""\
+        code = textwrap.dedent(
+            f"""\
             a = {left}
             b = {right}
             if a != b
-                b = 1""")
+                b = 1"""
+        )
 
         self.single_level_tester(code, exception=exceptions.InvalidTypeCombinationException)

--- a/tests/test_level/test_level_17.py
+++ b/tests/test_level/test_level_17.py
@@ -4,45 +4,57 @@ import textwrap
 from parameterized import parameterized
 from tests.Tester import HedyTester
 
-class TestsLevel17(HedyTester):
-  level = 17
 
-  def test_if_with_indent(self):
-    code = textwrap.dedent("""\
+class TestsLevel17(HedyTester):
+    level = 17
+
+    def test_if_with_indent(self):
+        code = textwrap.dedent(
+            """\
     naam is 'Hedy'
     if naam is 'Hedy':
-        print 'koekoek'""")
-    expected = textwrap.dedent("""\
+        print 'koekoek'"""
+        )
+        expected = textwrap.dedent(
+            """\
     naam = 'Hedy'
     if convert_numerals('Latin', naam) == convert_numerals('Latin', 'Hedy'):
-      print(f'''koekoek''')""")
+      print(f'''koekoek''')"""
+        )
 
-    self.single_level_tester(code=code, expected=expected)
+        self.single_level_tester(code=code, expected=expected)
 
-  def test_if_with_equals_sign(self):
-    code = textwrap.dedent("""\
+    def test_if_with_equals_sign(self):
+        code = textwrap.dedent(
+            """\
     naam is 'Hedy'
     if naam == Hedy:
-        print 'koekoek'""")
+        print 'koekoek'"""
+        )
 
-    expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
     naam = 'Hedy'
     if convert_numerals('Latin', naam) == convert_numerals('Latin', 'Hedy'):
-      print(f'''koekoek''')""")
+      print(f'''koekoek''')"""
+        )
 
-    self.single_level_tester(code=code, expected=expected)
+        self.single_level_tester(code=code, expected=expected)
 
-  def test_if_else(self):
-    code = textwrap.dedent("""\
+    def test_if_else(self):
+        code = textwrap.dedent(
+            """\
     antwoord is ask 'Hoeveel is 10 plus 10?'
     if antwoord is 20:
         print 'Goedzo!'
         print 'Het antwoord was inderdaad ' antwoord
     else:
         print 'Foutje'
-        print 'Het antwoord moest zijn ' antwoord""")
+        print 'Het antwoord moest zijn ' antwoord"""
+        )
 
-    expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
     antwoord = input(f'''Hoeveel is 10 plus 10?''')
     try:
       antwoord = int(antwoord)
@@ -56,52 +68,56 @@ class TestsLevel17(HedyTester):
       print(f'''Het antwoord was inderdaad {antwoord}''')
     else:
       print(f'''Foutje''')
-      print(f'''Het antwoord moest zijn {antwoord}''')""")
+      print(f'''Het antwoord moest zijn {antwoord}''')"""
+        )
 
+        self.single_level_tester(code=code, expected=expected)
 
-
-    self.single_level_tester(code=code, expected=expected)
-
-  def test_if_else_boolean(self):
-    code = textwrap.dedent("""\
+    def test_if_else_boolean(self):
+        code = textwrap.dedent(
+            """\
     computerc = 'PC'
     userc = 'Hedy'
     print 'Pilihan komputer: ' computerc
     if userc is computerc and userc is 'Hedy':
         print 'SERI'
     else:
-        print 'Komputer'""")
+        print 'Komputer'"""
+        )
 
-    expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
     computerc = 'PC'
     userc = 'Hedy'
     print(f'''Pilihan komputer: {computerc}''')
     if convert_numerals('Latin', userc) == convert_numerals('Latin', computerc) and convert_numerals('Latin', userc) == convert_numerals('Latin', 'Hedy'):
       print(f'''SERI''')
     else:
-      print(f'''Komputer''')""")
+      print(f'''Komputer''')"""
+        )
 
-    self.single_level_tester(code=code, expected=expected)
+        self.single_level_tester(code=code, expected=expected)
 
-
-  def test_for_loop_arabic(self):
-    code = textwrap.dedent("""\
+    def test_for_loop_arabic(self):
+        code = textwrap.dedent(
+            """\
     for دورة in range ١ to ٥:
-        print دورة""")
+        print دورة"""
+        )
 
-    expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
     step = 1 if 1 < 5 else -1
     for دورة in range(1, 5 + step, step):
       print(f'''{دورة}''')
-      time.sleep(0.1)""")
+      time.sleep(0.1)"""
+        )
 
-    self.single_level_tester(
-      code=code,
-      expected=expected,
-      expected_commands=['for', 'print'])
+        self.single_level_tester(code=code, expected=expected, expected_commands=["for", "print"])
 
-  def test_if_elif_boolean(self):
-    code = textwrap.dedent("""\
+    def test_if_elif_boolean(self):
+        code = textwrap.dedent(
+            """\
     computerc = 'PC'
     userc = 'Hedy'
     print 'Pilihan komputer: ' computerc
@@ -110,9 +126,11 @@ class TestsLevel17(HedyTester):
     elif userc is 'PC' and userc is 'Hedy':
         print 'HARI'
     else:
-        print 'Komputer'""")
+        print 'Komputer'"""
+        )
 
-    expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
     computerc = 'PC'
     userc = 'Hedy'
     print(f'''Pilihan komputer: {computerc}''')
@@ -121,118 +139,128 @@ class TestsLevel17(HedyTester):
     elif convert_numerals('Latin', userc) == convert_numerals('Latin', 'PC') and convert_numerals('Latin', userc) == convert_numerals('Latin', 'Hedy'):
       print(f'''HARI''')
     else:
-      print(f'''Komputer''')""")
+      print(f'''Komputer''')"""
+        )
 
-    self.single_level_tester(code=code, expected=expected)
+        self.single_level_tester(code=code, expected=expected)
 
-  def test_for_loop(self):
-    code = textwrap.dedent("""\
+    def test_for_loop(self):
+        code = textwrap.dedent(
+            """\
     a is 2
     b is 3
     for a in range 2 to 4:
         a is a + 2
-        b is b + 2""")
-    expected = textwrap.dedent("""\
+        b is b + 2"""
+        )
+        expected = textwrap.dedent(
+            """\
     a = 2
     b = 3
     step = 1 if 2 < 4 else -1
     for a in range(2, 4 + step, step):
       a = a + 2
       b = b + 2
-      time.sleep(0.1)""")
+      time.sleep(0.1)"""
+        )
 
+        self.single_level_tester(code=code, expected=expected)
 
-
-    self.single_level_tester(code=code, expected=expected)
-
-  def test_if__else(self):
-    code = textwrap.dedent("""\
+    def test_if__else(self):
+        code = textwrap.dedent(
+            """\
     a is 5
     if a is 1:
         x is 2
     else:
-        x is 222""")
-    expected = textwrap.dedent("""\
+        x is 222"""
+        )
+        expected = textwrap.dedent(
+            """\
     a = 5
     if convert_numerals('Latin', a) == convert_numerals('Latin', '1'):
       x = 2
     else:
-      x = 222""")
-    self.single_level_tester(code=code, expected=expected)
+      x = 222"""
+        )
+        self.single_level_tester(code=code, expected=expected)
 
-  def test_forloop(self):
-    code = textwrap.dedent("""\
+    def test_forloop(self):
+        code = textwrap.dedent(
+            """\
     for i in range 1 to 10:
         print i
-    print 'wie niet weg is is gezien'""")
-    expected = textwrap.dedent("""\
+    print 'wie niet weg is is gezien'"""
+        )
+        expected = textwrap.dedent(
+            """\
     step = 1 if 1 < 10 else -1
     for i in range(1, 10 + step, step):
       print(f'''{i}''')
       time.sleep(0.1)
-    print(f'''wie niet weg is is gezien''')""")
+    print(f'''wie niet weg is is gezien''')"""
+        )
 
+        self.single_level_tester(code=code, expected=expected)
 
-
-    self.single_level_tester(code=code, expected=expected)
-
-  def test_allow_space_after_else_line(self):
-    code = textwrap.dedent("""\
+    def test_allow_space_after_else_line(self):
+        code = textwrap.dedent(
+            """\
     a is 1
     if a is 1:
         print a
     else:
-        print 'nee'""")
+        print 'nee'"""
+        )
 
-    expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
     a = 1
     if convert_numerals('Latin', a) == convert_numerals('Latin', '1'):
       print(f'''{a}''')
     else:
-      print(f'''nee''')""")
+      print(f'''nee''')"""
+        )
 
-    self.multi_level_tester(
-      max_level=17,
-      code=code,
-      expected=expected,
-      expected_commands=['is', 'if', 'print', 'print']
-    )
+        self.multi_level_tester(
+            max_level=17, code=code, expected=expected, expected_commands=["is", "if", "print", "print"]
+        )
 
-  def test_while_undefined_var(self):
-    code = textwrap.dedent("""\
+    def test_while_undefined_var(self):
+        code = textwrap.dedent(
+            """\
       while antwoord != 25:
-          print 'hoera'""")
+          print 'hoera'"""
+        )
 
-    self.single_level_tester(
-      code=code,
-      exception=hedy.exceptions.UndefinedVarException
-    )
+        self.single_level_tester(code=code, exception=hedy.exceptions.UndefinedVarException)
 
-  def test_allow_space_before_colon(self):
+    def test_allow_space_before_colon(self):
 
-    code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
     a is 1
     if a is 1  :
         print a
     else:
-        print 'nee'""")
+        print 'nee'"""
+        )
 
-    expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
     a = 1
     if convert_numerals('Latin', a) == convert_numerals('Latin', '1'):
       print(f'''{a}''')
     else:
-      print(f'''nee''')""")
+      print(f'''nee''')"""
+        )
 
-    self.multi_level_tester(
-      code=code,
-      max_level=17,
-      expected=expected
-    )
+        self.multi_level_tester(code=code, max_level=17, expected=expected)
 
-  def test_if_under_else_in_for(self):
-    # todo can me multitester with higher levels!
-    code = textwrap.dedent("""\
+    def test_if_under_else_in_for(self):
+        # todo can me multitester with higher levels!
+        code = textwrap.dedent(
+            """\
     for i in range 0 to 10:
         antwoord is ask 'Wat is 5*5'
         if antwoord is 24:
@@ -240,9 +268,11 @@ class TestsLevel17(HedyTester):
         else:
             print 'Dat is goed!'
         if antwoord is 25:
-            i is 10""")
+            i is 10"""
+        )
 
-    expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
     step = 1 if 0 < 10 else -1
     for i in range(0, 10 + step, step):
       antwoord = input(f'''Wat is 5*5''')
@@ -259,112 +289,125 @@ class TestsLevel17(HedyTester):
         print(f'''Dat is goed!''')
       if convert_numerals('Latin', antwoord) == convert_numerals('Latin', '25'):
         i = 10
-      time.sleep(0.1)""")
+      time.sleep(0.1)"""
+        )
 
+        self.single_level_tester(code=code, expected=expected)
 
-
-    self.single_level_tester(code=code, expected=expected)
-
-  def test_if_elif(self):
-    code = textwrap.dedent("""\
+    def test_if_elif(self):
+        code = textwrap.dedent(
+            """\
       a is 5
       if a is 1:
           x is 2
       elif a is 2:
-          x is 222""")
-    expected = textwrap.dedent("""\
+          x is 222"""
+        )
+        expected = textwrap.dedent(
+            """\
       a = 5
       if convert_numerals('Latin', a) == convert_numerals('Latin', '1'):
         x = 2
       elif convert_numerals('Latin', a) == convert_numerals('Latin', '2'):
-        x = 222""")
+        x = 222"""
+        )
 
+        self.single_level_tester(code=code, expected=expected)
 
-
-    self.single_level_tester(code=code, expected=expected)
-
-  def test_if_elif_french(self):
-    code = textwrap.dedent("""\
+    def test_if_elif_french(self):
+        code = textwrap.dedent(
+            """\
       a est 5
       si a est 1:
           x est 2
       sinon si a est 2:
-          x est 222""")
-    expected = textwrap.dedent("""\
+          x est 222"""
+        )
+        expected = textwrap.dedent(
+            """\
       a = 5
       if convert_numerals('Latin', a) == convert_numerals('Latin', '1'):
         x = 2
       elif convert_numerals('Latin', a) == convert_numerals('Latin', '2'):
-        x = 222""")
+        x = 222"""
+        )
 
-    self.single_level_tester(code=code, expected=expected, lang='fr')
+        self.single_level_tester(code=code, expected=expected, lang="fr")
 
-  def test_if_with_multiple_elifs(self):
-    code = textwrap.dedent("""\
+    def test_if_with_multiple_elifs(self):
+        code = textwrap.dedent(
+            """\
       a is 5
       if a is 1:
           x is 2
       elif a is 4:
           x is 3
       elif a is 2:
-          x is 222""")
-    expected = textwrap.dedent("""\
+          x is 222"""
+        )
+        expected = textwrap.dedent(
+            """\
       a = 5
       if convert_numerals('Latin', a) == convert_numerals('Latin', '1'):
         x = 2
       elif convert_numerals('Latin', a) == convert_numerals('Latin', '4'):
         x = 3
       elif convert_numerals('Latin', a) == convert_numerals('Latin', '2'):
-        x = 222""")
+        x = 222"""
+        )
 
-    self.single_level_tester(code=code, expected=expected, expected_commands=['is', 'if', 'is', 'elif', 'is', 'elif', 'is'])
+        self.single_level_tester(
+            code=code, expected=expected, expected_commands=["is", "if", "is", "elif", "is", "elif", "is"]
+        )
 
-  def test_if_in_list_with_string_var_gives_type_error(self):
-    code = textwrap.dedent("""\
+    def test_if_in_list_with_string_var_gives_type_error(self):
+        code = textwrap.dedent(
+            """\
     items is 'red'
     if 'red' in items:
-        a is 1""")
-    self.multi_level_tester(
-      code=code,
-      exception=hedy.exceptions.InvalidArgumentTypeException
-    )
+        a is 1"""
+        )
+        self.multi_level_tester(code=code, exception=hedy.exceptions.InvalidArgumentTypeException)
 
-  def test_equality_with_lists(self):
-    code = textwrap.dedent("""\
+    def test_equality_with_lists(self):
+        code = textwrap.dedent(
+            """\
       m is [1, 2]
       n is [1, 2]
       if m is n:
-          a is 1""")
+          a is 1"""
+        )
 
-    expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
       m = [1, 2]
       n = [1, 2]
       if convert_numerals('Latin', m) == convert_numerals('Latin', n):
-        a = 1""")
+        a = 1"""
+        )
 
-    self.multi_level_tester(
-      code=code,
-      expected=expected
-    )
+        self.multi_level_tester(code=code, expected=expected)
 
-  def test_equality_with_incompatible_types_gives_error(self):
-    code = textwrap.dedent("""\
+    def test_equality_with_incompatible_types_gives_error(self):
+        code = textwrap.dedent(
+            """\
     a is 'test'
     b is 15
     if a is b:
-      c is 1""")
-    self.multi_level_tester(
-      code=code,
-      exception=hedy.exceptions.InvalidTypeCombinationException
-    )
+      c is 1"""
+        )
+        self.multi_level_tester(code=code, exception=hedy.exceptions.InvalidTypeCombinationException)
 
-  @parameterized.expand(HedyTester.comparison_commands)
-  def test_comparisons(self, comparison):
-    code = textwrap.dedent(f"""\
+    @parameterized.expand(HedyTester.comparison_commands)
+    def test_comparisons(self, comparison):
+        code = textwrap.dedent(
+            f"""\
       leeftijd is ask 'Hoe oud ben jij?'
       if leeftijd {comparison} 12:
-          print 'Dan ben je jonger dan ik!'""")
-    expected = textwrap.dedent(f"""\
+          print 'Dan ben je jonger dan ik!'"""
+        )
+        expected = textwrap.dedent(
+            f"""\
       leeftijd = input(f'''Hoe oud ben jij?''')
       try:
         leeftijd = int(leeftijd)
@@ -374,66 +417,66 @@ class TestsLevel17(HedyTester):
         except ValueError:
           pass
       if convert_numerals('Latin', leeftijd).zfill(100){comparison}convert_numerals('Latin', 12).zfill(100):
-        print(f'''Dan ben je jonger dan ik!''')""")
+        print(f'''Dan ben je jonger dan ik!''')"""
+        )
 
-    self.single_level_tester(code=code, expected=expected)
+        self.single_level_tester(code=code, expected=expected)
 
-  @parameterized.expand(HedyTester.number_comparison_commands)
-  def test_smaller_with_string_gives_type_error(self, comparison):
-    code = textwrap.dedent(f"""\
+    @parameterized.expand(HedyTester.number_comparison_commands)
+    def test_smaller_with_string_gives_type_error(self, comparison):
+        code = textwrap.dedent(
+            f"""\
       a is 'text'
       if a {comparison} 12:
-          b is 1""")
+          b is 1"""
+        )
 
-    self.multi_level_tester(
-      code=code,
-      exception=hedy.exceptions.InvalidArgumentTypeException
-    )
+        self.multi_level_tester(code=code, exception=hedy.exceptions.InvalidArgumentTypeException)
 
-  def test_not_equal_string_literal(self):
-    code = textwrap.dedent(f"""\
+    def test_not_equal_string_literal(self):
+        code = textwrap.dedent(
+            f"""\
     if 'quoted' != 'string':
-      sleep""")
-    expected = textwrap.dedent(f"""\
+      sleep"""
+        )
+        expected = textwrap.dedent(
+            f"""\
     if 'quoted'.zfill(100)!='string'.zfill(100):
-      time.sleep(1)""")
+      time.sleep(1)"""
+        )
 
-    self.multi_level_tester(
-      code=code,
-      expected=expected
-    )
+        self.multi_level_tester(code=code, expected=expected)
 
-  @parameterized.expand(["'text'", '1', '1.3', '[1, 2]'])
-  def test_not_equal(self, arg):
-    code = textwrap.dedent(f"""\
+    @parameterized.expand(["'text'", "1", "1.3", "[1, 2]"])
+    def test_not_equal(self, arg):
+        code = textwrap.dedent(
+            f"""\
       a = {arg}
       b = {arg}
       if a != b:
-          b = 1""")
+          b = 1"""
+        )
 
-    expected = textwrap.dedent(f"""\
+        expected = textwrap.dedent(
+            f"""\
       a = {arg}
       b = {arg}
       if convert_numerals('Latin', a).zfill(100)!=convert_numerals('Latin', b).zfill(100):
-        b = 1""")
+        b = 1"""
+        )
 
-    self.multi_level_tester(
-      code=code,
-      expected=expected
-    )
+        self.multi_level_tester(code=code, expected=expected)
 
-  @parameterized.expand([
-    ("'text'", '1'),        # text and number
-    ('[1, 2]', '1'),        # list and number
-    ('[1, 2]', "'text'")])  # list and text
-  def test_not_equal_with_diff_types_gives_error(self, left, right):
-    code = textwrap.dedent(f"""\
+    @parameterized.expand(
+        [("'text'", "1"), ("[1, 2]", "1"), ("[1, 2]", "'text'")]  # text and number  # list and number
+    )  # list and text
+    def test_not_equal_with_diff_types_gives_error(self, left, right):
+        code = textwrap.dedent(
+            f"""\
         a = {left}
         b = {right}
         if a != b:
-            b = 1""")
+            b = 1"""
+        )
 
-    self.multi_level_tester(
-      code=code,
-      exception=exceptions.InvalidTypeCombinationException
-    )
+        self.multi_level_tester(code=code, exception=exceptions.InvalidTypeCombinationException)

--- a/tests/test_level/test_level_18.py
+++ b/tests/test_level/test_level_18.py
@@ -3,52 +3,54 @@ import textwrap
 from tests.Tester import HedyTester
 from parameterized import parameterized
 
+
 class TestsLevel18(HedyTester):
     level = 18
 
     def test_print_brackets(self):
-      code = textwrap.dedent("""\
-      print('Hallo!')""")
+        code = textwrap.dedent(
+            """\
+      print('Hallo!')"""
+        )
 
-      expected = textwrap.dedent("""\
-      print(f'''Hallo!''')""")
-
-      self.multi_level_tester(
-        code=code,
-        expected=expected,
-        extra_check_function=self.is_not_turtle(),
-        expected_commands=['print']
-      )
-
-    def test_print_var_brackets(self):
-        code = textwrap.dedent("""\
-        naam is 'Hedy'
-        print('ik heet', naam)""")
-
-        expected = textwrap.dedent("""\
-        naam = 'Hedy'
-        print(f'''ik heet{naam}''')""")
+        expected = textwrap.dedent(
+            """\
+      print(f'''Hallo!''')"""
+        )
 
         self.multi_level_tester(
-          code=code,
-          expected=expected,
-          extra_check_function=self.is_not_turtle()
+            code=code, expected=expected, extra_check_function=self.is_not_turtle(), expected_commands=["print"]
         )
+
+    def test_print_var_brackets(self):
+        code = textwrap.dedent(
+            """\
+        naam is 'Hedy'
+        print('ik heet', naam)"""
+        )
+
+        expected = textwrap.dedent(
+            """\
+        naam = 'Hedy'
+        print(f'''ik heet{naam}''')"""
+        )
+
+        self.multi_level_tester(code=code, expected=expected, extra_check_function=self.is_not_turtle())
 
     def test_print_comma(self):
         code = "print('ik heet ,')"
         expected = "print(f'''ik heet ,''')"
-        self.multi_level_tester(
-            code=code,
-            expected=expected,
-            extra_check_function=self.is_not_turtle())
+        self.multi_level_tester(code=code, expected=expected, extra_check_function=self.is_not_turtle())
 
-    @parameterized.expand(['=', 'is'])
+    @parameterized.expand(["=", "is"])
     def test_input(self, assigment):
-        code = textwrap.dedent(f"""\
+        code = textwrap.dedent(
+            f"""\
         leeftijd {assigment} input('Hoe oud ben jij?')
-        print(leeftijd)""")
-        expected = textwrap.dedent("""\
+        print(leeftijd)"""
+        )
+        expected = textwrap.dedent(
+            """\
         leeftijd = input(f'''Hoe oud ben jij?''')
         try:
           leeftijd = int(leeftijd)
@@ -57,27 +59,27 @@ class TestsLevel18(HedyTester):
             leeftijd = float(leeftijd)
           except ValueError:
             pass
-        print(f'''{leeftijd}''')""")
-
-        self.multi_level_tester(
-          max_level=20,
-          code=code,
-          expected=expected,
-          extra_check_function=self.is_not_turtle()
+        print(f'''{leeftijd}''')"""
         )
 
+        self.multi_level_tester(max_level=20, code=code, expected=expected, extra_check_function=self.is_not_turtle())
+
     def test_if_with_equals_sign(self):
-      code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
       naam is 'Hedy'
       if naam == Hedy:
-          print('koekoek')""")
+          print('koekoek')"""
+        )
 
-      expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
       naam = 'Hedy'
       if convert_numerals('Latin', naam) == convert_numerals('Latin', 'Hedy'):
-        print(f'''koekoek''')""")
+        print(f'''koekoek''')"""
+        )
 
-      self.single_level_tester(code=code, expected=expected)
+        self.single_level_tester(code=code, expected=expected)
 
     # issue also in level 17, leaving for now.
     # def test_bigger(self):
@@ -119,16 +121,19 @@ class TestsLevel18(HedyTester):
     #     )
 
     def test_if_else(self):
-      code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
       antwoord is input('Hoeveel is 10 plus 10?')
       if antwoord is 20:
           print('Goedzo!')
           print('Het antwoord was inderdaad', antwoord)
       else:
           print('Foutje')
-          print('Het antwoord moest zijn', antwoord)""")
+          print('Het antwoord moest zijn', antwoord)"""
+        )
 
-      expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
       antwoord = input(f'''Hoeveel is 10 plus 10?''')
       try:
         antwoord = int(antwoord)
@@ -142,79 +147,83 @@ class TestsLevel18(HedyTester):
         print(f'''Het antwoord was inderdaad{antwoord}''')
       else:
         print(f'''Foutje''')
-        print(f'''Het antwoord moest zijn{antwoord}''')""")
+        print(f'''Het antwoord moest zijn{antwoord}''')"""
+        )
 
-      self.multi_level_tester(
-        code=code,
-        expected=expected,
-        expected_commands=['input', 'if', 'print', 'print', 'print', 'print'],
-        extra_check_function=self.is_not_turtle()
-      )
+        self.multi_level_tester(
+            code=code,
+            expected=expected,
+            expected_commands=["input", "if", "print", "print", "print", "print"],
+            extra_check_function=self.is_not_turtle(),
+        )
 
     def test_for_loop(self):
-      code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
       a is 2
       b is 3
       for a in range(2, 4):
           a is a + 2
-          b is b + 2""")
-      expected = textwrap.dedent("""\
+          b is b + 2"""
+        )
+        expected = textwrap.dedent(
+            """\
       a = 2
       b = 3
       step = 1 if 2 < 4 else -1
       for a in range(2, 4 + step, step):
         a = a + 2
         b = b + 2
-        time.sleep(0.1)""")
+        time.sleep(0.1)"""
+        )
 
-      self.multi_level_tester(
-        code=code,
-        expected=expected,
-        extra_check_function=self.is_not_turtle()
-      )
+        self.multi_level_tester(code=code, expected=expected, extra_check_function=self.is_not_turtle())
 
     def test_for_nesting(self):
-      code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
       for i in range(1, 3):
           for j in range(1, 4):
-              print('rondje: ', i, ' tel: ', j)""")
-      expected = textwrap.dedent("""\
+              print('rondje: ', i, ' tel: ', j)"""
+        )
+        expected = textwrap.dedent(
+            """\
       step = 1 if 1 < 3 else -1
       for i in range(1, 3 + step, step):
         step = 1 if 1 < 4 else -1
         for j in range(1, 4 + step, step):
           print(f'''rondje: {i} tel: {j}''')
-          time.sleep(0.1)""")
+          time.sleep(0.1)"""
+        )
 
-      self.multi_level_tester(
-
-        code=code,
-        expected=expected,
-        extra_check_function=self.is_not_turtle()
-      )
+        self.multi_level_tester(code=code, expected=expected, extra_check_function=self.is_not_turtle())
 
     def test_for_loop_arabic(self):
-      code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
       for دورة in range(١, ٥):
-          print(دورة)""")
+          print(دورة)"""
+        )
 
-      expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
       step = 1 if 1 < 5 else -1
       for دورة in range(1, 5 + step, step):
         print(f'''{دورة}''')
-        time.sleep(0.1)""")
+        time.sleep(0.1)"""
+        )
 
-      self.single_level_tester(
-        code=code,
-        expected=expected,
-        expected_commands=['for', 'print'])
+        self.single_level_tester(code=code, expected=expected, expected_commands=["for", "print"])
 
     def test_input_with_list(self):
-      code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
       color is ['green', 'blue']
-      choice is input('Is your favorite color one of: ', color)""")
+      choice is input('Is your favorite color one of: ', color)"""
+        )
 
-      expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
       color = ['green', 'blue']
       choice = input(f'''Is your favorite color one of: {color}''')
       try:
@@ -223,17 +232,15 @@ class TestsLevel18(HedyTester):
         try:
           choice = float(choice)
         except ValueError:
-          pass""")
+          pass"""
+        )
 
-      self.multi_level_tester(
-          code=code,
-          expected=expected,
-          extra_check_function=self.is_not_turtle()
-      )
-    
+        self.multi_level_tester(code=code, expected=expected, extra_check_function=self.is_not_turtle())
+
     def test_input_without_text_inside(self):
-      code = "x = input()"
-      expected = textwrap.dedent("""\
+        code = "x = input()"
+        expected = textwrap.dedent(
+            """\
       x = input(f'''''')
       try:
         x = int(x)
@@ -241,48 +248,36 @@ class TestsLevel18(HedyTester):
         try:
           x = float(x)
         except ValueError:
-          pass""")
-      self.multi_level_tester(
-        code=code,
-        expected=expected,
-        extra_check_function=self.is_not_turtle()
-      )
-    
+          pass"""
+        )
+        self.multi_level_tester(code=code, expected=expected, extra_check_function=self.is_not_turtle())
+
     def test_print_without_text_inside(self):
-      self.multi_level_tester(
-        code="print()",
-        expected="print(f'''''')",
-        extra_check_function=self.is_not_turtle()
-      )
+        self.multi_level_tester(code="print()", expected="print(f'''''')", extra_check_function=self.is_not_turtle())
 
     # negative tests
 
     def test_while_undefined_var(self):
-      code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         while antwoord != 25:
-            print('hoera')""")
+            print('hoera')"""
+        )
 
-      self.single_level_tester(
-        code=code,
-        exception=hedy.exceptions.UndefinedVarException
-      )
+        self.single_level_tester(code=code, exception=hedy.exceptions.UndefinedVarException)
 
     def test_var_undefined_error_message(self):
-      code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         naam is 'Hedy'
-        print('ik heet ', name)""")
+        print('ik heet ', name)"""
+        )
 
-      self.multi_level_tester(
-        code=code,
-        exception=hedy.exceptions.UndefinedVarException
-      )
+        self.multi_level_tester(code=code, exception=hedy.exceptions.UndefinedVarException)
 
-      # deze extra check functie kan nu niet mee omdat die altijd op result werkt
-      # evt toch splitsen in 2 (pos en neg?)
-      # self.assertEqual('name', context.exception.arguments['name'])
-    
+        # deze extra check functie kan nu niet mee omdat die altijd op result werkt
+        # evt toch splitsen in 2 (pos en neg?)
+        # self.assertEqual('name', context.exception.arguments['name'])
+
     def test_input_without_argument(self):
-      self.multi_level_tester(
-        code="name is input",
-        exception=hedy.exceptions.IncompleteCommandException
-      )   
+        self.multi_level_tester(code="name is input", exception=hedy.exceptions.IncompleteCommandException)

--- a/tests/test_querylog.py
+++ b/tests/test_querylog.py
@@ -1,38 +1,39 @@
 from website import querylog, log_queue
 import unittest
 
+
 class TestQueryLog(unittest.TestCase):
-  def setUp(self):
-    self.records = []
-    querylog.LOG_QUEUE.set_transmitter(self._fake_transmitter)
+    def setUp(self):
+        self.records = []
+        querylog.LOG_QUEUE.set_transmitter(self._fake_transmitter)
 
-  def _fake_transmitter(self, ts, records):
-    self.records.extend(records)
+    def _fake_transmitter(self, ts, records):
+        self.records.extend(records)
 
-  def test_regular_xmit(self):
-    with querylog.LogRecord(banaan='geel') as record:
-      record.set(bloem='rood')
+    def test_regular_xmit(self):
+        with querylog.LogRecord(banaan="geel") as record:
+            record.set(bloem="rood")
 
-    querylog.LOG_QUEUE.transmit_now()
+        querylog.LOG_QUEUE.transmit_now()
 
-    self.assertEqual(len(self.records), 1)
-    self.assertEqual(self.records[0]['banaan'], 'geel')
-    self.assertEqual(self.records[0]['bloem'], 'rood')
+        self.assertEqual(len(self.records), 1)
+        self.assertEqual(self.records[0]["banaan"], "geel")
+        self.assertEqual(self.records[0]["bloem"], "rood")
 
-  def test_emergency_recovery(self):
-    querylog.begin_global_log_record(banaan='geel')
-    querylog.log_value(bloem='rood')
+    def test_emergency_recovery(self):
+        querylog.begin_global_log_record(banaan="geel")
+        querylog.log_value(bloem="rood")
 
-    querylog.emergency_shutdown()
+        querylog.emergency_shutdown()
 
-    recovered_queue = log_queue.LogQueue('querylog', batch_window_s=300)
-    recovered_queue.try_load_emergency_saves()
-    recovered_queue.set_transmitter(self._fake_transmitter)
+        recovered_queue = log_queue.LogQueue("querylog", batch_window_s=300)
+        recovered_queue.try_load_emergency_saves()
+        recovered_queue.set_transmitter(self._fake_transmitter)
 
-    self.assertEqual(self.records, [])
+        self.assertEqual(self.records, [])
 
-    recovered_queue.transmit_now()
+        recovered_queue.transmit_now()
 
-    self.assertEqual(self.records[0]['banaan'], 'geel')
-    self.assertEqual(self.records[0]['bloem'], 'rood')
-    self.assertEqual(self.records[0]['terminated'], True)
+        self.assertEqual(self.records[0]["banaan"], "geel")
+        self.assertEqual(self.records[0]["bloem"], "rood")
+        self.assertEqual(self.records[0]["terminated"], True)

--- a/tests/test_snippets/test_adventures.py
+++ b/tests/test_snippets/test_adventures.py
@@ -9,88 +9,110 @@ from hedy_content import ALL_KEYWORD_LANGUAGES, KEYWORDS
 
 
 # Set the current directory to the root Hedy folder
-os.chdir(os.path.join(os.getcwd(), __file__.replace(os.path.basename(__file__), '')))
+os.chdir(os.path.join(os.getcwd(), __file__.replace(os.path.basename(__file__), "")))
 
 unique_snippets_table = set()
 filtered_language = None
 
-def collect_snippets(path, filtered_language = None):
-  Hedy_snippets = []
-  files = [f for f in os.listdir(path) if os.path.isfile(os.path.join(path, f)) and f.endswith('.yaml')]
-  for f in files:
-      lang = f.split(".")[0]
-      if not filtered_language or (filtered_language and lang == filtered_language):
-          f = os.path.join(path, f)
-          yaml = YamlFile.for_file(f)
 
-          for name, adventure in yaml['adventures'].items():
-              if not name == 'next': # code in next sometimes uses examples from higher levels so is potentially wrong
-                for level_number in adventure['levels']:
-                    if level_number > hedy.HEDY_MAX_LEVEL:
-                        print('content above max level!')
-                    else:
-                        level = adventure['levels'][level_number]
-                        adventure_name = adventure['name']
+def collect_snippets(path, filtered_language=None):
+    Hedy_snippets = []
+    files = [f for f in os.listdir(path) if os.path.isfile(os.path.join(path, f)) and f.endswith(".yaml")]
+    for f in files:
+        lang = f.split(".")[0]
+        if not filtered_language or (filtered_language and lang == filtered_language):
+            f = os.path.join(path, f)
+            yaml = YamlFile.for_file(f)
 
-                        code_snippet_counter = 0
-                        # code snippets inside story_text
-                        for tag in utils.markdown_to_html_tags(level['story_text']):
-                            if tag.name != 'pre' or not tag.contents[0]:
-                                continue
-                            # Can be used to catch more languages with example codes in the story_text
-                            # feedback = f"Example code in story text {lang}, {adventure_name}, {level_number}, not recommended!"
-                            # print(feedback)
-                            code_snippet_counter += 1
+            for name, adventure in yaml["adventures"].items():
+                if (
+                    not name == "next"
+                ):  # code in next sometimes uses examples from higher levels so is potentially wrong
+                    for level_number in adventure["levels"]:
+                        if level_number > hedy.HEDY_MAX_LEVEL:
+                            print("content above max level!")
+                        else:
+                            level = adventure["levels"][level_number]
+                            adventure_name = adventure["name"]
+
+                            code_snippet_counter = 0
+                            # code snippets inside story_text
+                            for tag in utils.markdown_to_html_tags(level["story_text"]):
+                                if tag.name != "pre" or not tag.contents[0]:
+                                    continue
+                                # Can be used to catch more languages with example codes in the story_text
+                                # feedback = f"Example code in story text {lang}, {adventure_name}, {level_number}, not recommended!"
+                                # print(feedback)
+                                code_snippet_counter += 1
+                                try:
+                                    code = tag.contents[0].contents[0]
+                                    if hash(code) in unique_snippets_table:
+
+                                        continue
+                                    else:
+                                        unique_snippets_table.add(hash(code))
+                                except:
+                                    print("Code container is empty...")
+                                    continue
+                                Hedy_snippets.append(
+                                    Snippet(
+                                        f,
+                                        level_number,
+                                        adventure_name + " snippet #" + str(code_snippet_counter),
+                                        code,
+                                        adventure_name,
+                                    )
+                                )
+                            # code snippets inside start_code
                             try:
-                                code = tag.contents[0].contents[0]
-                                if hash(code) in unique_snippets_table:
+                                start_code = level["start_code"]
+                                if hash(start_code) in unique_snippets_table:
 
                                     continue
                                 else:
-                                    unique_snippets_table.add(hash(code))
-                            except:
-                                print("Code container is empty...")
-                                continue
-                            Hedy_snippets.append(Snippet(f, level_number, adventure_name + ' snippet #' + str(code_snippet_counter), code, adventure_name))
-                        # code snippets inside start_code
-                        try:
-                            start_code = level['start_code']
-                            if hash(start_code) in unique_snippets_table:
-
-                                continue
-                            else:
-                                unique_snippets_table.add(hash(start_code))
-                            Hedy_snippets.append(Snippet(f, level_number, 'start_code', start_code, adventure_name))
-                        except KeyError:
-                            print(f'Problem reading startcode for {lang} level {level}')
-                            pass
-                        # Code snippets inside example code
-                        try:
-                            example_code = utils.markdown_to_html_tags(level['example_code'])
-                        except Exception as E:
-                            print(E)
-                        for tag in example_code:
-                            if tag.name != 'pre' or not tag.contents[0]:
-                                continue
-                            code_snippet_counter += 1
+                                    unique_snippets_table.add(hash(start_code))
+                                Hedy_snippets.append(Snippet(f, level_number, "start_code", start_code, adventure_name))
+                            except KeyError:
+                                print(f"Problem reading startcode for {lang} level {level}")
+                                pass
+                            # Code snippets inside example code
                             try:
-                                code = tag.contents[0].contents[0]
-                                # test only unique snippets
-                                if hash(code) in unique_snippets_table:
+                                example_code = utils.markdown_to_html_tags(level["example_code"])
+                            except Exception as E:
+                                print(E)
+                            for tag in example_code:
+                                if tag.name != "pre" or not tag.contents[0]:
                                     continue
-                                else:
-                                    unique_snippets_table.add(hash(code))
-                            except:
-                                print("Code container is empty...")
-                                continue
-                            Hedy_snippets.append(Snippet(f, level_number, adventure_name + ' snippet #' + str(code_snippet_counter), code, adventure_name))
+                                code_snippet_counter += 1
+                                try:
+                                    code = tag.contents[0].contents[0]
+                                    # test only unique snippets
+                                    if hash(code) in unique_snippets_table:
+                                        continue
+                                    else:
+                                        unique_snippets_table.add(hash(code))
+                                except:
+                                    print("Code container is empty...")
+                                    continue
+                                Hedy_snippets.append(
+                                    Snippet(
+                                        f,
+                                        level_number,
+                                        adventure_name + " snippet #" + str(code_snippet_counter),
+                                        code,
+                                        adventure_name,
+                                    )
+                                )
 
-  return Hedy_snippets
+    return Hedy_snippets
+
 
 # use this to filter on 1 lang, zh_Hans for Chinese, nb_NO for Norwegian, pt_PT for Portuguese
 # filtered_language = 'nl'
 
-Hedy_snippets = [(s.name, s) for s in collect_snippets(path='../../content/adventures', filtered_language=filtered_language)]
+Hedy_snippets = [
+    (s.name, s) for s in collect_snippets(path="../../content/adventures", filtered_language=filtered_language)
+]
 
 # level = 1
 # if level:
@@ -98,11 +120,11 @@ Hedy_snippets = [(s.name, s) for s in collect_snippets(path='../../content/adven
 
 Hedy_snippets = HedyTester.translate_keywords_in_snippets(Hedy_snippets)
 
-class TestsAdventurePrograms(unittest.TestCase):
 
-  @parameterized.expand(Hedy_snippets)
-  def test_adventures(self, name, snippet):
-    if snippet is not None:
-      print(snippet.code)
-      result = HedyTester.validate_Hedy_code(snippet)
-      self.assertTrue(result)
+class TestsAdventurePrograms(unittest.TestCase):
+    @parameterized.expand(Hedy_snippets)
+    def test_adventures(self, name, snippet):
+        if snippet is not None:
+            print(snippet.code)
+            result = HedyTester.validate_Hedy_code(snippet)
+            self.assertTrue(result)

--- a/tests/test_snippets/test_level_commands.py
+++ b/tests/test_snippets/test_level_commands.py
@@ -8,13 +8,14 @@ from parameterized import parameterized
 from hedy_content import ALL_KEYWORD_LANGUAGES
 
 # Set the current directory to the root Hedy folder
-os.chdir(os.path.join(os.getcwd(), __file__.replace(os.path.basename(__file__), '')))
+os.chdir(os.path.join(os.getcwd(), __file__.replace(os.path.basename(__file__), "")))
 
 unique_snippets_table = set()
 
+
 def collect_snippets(path):
     Hedy_snippets = []
-    files = [f for f in os.listdir(path) if os.path.isfile(os.path.join(path, f)) and f.endswith('.yaml')]
+    files = [f for f in os.listdir(path) if os.path.isfile(os.path.join(path, f)) and f.endswith(".yaml")]
     for file in files:
         lang = file.split(".")[0]
         file = os.path.join(path, file)
@@ -23,28 +24,34 @@ def collect_snippets(path):
         for level in yaml:
             level_number = int(level)
             if level_number > hedy.HEDY_MAX_LEVEL:
-                print('content above max level!')
+                print("content above max level!")
             else:
                 try:
                     # commands.k.demo_code
                     for k, command in enumerate(yaml[level]):
                         # test only unique snippets
-                        if hash(command['demo_code']) in unique_snippets_table:
+                        if hash(command["demo_code"]) in unique_snippets_table:
                             continue
                         else:
-                            unique_snippets_table.add(hash(command['demo_code']))
-                        command_text_short = command['name'] if 'name' in command.keys() else command['explanation'][0:10]
+                            unique_snippets_table.add(hash(command["demo_code"]))
+                        command_text_short = (
+                            command["name"] if "name" in command.keys() else command["explanation"][0:10]
+                        )
                         Hedy_snippets.append(
-                            Snippet(filename=file, level=level, field_name='command ' + command_text_short + ' demo_code',
-                                    code=command['demo_code']))
+                            Snippet(
+                                filename=file,
+                                level=level,
+                                field_name="command " + command_text_short + " demo_code",
+                                code=command["demo_code"],
+                            )
+                        )
                 except:
-                    print(f'Problem reading commands yaml for {lang} level {level}')
-
+                    print(f"Problem reading commands yaml for {lang} level {level}")
 
     return Hedy_snippets
 
 
-Hedy_snippets = [(s.name, s) for s in collect_snippets(path='../../content/commands')]
+Hedy_snippets = [(s.name, s) for s in collect_snippets(path="../../content/commands")]
 Hedy_snippets = HedyTester.translate_keywords_in_snippets(Hedy_snippets)
 
 # lang = 'ar' #useful if you want to test just 1 language
@@ -53,15 +60,9 @@ Hedy_snippets = HedyTester.translate_keywords_in_snippets(Hedy_snippets)
 
 
 class TestsCommandPrograms(unittest.TestCase):
-
     @parameterized.expand(Hedy_snippets)
     def test_defaults(self, name, snippet):
         if snippet is not None:
             print(snippet.code)
             result = HedyTester.validate_Hedy_code(snippet)
             self.assertTrue(result)
-
-
-
-
-

--- a/tests/test_snippets/test_parsons.py
+++ b/tests/test_snippets/test_parsons.py
@@ -7,27 +7,28 @@ from parameterized import parameterized
 from hedy_content import ALL_KEYWORD_LANGUAGES
 
 # Set the current directory to the root Hedy folder
-os.chdir(os.path.join(os.getcwd(), __file__.replace(os.path.basename(__file__), '')))
+os.chdir(os.path.join(os.getcwd(), __file__.replace(os.path.basename(__file__), "")))
 
 unique_snippets_table = set()
 
+
 def collect_snippets(path):
     Hedy_snippets = []
-    files = [f for f in os.listdir(path) if os.path.isfile(os.path.join(path, f)) and f.endswith('.yaml')]
+    files = [f for f in os.listdir(path) if os.path.isfile(os.path.join(path, f)) and f.endswith(".yaml")]
     for file in files:
         lang = file.split(".")[0]
         file = os.path.join(path, file)
         yaml = YamlFile.for_file(file)
-        levels = yaml.get('levels')
+        levels = yaml.get("levels")
 
         for level, content in levels.items():
             level_number = int(level)
             if level_number > hedy.HEDY_MAX_LEVEL:
-                print('content above max level!')
+                print("content above max level!")
             else:
                 try:
                     for exercise_id, exercise in levels[level].items():
-                        lines = exercise.get('code_lines')
+                        lines = exercise.get("code_lines")
                         code = ""
                         # The lines have a letter: A: ..., B:...., C:....
                         for letter in "ABCDEFGHIJKLMNOPQRSTUVWXYZ":
@@ -41,19 +42,20 @@ def collect_snippets(path):
                             continue
                         else:
                             unique_snippets_table.add(hash(code))
-                        Hedy_snippets.append(Snippet(filename=file, level=level, field_name=f"{exercise_id}", code=code))
+                        Hedy_snippets.append(
+                            Snippet(filename=file, level=level, field_name=f"{exercise_id}", code=code)
+                        )
                 except:
-                    print(f'Problem reading commands yaml for {lang} level {level}')
-
+                    print(f"Problem reading commands yaml for {lang} level {level}")
 
     return Hedy_snippets
 
-Hedy_snippets = [(s.name, s) for s in collect_snippets(path='../../content/parsons')]
+
+Hedy_snippets = [(s.name, s) for s in collect_snippets(path="../../content/parsons")]
 Hedy_snippets = HedyTester.translate_keywords_in_snippets(Hedy_snippets)
 
 
 class TestsParsonsPrograms(unittest.TestCase):
-
     @parameterized.expand(Hedy_snippets)
     def test_parsons(self, name, snippet):
         if snippet is not None:

--- a/tests/test_translation_error.py
+++ b/tests/test_translation_error.py
@@ -22,13 +22,12 @@ def create_exceptions():
 
 
 def create_exception(ex_class):
-    ex_args = [f'{n}-value' for n in ex_class.__init__.__code__.co_varnames if n not in ['self', 'arguments']]
+    ex_args = [f"{n}-value" for n in ex_class.__init__.__code__.co_varnames if n not in ["self", "arguments"]]
     return ex_class(*ex_args)
 
 
 class TestsTranslationError(HedyTester):
-
     @parameterized.expand(exception_language_input(), name_func=custom_name_func)
     def test_translate_hedy_exception(self, exception, language):
-        with app.test_request_context(headers={'Accept-Language': language}):
+        with app.test_request_context(headers={"Accept-Language": language}):
             translate_error(exception.error_code, exception.arguments)

--- a/tests/test_translation_level/test_translation_level_01.py
+++ b/tests/test_translation_level/test_translation_level_01.py
@@ -1,25 +1,27 @@
 from parameterized import parameterized
+
 # from test_level_01 import HedyTester
 from tests.Tester import HedyTester
 import hedy_translation
 import hedy
 
-    # tests should be ordered as follows:
-    # * Translation from English to Dutch
-    # * Translation from Dutch to English
-    # * Translation to several languages
-    # * Error handling
+# tests should be ordered as follows:
+# * Translation from English to Dutch
+# * Translation from Dutch to English
+# * Translation to several languages
+# * Error handling
+
 
 class TestsTranslationLevel1(HedyTester):
     level = 1
-    keywords_from = hedy_translation.keywords_to_dict('en')
-    keywords_to = hedy_translation.keywords_to_dict('nl')
+    keywords_from = hedy_translation.keywords_to_dict("en")
+    keywords_to = hedy_translation.keywords_to_dict("nl")
 
     def test_print_english_dutch(self):
-        code = 'print Hallo welkom bij Hedy!'
+        code = "print Hallo welkom bij Hedy!"
 
         result = hedy_translation.translate_keywords(code, from_lang="en", to_lang="nl", level=self.level)
-        expected = 'print Hallo welkom bij Hedy!'
+        expected = "print Hallo welkom bij Hedy!"
 
         self.assertEqual(expected, result)
 
@@ -40,10 +42,10 @@ class TestsTranslationLevel1(HedyTester):
         self.assertEqual(expected, result)
 
     def test_ask_echo_english_dutch(self):
-        code = 'print Hallo welkom bij Hedy\'\'\nvraag hoe heet je\necho'
+        code = "print Hallo welkom bij Hedy''\nvraag hoe heet je\necho"
 
         result = hedy_translation.translate_keywords(code, from_lang="nl", to_lang="en", level=self.level)
-        expected = 'print Hallo welkom bij Hedy\'\'\nask hoe heet je\necho'
+        expected = "print Hallo welkom bij Hedy''\nask hoe heet je\necho"
 
         self.assertEqual(expected, result)
 
@@ -54,7 +56,6 @@ class TestsTranslationLevel1(HedyTester):
         expected = "print print ask echo"
 
         self.assertEqual(expected, result)
-
 
     def test_forward_english_dutch(self):
         code = "forward 50"
@@ -72,16 +73,13 @@ class TestsTranslationLevel1(HedyTester):
 
         self.assertEqual(expected, result)
 
-
-
     def test_print_dutch_english(self):
-        code = 'print Hallo welkom bij Hedy!'
+        code = "print Hallo welkom bij Hedy!"
 
         result = hedy_translation.translate_keywords(code, from_lang="nl", to_lang="en", level=self.level)
-        expected = 'print Hallo welkom bij Hedy!'
+        expected = "print Hallo welkom bij Hedy!"
 
         self.assertEqual(expected, result)
-
 
     def test_ask_dutch_english(self):
         code = "vraag Hallo welkom bij Hedy!\nvraag veel plezier"
@@ -100,10 +98,10 @@ class TestsTranslationLevel1(HedyTester):
         self.assertEqual(expected, result)
 
     def test_ask_echo_dutch_english(self):
-        code = 'vraag Hallo welkom bij Hedy!\necho hoi'
+        code = "vraag Hallo welkom bij Hedy!\necho hoi"
 
         result = hedy_translation.translate_keywords(code, from_lang="nl", to_lang="en", level=self.level)
-        expected = 'ask Hallo welkom bij Hedy!\necho hoi'
+        expected = "ask Hallo welkom bij Hedy!\necho hoi"
 
         self.assertEqual(expected, result)
 
@@ -132,14 +130,12 @@ class TestsTranslationLevel1(HedyTester):
         self.assertEqual(expected, result)
 
     def test_translate_back(self):
-        code = 'print Hallo welkom bij Hedy\nask hoe heet je\necho'
+        code = "print Hallo welkom bij Hedy\nask hoe heet je\necho"
 
         result = hedy_translation.translate_keywords(code, from_lang="en", to_lang="nl", level=self.level)
         result = hedy_translation.translate_keywords(result, from_lang="nl", to_lang="en", level=self.level)
 
         self.assertEqual(code, result)
-
-
 
     def test_invalid(self):
         code = "hallo"
@@ -166,14 +162,14 @@ class TestsTranslationLevel1(HedyTester):
 
         self.assertEqual(expected, result)
 
-    @parameterized.expand([('en', 'forward'), ('es', 'adelante')])
+    @parameterized.expand([("en", "forward"), ("es", "adelante")])
     def test_forward_type_error_translates_command(self, lang, forward):
-        code = f'{forward} text'
+        code = f"{forward} text"
 
         self.multi_level_tester(
             lang=lang,
             code=code,
             max_level=self.max_turtle_level,
             exception=hedy.exceptions.InvalidArgumentTypeException,
-            extra_check_function=self.exception_command(forward)
+            extra_check_function=self.exception_command(forward),
         )

--- a/tests/test_translation_level/test_translation_level_02.py
+++ b/tests/test_translation_level/test_translation_level_02.py
@@ -18,8 +18,7 @@ class TestsTranslationLevel2(HedyTester):
     def test_print(self):
         code = "print Hallo welkom bij Hedy!"
 
-        result = hedy_translation.translate_keywords(
-            code, "nl", "en", self.level)
+        result = hedy_translation.translate_keywords(code, "nl", "en", self.level)
         expected = "print Hallo welkom bij Hedy!"
 
         self.assertEqual(expected, result)
@@ -27,8 +26,7 @@ class TestsTranslationLevel2(HedyTester):
     def test_print_kewords(self):
         code = "print print ask echo"
 
-        result = hedy_translation.translate_keywords(
-            code, "en", "nl", self.level)
+        result = hedy_translation.translate_keywords(code, "en", "nl", self.level)
         expected = "print print ask echo"
 
         self.assertEqual(expected, result)
@@ -36,8 +34,7 @@ class TestsTranslationLevel2(HedyTester):
     def test_ask_assign_english_dutch(self):
         code = "mens is ask Hallo welkom bij Hedy!"
 
-        result = hedy_translation.translate_keywords(
-            code, "en", "nl", self.level)
+        result = hedy_translation.translate_keywords(code, "en", "nl", self.level)
         expected = "mens is vraag Hallo welkom bij Hedy!"
 
         self.assertEqual(expected, result)
@@ -45,8 +42,7 @@ class TestsTranslationLevel2(HedyTester):
     def test_forward_assigned_value_english_dutch(self):
         code = "value is 50\nforward value"
 
-        result = hedy_translation.translate_keywords(
-            code, "en", "nl", self.level)
+        result = hedy_translation.translate_keywords(code, "en", "nl", self.level)
         expected = "value is 50\nvooruit value"
 
         self.assertEqual(expected, result)
@@ -54,8 +50,7 @@ class TestsTranslationLevel2(HedyTester):
     def test_sleep(self):
         code = "sleep"
 
-        result = hedy_translation.translate_keywords(
-            code, "en", "nl", self.level)
+        result = hedy_translation.translate_keywords(code, "en", "nl", self.level)
         expected = "slaap"
 
         self.assertEqual(expected, result)
@@ -63,8 +58,7 @@ class TestsTranslationLevel2(HedyTester):
     def test_print_var_text(self):
         code = "welkom is Hallo welkom bij Hedy\nprint welkom Veel plezier"
 
-        result = hedy_translation.translate_keywords(
-            code, "en", "nl", self.level)
+        result = hedy_translation.translate_keywords(code, "en", "nl", self.level)
         expected = "welkom is Hallo welkom bij Hedy\nprint welkom Veel plezier"
 
         self.assertEqual(expected, result)
@@ -72,8 +66,7 @@ class TestsTranslationLevel2(HedyTester):
     def test_ask_kewords(self):
         code = "hedy is vraag print ask echo"
 
-        result = hedy_translation.translate_keywords(
-            code, "en", "nl", self.level)
+        result = hedy_translation.translate_keywords(code, "en", "nl", self.level)
         expected = "hedy is vraag print ask echo"
 
         self.assertEqual(expected, result)
@@ -81,8 +74,7 @@ class TestsTranslationLevel2(HedyTester):
     def test_ask_print(self):
         code = "hedy is hello\nprint hedy"
 
-        result = hedy_translation.translate_keywords(
-            code, "en", "nl", self.level)
+        result = hedy_translation.translate_keywords(code, "en", "nl", self.level)
         expected = "hedy is hello\nprint hedy"
 
         self.assertEqual(expected, result)
@@ -90,8 +82,7 @@ class TestsTranslationLevel2(HedyTester):
     def test_ask_assign_dutch_english(self):
         code = "mens is vraag Hallo welkom bij Hedy!"
 
-        result = hedy_translation.translate_keywords(
-            code, "nl", "en", self.level)
+        result = hedy_translation.translate_keywords(code, "nl", "en", self.level)
         expected = "mens is ask Hallo welkom bij Hedy!"
 
         self.assertEqual(expected, result)
@@ -99,10 +90,8 @@ class TestsTranslationLevel2(HedyTester):
     def test_translate_back(self):
         code = "print welkom bij Hedy\nnaam is ask what is your name\nprint naam"
 
-        result = hedy_translation.translate_keywords(
-            code, "en", "nl", self.level)
-        result = hedy_translation.translate_keywords(
-            code, "nl", "en", self.level)
+        result = hedy_translation.translate_keywords(code, "en", "nl", self.level)
+        result = hedy_translation.translate_keywords(code, "nl", "en", self.level)
 
         expected = "print welkom bij Hedy\nnaam is ask what is your name\nprint naam"
 
@@ -111,8 +100,7 @@ class TestsTranslationLevel2(HedyTester):
     def test_invalid(self):
         code = "hallo"
 
-        result = hedy_translation.translate_keywords(
-            code, "en", "nl", self.level)
+        result = hedy_translation.translate_keywords(code, "en", "nl", self.level)
         expected = "hallo"
 
         self.assertEqual(expected, result)
@@ -120,8 +108,7 @@ class TestsTranslationLevel2(HedyTester):
     def test_invalid_space(self):
         code = " print Hedy"
 
-        result = hedy_translation.translate_keywords(
-            code, "en", "nl", self.level)
+        result = hedy_translation.translate_keywords(code, "en", "nl", self.level)
         expected = " print Hedy"
 
         self.assertEqual(expected, result)
@@ -129,34 +116,39 @@ class TestsTranslationLevel2(HedyTester):
     def test_echo(self):
         code = "echo Hedy"
 
-        result = hedy_translation.translate_keywords(
-            code, "en", "nl", self.level)
+        result = hedy_translation.translate_keywords(code, "en", "nl", self.level)
         expected = "echo Hedy"
 
         self.assertEqual(expected, result)
 
-    @parameterized.expand(HedyTester.as_list_of_tuples(all_keywords["ask"], all_keywords["is"], all_keywords["print"], list(ALL_KEYWORD_LANGUAGES.keys())))
+    @parameterized.expand(
+        HedyTester.as_list_of_tuples(
+            all_keywords["ask"], all_keywords["is"], all_keywords["print"], list(ALL_KEYWORD_LANGUAGES.keys())
+        )
+    )
     def test_ask_print_all_lang(self, ask_keyword, is_keyword, print_keyword, lang):
-        code = textwrap.dedent(f"""\
+        code = textwrap.dedent(
+            f"""\
         {print_keyword} Hello, tell us your name please
         name {is_keyword} {ask_keyword} Whats your name?
-        {print_keyword} name is your name!""")
+        {print_keyword} name is your name!"""
+        )
 
-        result = hedy_translation.translate_keywords(
-            code, from_lang=lang, to_lang="en", level=self.level)
+        result = hedy_translation.translate_keywords(code, from_lang=lang, to_lang="en", level=self.level)
 
-        expected = textwrap.dedent(f"""\
+        expected = textwrap.dedent(
+            f"""\
         print Hello, tell us your name please
         name is ask Whats your name?
-        print name is your name!""")
+        print name is your name!"""
+        )
 
         self.assertEqual(expected, result)
 
     def no_argument_ask_english(self):
         code = "ask"
 
-        result = hedy_translation.translate_keywords(
-            code, "en", "nl", self.level)
+        result = hedy_translation.translate_keywords(code, "en", "nl", self.level)
         expected = "vraag"
 
         self.assertEqual(expected, result)
@@ -164,8 +156,7 @@ class TestsTranslationLevel2(HedyTester):
     def no_argument_ask_dutch(self):
         code = "vraag"
 
-        result = hedy_translation.translate_keywords(
-            code, "nl", "en", self.level)
+        result = hedy_translation.translate_keywords(code, "nl", "en", self.level)
         expected = "ask"
 
         self.assertEqual(expected, result)

--- a/tests/test_translation_level/test_translation_level_03.py
+++ b/tests/test_translation_level/test_translation_level_03.py
@@ -6,11 +6,12 @@ from tests.Tester import HedyTester
 import hedy_translation
 
 
-    # tests should be ordered as follows:
-    # * Translation from English to Dutch
-    # * Translation from Dutch to English
-    # * Translation to several languages
-    # * Error handling
+# tests should be ordered as follows:
+# * Translation from English to Dutch
+# * Translation from Dutch to English
+# * Translation to several languages
+# * Error handling
+
 
 class TestsTranslationLevel3(HedyTester):
     level = 3
@@ -48,174 +49,183 @@ class TestsTranslationLevel3(HedyTester):
         self.assertEqual(expected, result)
 
     def test_issue_1856(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         print Hoi Ik ben Hedy de Waarzegger
         vraag is ask Wat wil je weten?
         print vraag
         antwoorden is ja, nee, misschien
         print Mijn glazen bol zegt...
         sleep 2
-        print antwoorden at random""")
+        print antwoorden at random"""
+        )
 
         result = hedy_translation.translate_keywords(code, "en", "nl", self.level)
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         print Hoi Ik ben Hedy de Waarzegger
         vraag is vraag Wat wil je weten?
         print vraag
         antwoorden is ja, nee, misschien
         print Mijn glazen bol zegt...
         slaap 2
-        print antwoorden op willekeurig""")
+        print antwoorden op willekeurig"""
+        )
 
         self.assertEqual(expected, result)
 
     def test_issue_1856_reverse(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         print Hoi Ik ben Hedy de Waarzegger
         vraag is vraag Wat wil je weten?
         print vraag
         antwoorden is ja, nee, misschien
         print Mijn glazen bol zegt...
         slaap 2
-        print antwoorden op willekeurig""")
+        print antwoorden op willekeurig"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         print Hoi Ik ben Hedy de Waarzegger
         vraag is ask Wat wil je weten?
         print vraag
         antwoorden is ja, nee, misschien
         print Mijn glazen bol zegt...
         sleep 2
-        print antwoorden at random""")
+        print antwoorden at random"""
+        )
 
         result = hedy_translation.translate_keywords(code, "nl", "en", self.level)
-
 
         self.assertEqual(expected, result)
 
     def test_issue_1856_v3(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         print Hoi Ik ben Hedy de Waarzegger
         vraag is ask Wat wil je weten?
         print vraag
         antwoorden is ja, nee, misschien
         print Mijn glazen bol zegt...
         slaap 2
-        print antwoorden op willekeurig""")
+        print antwoorden op willekeurig"""
+        )
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         print Hoi Ik ben Hedy de Waarzegger
         vraag is ask Wat wil je weten?
         print vraag
         antwoorden is ja, nee, misschien
         print Mijn glazen bol zegt...
         sleep 2
-        print antwoorden at random""")
+        print antwoorden at random"""
+        )
 
         result = hedy_translation.translate_keywords(code, "nl", "en", self.level)
 
         self.assertEqual(expected, result)
 
     def test_add_remove_en_nl(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         dieren is koe, kiep
         add muis to dieren
         remove koe from dieren
-        print dieren at random""")
+        print dieren at random"""
+        )
 
         result = hedy_translation.translate_keywords(code, "en", "nl", self.level)
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         dieren is koe, kiep
         voeg muis toe aan dieren
         verwijder koe uit dieren
-        print dieren op willekeurig""")
+        print dieren op willekeurig"""
+        )
 
         self.assertEqual(expected, result)
 
-    @parameterized.expand([
-        ('en', 'print'),
-        ('es', 'imprimir'),
-        ('es', 'print')])
+    @parameterized.expand([("en", "print"), ("es", "imprimir"), ("es", "print")])
     def test_print_type_error_translates_command(self, lang, command):
-        code = textwrap.dedent(f"""\
+        code = textwrap.dedent(
+            f"""\
             letters is a, b, b
-            {command} letters""")
+            {command} letters"""
+        )
 
         self.multi_level_tester(
             lang=lang,
             code=code,
             max_level=11,
             exception=hedy.exceptions.InvalidArgumentTypeException,
-            extra_check_function=self.exception_command(command)
+            extra_check_function=self.exception_command(command),
         )
 
-    @parameterized.expand([
-        ('en', 'at'),
-        ('es', 'en'),
-        ('es', 'at')])
+    @parameterized.expand([("en", "at"), ("es", "en"), ("es", "at")])
     def test_list_at_index_type_error_translates_command(self, lang, at):
-        code = textwrap.dedent(f"""\
+        code = textwrap.dedent(
+            f"""\
             letters is ask 'What are the letters?'
-            print letters {at} 1""")
+            print letters {at} 1"""
+        )
 
         self.multi_level_tester(
             lang=lang,
             code=code,
             max_level=11,
             exception=hedy.exceptions.InvalidArgumentTypeException,
-            extra_check_function=self.exception_command(at)
+            extra_check_function=self.exception_command(at),
         )
 
-    @parameterized.expand([
-        ('en', 'at random'),
-        ('es', 'en aleatorio'),
-        ('es', 'at aleatorio'),
-        ('es', 'en random')])
+    @parameterized.expand([("en", "at random"), ("es", "en aleatorio"), ("es", "at aleatorio"), ("es", "en random")])
     def test_list_at_random_type_error_translates_command(self, lang, at_random):
-        code = textwrap.dedent(f"""\
+        code = textwrap.dedent(
+            f"""\
             letters is ask 'What are the letters?'
-            print letters {at_random}""")
+            print letters {at_random}"""
+        )
 
         self.multi_level_tester(
             lang=lang,
             code=code,
             max_level=11,
             exception=hedy.exceptions.InvalidArgumentTypeException,
-            extra_check_function=self.exception_command(at_random)
+            extra_check_function=self.exception_command(at_random),
         )
 
-    @parameterized.expand([
-        ('en', 'add', 'to'),
-        ('es', 'añadir', 'a'),
-        ('es', 'añadir', 'to'),
-        ('es', 'add', 'a')])
+    @parameterized.expand([("en", "add", "to"), ("es", "añadir", "a"), ("es", "añadir", "to"), ("es", "add", "a")])
     def test_add_to_list_type_error_translates_command(self, lang, add, to):
-        code = textwrap.dedent(f"""\
+        code = textwrap.dedent(
+            f"""\
             color is yellow
-            {add} blue {to} color""")
-
-        self.multi_level_tester(
-            lang=lang,
-            code=code,
-            max_level=11,
-            exception=hedy.exceptions.InvalidArgumentTypeException,
-            extra_check_function=self.exception_command(f'{add} {to}')
+            {add} blue {to} color"""
         )
 
-    @parameterized.expand([
-        ('en', 'add', 'to'),
-        ('es', 'borrar', 'de'),
-        ('es', 'borrar', 'from'),
-        ('es', 'remove', 'de')])
+        self.multi_level_tester(
+            lang=lang,
+            code=code,
+            max_level=11,
+            exception=hedy.exceptions.InvalidArgumentTypeException,
+            extra_check_function=self.exception_command(f"{add} {to}"),
+        )
+
+    @parameterized.expand(
+        [("en", "add", "to"), ("es", "borrar", "de"), ("es", "borrar", "from"), ("es", "remove", "de")]
+    )
     def test_remove_from_list_type_error_translates_command(self, lang, remove, from_):
-        code = textwrap.dedent(f"""\
+        code = textwrap.dedent(
+            f"""\
             color is yellow
-            {remove} blue {from_} color""")
+            {remove} blue {from_} color"""
+        )
 
         self.multi_level_tester(
             lang=lang,
             code=code,
             max_level=11,
             exception=hedy.exceptions.InvalidArgumentTypeException,
-            extra_check_function=self.exception_command(f'{remove} {from_}')
+            extra_check_function=self.exception_command(f"{remove} {from_}"),
         )

--- a/tests/test_translation_level/test_translation_level_04.py
+++ b/tests/test_translation_level/test_translation_level_04.py
@@ -5,11 +5,12 @@ from parameterized import parameterized
 from tests.Tester import HedyTester
 import hedy_translation
 
-    # tests should be ordered as follows:
-    # * Translation from English to Dutch
-    # * Translation from Dutch to English
-    # * Translation to several languages
-    # * Error handling
+# tests should be ordered as follows:
+# * Translation from English to Dutch
+# * Translation from Dutch to English
+# * Translation to several languages
+# * Error handling
+
 
 class TestsTranslationLevel4(HedyTester):
     level = 4
@@ -62,7 +63,6 @@ class TestsTranslationLevel4(HedyTester):
 
         self.assertEqual(expected, result)
 
-
     def test_print_nl_en(self):
         code = "print 'Hello welcome to Hedy.'"
 
@@ -87,16 +87,18 @@ class TestsTranslationLevel4(HedyTester):
 
         self.assertEqual(expected, result)
 
-    @parameterized.expand([('en', 'ask'), ('es', 'preguntar'), ('es', 'ask')])
+    @parameterized.expand([("en", "ask"), ("es", "preguntar"), ("es", "ask")])
     def test_ask_type_error_translates_command(self, lang, ask):
-        code = textwrap.dedent(f"""\
+        code = textwrap.dedent(
+            f"""\
             colors is orange, blue, green
-            favorite is {ask} 'Is your fav color' colors""")
+            favorite is {ask} 'Is your fav color' colors"""
+        )
 
         self.multi_level_tester(
             lang=lang,
             code=code,
             max_level=11,
             exception=hedy.exceptions.InvalidArgumentTypeException,
-            extra_check_function=self.exception_command(ask)
+            extra_check_function=self.exception_command(ask),
         )

--- a/tests/test_translation_level/test_translation_level_05.py
+++ b/tests/test_translation_level/test_translation_level_05.py
@@ -14,15 +14,14 @@ from parameterized import parameterized
 
 class TestsTranslationLevel5(HedyTester):
     level = 5
-    keywords_from = hedy_translation.keywords_to_dict('en')
-    keywords_to = hedy_translation.keywords_to_dict('nl')
+    keywords_from = hedy_translation.keywords_to_dict("en")
+    keywords_to = hedy_translation.keywords_to_dict("nl")
     all_keywords = hedy_translation.all_keywords_to_dict()
 
     def test_print_english_dutch(self):
         code = "print 'Hallo welkom bij Hedy!'"
 
-        result = hedy_translation.translate_keywords(
-            code, from_lang="en", to_lang="nl", level=self.level)
+        result = hedy_translation.translate_keywords(code, from_lang="en", to_lang="nl", level=self.level)
         expected = "print 'Hallo welkom bij Hedy!'"
 
         self.assertEqual(expected, result)
@@ -30,8 +29,7 @@ class TestsTranslationLevel5(HedyTester):
     def test_print2_english_dutch(self):
         code = "print Hallo 'welkom bij Hedy!'"
 
-        result = hedy_translation.translate_keywords(
-            code, from_lang="en", to_lang="nl", level=self.level)
+        result = hedy_translation.translate_keywords(code, from_lang="en", to_lang="nl", level=self.level)
         expected = "print Hallo 'welkom bij Hedy!'"
 
         self.assertEqual(expected, result)
@@ -39,8 +37,7 @@ class TestsTranslationLevel5(HedyTester):
     def test_ask_assign_english_dutch(self):
         code = "answer is ask 'What is 10 plus 10?'"
 
-        result = hedy_translation.translate_keywords(
-            code, from_lang="en", to_lang="nl", level=self.level)
+        result = hedy_translation.translate_keywords(code, from_lang="en", to_lang="nl", level=self.level)
         expected = "answer is vraag 'What is 10 plus 10?'"
 
         self.assertEqual(expected, result)
@@ -48,8 +45,7 @@ class TestsTranslationLevel5(HedyTester):
     def test_if_else_english_dutch(self):
         code = "if answer is far forward 100 else forward 5"
 
-        result = hedy_translation.translate_keywords(
-            code, from_lang="en", to_lang="nl", level=self.level)
+        result = hedy_translation.translate_keywords(code, from_lang="en", to_lang="nl", level=self.level)
         expected = "als answer is far vooruit 100 anders vooruit 5"
 
         self.assertEqual(expected, result)
@@ -57,8 +53,7 @@ class TestsTranslationLevel5(HedyTester):
     def test_in_list_english_dutch(self):
         code = "if color in pretty_colors print 'pretty!'"
 
-        result = hedy_translation.translate_keywords(
-            code, from_lang="en", to_lang="nl", level=self.level)
+        result = hedy_translation.translate_keywords(code, from_lang="en", to_lang="nl", level=self.level)
         expected = "als color in pretty_colors print 'pretty!'"
 
         self.assertEqual(expected, result)
@@ -66,8 +61,7 @@ class TestsTranslationLevel5(HedyTester):
     def test_print_dutch_english(self):
         code = "print 'Hallo welkom bij Hedy!'"
 
-        result = hedy_translation.translate_keywords(
-            code, from_lang="nl", to_lang="en", level=self.level)
+        result = hedy_translation.translate_keywords(code, from_lang="nl", to_lang="en", level=self.level)
         expected = "print 'Hallo welkom bij Hedy!'"
 
         self.assertEqual(expected, result)
@@ -75,8 +69,7 @@ class TestsTranslationLevel5(HedyTester):
     def test_print2_dutch_english(self):
         code = "print Hallo 'welkom bij Hedy!'"
 
-        result = hedy_translation.translate_keywords(
-            code, from_lang="nl", to_lang="en", level=self.level)
+        result = hedy_translation.translate_keywords(code, from_lang="nl", to_lang="en", level=self.level)
         expected = "print Hallo 'welkom bij Hedy!'"
 
         self.assertEqual(expected, result)
@@ -84,101 +77,114 @@ class TestsTranslationLevel5(HedyTester):
     def test_ask_assign_dutch_english(self):
         code = "answer is vraag 'What is 10 plus 10?'"
 
-        result = hedy_translation.translate_keywords(
-            code, from_lang="nl", to_lang="en", level=self.level)
+        result = hedy_translation.translate_keywords(code, from_lang="nl", to_lang="en", level=self.level)
         expected = "answer is ask 'What is 10 plus 10?'"
 
         self.assertEqual(expected, result)
 
     def test_2116(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
             people is mom, dad, Emma, Sophie
             dishwasher is people op willekeurig
             als dishwasher is Sophie
             print 'too bad I have to do the dishes'
             anders
-            print 'luckily no dishes because' dishwasher 'is already washing up'""")
+            print 'luckily no dishes because' dishwasher 'is already washing up'"""
+        )
 
-        result = hedy_translation.translate_keywords(
-            code, from_lang="nl", to_lang="en", level=self.level)
-        expected = textwrap.dedent("""\
+        result = hedy_translation.translate_keywords(code, from_lang="nl", to_lang="en", level=self.level)
+        expected = textwrap.dedent(
+            """\
             people is mom, dad, Emma, Sophie
             dishwasher is people at random
             if dishwasher is Sophie
             print 'too bad I have to do the dishes'
             else
-            print 'luckily no dishes because' dishwasher 'is already washing up'""")
+            print 'luckily no dishes because' dishwasher 'is already washing up'"""
+        )
 
         self.assertEqual(expected, result)
 
     def test_if_else_dutch_english(self):
-        code = textwrap.dedent(
-            "als answer is far vooruit 100 anders vooruit 5")
+        code = textwrap.dedent("als answer is far vooruit 100 anders vooruit 5")
 
-        result = hedy_translation.translate_keywords(
-            code, from_lang="nl", to_lang="en", level=self.level)
+        result = hedy_translation.translate_keywords(code, from_lang="nl", to_lang="en", level=self.level)
         expected = "if answer is far forward 100 else forward 5"
 
         self.assertEqual(expected, result)
 
     def test_ifelse_should_go_before_assign(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
             kleur is geel
             als kleur is groen antwoord is ok anders antwoord is stom
-            print antwoord""")
+            print antwoord"""
+        )
 
-        result = hedy_translation.translate_keywords(
-            code, from_lang="nl", to_lang="en", level=self.level)
-        expected = textwrap.dedent("""\
+        result = hedy_translation.translate_keywords(code, from_lang="nl", to_lang="en", level=self.level)
+        expected = textwrap.dedent(
+            """\
             kleur is geel
             if kleur is groen antwoord is ok else antwoord is stom
-            print antwoord""")
+            print antwoord"""
+        )
 
         self.assertEqual(expected, result)
 
     def test_in_list_dutch_english(self):
         code = "als hond in dieren print 'Cute!'"
 
-        result = hedy_translation.translate_keywords(
-            code, from_lang="nl", to_lang="en", level=self.level)
+        result = hedy_translation.translate_keywords(code, from_lang="nl", to_lang="en", level=self.level)
         expected = "if hond in dieren print 'Cute!'"
 
         self.assertEqual(expected, result)
 
-    @parameterized.expand(HedyTester.as_list_of_tuples(all_keywords["if"], all_keywords["print"], all_keywords["is"], all_keywords["else"], list(ALL_KEYWORD_LANGUAGES.keys())))
+    @parameterized.expand(
+        HedyTester.as_list_of_tuples(
+            all_keywords["if"],
+            all_keywords["print"],
+            all_keywords["is"],
+            all_keywords["else"],
+            list(ALL_KEYWORD_LANGUAGES.keys()),
+        )
+    )
     def test_print_if_is_else_all_lang(self, if_keyword, print_keyword, is_kwrd, else_kwrd, lang):
         code = f"{if_keyword} name {is_kwrd} Hedy {print_keyword} 'Great!' {else_kwrd} {print_keyword} 'Oh no'"
 
-        result = hedy_translation.translate_keywords(
-            code, from_lang=lang, to_lang="en", level=self.level)
+        result = hedy_translation.translate_keywords(code, from_lang=lang, to_lang="en", level=self.level)
         expected = "if name is Hedy print 'Great!' else print 'Oh no'"
 
         self.assertEqual(expected, result)
 
-    @parameterized.expand([('en', 'is'), ('es', 'es'), ('es', 'is')])
+    @parameterized.expand([("en", "is"), ("es", "es"), ("es", "is")])
     def test_equality_type_error_translates_command(self, lang, is_):
-        code = textwrap.dedent(f"""\
+        code = textwrap.dedent(
+            f"""\
             letters is a, b, c
-            if letters {is_} '10' print 'wrong!'""")
-
-        self.multi_level_tester(
-            lang=lang,
-            code=code,
-            max_level=7,
-            exception=hedy.exceptions.InvalidArgumentTypeException,
-            extra_check_function=self.exception_command(is_)
+            if letters {is_} '10' print 'wrong!'"""
         )
 
-    @parameterized.expand([('en', 'in'), ('es', 'en'), ('es', 'in')])
+        self.multi_level_tester(
+            lang=lang,
+            code=code,
+            max_level=7,
+            exception=hedy.exceptions.InvalidArgumentTypeException,
+            extra_check_function=self.exception_command(is_),
+        )
+
+    @parameterized.expand([("en", "in"), ("es", "en"), ("es", "in")])
     def test_in_list_type_error_translates_command(self, lang, in_):
-        code = textwrap.dedent(f"""\
+        code = textwrap.dedent(
+            f"""\
             letters is 'test'
-            if 10 {in_} letters print 'wrong!'""")
+            if 10 {in_} letters print 'wrong!'"""
+        )
 
         self.multi_level_tester(
             lang=lang,
             code=code,
             max_level=7,
             exception=hedy.exceptions.InvalidArgumentTypeException,
-            extra_check_function=self.exception_command(in_)
+            extra_check_function=self.exception_command(in_),
         )

--- a/tests/test_translation_level/test_translation_level_06.py
+++ b/tests/test_translation_level/test_translation_level_06.py
@@ -13,8 +13,8 @@ import textwrap
 
 class TestsTranslationLevel6(HedyTester):
     level = 6
-    keywords_from = hedy_translation.keywords_to_dict('en')
-    keywords_to = hedy_translation.keywords_to_dict('nl')
+    keywords_from = hedy_translation.keywords_to_dict("en")
+    keywords_to = hedy_translation.keywords_to_dict("nl")
 
     def test_multiplication(self):
         code = "vermenigvuldiging is 3 * 8"
@@ -46,9 +46,9 @@ class TestsTranslationLevel6(HedyTester):
         result = hedy_translation.translate_keywords(code, from_lang="nl", to_lang="en", level=self.level)
         expected = "angle = 360 / angles"
         self.assertEqual(expected, result)
-    
+
     def test_translate_back_is(self):
-        code ="breuk is 13 / 4"
+        code = "breuk is 13 / 4"
 
         result = hedy_translation.translate_keywords(code, from_lang="en", to_lang="nl", level=self.level)
         result = hedy_translation.translate_keywords(result, from_lang="nl", to_lang="en", level=self.level)
@@ -80,7 +80,7 @@ class TestsTranslationLevel6(HedyTester):
         expected = "nombre is ask '¿Cual es tu nombre?'"
 
         self.assertEqual(expected, result)
-    
+
     def test_assign_list_is_spanish_english(self):
         code = "lenguajes es Hedy, Python, C"
 
@@ -91,42 +91,52 @@ class TestsTranslationLevel6(HedyTester):
         self.assertEqual(result, expected)
 
     def test_assign_list_var_spanish_english(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         lenguajes es Hedy, Python, C
-        a = lenguajes en 0""")
+        a = lenguajes en 0"""
+        )
 
         result = hedy_translation.translate_keywords(code, from_lang="es", to_lang="en", level=self.level)
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         lenguajes is Hedy, Python, C
-        a = lenguajes at 0""")
+        a = lenguajes at 0"""
+        )
 
         self.assertEqual(result, expected)
 
-    @parameterized.expand([('en', '='), ('es', '=')])
+    @parameterized.expand([("en", "="), ("es", "=")])
     def test_equality_type_error_translates_command(self, lang, is_):
-        code = textwrap.dedent(f"""\
+        code = textwrap.dedent(
+            f"""\
             letters is a, b, c
-            if letters {is_} '10' print 'wrong!'""")
-
-        self.multi_level_tester(
-            lang=lang,
-            code=code,
-            max_level=7,
-            exception=hedy.exceptions.InvalidArgumentTypeException,
-            extra_check_function=self.exception_command(is_)
+            if letters {is_} '10' print 'wrong!'"""
         )
 
-    @parameterized.expand([('en', '+'), ('es', '+'), ('en', '-'), ('es', '-'), ('en', '*'), ('es', '*'), ('en', '/'), ('es', '/')])
+        self.multi_level_tester(
+            lang=lang,
+            code=code,
+            max_level=7,
+            exception=hedy.exceptions.InvalidArgumentTypeException,
+            extra_check_function=self.exception_command(is_),
+        )
+
+    @parameterized.expand(
+        [("en", "+"), ("es", "+"), ("en", "-"), ("es", "-"), ("en", "*"), ("es", "*"), ("en", "/"), ("es", "/")]
+    )
     def test_expression_type_error_uses_arith_operator(self, lang, operator):
-        code = textwrap.dedent(f"""\
+        code = textwrap.dedent(
+            f"""\
             a is test
-            print a {operator} 2""")
+            print a {operator} 2"""
+        )
 
         self.multi_level_tester(
             lang=lang,
             code=code,
             max_level=7,
             exception=hedy.exceptions.InvalidArgumentTypeException,
-            extra_check_function=self.exception_command(operator)
+            extra_check_function=self.exception_command(operator),
         )

--- a/tests/test_translation_level/test_translation_level_07.py
+++ b/tests/test_translation_level/test_translation_level_07.py
@@ -14,8 +14,8 @@ from tests.Tester import HedyTester
 
 class TestsTranslationLevel7(HedyTester):
     level = 7
-    keywords_from = hedy_translation.keywords_to_dict('en')
-    keywords_to = hedy_translation.keywords_to_dict('nl')
+    keywords_from = hedy_translation.keywords_to_dict("en")
+    keywords_to = hedy_translation.keywords_to_dict("nl")
 
     def test_repeat_english_dutch(self):
         code = "repeat 3 times print 'Hedy is fun!'"
@@ -57,18 +57,19 @@ class TestsTranslationLevel7(HedyTester):
 
         self.assertEqual(code, result)
 
-    @parameterized.expand([('en', 'repeat', 'times'),
-                           ('es', 'repetir', 'veces'),
-                           ('es', 'repetir', 'times'),
-                           ('es', 'repeat', 'veces')])
+    @parameterized.expand(
+        [("en", "repeat", "times"), ("es", "repetir", "veces"), ("es", "repetir", "times"), ("es", "repeat", "veces")]
+    )
     def test_repeat_type_error_translates_command(self, lang, repeat, times):
-        code = textwrap.dedent(f"""\
+        code = textwrap.dedent(
+            f"""\
             a is 1, 2, 3
-            {repeat} a {times} print 'n'""")
+            {repeat} a {times} print 'n'"""
+        )
 
         self.single_level_tester(
             lang=lang,
             code=code,
             exception=hedy.exceptions.InvalidArgumentTypeException,
-            extra_check_function=self.exception_command(f'{repeat} {times}')
+            extra_check_function=self.exception_command(f"{repeat} {times}"),
         )

--- a/tests/test_translation_level/test_translation_level_08.py
+++ b/tests/test_translation_level/test_translation_level_08.py
@@ -13,104 +13,128 @@ import textwrap
 
 class TestsTranslationLevel8(HedyTester):
     level = 8
-    keywords_from = hedy_translation.keywords_to_dict('en')
-    keywords_to = hedy_translation.keywords_to_dict('nl')
+    keywords_from = hedy_translation.keywords_to_dict("en")
+    keywords_to = hedy_translation.keywords_to_dict("nl")
 
     def test_repeat_indent_english_dutch(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         repeat 3 times
-            print 'Hedy is fun!'""")
+            print 'Hedy is fun!'"""
+        )
 
         result = hedy_translation.translate_keywords(code, from_lang="en", to_lang="nl", level=self.level)
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         herhaal 3 keer
-            print 'Hedy is fun!'""")
+            print 'Hedy is fun!'"""
+        )
 
         self.assertEqual(expected, result)
 
     def test_repeat_indent_english_french(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         repeat 3 times
-            print 'Hedy is fun!'""")
+            print 'Hedy is fun!'"""
+        )
 
         result = hedy_translation.translate_keywords(code, from_lang="en", to_lang="fr", level=self.level)
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         répète 3 fois
-            affiche 'Hedy is fun!'""")
+            affiche 'Hedy is fun!'"""
+        )
 
         self.assertEqual(expected, result)
 
     def test_repeat_multiple_indent_english_dutch(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         repeat 3 times
             print 'Hedy is fun!'
             print 'print 3 keer'
-        print 'print 1 keer'""")
+        print 'print 1 keer'"""
+        )
 
         result = hedy_translation.translate_keywords(code, from_lang="en", to_lang="nl", level=self.level)
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         herhaal 3 keer
             print 'Hedy is fun!'
             print 'print 3 keer'
-        print 'print 1 keer'""")
+        print 'print 1 keer'"""
+        )
 
         self.assertEqual(expected, result)
 
     def test_repeat_indent_dutch_english(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         herhaal 3 keer
-            print 'Hedy is fun!'""")
+            print 'Hedy is fun!'"""
+        )
 
         result = hedy_translation.translate_keywords(code, from_lang="nl", to_lang="en", level=self.level)
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         repeat 3 times
-            print 'Hedy is fun!'""")
+            print 'Hedy is fun!'"""
+        )
 
         self.assertEqual(expected, result)
 
     def test_ifelse_indent_dutch_english(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         if naam is hedy
             print 'Hallo Hedy'
             print 'hoe gaat het?'
         else
-            print 'Hallo' hedy""")
+            print 'Hallo' hedy"""
+        )
 
         result = hedy_translation.translate_keywords(code, from_lang="en", to_lang="nl", level=self.level)
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         als naam is hedy
             print 'Hallo Hedy'
             print 'hoe gaat het?'
         anders
-            print 'Hallo' hedy""")
+            print 'Hallo' hedy"""
+        )
 
         self.assertEqual(expected, result)
 
     def test_indent_translate_back(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         naam = hedy
         if naam is hedy
             print 'Hallo Hedy'
             print 'Hoe gaat het?'
         repeat 5 times
-            print '5 keer'""")
+            print '5 keer'"""
+        )
 
         result = hedy_translation.translate_keywords(code, from_lang="en", to_lang="nl", level=self.level)
         result = hedy_translation.translate_keywords(result, from_lang="nl", to_lang="en", level=self.level)
 
         self.assertEqual(code, result)
 
-    @parameterized.expand([('en', 'is'), ('es', 'es'), ('es', 'is'), ('en', '='), ('es', '=')])
+    @parameterized.expand([("en", "is"), ("es", "es"), ("es", "is"), ("en", "="), ("es", "=")])
     def test_equality_type_error_translates_command(self, lang, is_):
-        code = textwrap.dedent(f"""\
+        code = textwrap.dedent(
+            f"""\
             letters is a, b, c
             if letters {is_} '10'
-                print 'wrong!'""")
+                print 'wrong!'"""
+        )
 
         self.multi_level_tester(
             lang=lang,
             code=code,
             max_level=11,
             exception=hedy.exceptions.InvalidArgumentTypeException,
-            extra_check_function=self.exception_command(is_)
+            extra_check_function=self.exception_command(is_),
         )

--- a/tests/test_translation_level/test_translation_level_09.py
+++ b/tests/test_translation_level/test_translation_level_09.py
@@ -12,65 +12,76 @@ import textwrap
 
 class TestsTranslationLevel9(HedyTester):
     level = 9
-    keywords_from = hedy_translation.keywords_to_dict('en')
-    keywords_to = hedy_translation.keywords_to_dict('nl')
+    keywords_from = hedy_translation.keywords_to_dict("en")
+    keywords_to = hedy_translation.keywords_to_dict("nl")
 
     def test_double_repeat_indent_english_dutch(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         repeat 3 times
             repeat 5 times
-                print 'hi'""")
+                print 'hi'"""
+        )
 
         result = hedy_translation.translate_keywords(code, from_lang="en", to_lang="nl", level=self.level)
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         herhaal 3 keer
             herhaal 5 keer
-                print 'hi'""")
+                print 'hi'"""
+        )
 
         self.assertEqual(expected, result)
 
     def test_repeat_ifelse_english_dutch(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         repeat 3 times
             if naam is hedy
                 print 'hello'
             else
                 repeat 2 times
-                    print 'oh'""")
-
+                    print 'oh'"""
+        )
 
         result = hedy_translation.translate_keywords(code, from_lang="en", to_lang="nl", level=self.level)
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         herhaal 3 keer
             als naam is hedy
                 print 'hello'
             anders
                 herhaal 2 keer
-                    print 'oh'""")
+                    print 'oh'"""
+        )
 
         self.assertEqual(expected, result)
 
     def test_multiple_ifelse_dutch_english(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         als 10 is 10
             als 2 is 3
                 print 'wat raar'
             anders
-                print 'gelukkig'""")
-
+                print 'gelukkig'"""
+        )
 
         result = hedy_translation.translate_keywords(code, from_lang="nl", to_lang="en", level=self.level)
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         if 10 is 10
             if 2 is 3
                 print 'wat raar'
             else
-                print 'gelukkig'""")
+                print 'gelukkig'"""
+        )
 
         self.assertEqual(expected, result)
 
     def test_indent_translate_back(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         naam = hedy
         if naam is hedy
             repeat 4 times
@@ -78,7 +89,8 @@ class TestsTranslationLevel9(HedyTester):
                 print 'Hoe gaat het?'
         else
             repeat 5 times
-                print '5 keer'""")
+                print '5 keer'"""
+        )
 
         result = hedy_translation.translate_keywords(code, from_lang="en", to_lang="nl", level=self.level)
         result = hedy_translation.translate_keywords(result, from_lang="nl", to_lang="en", level=self.level)

--- a/tests/test_translation_level/test_translation_level_10.py
+++ b/tests/test_translation_level/test_translation_level_10.py
@@ -15,60 +15,70 @@ class TestsTranslationLevel10(HedyTester):
     level = 10
 
     def test_for_english_dutch(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         dieren is hond, kat, vis
         for dier in dieren
-            print 'hallo' dier""")
+            print 'hallo' dier"""
+        )
 
         result = hedy_translation.translate_keywords(code, from_lang="en", to_lang="nl", level=self.level)
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         dieren is hond, kat, vis
         voor dier in dieren
-            print 'hallo' dier""")
+            print 'hallo' dier"""
+        )
 
         self.assertEqual(expected, result)
 
     def test_for_dutch_english(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         dieren is hond, kat, vis
         voor dier in dieren
             voor animal in dieren
-                print 'hallo' dier""")
+                print 'hallo' dier"""
+        )
 
         result = hedy_translation.translate_keywords(code, from_lang="nl", to_lang="en", level=self.level)
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         dieren is hond, kat, vis
         for dier in dieren
             for animal in dieren
-                print 'hallo' dier""")
+                print 'hallo' dier"""
+        )
 
         self.assertEqual(expected, result)
 
     def test_repeat_translate_back(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         dieren is hond, kat, vis
         voor dier in dieren
             voor animal in dieren
-                print 'hallo' dier""")
+                print 'hallo' dier"""
+        )
 
         result = hedy_translation.translate_keywords(code, from_lang="nl", to_lang="en", level=self.level)
         result = hedy_translation.translate_keywords(result, from_lang="en", to_lang="nl", level=self.level)
 
         self.assertEqual(result, code)
 
-    @parameterized.expand([('en', 'for', 'in'),
-                           ('es', 'para', 'en'),
-                           ('es', 'para', 'in'),
-                           ('es', 'for', 'en')])
+    @parameterized.expand([("en", "for", "in"), ("es", "para", "en"), ("es", "para", "in"), ("es", "for", "en")])
     def test_for_list_type_error_translates_command(self, lang, for_, in_):
-        code = textwrap.dedent(f"""\
+        code = textwrap.dedent(
+            f"""\
             dieren is 'text'
             {for_} dier {in_} dieren
-                print dier""")
+                print dier"""
+        )
 
         self.multi_level_tester(
             lang=lang,
             code=code,
             max_level=11,
             exception=hedy.exceptions.InvalidArgumentTypeException,
-            extra_check_function=self.exception_command(f'{for_} {in_}'))
+            extra_check_function=self.exception_command(f"{for_} {in_}"),
+        )

--- a/tests/test_translation_level/test_translation_level_11.py
+++ b/tests/test_translation_level/test_translation_level_11.py
@@ -14,54 +14,79 @@ from parameterized import parameterized
 
 class TestsTranslationLevel11(HedyTester):
     level = 11
-    keywords_from = hedy_translation.keywords_to_dict('en')
-    keywords_to = hedy_translation.keywords_to_dict('nl')
+    keywords_from = hedy_translation.keywords_to_dict("en")
+    keywords_to = hedy_translation.keywords_to_dict("nl")
     all_keywords = hedy_translation.all_keywords_to_dict()
 
     def test_for_in_english_dutch(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         for counter in range 1 to 5
-            print counter""")
+            print counter"""
+        )
 
-        result = hedy_translation.translate_keywords(
-            code, from_lang="en", to_lang="nl", level=self.level)
-        expected = textwrap.dedent("""\
+        result = hedy_translation.translate_keywords(code, from_lang="en", to_lang="nl", level=self.level)
+        expected = textwrap.dedent(
+            """\
         voor counter in bereik 1 tot 5
-            print counter""")
+            print counter"""
+        )
 
         self.assertEqual(expected, result)
 
-    @parameterized.expand(HedyTester.as_list_of_tuples(all_keywords["ask"], all_keywords["for"], all_keywords["in"], all_keywords["range"], all_keywords["to"], all_keywords["print"], list(ALL_KEYWORD_LANGUAGES.keys())))
-    def test_for_in_all_lang(self, ask_keyword, for_keyword, in_keyword, range_keyword, to_keyword, print_keyword, lang):
-        code = textwrap.dedent(f"""\
+    @parameterized.expand(
+        HedyTester.as_list_of_tuples(
+            all_keywords["ask"],
+            all_keywords["for"],
+            all_keywords["in"],
+            all_keywords["range"],
+            all_keywords["to"],
+            all_keywords["print"],
+            list(ALL_KEYWORD_LANGUAGES.keys()),
+        )
+    )
+    def test_for_in_all_lang(
+        self, ask_keyword, for_keyword, in_keyword, range_keyword, to_keyword, print_keyword, lang
+    ):
+        code = textwrap.dedent(
+            f"""\
         nummer = {ask_keyword} 'hoe oud ben je'
         {for_keyword} counter {in_keyword} {range_keyword} 1 {to_keyword} 5
             {for_keyword} count {in_keyword} {range_keyword} nummer {to_keyword} 0
-                {print_keyword} 'hoi' counter""")
+                {print_keyword} 'hoi' counter"""
+        )
 
-        result = hedy_translation.translate_keywords(
-            code, from_lang=lang, to_lang="en", level=self.level)
-        expected = textwrap.dedent("""\
+        result = hedy_translation.translate_keywords(code, from_lang=lang, to_lang="en", level=self.level)
+        expected = textwrap.dedent(
+            """\
         nummer = ask 'hoe oud ben je'
         for counter in range 1 to 5
             for count in range nummer to 0
-                print 'hoi' counter""")
+                print 'hoi' counter"""
+        )
 
         self.assertEqual(expected, result)
 
-    @parameterized.expand([('en', 'in', 'range', 'to'),
-                           ('es', 'en', 'rango', 'a'),
-                           ('es', 'in', 'rango', 'a'),
-                           ('es', 'en', 'rango', 'a')])
+    @parameterized.expand(
+        [
+            ("en", "in", "range", "to"),
+            ("es", "en", "rango", "a"),
+            ("es", "in", "rango", "a"),
+            ("es", "en", "rango", "a"),
+        ]
+    )
     def test_for_loop_type_error_translates_command(self, lang, in_, range_, to):
-        code = textwrap.dedent(f"""\
+        code = textwrap.dedent(
+            f"""\
             end is 'text'
             for a {in_} {range_} 1 {to} end
-                print end""")
+                print end"""
+        )
 
         self.multi_level_tester(
             lang=lang,
             code=code,
             max_level=11,
             exception=hedy.exceptions.InvalidArgumentTypeException,
-            extra_check_function=self.exception_command(f'{in_} {range_} {to}'))
+            extra_check_function=self.exception_command(f"{in_} {range_} {to}"),
+        )

--- a/tests/test_translation_level/test_translation_level_12.py
+++ b/tests/test_translation_level/test_translation_level_12.py
@@ -31,15 +31,19 @@ class TestsTranslationLevel12(HedyTester):
         self.assertEqual(expected, result)
 
     def test_text_in_quotes_ifs_english_dutch(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         naam = 'hedy'
         if naam is 'hedy'
-            print 'hallo ' naam""")
+            print 'hallo ' naam"""
+        )
 
         result = hedy_translation.translate_keywords(code, from_lang="en", to_lang="nl", level=self.level)
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         naam = 'hedy'
         als naam is 'hedy'
-            print 'hallo ' naam""")
+            print 'hallo ' naam"""
+        )
 
         self.assertEqual(expected, result)

--- a/tests/test_translation_level/test_translation_level_13.py
+++ b/tests/test_translation_level/test_translation_level_13.py
@@ -15,61 +15,77 @@ class TestsTranslationLevel13(HedyTester):
     level = 13
 
     def test_and_condition_english_dutch(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         naam = 'hedy'
         leeftijd = 2
         if naam is 'hedy' and leeftijd is 2
-            print 'hallo'""")
+            print 'hallo'"""
+        )
 
         result = hedy_translation.translate_keywords(code, from_lang="en", to_lang="nl", level=self.level)
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         naam = 'hedy'
         leeftijd = 2
         als naam is 'hedy' en leeftijd is 2
-            print 'hallo'""")
+            print 'hallo'"""
+        )
 
         self.assertEqual(expected, result)
 
     def test_or_condition_english_dutch(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         naam = 'hedy'
         leeftijd = 2
         if naam is 'niet hedy' or leeftijd is 2
-            print 'hallo'""")
+            print 'hallo'"""
+        )
 
         result = hedy_translation.translate_keywords(code, from_lang="en", to_lang="nl", level=self.level)
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         naam = 'hedy'
         leeftijd = 2
         als naam is 'niet hedy' of leeftijd is 2
-            print 'hallo'""")
+            print 'hallo'"""
+        )
 
         self.assertEqual(expected, result)
 
     def test_and_condition_acces_list_english_dutch(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         naam is 'hedy', 'niet hedy'
         if 'hedy' in naam and 'niet hedy' in naam
-            print 'hallo'""")
+            print 'hallo'"""
+        )
 
         result = hedy_translation.translate_keywords(code, from_lang="en", to_lang="nl", level=self.level)
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         naam is 'hedy', 'niet hedy'
         als 'hedy' in naam en 'niet hedy' in naam
-            print 'hallo'""")
+            print 'hallo'"""
+        )
 
         self.assertEqual(expected, result)
 
     def test_or_condition_acces_list_english_dutch(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         naam is 'hedy', 'niet hedy'
         if 'hedy' in naam or 'niet hedy' in naam
-            print 'hallo'""")
+            print 'hallo'"""
+        )
 
         result = hedy_translation.translate_keywords(code, from_lang="en", to_lang="nl", level=self.level)
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         naam is 'hedy', 'niet hedy'
         als 'hedy' in naam of 'niet hedy' in naam
-            print 'hallo'""")
+            print 'hallo'"""
+        )
 
         self.assertEqual(expected, result)

--- a/tests/test_translation_level/test_translation_level_14.py
+++ b/tests/test_translation_level/test_translation_level_14.py
@@ -18,107 +18,132 @@ class TestsTranslationLevel14(HedyTester):
     all_keywords_dict = hedy_translation.all_keywords_to_dict()
 
     def test_bigger(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         hedy = 5
         if hedy > 6
-            print 'hedy'""")
+            print 'hedy'"""
+        )
 
-        result = hedy_translation.translate_keywords(
-            code, from_lang="en", to_lang="nl", level=self.level)
-        expected = textwrap.dedent("""\
+        result = hedy_translation.translate_keywords(code, from_lang="en", to_lang="nl", level=self.level)
+        expected = textwrap.dedent(
+            """\
         hedy = 5
         als hedy > 6
-            print 'hedy'""")
+            print 'hedy'"""
+        )
 
         self.assertEqual(expected, result)
 
     def test_smaller(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         hedy = 5
         if hedy < 6
-            print 'hedy'""")
+            print 'hedy'"""
+        )
 
-        result = hedy_translation.translate_keywords(
-            code, from_lang="en", to_lang="nl", level=self.level)
-        expected = textwrap.dedent("""\
+        result = hedy_translation.translate_keywords(code, from_lang="en", to_lang="nl", level=self.level)
+        expected = textwrap.dedent(
+            """\
         hedy = 5
         als hedy < 6
-            print 'hedy'""")
+            print 'hedy'"""
+        )
 
         self.assertEqual(expected, result)
 
     def test_bigger_equal(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         hedy = 5
         if hedy >= 6
-            print 'hedy'""")
+            print 'hedy'"""
+        )
 
-        result = hedy_translation.translate_keywords(
-            code, from_lang="en", to_lang="nl", level=self.level)
-        expected = textwrap.dedent("""\
+        result = hedy_translation.translate_keywords(code, from_lang="en", to_lang="nl", level=self.level)
+        expected = textwrap.dedent(
+            """\
         hedy = 5
         als hedy >= 6
-            print 'hedy'""")
+            print 'hedy'"""
+        )
 
         self.assertEqual(expected, result)
 
     def test_smaller_equal(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         hedy = 5
         if hedy <= 6
-            print 'hedy'""")
+            print 'hedy'"""
+        )
 
-        result = hedy_translation.translate_keywords(
-            code, from_lang="en", to_lang="nl", level=self.level)
-        expected = textwrap.dedent("""\
+        result = hedy_translation.translate_keywords(code, from_lang="en", to_lang="nl", level=self.level)
+        expected = textwrap.dedent(
+            """\
         hedy = 5
         als hedy <= 6
-            print 'hedy'""")
+            print 'hedy'"""
+        )
 
         self.assertEqual(expected, result)
 
     def test_not_equal(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         hedy = 5
         if hedy != 6
-            print 'hedy'""")
+            print 'hedy'"""
+        )
 
-        result = hedy_translation.translate_keywords(
-            code, from_lang="en", to_lang="nl", level=self.level)
-        expected = textwrap.dedent("""\
+        result = hedy_translation.translate_keywords(code, from_lang="en", to_lang="nl", level=self.level)
+        expected = textwrap.dedent(
+            """\
         hedy = 5
         als hedy != 6
-            print 'hedy'""")
+            print 'hedy'"""
+        )
 
         self.assertEqual(expected, result)
 
     def test_double_equals(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         hedy = 5
         if hedy == 6
-            print 'hedy'""")
+            print 'hedy'"""
+        )
 
-        result = hedy_translation.translate_keywords(
-            code, from_lang="en", to_lang="nl", level=self.level)
-        expected = textwrap.dedent("""\
+        result = hedy_translation.translate_keywords(code, from_lang="en", to_lang="nl", level=self.level)
+        expected = textwrap.dedent(
+            """\
         hedy = 5
         als hedy == 6
-            print 'hedy'""")
+            print 'hedy'"""
+        )
 
         self.assertEqual(expected, result)
 
-    @parameterized.expand(HedyTester.as_list_of_tuples(all_keywords_dict["if"], all_keywords_dict["print"], list(ALL_KEYWORD_LANGUAGES.keys())))
+    @parameterized.expand(
+        HedyTester.as_list_of_tuples(
+            all_keywords_dict["if"], all_keywords_dict["print"], list(ALL_KEYWORD_LANGUAGES.keys())
+        )
+    )
     def test_double_equals_all_lang(self, if_keyword, print_keyword, lang):
-        code = textwrap.dedent(f"""\
+        code = textwrap.dedent(
+            f"""\
         hedy = 5
         {if_keyword} hedy == 6
-            {print_keyword} 'hedy'""")
+            {print_keyword} 'hedy'"""
+        )
 
-        result = hedy_translation.translate_keywords(
-            code, from_lang=lang, to_lang="nl", level=self.level)
-        expected = textwrap.dedent("""\
+        result = hedy_translation.translate_keywords(code, from_lang=lang, to_lang="nl", level=self.level)
+        expected = textwrap.dedent(
+            """\
         hedy = 5
         als hedy == 6
-            print 'hedy'""")
+            print 'hedy'"""
+        )
 
         self.assertEqual(expected, result)

--- a/tests/test_translation_level/test_translation_level_15.py
+++ b/tests/test_translation_level/test_translation_level_15.py
@@ -15,51 +15,63 @@ class TestsTranslationLevel15(HedyTester):
     level = 15
 
     def test_while_loop_english_dutch(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         answer = 0
         while answer != 25
             answer = ask 'What is 5 * 5'
-        print 'Good job!'""")
+        print 'Good job!'"""
+        )
 
         result = hedy_translation.translate_keywords(code, from_lang="en", to_lang="nl", level=self.level)
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         answer = 0
         zolang answer != 25
             answer = vraag 'What is 5 * 5'
-        print 'Good job!'""")
+        print 'Good job!'"""
+        )
 
         self.assertEqual(expected, result)
 
     def test_while_loop_dutch_english(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         answer = 0
         zolang answer != 25
             answer = vraag 'What is 5 * 5'
-        print 'Good job!'""")
+        print 'Good job!'"""
+        )
 
         result = hedy_translation.translate_keywords(code, from_lang="nl", to_lang="en", level=self.level)
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         answer = 0
         while answer != 25
             answer = ask 'What is 5 * 5'
-        print 'Good job!'""")
+        print 'Good job!'"""
+        )
 
         self.assertEqual(expected, result)
 
     def test_multiple_while_loop_english_dutch(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         answer = 0
         while answer != 25
             while answer > 30
                 answer = ask 'What is 5 * 5'
-        print 'Good job!'""")
+        print 'Good job!'"""
+        )
 
         result = hedy_translation.translate_keywords(code, from_lang="en", to_lang="nl", level=self.level)
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         answer = 0
         zolang answer != 25
             zolang answer > 30
                 answer = vraag 'What is 5 * 5'
-        print 'Good job!'""")
+        print 'Good job!'"""
+        )
 
         self.assertEqual(expected, result)

--- a/tests/test_translation_level/test_translation_level_16.py
+++ b/tests/test_translation_level/test_translation_level_16.py
@@ -23,25 +23,33 @@ class TestsTranslationLevel16(HedyTester):
         self.assertEqual(expected, result)
 
     def test_access_list_english_dutch(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         fruit = ['appel', 'banaan', 'kers']
-        print fruit[2]""")
+        print fruit[2]"""
+        )
 
         result = hedy_translation.translate_keywords(code, from_lang="en", to_lang="nl", level=self.level)
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         fruit = ['appel', 'banaan', 'kers']
-        print fruit[2]""")
+        print fruit[2]"""
+        )
 
         self.assertEqual(expected, result)
 
     def test_access_list_random_dutch_english(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         fruit = ['appel', 'banaan', 'kers']
-        print fruit[willekeurig]""")
+        print fruit[willekeurig]"""
+        )
 
         result = hedy_translation.translate_keywords(code, from_lang="nl", to_lang="en", level=self.level)
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         fruit = ['appel', 'banaan', 'kers']
-        print fruit[random]""")
+        print fruit[random]"""
+        )
 
         self.assertEqual(expected, result)

--- a/tests/test_translation_level/test_translation_level_17.py
+++ b/tests/test_translation_level/test_translation_level_17.py
@@ -15,95 +15,119 @@ class TestsTranslationLevel17(HedyTester):
     level = 17
 
     def test_indent_for_loop_english_dutch(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         for i in range 1 to 12:
-            print 'Hedy' i""")
+            print 'Hedy' i"""
+        )
 
         result = hedy_translation.translate_keywords(code, from_lang="en", to_lang="nl", level=self.level)
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         voor i in bereik 1 tot 12:
-            print 'Hedy' i""")
+            print 'Hedy' i"""
+        )
 
         self.assertEqual(expected, result)
 
     def test_indent_while_loop_english_dutch(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         i = 3
         while i < 2:
-            print 'Hedy' i""")
+            print 'Hedy' i"""
+        )
 
         result = hedy_translation.translate_keywords(code, from_lang="en", to_lang="nl", level=self.level)
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         i = 3
         zolang i < 2:
-            print 'Hedy' i""")
+            print 'Hedy' i"""
+        )
 
         self.assertEqual(expected, result)
 
     def test_indent_for_list_english_dutch(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         hedy = ['hedy', 'andre', 'luca']
         for naam in hedy:
-            print naam""")
+            print naam"""
+        )
 
         result = hedy_translation.translate_keywords(code, from_lang="en", to_lang="nl", level=self.level)
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         hedy = ['hedy', 'andre', 'luca']
         voor naam in hedy:
-            print naam""")
+            print naam"""
+        )
 
         self.assertEqual(expected, result)
 
     def test_indent_ifs_english_dutch(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         hedy = 4
         if hedy is 4:
-            print 'hedy'""")
+            print 'hedy'"""
+        )
 
         result = hedy_translation.translate_keywords(code, from_lang="en", to_lang="nl", level=self.level)
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         hedy = 4
         als hedy is 4:
-            print 'hedy'""")
+            print 'hedy'"""
+        )
 
         self.assertEqual(expected, result)
 
     def test_indent_elses_english_dutch(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         hedy = 4
         if hedy is 4:
             print 'hedy'
         else:
-            print 'nee'""")
+            print 'nee'"""
+        )
 
         result = hedy_translation.translate_keywords(code, from_lang="en", to_lang="nl", level=self.level)
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         hedy = 4
         als hedy is 4:
             print 'hedy'
         anders:
-            print 'nee'""")
+            print 'nee'"""
+        )
 
         self.assertEqual(expected, result)
 
     def test_elif_english_dutch(self):
-        code = textwrap.dedent("""\n
+        code = textwrap.dedent(
+            """\n
         hedy = 4
         if hedy is 4:
             print 'hedy'
         elif hedy is 5:
             print 5
         else:
-            print 'nee'""")
+            print 'nee'"""
+        )
 
         result = hedy_translation.translate_keywords(code, from_lang="en", to_lang="nl", level=self.level)
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         hedy = 4
         als hedy is 4:
             print 'hedy'
         alsanders hedy is 5:
             print 5
         anders:
-            print 'nee'""")
+            print 'nee'"""
+        )
 
         self.assertEqual(expected, result)

--- a/tests/test_translation_level/test_translation_level_18.py
+++ b/tests/test_translation_level/test_translation_level_18.py
@@ -10,43 +10,56 @@ import textwrap
 # * Translation to several languages
 # * Error handling
 
+
 class TestsTranslationLevel18(HedyTester):
     level = 18
 
     def test_input(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         leeftijd is input('Hoe oud ben jij?')
-        print(leeftijd)""")
+        print(leeftijd)"""
+        )
 
         result = hedy_translation.translate_keywords(code, from_lang="en", to_lang="nl", level=self.level)
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         leeftijd is invoer('Hoe oud ben jij?')
-        print(leeftijd)""")
+        print(leeftijd)"""
+        )
 
         self.assertEqual(expected, result)
 
     def test_range_with_brackets(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         for i in range(0, 10):
-            print('hallo!')""")
+            print('hallo!')"""
+        )
 
         result = hedy_translation.translate_keywords(code, from_lang="en", to_lang="nl", level=self.level)
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         voor i in bereik(0, 10):
-            print('hallo!')""")
+            print('hallo!')"""
+        )
 
         self.assertEqual(expected, result)
 
     def test_input_empty_brackets(self):
-        code = textwrap.dedent("""\
+        code = textwrap.dedent(
+            """\
         nombre es entrada()
-        imprimir(nombre)""")
+        imprimir(nombre)"""
+        )
 
         result = hedy_translation.translate_keywords(code, from_lang="es", to_lang="en", level=self.level)
 
-        expected = textwrap.dedent("""\
+        expected = textwrap.dedent(
+            """\
         nombre is input()
-        print(nombre)""")
+        print(nombre)"""
+        )
 
         self.assertEqual(expected, result)
 
@@ -58,4 +71,3 @@ class TestsTranslationLevel18(HedyTester):
         expected = textwrap.dedent("print()")
 
         self.assertEqual(expected, result)
-

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,16 +2,19 @@ import unittest
 import utils
 import bcrypt
 
+
 class TestUtils(unittest.TestCase):
-  def test_slashjoin(self):
-    self.assertEqual('http://hedycode.com/banaan/xyz', utils.slash_join('http://hedycode.com/', '/banaan', '', '/xyz'))
-    self.assertEqual('/one/two', utils.slash_join('/one/two'))
-    self.assertEqual('/one/two', utils.slash_join(None, '/one/two'))
+    def test_slashjoin(self):
+        self.assertEqual(
+            "http://hedycode.com/banaan/xyz", utils.slash_join("http://hedycode.com/", "/banaan", "", "/xyz")
+        )
+        self.assertEqual("/one/two", utils.slash_join("/one/two"))
+        self.assertEqual("/one/two", utils.slash_join(None, "/one/two"))
 
-  def test_extract_rounds(self):
-    salt = bcrypt.gensalt (rounds=7).decode ('utf-8')
-    self.assertEqual(7, utils.extract_bcrypt_rounds(salt))
+    def test_extract_rounds(self):
+        salt = bcrypt.gensalt(rounds=7).decode("utf-8")
+        self.assertEqual(7, utils.extract_bcrypt_rounds(salt))
 
-  def test_extract_default_rounds(self):
-    salt = bcrypt.gensalt ().decode ('utf-8')
-    self.assertEqual(12, utils.extract_bcrypt_rounds(salt))
+    def test_extract_default_rounds(self):
+        salt = bcrypt.gensalt().decode("utf-8")
+        self.assertEqual(12, utils.extract_bcrypt_rounds(salt))

--- a/tests/tests_z_yamlfile.py
+++ b/tests/tests_z_yamlfile.py
@@ -4,37 +4,38 @@ import os
 import time
 from website.yaml_file import YamlFile
 
+
 class TestYamlFile(unittest.TestCase):
-  def test_load_yaml_equivalent(self):
-    """Test that when we load a YAML file uncached and cached, it produces the same data.
+    def test_load_yaml_equivalent(self):
+        """Test that when we load a YAML file uncached and cached, it produces the same data.
 
-    Also get a gauge for the speedup we get from loading a pickled file,
-    although we're not going to fail the test on the numbers we get from that.
-    """
-    n = 50
+        Also get a gauge for the speedup we get from loading a pickled file,
+        although we're not going to fail the test on the numbers we get from that.
+        """
+        n = 50
 
-    # Pick a file with unicode in it so we're sure it gets handled properly
-    file = YamlFile(
-      os.path.join(os.path.dirname(__file__), '..', 'content/adventures/hu.yaml'), 
-      try_pickle=True)
+        # Pick a file with unicode in it so we're sure it gets handled properly
+        file = YamlFile(os.path.join(os.path.dirname(__file__), "..", "content/adventures/hu.yaml"), try_pickle=True)
 
-    # Remove pickled version of this file if it exists, it may
-    # influence the tests
-    if os.path.isfile(file.pickle_filename):
-      os.unlink(file.pickle_filename)
+        # Remove pickled version of this file if it exists, it may
+        # influence the tests
+        if os.path.isfile(file.pickle_filename):
+            os.unlink(file.pickle_filename)
 
-    start = time.time()
-    for _ in range(n):
-      original_data = file.load_uncached()
-    original_seconds = time.time() - start
+        start = time.time()
+        for _ in range(n):
+            original_data = file.load_uncached()
+        original_seconds = time.time() - start
 
-    # Generate the pickle file
-    file.access()
+        # Generate the pickle file
+        file.access()
 
-    start = time.time()
-    for _ in range(n):
-      cached_data = file.load_pickle()
-    cached_seconds = time.time() - start
+        start = time.time()
+        for _ in range(n):
+            cached_data = file.load_pickle()
+        cached_seconds = time.time() - start
 
-    self.assertEqual(original_data, cached_data)
-    print(f'YAML loading takes {original_seconds / n} seconds, unpickling takes {cached_seconds / n} ({original_seconds / cached_seconds:.1f}x faster)')
+        self.assertEqual(original_data, cached_data)
+        print(
+            f"YAML loading takes {original_seconds / n} seconds, unpickling takes {cached_seconds / n} ({original_seconds / cached_seconds:.1f}x faster)"
+        )

--- a/tests_e2e.py
+++ b/tests_e2e.py
@@ -185,13 +185,23 @@ class AuthHelper(unittest.TestCase):
     def switch_user(self, user):
         self.user = self.login_user(user["username"])
 
-    def post_data(self, path, body, expect_http_code=200, no_cookie=False, return_headers=False, put_data=False):
+    def post_data(
+        self,
+        path,
+        body,
+        expect_http_code=200,
+        no_cookie=False,
+        return_headers=False,
+        put_data=False,
+    ):
         cookies = self.user_cookies[self.username] if self.username and not no_cookie else None
 
         method = "put" if put_data else "post"
         response = request(method, path, body=body, cookies=cookies)
         self.assertEqual(
-            response["code"], expect_http_code, f"While {method}ing {body} to {path} (user: {self.username})"
+            response["code"],
+            expect_http_code,
+            f'While {method}ing {body} to {path} (user: {self.username}). Response: {response["body"]}',
         )
 
         return response["headers"] if return_headers else response["body"]
@@ -201,7 +211,11 @@ class AuthHelper(unittest.TestCase):
 
         method = "delete"
         response = request(method, path, cookies=cookies)
-        self.assertEqual(response["code"], expect_http_code, f"While {method}ing {path} (user: {self.username})")
+        self.assertEqual(
+            response["code"],
+            expect_http_code,
+            f"While {method}ing {path} (user: {self.username})",
+        )
 
         return response["headers"] if return_headers else response["body"]
 
@@ -209,7 +223,11 @@ class AuthHelper(unittest.TestCase):
         cookies = self.user_cookies[self.username] if self.username and not no_cookie else None
         response = request("get", path, body="", cookies=cookies)
 
-        self.assertEqual(response["code"], expect_http_code, f"While reading {path} (user: {self.username})")
+        self.assertEqual(
+            response["code"],
+            expect_http_code,
+            f'While reading {path} (user: {self.username}). Response: {response["body"]}',
+        )
 
         return response["headers"] if return_headers else response["body"]
 
@@ -260,7 +278,10 @@ class TestPages(AuthHelper):
         # WHEN trying all languages to reach the highscore page
         # THEN receive an OK response from the server
         self.given_fresh_user_is_logged_in()
-        body = {"email": self.user["email"], "keyword_language": self.user["keyword_language"]}
+        body = {
+            "email": self.user["email"],
+            "keyword_language": self.user["keyword_language"],
+        }
 
         for language in ALL_LANGUAGES.keys():
             body["language"] = language
@@ -315,7 +336,10 @@ class TestPages(AuthHelper):
         self.given_fresh_user_is_logged_in()
 
         # THEN we can retrieve the different filtering options of the programs page
-        filters = ["?level=null&adventure=null", "?level=4&adventure=null" "?level=2&adventure=story"]
+        filters = [
+            "?level=null&adventure=null",
+            "?level=4&adventure=null" "?level=2&adventure=story",
+        ]
         for filter in filters:
             self.get_data("/programs" + filter)
 
@@ -337,7 +361,10 @@ class TestPages(AuthHelper):
         # THEN receive an OK response from the server
         self.given_fresh_user_is_logged_in()
 
-        body = {"email": self.user["email"], "keyword_language": self.user["keyword_language"]}
+        body = {
+            "email": self.user["email"],
+            "keyword_language": self.user["keyword_language"],
+        }
         pages = [
             "/",
             "/hedy",
@@ -412,11 +439,36 @@ class TestAuth(AuthHelper):
             {"username": username, "password": "foo"},
             {"username": username, "password": "foobar"},
             {"username": username, "password": "foobar", "email": "me@something"},
-            {"username": username, "password": "foobar", "email": "me@something.com", "language": 123},
-            {"username": username, "password": "foobar", "email": "me@something.com", "language": True},
-            {"username": username, "password": "foobar", "email": "me@something.com", "prog_experience": [2]},
-            {"username": username, "password": "foobar", "email": "me@something.com", "prog_experience": "foo"},
-            {"username": username, "password": "foobar", "email": "me@something.com", "experience_languages": "python"},
+            {
+                "username": username,
+                "password": "foobar",
+                "email": "me@something.com",
+                "language": 123,
+            },
+            {
+                "username": username,
+                "password": "foobar",
+                "email": "me@something.com",
+                "language": True,
+            },
+            {
+                "username": username,
+                "password": "foobar",
+                "email": "me@something.com",
+                "prog_experience": [2],
+            },
+            {
+                "username": username,
+                "password": "foobar",
+                "email": "me@something.com",
+                "prog_experience": "foo",
+            },
+            {
+                "username": username,
+                "password": "foobar",
+                "email": "me@something.com",
+                "experience_languages": "python",
+            },
         ]
         for invalid_body in invalid_bodies:
             # THEN receive an invalid response code from the server
@@ -449,7 +501,14 @@ class TestAuth(AuthHelper):
 
     def test_invalid_login(self):
         # WHEN attempting logins with invalid bodies
-        invalid_bodies = ["", [], {}, {"username": 1}, {"username": "user@me"}, {"username:": "user: me"}]
+        invalid_bodies = [
+            "",
+            [],
+            {},
+            {"username": 1},
+            {"username": "user@me"},
+            {"username:": "user: me"},
+        ]
         for invalid_body in invalid_bodies:
             # THEN receive an invalid response code from the server
             self.post_data("auth/login", invalid_body, expect_http_code=400)
@@ -461,7 +520,9 @@ class TestAuth(AuthHelper):
         # WHEN logging in the user
         # THEN receive an OK response code from the server
         headers = self.post_data(
-            "auth/login", {"username": self.username, "password": self.user["password"]}, return_headers=True
+            "auth/login",
+            {"username": self.username, "password": self.user["password"]},
+            return_headers=True,
         )
 
         # THEN validate the cookie sent in the response
@@ -487,7 +548,10 @@ class TestAuth(AuthHelper):
 
         for invalid_verification in invalid_verifications:
             # THEN receive an invalid response code from the server
-            self.get_data("auth/verify?" + urllib.parse.urlencode(invalid_verification), expect_http_code=400)
+            self.get_data(
+                "auth/verify?" + urllib.parse.urlencode(invalid_verification),
+                expect_http_code=400,
+            )
 
         # WHEN submitting well-formed verifications with invalid values
         incorrect_verifications = [
@@ -499,7 +563,10 @@ class TestAuth(AuthHelper):
 
         for incorrect_verification in incorrect_verifications:
             # THEN receive a forbidden response code from the server
-            self.get_data("auth/verify?" + urllib.parse.urlencode(incorrect_verification), expect_http_code=403)
+            self.get_data(
+                "auth/verify?" + urllib.parse.urlencode(incorrect_verification),
+                expect_http_code=403,
+            )
 
     def test_verify_email(self):
         # GIVEN a new user
@@ -581,7 +648,11 @@ class TestAuth(AuthHelper):
 
         # WHEN attempting to change password without sending the correct old password
         # THEN receive an invalid response code from the server
-        body = {"old_password": "pass1", "password": "123456", "password_repeat": "123456"}
+        body = {
+            "old_password": "pass1",
+            "password": "123456",
+            "password_repeat": "123456",
+        }
         self.post_data("auth/change_password", body, expect_http_code=403)
 
     def test_change_password(self):
@@ -593,13 +664,19 @@ class TestAuth(AuthHelper):
         # THEN receive an OK response code from the server
         self.post_data(
             "auth/change_password",
-            {"old_password": self.user["password"], "password": "pas1234", "password_repeat": "pas1234"},
+            {
+                "old_password": self.user["password"],
+                "password": "pas1234",
+                "password_repeat": "pas1234",
+            },
         )
 
         # WHEN attempting to login with old password
         # THEN receive a forbidden response code from the server
         self.post_data(
-            "auth/login", {"username": self.username, "password": self.user["password"]}, expect_http_code=403
+            "auth/login",
+            {"username": self.username, "password": self.user["password"]},
+            expect_http_code=403,
         )
 
         # GIVEN the same user
@@ -690,7 +767,11 @@ class TestAuth(AuthHelper):
         new_email = self.username + "@newhedy.com"
         body = self.post_data(
             "profile",
-            {"email": new_email, "language": self.user["language"], "keyword_language": self.user["keyword_language"]},
+            {
+                "email": new_email,
+                "language": self.user["language"],
+                "keyword_language": self.user["keyword_language"],
+            },
         )
 
         # THEN confirm that the server replies with an email verification token
@@ -705,7 +786,11 @@ class TestAuth(AuthHelper):
         self.given_user_is_logged_in()
 
         # WHEN trying to update the profile with an invalid language
-        body = {"email": self.user["email"], "language": "abc", "keyword_language": self.user["keyword_language"]}
+        body = {
+            "email": self.user["email"],
+            "language": "abc",
+            "keyword_language": self.user["keyword_language"],
+        }
         # THEN receive an invalid response code from the server
         self.post_data("profile", body, expect_http_code=400)
 
@@ -784,7 +869,12 @@ class TestAuth(AuthHelper):
             {"username": "foobar", "token": "some"},
             {"username": "foobar", "token": "some", "password": 1},
             {"username": "foobar", "token": "some", "password": "short"},
-            {"username": "foobar", "token": "some", "password": "short", "password_repeat": 123},
+            {
+                "username": "foobar",
+                "token": "some",
+                "password": "short",
+                "password_repeat": 123,
+            },
             {"username": "foobar", "token": "some", "password_repeat": "panda123"},
         ]
 
@@ -796,7 +886,12 @@ class TestAuth(AuthHelper):
         # THEN receive a forbidden response code from the server
         self.post_data(
             "auth/reset",
-            {"username": self.username, "password": "123456", "password_repeat": "123456", "token": "foobar"},
+            {
+                "username": self.username,
+                "password": "123456",
+                "password_repeat": "123456",
+                "token": "foobar",
+            },
             expect_http_code=403,
         )
 
@@ -830,7 +925,12 @@ class TestAuth(AuthHelper):
         self.given_user_is_logged_in()
 
         # Create a program -> make sure it is not public
-        program = {"code": "hello world", "name": "program 1", "level": 1, "shared": False}
+        program = {
+            "code": "hello world",
+            "name": "program 1",
+            "level": 1,
+            "shared": False,
+        }
         program_id = self.post_data("programs", program)["id"]
 
         # WHEN attempting to create a public profile with invalid bodies
@@ -843,10 +943,26 @@ class TestAuth(AuthHelper):
             {"image": "123", "personal_text": 123},
             {"image": "123", "personal_text": 123},
             {"image": "123", "personal_text": 123, "favourite_program": 123},
-            {"image": "123", "personal_text": "Welcome to my profile!", "favourite_program": 123},
-            {"image": "5", "personal_text": "Welcome to my profile!", "favourite_program": 123},
-            {"image": "5", "personal_text": "Welcome to my profile!", "favourite_program": "abcdefghi"},
-            {"image": "5", "personal_text": "Welcome to my profile!", "favourite_program": program_id},
+            {
+                "image": "123",
+                "personal_text": "Welcome to my profile!",
+                "favourite_program": 123,
+            },
+            {
+                "image": "5",
+                "personal_text": "Welcome to my profile!",
+                "favourite_program": 123,
+            },
+            {
+                "image": "5",
+                "personal_text": "Welcome to my profile!",
+                "favourite_program": "abcdefghi",
+            },
+            {
+                "image": "5",
+                "personal_text": "Welcome to my profile!",
+                "favourite_program": program_id,
+            },
         ]
         for invalid_body in invalid_bodies:
             # THEN receive an invalid response code from the server
@@ -867,10 +983,19 @@ class TestAuth(AuthHelper):
         self.given_user_is_logged_in()
 
         # Create a program that is public -> can be set as favourite on the public profile
-        program = {"code": "hello world", "name": "program 1", "level": 1, "shared": True}
+        program = {
+            "code": "hello world",
+            "name": "program 1",
+            "level": 1,
+            "shared": True,
+        }
         program_id = self.post_data("programs", program)["id"]
 
-        public_profile = {"image": "9", "personal_text": "welcome to my profile!", "favourite_program": program_id}
+        public_profile = {
+            "image": "9",
+            "personal_text": "welcome to my profile!",
+            "favourite_program": program_id,
+        }
 
         # WHEN creating a new public profile with favourite program
         # THEN receive an OK response code from the server
@@ -898,7 +1023,7 @@ class TestProgram(AuthHelper):
 
         # WHEN retrieving own programs but without sending a cookie
         # THEN receive a forbidden response code from the server
-        self.get_data("programs_list", expect_http_code=403, no_cookie=True)
+        self.get_data("programs/list", expect_http_code=403, no_cookie=True)
 
     def test_get_programs(self):
         # GIVEN a logged in user
@@ -906,7 +1031,7 @@ class TestProgram(AuthHelper):
 
         # WHEN retrieving own programs sending a cookie
         # THEN receive an OK response code from the server
-        body = self.get_data("programs_list")
+        body = self.get_data("programs/list")
 
         # THEN verify that the server sent a body that is an object of the shape `{programs:[...]}`.
         self.assertIsInstance(body, dict)
@@ -927,7 +1052,12 @@ class TestProgram(AuthHelper):
             {"code": "hello world", "name": 1},
             {"code": "hello world", "name": "program 1"},
             {"code": "hello world", "name": "program 1", "level": "1"},
-            {"code": "hello world", "name": "program 1", "level": 1, "adventure_name": 1},
+            {
+                "code": "hello world",
+                "name": "program 1",
+                "level": 1,
+                "adventure_name": 1,
+            },
         ]
 
         for invalid_body in invalid_bodies:
@@ -949,7 +1079,12 @@ class TestProgram(AuthHelper):
         self.given_fresh_user_is_logged_in()
 
         # WHEN submitting a valid program
-        program = {"code": "hello world", "name": "program 1", "level": 1, "shared": False}
+        program = {
+            "code": "hello world",
+            "name": "program 1",
+            "level": 1,
+            "shared": False,
+        }
         # THEN receive an OK response code from the server
         program = self.post_data("programs", program)
         # THEN verify that the returned program has both a name and an id
@@ -958,7 +1093,7 @@ class TestProgram(AuthHelper):
         self.assertIsInstance(program["name"], str)
 
         # WHEN retrieving programs after saving a program
-        saved_programs = self.get_data("programs_list")["programs"]
+        saved_programs = self.get_data("programs/list")["programs"]
         print(saved_programs)
 
         # THEN verify that the program we just saved is in the list
@@ -984,7 +1119,12 @@ class TestProgram(AuthHelper):
             {"code": "hello world", "name": 1},
             {"code": "hello world", "name": "program 1"},
             {"code": "hello world", "name": "program 1", "level": "1"},
-            {"code": "hello world", "name": "program 1", "level": 1, "adventure_name": 1},
+            {
+                "code": "hello world",
+                "name": "program 1",
+                "level": 1,
+                "adventure_name": 1,
+            },
         ]
 
         for invalid_body in invalid_bodies:
@@ -993,7 +1133,12 @@ class TestProgram(AuthHelper):
 
         # WHEN sharing a program without being logged in
         # THEN receive a forbidden response code from the server
-        self.post_data("programs/share", {"id": "123456", "public": True}, expect_http_code=403, no_cookie=True)
+        self.post_data(
+            "programs/share",
+            {"id": "123456", "public": True},
+            expect_http_code=403,
+            no_cookie=True,
+        )
 
         # WHEN sharing a program that does not exist
         # THEN receive a not found response code from the server
@@ -1002,7 +1147,12 @@ class TestProgram(AuthHelper):
     def test_valid_make_program_public(self):
         # GIVEN a logged in user with at least one program
         self.given_user_is_logged_in()
-        program = {"code": "hello world", "name": "program 1", "level": 1, "shared": False}
+        program = {
+            "code": "hello world",
+            "name": "program 1",
+            "level": 1,
+            "shared": False,
+        }
         program_id = self.post_data("programs", program)["id"]
 
         # WHEN making a program public
@@ -1015,7 +1165,7 @@ class TestProgram(AuthHelper):
             },
         )
 
-        saved_programs = self.get_data("programs_list")["programs"]
+        saved_programs = self.get_data("programs/list")["programs"]
         for program in saved_programs:
             if program["id"] != program_id:
                 continue
@@ -1031,7 +1181,12 @@ class TestProgram(AuthHelper):
     def test_valid_make_program_private(self):
         # GIVEN a logged in user with at least one public program
         self.given_user_is_logged_in()
-        program = {"code": "hello world", "name": "program 1", "level": 1, "shared": False}
+        program = {
+            "code": "hello world",
+            "name": "program 1",
+            "level": 1,
+            "shared": False,
+        }
         program_id = self.post_data("programs", program)["id"]
         self.post_data("programs/share", {"id": program_id, "public": True})
 
@@ -1039,7 +1194,7 @@ class TestProgram(AuthHelper):
         # THEN receive an OK response code from the server
         self.post_data("programs/share", {"id": program_id, "public": False})
 
-        saved_programs = self.get_data("programs_list")["programs"]
+        saved_programs = self.get_data("programs/list")["programs"]
         for program in saved_programs:
             if program["id"] != program_id:
                 continue
@@ -1055,7 +1210,12 @@ class TestProgram(AuthHelper):
     def test_invalid_delete_program(self):
         # GIVEN a logged in user with at least one program
         self.given_user_is_logged_in()
-        program = {"code": "hello world", "name": "program 1", "level": 1, "shared": False}
+        program = {
+            "code": "hello world",
+            "name": "program 1",
+            "level": 1,
+            "shared": False,
+        }
         self.post_data("programs", program)["id"]
         program_id = "123456"
 
@@ -1066,14 +1226,19 @@ class TestProgram(AuthHelper):
     def test_valid_delete_program(self):
         # GIVEN a logged in user with at least one program
         self.given_user_is_logged_in()
-        program = {"code": "hello world", "name": "program 1", "level": 1, "shared": False}
+        program = {
+            "code": "hello world",
+            "name": "program 1",
+            "level": 1,
+            "shared": False,
+        }
         program_id = self.post_data("programs", program)["id"]
 
         # WHEN deleting a program
         # THEN receive an OK response code from the server
         headers = self.post_data("programs/delete/", {"id": program_id}, return_headers=True)
 
-        saved_programs = self.get_data("programs_list")["programs"]
+        saved_programs = self.get_data("programs/list")["programs"]
         for program in saved_programs:
             # THEN the program should not be any longer in the list of programs
             self.assertNotEqual(program["id"], program_id)
@@ -1081,7 +1246,12 @@ class TestProgram(AuthHelper):
     def test_destroy_account_with_programs(self):
         # GIVEN a logged in user with at least one program
         self.given_user_is_logged_in()
-        program = {"code": "hello world", "name": "program 1", "level": 1, "shared": False}
+        program = {
+            "code": "hello world",
+            "name": "program 1",
+            "level": 1,
+            "shared": False,
+        }
         program_id = self.post_data("programs", program)["id"]
 
         # WHEN deleting the user account
@@ -1164,7 +1334,13 @@ class TestClasses(AuthHelper):
 
         # WHEN attempting to update a class with no cookie
         # THEN receive a forbidden status code from the server
-        self.post_data("class/" + Class["id"], {"name": "class2"}, expect_http_code=403, put_data=True, no_cookie=True)
+        self.post_data(
+            "class/" + Class["id"],
+            {"name": "class2"},
+            expect_http_code=403,
+            put_data=True,
+            no_cookie=True,
+        )
 
         # WHEN attempting to update a class that does not exist
         # THEN receive a not found status code from the server
@@ -1175,7 +1351,12 @@ class TestClasses(AuthHelper):
 
         for invalid_body in invalid_bodies:
             # THEN receive an invalid response code from the server
-            self.post_data("class/" + Class["id"], invalid_body, expect_http_code=400, put_data=True)
+            self.post_data(
+                "class/" + Class["id"],
+                invalid_body,
+                expect_http_code=400,
+                put_data=True,
+            )
 
     def test_update_class(self):
         # GIVEN a user with teacher permissions and a class
@@ -1283,10 +1464,20 @@ class TestClasses(AuthHelper):
         student = self.user
         self.post_data("class/join", {"id": Class["id"]}, expect_http_code=200)
         # GIVEN a student with two programs, one public and one private
-        public_program = {"code": "hello world", "name": "program 1", "level": 1, "shared": False}
+        public_program = {
+            "code": "hello world",
+            "name": "program 1",
+            "level": 1,
+            "shared": False,
+        }
         public_program_id = self.post_data("programs", public_program)["id"]
         self.post_data("programs/share", {"id": public_program_id, "public": True})
-        private_program = {"code": "hello world", "name": "program 2", "level": 2, "shared": False}
+        private_program = {
+            "code": "hello world",
+            "name": "program 2",
+            "level": 2,
+            "shared": False,
+        }
         private_program_id = self.post_data("programs", private_program)["id"]
 
         # GIVEN the aforementioned teacher
@@ -1331,12 +1522,21 @@ class TestCustomizeClasses(AuthHelper):
             {"levels": [1, 2, 3], "adventures": []},
             {"levels": [1, 2, 3], "adventures": {}},
             {"levels": [1, 2, 3], "adventures": {}, "opening_dates": {}},
-            {"levels": [1, 2, 3], "adventures": {}, "opening_dates": {}, "teacher_adventures": []},
+            {
+                "levels": [1, 2, 3],
+                "adventures": {},
+                "opening_dates": {},
+                "teacher_adventures": [],
+            },
         ]
 
         for invalid_body in invalid_bodies:
             # THEN receive an invalid response code from the server
-            self.post_data("for-teachers/customize-class/" + class_id, invalid_body, expect_http_code=400)
+            self.post_data(
+                "for-teachers/customize-class/" + class_id,
+                invalid_body,
+                expect_http_code=400,
+            )
 
         # WHEN customizing a class that doesn't exist
         # THEN receive a not found response code from the server
@@ -1354,7 +1554,13 @@ class TestCustomizeClasses(AuthHelper):
         class_id = self.get_data("classes")[0].get("id")
 
         valid_bodies = [
-            {"levels": [], "adventures": {}, "opening_dates": {}, "teacher_adventures": [], "other_settings": []},
+            {
+                "levels": [],
+                "adventures": {},
+                "opening_dates": {},
+                "teacher_adventures": [],
+                "other_settings": [],
+            },
             {
                 "levels": ["1"],
                 "adventures": {"story": ["1"]},
@@ -1414,7 +1620,11 @@ class TestCustomizeClasses(AuthHelper):
 
         for valid_body in valid_bodies:
             # THEN receive an invalid response code from the server
-            self.post_data("for-teachers/customize-class/" + class_id, valid_body, expect_http_code=200)
+            self.post_data(
+                "for-teachers/customize-class/" + class_id,
+                valid_body,
+                expect_http_code=200,
+            )
 
     def test_remove_customization(self):
         # GIVEN a user with teacher permissions
@@ -1429,7 +1639,13 @@ class TestCustomizeClasses(AuthHelper):
 
         # WHEN creating class customizations
         # THEN receive an OK response code with the server
-        body = {"levels": [], "adventures": {}, "opening_dates": {}, "teacher_adventures": [], "other_settings": []}
+        body = {
+            "levels": [],
+            "adventures": {},
+            "opening_dates": {},
+            "teacher_adventures": [],
+            "other_settings": [],
+        }
         self.post_data("for-teachers/customize-class/" + class_id, body, expect_http_code=200)
 
         # WHEN deleting class customizations
@@ -1458,8 +1674,16 @@ class TestCustomAdventures(AuthHelper):
 
         # WHEN attempting to create an adventure that already exists
         # THEN receive an 400 error from the server
-        self.post_data("for-teachers/create_adventure", {"name": "test_adventure"}, expect_http_code=200)
-        self.post_data("for-teachers/create_adventure", {"name": "test_adventure"}, expect_http_code=400)
+        self.post_data(
+            "for-teachers/create_adventure",
+            {"name": "test_adventure"},
+            expect_http_code=200,
+        )
+        self.post_data(
+            "for-teachers/create_adventure",
+            {"name": "test_adventure"},
+            expect_http_code=400,
+        )
 
     def test_create_adventure(self):
         # GIVEN a new teacher
@@ -1467,7 +1691,11 @@ class TestCustomAdventures(AuthHelper):
 
         # WHEN attempting to create a valid adventure
         # THEN receive an OK response with the server
-        self.post_data("for-teachers/create_adventure", {"name": "test_adventure"}, expect_http_code=200)
+        self.post_data(
+            "for-teachers/create_adventure",
+            {"name": "test_adventure"},
+            expect_http_code=200,
+        )
 
     def test_invalid_view_adventure(self):
         # GIVEN a new user
@@ -1491,7 +1719,9 @@ class TestCustomAdventures(AuthHelper):
         # WHEN attempting to create a valid adventure
         # THEN receive an OK response with the server
         adventure_id = self.post_data(
-            "for-teachers/create_adventure", {"name": "test_adventure"}, expect_http_code=200
+            "for-teachers/create_adventure",
+            {"name": "test_adventure"},
+            expect_http_code=200,
         ).get("id")
 
         # WHEN attempting to view the adventure using the id from the returned body
@@ -1505,7 +1735,9 @@ class TestCustomAdventures(AuthHelper):
         # WHEN attempting to create a valid adventure
         # THEN receive an OK response with the server
         adventure_id = self.post_data(
-            "for-teachers/create_adventure", {"name": "test_adventure"}, expect_http_code=200
+            "for-teachers/create_adventure",
+            {"name": "test_adventure"},
+            expect_http_code=200,
         ).get("id")
 
         # WHEN attempting to updating an adventure with invalid data
@@ -1519,7 +1751,13 @@ class TestCustomAdventures(AuthHelper):
             {"id": "123", "name": 123, "classes": []},
             {"id": "123", "name": 123, "classes": [], "level": 5},
             {"id": "123", "name": 123, "classes": [], "level": 5, "content": 123},
-            {"id": adventure_id, "name": "panda", "classes": [], "level": "5", "content": "too short!"},
+            {
+                "id": adventure_id,
+                "name": "panda",
+                "classes": [],
+                "level": "5",
+                "content": "too short!",
+            },
             {
                 "id": adventure_id,
                 "name": "panda",
@@ -1553,7 +1791,9 @@ class TestCustomAdventures(AuthHelper):
         # WHEN attempting to create a valid adventure
         # THEN receive an OK response from the server
         adventure_id = self.post_data(
-            "for-teachers/create_adventure", {"name": "test_adventure"}, expect_http_code=200
+            "for-teachers/create_adventure",
+            {"name": "test_adventure"},
+            expect_http_code=200,
         ).get("id")
 
         # WHEN attempting to update an adventure with a valid body
@@ -1575,7 +1815,9 @@ class TestCustomAdventures(AuthHelper):
         # WHEN attempting to create a valid adventure
         # THEN receive an OK response from the server
         adventure_id = self.post_data(
-            "for-teachers/create_adventure", {"name": "test_adventure"}, expect_http_code=200
+            "for-teachers/create_adventure",
+            {"name": "test_adventure"},
+            expect_http_code=200,
         ).get("id")
 
         # WHEN attempting to create a valid adventure
@@ -1603,11 +1845,18 @@ class TestCustomAdventures(AuthHelper):
 
         # WHEN attempting to create a valid adventure
         # THEN receive an OK response from the server
-        body = self.post_data("for-teachers/create_adventure", {"name": "test_adventure"}, expect_http_code=200)
+        body = self.post_data(
+            "for-teachers/create_adventure",
+            {"name": "test_adventure"},
+            expect_http_code=200,
+        )
 
         # WHEN attempting to remove the adventure
         # THEN receive an OK response from the server
-        self.delete_data("for-teachers/customize-adventure/" + body.get("id", ""), expect_http_code=200)
+        self.delete_data(
+            "for-teachers/customize-adventure/" + body.get("id", ""),
+            expect_http_code=200,
+        )
 
 
 class TestMultipleAccounts(AuthHelper):
@@ -1632,7 +1881,12 @@ class TestMultipleAccounts(AuthHelper):
             {"accounts": [{"username": 123}]},
             {"accounts": [{"username": "panda", "password": 123}]},
             {"accounts": [{"username": "@", "password": "test123"}]},
-            {"accounts": [{"username": "panda", "password": "test123"}, {"username": "panda2", "password": 123}]},
+            {
+                "accounts": [
+                    {"username": "panda", "password": "test123"},
+                    {"username": "panda2", "password": 123},
+                ]
+            },
         ]
 
         for invalid_body in invalid_bodies:
@@ -1645,7 +1899,10 @@ class TestMultipleAccounts(AuthHelper):
         # WHEN attempting to create a valid adventure
         # THEN receive an OK response with the server
         body = {
-            "accounts": [{"username": "panda", "password": "test123"}, {"username": "panda2", "password": "test321"}]
+            "accounts": [
+                {"username": "panda", "password": "test123"},
+                {"username": "panda2", "password": "test321"},
+            ]
         }
         self.post_data("for-teachers/create-accounts", body, expect_http_code=200)
 

--- a/tests_e2e.py
+++ b/tests_e2e.py
@@ -19,25 +19,27 @@ from config import config as CONFIG
 from hedy import HEDY_MAX_LEVEL
 from hedy_content import ALL_LANGUAGES
 
-HOST = os.getenv('ENDPOINT', 'http://localhost:' + str(CONFIG['port']) + '/')
-if not HOST.endswith('/'): HOST += '/'
+HOST = os.getenv("ENDPOINT", "http://localhost:" + str(CONFIG["port"]) + "/")
+if not HOST.endswith("/"):
+    HOST += "/"
 
 # This dict has global scope and holds all created users and their still current sessions (as cookies), for convenient reuse wherever needed
 USERS = {}
 
 # *** HELPERS ***
 
-def request(method, path, headers={}, body='', cookies=None):
 
-    if method not in['get', 'post', 'put', 'delete']:
-        raise Exception('request - Invalid method: ' + str(method))
+def request(method, path, headers={}, body="", cookies=None):
+
+    if method not in ["get", "post", "put", "delete"]:
+        raise Exception("request - Invalid method: " + str(method))
 
     # We pass the X-Testing header to let the server know that this is a request coming from an E2E test, thus no transactional emails should be sent.
-    headers['X-Testing'] = '1'
+    headers["X-Testing"] = "1"
 
     # If sending an object as body, stringify it and set the proper content-type header
     if isinstance(body, dict):
-        headers['content-type'] = 'application/json'
+        headers["content-type"] = "application/json"
         body = json.dumps(body)
 
     start = utils.timems()
@@ -48,24 +50,25 @@ def request(method, path, headers={}, body='', cookies=None):
     if cookies is not None:
         cookies.update(response.cookies)
 
-    ret = {'time': utils.timems() - start}
+    ret = {"time": utils.timems() - start}
 
     if response.history and response.history[0]:
         # This code branch will be executed if there is a redirect
-        ret['code']    = response.history[0].status_code
-        ret['headers'] = response.history[0].headers
-        if getattr(response.history[0], '_content'):
+        ret["code"] = response.history[0].status_code
+        ret["headers"] = response.history[0].headers
+        if getattr(response.history[0], "_content"):
             # We can assume that bodies returned from redirected responses are always plain text, since no JSON endpoint in the server is reachable through a redirect.
-            ret['body'] = getattr(response.history[0], '_content').decode('utf-8')
+            ret["body"] = getattr(response.history[0], "_content").decode("utf-8")
     else:
-        ret['code']    = response.status_code
-        ret['headers'] = response.headers
-        if 'Content-Type' in response.headers and response.headers['Content-Type'] == 'application/json':
-            ret['body'] = response.json()
+        ret["code"] = response.status_code
+        ret["headers"] = response.headers
+        if "Content-Type" in response.headers and response.headers["Content-Type"] == "application/json":
+            ret["body"] = response.json()
         else:
-            ret['body'] = response.text
+            ret["body"] = response.text
 
     return ret
+
 
 class AuthHelper(unittest.TestCase):
     def setUp(self):
@@ -80,34 +83,41 @@ class AuthHelper(unittest.TestCase):
 
     @property
     def username(self):
-        return self.user['username'] if self.user else None
+        return self.user["username"] if self.user else None
 
     def make_username(self):
         # We create usernames with a random component so that if a test fails, we don't have to do a cleaning of the DB so that the test suite can run again
         # This also allows us to run concurrent tests without having username conflicts.
-        username = 'user' + str(random.randint(10000, 100000))
+        username = "user" + str(random.randint(10000, 100000))
         return username
 
     # If user with `username` exists, return it. Otherwise, create it.
     def assert_user_exists(self, username):
         if not isinstance(username, str):
-            raise Exception('AuthHelper.assert_user_exists - Invalid username: ' + str(username))
+            raise Exception("AuthHelper.assert_user_exists - Invalid username: " + str(username))
 
         if username in USERS:
             return USERS[username]
-        body = {'username': username, 'email': username + '@hedy.com', 'language': 'nl', 'keyword_language': 'en',
-                'agree_terms': 'yes', 'password': 'foobar', 'password_repeat': 'foobar'}
-        response = request('post', 'auth/signup', {}, body, cookies=self.user_cookies[username])
+        body = {
+            "username": username,
+            "email": username + "@hedy.com",
+            "language": "nl",
+            "keyword_language": "en",
+            "agree_terms": "yes",
+            "password": "foobar",
+            "password_repeat": "foobar",
+        }
+        response = request("post", "auth/signup", {}, body, cookies=self.user_cookies[username])
 
         # It might sometimes happen that by the time we attempted to create the user, another test did it already.
         # In this case, we get a 403. We invoke the function recursively.
-        if response['code'] == 403:
+        if response["code"] == 403:
             return self.assert_user_exists(username)
 
         # Store the user & also the verify token for use in upcoming tests
         USERS[username] = body
 
-        USERS[username]['verify_token'] = response['body']['token']
+        USERS[username]["verify_token"] = response["body"]["token"]
         return USERS[username]
 
     # Returns the first created user, if any; otherwise, creates one.
@@ -119,13 +129,19 @@ class AuthHelper(unittest.TestCase):
     def get_any_logged_user(self):
         # If there's no logged in user, we login the user
         user = self.get_any_user()
-        return self.login_user(user['username'])
+        return self.login_user(user["username"])
 
     def login_user(self, username):
         """Login another user. Does not BECOME that user for all subsequent request."""
         self.assert_user_exists(username)
         user = USERS[username]
-        request('post', 'auth/login', {}, {'username': user['username'], 'password': user['password']}, cookies=self.user_cookies[username])
+        request(
+            "post",
+            "auth/login",
+            {},
+            {"username": user["username"], "password": user["password"]},
+            cookies=self.user_cookies[username],
+        )
         return user
 
     def given_specific_user_is_logged_in(self, username):
@@ -137,7 +153,7 @@ class AuthHelper(unittest.TestCase):
         cookie.load(cookie_string)
 
         for key, cookie in cookie.items():
-            if key == CONFIG['session']['cookie_name']:
+            if key == CONFIG["session"]["cookie_name"]:
                 return cookie
 
     def given_fresh_user_is_logged_in(self):
@@ -149,7 +165,7 @@ class AuthHelper(unittest.TestCase):
 
         Need to log in again to refresh the session.
         """
-        self.post_data('admin/markAsTeacher', {'username': self.username, 'is_teacher': True})
+        self.post_data("admin/markAsTeacher", {"username": self.username, "is_teacher": True})
         return self.login_user(self.username)
 
     def given_user_is_logged_in(self):
@@ -167,85 +183,88 @@ class AuthHelper(unittest.TestCase):
         self.user = self.get_any_user()
 
     def switch_user(self, user):
-        self.user = self.login_user(user['username'])
+        self.user = self.login_user(user["username"])
 
     def post_data(self, path, body, expect_http_code=200, no_cookie=False, return_headers=False, put_data=False):
         cookies = self.user_cookies[self.username] if self.username and not no_cookie else None
 
-        method = 'put' if put_data else 'post'
+        method = "put" if put_data else "post"
         response = request(method, path, body=body, cookies=cookies)
-        self.assertEqual(response['code'], expect_http_code, f'While {method}ing {body} to {path} (user: {self.username})')
+        self.assertEqual(
+            response["code"], expect_http_code, f"While {method}ing {body} to {path} (user: {self.username})"
+        )
 
-        return response['headers'] if return_headers else response['body']
+        return response["headers"] if return_headers else response["body"]
 
     def delete_data(self, path, expect_http_code=200, no_cookie=False, return_headers=False):
         cookies = self.user_cookies[self.username] if self.username and not no_cookie else None
 
-        method = 'delete'
+        method = "delete"
         response = request(method, path, cookies=cookies)
-        self.assertEqual(response['code'], expect_http_code,
-                         f'While {method}ing {path} (user: {self.username})')
+        self.assertEqual(response["code"], expect_http_code, f"While {method}ing {path} (user: {self.username})")
 
-        return response['headers'] if return_headers else response['body']
+        return response["headers"] if return_headers else response["body"]
 
     def get_data(self, path, expect_http_code=200, no_cookie=False, return_headers=False):
         cookies = self.user_cookies[self.username] if self.username and not no_cookie else None
-        response = request('get', path, body='', cookies=cookies)
+        response = request("get", path, body="", cookies=cookies)
 
-        self.assertEqual(response['code'], expect_http_code, f'While reading {path} (user: {self.username})')
+        self.assertEqual(response["code"], expect_http_code, f"While reading {path} (user: {self.username})")
 
-        return response['headers'] if return_headers else response['body']
+        return response["headers"] if return_headers else response["body"]
 
     def destroy_current_user(self):
         assert self.username is not None
-        self.post_data('auth/destroy', '')
+        self.post_data("auth/destroy", "")
         # Remove any records of this user
         USERS.pop(self.username)
 
+
 # *** TESTS ***
+
 
 class TestPages(AuthHelper):
     def test_get_login_page(self):
         # WHEN attempting to get the login page
         # THEN receive an OK response code from the server
-        self.get_data('/login')
+        self.get_data("/login")
 
     def test_get_signup_page(self):
         # WHEN attempting to get the signup page
         # THEN receive an OK response code from the server
-        self.get_data('/signup')
+        self.get_data("/signup")
 
     def test_get_recover_page(self):
         # WHEN attempting to get the signup page
         # THEN receive an OK response code from the server
-        self.get_data('/recover')
+        self.get_data("/recover")
 
     def test_get_admin_page(self):
         # WHEN attempting to get the admin page
         # THEN receive an OK response code from the server
         # (Note: this only happens in a dev environment)
-        self.get_data('/admin')
+        self.get_data("/admin")
 
     def test_get_cheatsheet(self):
         # WHEN attempting to get the cheatsheet page
         # THEN receive an OK response code from the server
-        self.get_data('/cheatsheet')
+        self.get_data("/cheatsheet")
 
     def test_invalid_get_cheatsheet(self):
         # WHEN attempting to get the cheatsheet page with an invalid value
         # THEN receive an 404 response code from the server
-        self.get_data('/cheatsheet/123', expect_http_code=404)
-        self.get_data('/cheatsheet/panda', expect_http_code=404)
+        self.get_data("/cheatsheet/123", expect_http_code=404)
+        self.get_data("/cheatsheet/panda", expect_http_code=404)
 
     def test_highscore_pages(self):
         # WHEN trying all languages to reach the highscore page
         # THEN receive an OK response from the server
         self.given_fresh_user_is_logged_in()
-        body = {'email': self.user['email'], 'keyword_language': self.user['keyword_language']}
+        body = {"email": self.user["email"], "keyword_language": self.user["keyword_language"]}
 
         for language in ALL_LANGUAGES.keys():
-            body['language'] = language
-            self.post_data('profile', body)
+            body["language"] = language
+            self.post_data("profile", body)
             self.get_data("/highscores")
 
     def test_valid_country_highscore_page(self):
@@ -255,12 +274,12 @@ class TestPages(AuthHelper):
 
         # Add a country to the user profile
         body = {
-            'email': self.user['email'],
-            'language': self.user['language'],
-            'keyword_language': self.user['keyword_language'],
-            'country': 'NL'
+            "email": self.user["email"],
+            "language": self.user["language"],
+            "keyword_language": self.user["keyword_language"],
+            "country": "NL",
         }
-        self.post_data('profile', body)
+        self.post_data("profile", body)
 
         # Receive a valid response
         self.get_data("/highscores/country")
@@ -274,12 +293,12 @@ class TestPages(AuthHelper):
     def test_valid_class_highscore_page(self):
         # WHEN a teacher is logged in and create a class
         self.given_teacher_is_logged_in()
-        self.post_data('class', {'name': 'class1'})
-        Class = self.get_data('classes')[0]
+        self.post_data("class", {"name": "class1"})
+        Class = self.get_data("classes")[0]
 
         # THEN a fresh user logs in and joins this class
         self.given_fresh_user_is_logged_in()
-        self.post_data('class/join', {'id': Class['id']}, expect_http_code=200)
+        self.post_data("class/join", {"id": Class["id"]}, expect_http_code=200)
 
         # THEN we can access the class highscore page
         self.get_data("/highscores/class")
@@ -296,11 +315,7 @@ class TestPages(AuthHelper):
         self.given_fresh_user_is_logged_in()
 
         # THEN we can retrieve the different filtering options of the programs page
-        filters = [
-            "?level=null&adventure=null",
-            "?level=4&adventure=null"
-            "?level=2&adventure=story"
-        ]
+        filters = ["?level=null&adventure=null", "?level=4&adventure=null" "?level=2&adventure=story"]
         for filter in filters:
             self.get_data("/programs" + filter)
 
@@ -312,7 +327,7 @@ class TestPages(AuthHelper):
         filters = [
             "?level=null&adventure=null&lang=null",
             "?level=3&adventure=parrot&lang=null",
-            "?level=11&adventure=fortune&lang=es"
+            "?level=11&adventure=fortune&lang=es",
         ]
         for filter in filters:
             self.get_data("/explore" + filter)
@@ -322,49 +337,61 @@ class TestPages(AuthHelper):
         # THEN receive an OK response from the server
         self.given_fresh_user_is_logged_in()
 
-        body = {'email': self.user['email'], 'keyword_language': self.user['keyword_language']}
-        pages = ['/', '/hedy', '/landing-page', '/tutorial', '/explore', '/learn-more', '/programs', '/my-achievements', '/my-profile']
+        body = {"email": self.user["email"], "keyword_language": self.user["keyword_language"]}
+        pages = [
+            "/",
+            "/hedy",
+            "/landing-page",
+            "/tutorial",
+            "/explore",
+            "/learn-more",
+            "/programs",
+            "/my-achievements",
+            "/my-profile",
+        ]
 
         for language in ALL_LANGUAGES.keys():
-            body['language'] = language
-            self.post_data('profile', body)
+            body["language"] = language
+            self.post_data("profile", body)
 
             for page in pages:
                 if page == "/hedy":
-                    for i in range(2, HEDY_MAX_LEVEL+1):
+                    for i in range(2, HEDY_MAX_LEVEL + 1):
                         self.get_data(page + "/" + str(i))
                 self.get_data(page)
+
 
 class TestSessionVariables(AuthHelper):
     def test_get_session_variables(self):
         # WHEN getting session variables from the main environment
-        body = self.get_data('/session_main')
+        body = self.get_data("/session_main")
 
         # THEN the body should contain a `session` with `session_id` and a `proxy_enabled` field
-        self.assertIn('session', body)
-        self.assertIn('session_id', body['session'])
-        self.assertIn('proxy_enabled', body)
+        self.assertIn("session", body)
+        self.assertIn("session_id", body["session"])
+        self.assertIn("proxy_enabled", body)
 
-        session = body['session']
-        proxy_enabled = body['proxy_enabled']
+        session = body["session"]
+        proxy_enabled = body["proxy_enabled"]
 
         # WHEN getting session variables from the test environment
-        test_body = self.get_data('/session_test')
+        test_body = self.get_data("/session_test")
         if not proxy_enabled:
             # If proxying to test is disabled, there is nothing else to test.
             return
 
         # THEN the body should contain a `session` with `session_id` and a `test_session` field
-        self.assertIn('session', test_body)
-        self.assertIn('session_id', test_body['session'])
-        self.assertIn('test_session', test_body['session'])
-        self.assertEquals(test_body['session']['session_id'], session['id'])
+        self.assertIn("session", test_body)
+        self.assertIn("session_id", test_body["session"])
+        self.assertIn("test_session", test_body["session"])
+        self.assertEquals(test_body["session"]["session_id"], session["id"])
 
         # WHEN getting session variables from the main environment
-        body = self.get_data('/session_main')
+        body = self.get_data("/session_main")
         # THEN the body should have a session with a session_id that is still the same and a `test_session` field as well
-        self.assertEqual(body['session']['session_id'], session['id'])
-        self.assertEqual(body['session']['test_session'], test_body['session']['session_id'])
+        self.assertEqual(body["session"]["session_id"], session["id"])
+        self.assertEqual(body["session"]["test_session"], test_body["session"]["session_id"])
+
 
 class TestAuth(AuthHelper):
     def test_invalid_signups(self):
@@ -372,60 +399,60 @@ class TestAuth(AuthHelper):
         username = self.make_username()
         # WHEN attempting signups with invalid bodies
         invalid_bodies = [
-            '',
+            "",
             [],
             {},
-            {'username': 1},
-            {'username': 'user@me', 'password': 'foobar', 'email': 'a@a.com'},
-            {'username:': 'user: me', 'password': 'foobar', 'email': 'a@a.co'},
-            {'username': 't'},
-            {'username': '    t    '},
-            {'username': username},
-            {'username': username, 'password': 1},
-            {'username': username, 'password': 'foo'},
-            {'username': username, 'password': 'foobar'},
-            {'username': username, 'password': 'foobar', 'email': 'me@something'},
-            {'username': username, 'password': 'foobar', 'email': 'me@something.com', 'language': 123},
-            {'username': username, 'password': 'foobar', 'email': 'me@something.com', 'language': True},
-            {'username': username, 'password': 'foobar', 'email': 'me@something.com', 'prog_experience': [2]},
-            {'username': username, 'password': 'foobar', 'email': 'me@something.com', 'prog_experience': 'foo'},
-            {'username': username, 'password': 'foobar', 'email': 'me@something.com', 'experience_languages': 'python'}
+            {"username": 1},
+            {"username": "user@me", "password": "foobar", "email": "a@a.com"},
+            {"username:": "user: me", "password": "foobar", "email": "a@a.co"},
+            {"username": "t"},
+            {"username": "    t    "},
+            {"username": username},
+            {"username": username, "password": 1},
+            {"username": username, "password": "foo"},
+            {"username": username, "password": "foobar"},
+            {"username": username, "password": "foobar", "email": "me@something"},
+            {"username": username, "password": "foobar", "email": "me@something.com", "language": 123},
+            {"username": username, "password": "foobar", "email": "me@something.com", "language": True},
+            {"username": username, "password": "foobar", "email": "me@something.com", "prog_experience": [2]},
+            {"username": username, "password": "foobar", "email": "me@something.com", "prog_experience": "foo"},
+            {"username": username, "password": "foobar", "email": "me@something.com", "experience_languages": "python"},
         ]
         for invalid_body in invalid_bodies:
             # THEN receive an invalid response code from the server
-            self.post_data('auth/signup', invalid_body, expect_http_code=400)
+            self.post_data("auth/signup", invalid_body, expect_http_code=400)
 
     def test_signup(self):
         # GIVEN a valid username and signup body
         username = self.make_username()
-        user = {'username': username, 'email': username + '@hedy.com', 'password': 'foobar',
-                'password_repeat': 'foobar', 'language': 'nl', 'keyword_language': 'en', 'agree_terms': 'yes'}
+        user = {
+            "username": username,
+            "email": username + "@hedy.com",
+            "password": "foobar",
+            "password_repeat": "foobar",
+            "language": "nl",
+            "keyword_language": "en",
+            "agree_terms": "yes",
+        }
 
         # WHEN signing up a new user
         # THEN receive an OK response code from the server
-        body = self.post_data('auth/signup', user)
+        body = self.post_data("auth/signup", user)
 
         # THEN receive a body containing a token
         self.assertIsInstance(body, dict)
-        self.assertIsInstance(body['token'], str)
+        self.assertIsInstance(body["token"], str)
 
         # FINALLY Store the user and its token for upcoming tests
-        user['verify_token'] = body['token']
+        user["verify_token"] = body["token"]
         USERS[username] = user
 
     def test_invalid_login(self):
         # WHEN attempting logins with invalid bodies
-        invalid_bodies = [
-            '',
-            [],
-            {},
-            {'username': 1},
-            {'username': 'user@me'},
-            {'username:': 'user: me'}
-        ]
+        invalid_bodies = ["", [], {}, {"username": 1}, {"username": "user@me"}, {"username:": "user: me"}]
         for invalid_body in invalid_bodies:
             # THEN receive an invalid response code from the server
-            self.post_data('auth/login', invalid_body, expect_http_code=400)
+            self.post_data("auth/login", invalid_body, expect_http_code=400)
 
     def test_login(self):
         # GIVEN an existing user
@@ -433,15 +460,17 @@ class TestAuth(AuthHelper):
 
         # WHEN logging in the user
         # THEN receive an OK response code from the server
-        headers = self.post_data('auth/login', {'username': self.username, 'password': self.user['password']}, return_headers=True)
+        headers = self.post_data(
+            "auth/login", {"username": self.username, "password": self.user["password"]}, return_headers=True
+        )
 
         # THEN validate the cookie sent in the response
-        self.assertIsInstance(headers['Set-Cookie'], str)
-        hedy_cookie = self.get_hedy_cookie(headers['Set-Cookie'])
+        self.assertIsInstance(headers["Set-Cookie"], str)
+        hedy_cookie = self.get_hedy_cookie(headers["Set-Cookie"])
         self.assertNotEqual(hedy_cookie, None)
-        self.assertEqual(hedy_cookie['httponly'], True)
-        self.assertEqual(hedy_cookie['path'], '/')
-        self.assertEqual(hedy_cookie['samesite'], 'Lax,')
+        self.assertEqual(hedy_cookie["httponly"], True)
+        self.assertEqual(hedy_cookie["path"], "/")
+        self.assertEqual(hedy_cookie["samesite"], "Lax,")
 
     def test_invalid_verify_email(self):
         # GIVEN a new user
@@ -451,26 +480,26 @@ class TestAuth(AuthHelper):
         # WHEN submitting invalid verifications
         invalid_verifications = [
             # Missing token
-            {'username': self.username},
+            {"username": self.username},
             # Missing username
-            {'token': self.user['verify_token']},
+            {"token": self.user["verify_token"]},
         ]
 
         for invalid_verification in invalid_verifications:
             # THEN receive an invalid response code from the server
-            self.get_data('auth/verify?' + urllib.parse.urlencode(invalid_verification), expect_http_code=400)
+            self.get_data("auth/verify?" + urllib.parse.urlencode(invalid_verification), expect_http_code=400)
 
         # WHEN submitting well-formed verifications with invalid values
         incorrect_verifications = [
             # Invalid username
-            {'username': 'foobar', 'token': self.user['verify_token']},
+            {"username": "foobar", "token": self.user["verify_token"]},
             # Invalid token
-            {'username': self.username, 'token': 'foobar'}
+            {"username": self.username, "token": "foobar"},
         ]
 
         for incorrect_verification in incorrect_verifications:
             # THEN receive a forbidden response code from the server
-            self.get_data('auth/verify?' + urllib.parse.urlencode(incorrect_verification), expect_http_code=403)
+            self.get_data("auth/verify?" + urllib.parse.urlencode(incorrect_verification), expect_http_code=403)
 
     def test_verify_email(self):
         # GIVEN a new user
@@ -479,23 +508,31 @@ class TestAuth(AuthHelper):
 
         # WHEN attepting to verify the user
         # THEN receive a redirect from the server taking us to `/landing-page`
-        headers = self.get_data('auth/verify?' + urllib.parse.urlencode({'username': self.username, 'token': self.user['verify_token']}), expect_http_code=302, return_headers=True)
-        self.assertEqual(headers['location'], HOST + 'landing-page')
+        headers = self.get_data(
+            "auth/verify?" + urllib.parse.urlencode({"username": self.username, "token": self.user["verify_token"]}),
+            expect_http_code=302,
+            return_headers=True,
+        )
+        self.assertEqual(headers["location"], HOST + "landing-page")
 
         # WHEN attepting to verify the user again (the operation should be idempotent)
         # THEN (again) receive a redirect from the server taking us to `/landing-page`
-        headers = self.get_data('auth/verify?' + urllib.parse.urlencode({'username': self.username, 'token': self.user['verify_token']}), expect_http_code=302, return_headers=True)
-        self.assertEqual(headers['location'], HOST + 'landing-page')
+        headers = self.get_data(
+            "auth/verify?" + urllib.parse.urlencode({"username": self.username, "token": self.user["verify_token"]}),
+            expect_http_code=302,
+            return_headers=True,
+        )
+        self.assertEqual(headers["location"], HOST + "landing-page")
 
         # WHEN retrieving profile to see that the user is no longer marked with `verification_pending`
         self.given_specific_user_is_logged_in(self.username)
-        profile = self.get_data('profile')
+        profile = self.get_data("profile")
 
         # THEN check that the `verification_pending` has been removed from the user profile
-        self.assertNotIn('verification_pending', profile)
+        self.assertNotIn("verification_pending", profile)
 
         # FINALLY remove token from user since it's already been used.
-        self.user.pop('verify_token')
+        self.user.pop("verify_token")
 
     def test_logout(self):
         # GIVEN a logged in user
@@ -503,11 +540,11 @@ class TestAuth(AuthHelper):
 
         # WHEN logging out the user
         # THEN receive an OK response code from the server
-        self.post_data('auth/logout', '')
+        self.post_data("auth/logout", "")
 
         # WHEN retrieving the user profile with the same cookie
         # THEN receive a forbidden response code from the server
-        self.get_data('profile', expect_http_code=403)
+        self.get_data("profile", expect_http_code=403)
 
     def test_destroy_account(self):
         # GIVEN a logged in user
@@ -519,7 +556,7 @@ class TestAuth(AuthHelper):
 
         # WHEN retrieving the profile of the user
         # THEN receive a forbidden response code from the server
-        self.get_data('profile', expect_http_code=403)
+        self.get_data("profile", expect_http_code=403)
 
     def test_invalid_change_password(self):
         # GIVEN a logged in user
@@ -527,48 +564,52 @@ class TestAuth(AuthHelper):
 
         # WHEN attempting change password with invalid bodies
         invalid_bodies = [
-            '',
+            "",
             [],
             {},
-            {'old_password': 123456},
-            {'old_password': 'pass1'},
-            {'old_password': 'pass1', 'password': 123456},
-            {'old_password': 'pass1', 'password': 'short'},
-            {'old_password': 'pass1', 'password': 123456, 'password_repeat': 'panda'},
-            {'old_password': 'pass1', 'password_repeat': 'panda'},
+            {"old_password": 123456},
+            {"old_password": "pass1"},
+            {"old_password": "pass1", "password": 123456},
+            {"old_password": "pass1", "password": "short"},
+            {"old_password": "pass1", "password": 123456, "password_repeat": "panda"},
+            {"old_password": "pass1", "password_repeat": "panda"},
         ]
 
         for invalid_body in invalid_bodies:
             # THEN receive an invalid response code from the server
-            self.post_data('auth/change_password', invalid_body, expect_http_code=400)
+            self.post_data("auth/change_password", invalid_body, expect_http_code=400)
 
         # WHEN attempting to change password without sending the correct old password
         # THEN receive an invalid response code from the server
-        body = {'old_password': 'pass1', 'password': '123456', 'password_repeat': '123456'}
-        self.post_data('auth/change_password', body, expect_http_code=403)
+        body = {"old_password": "pass1", "password": "123456", "password_repeat": "123456"}
+        self.post_data("auth/change_password", body, expect_http_code=403)
 
     def test_change_password(self):
         # GIVEN a logged in user
         self.given_user_is_logged_in()
 
         # WHEN attempting to change the user's password
-        new_password = 'pas1234'
+        new_password = "pas1234"
         # THEN receive an OK response code from the server
-        self.post_data('auth/change_password', {'old_password': self.user['password'],
-                                                'password': 'pas1234', 'password_repeat': 'pas1234'})
+        self.post_data(
+            "auth/change_password",
+            {"old_password": self.user["password"], "password": "pas1234", "password_repeat": "pas1234"},
+        )
 
         # WHEN attempting to login with old password
         # THEN receive a forbidden response code from the server
-        self.post_data('auth/login', {'username': self.username, 'password': self.user['password']}, expect_http_code=403)
+        self.post_data(
+            "auth/login", {"username": self.username, "password": self.user["password"]}, expect_http_code=403
+        )
 
         # GIVEN the same user
 
         # WHEN attempting to login with new password
         # THEN receive an OK response code from the server
-        self.post_data('auth/login', {'username': self.username, 'password': new_password})
+        self.post_data("auth/login", {"username": self.username, "password": new_password})
 
         # FINALLY update password on user
-        self.user['password'] = new_password
+        self.user["password"] = new_password
 
     def test_profile_get(self):
         # GIVEN a new user
@@ -577,16 +618,16 @@ class TestAuth(AuthHelper):
 
         # WHEN retrieving the user profile
         # THEN receive an OK response code from the server
-        profile = self.get_data('profile')
+        profile = self.get_data("profile")
 
         # THEN check that the fields returned by the server have the correct values
         self.assertIsInstance(profile, dict)
-        self.assertEqual(profile['username'], self.username),
-        self.assertEqual(profile['email'],    self.user['email']),
-        self.assertEqual(profile['verification_pending'], True)
-        self.assertIsInstance(profile['student_classes'], list)
-        self.assertEqual(len(profile['student_classes']), 0)
-        self.assertIsInstance(profile['session_expires_at'], int)
+        self.assertEqual(profile["username"], self.username),
+        self.assertEqual(profile["email"], self.user["email"]),
+        self.assertEqual(profile["verification_pending"], True)
+        self.assertIsInstance(profile["student_classes"], list)
+        self.assertEqual(len(profile["student_classes"]), 0)
+        self.assertIsInstance(profile["session_expires_at"], int)
 
     def test_invalid_profile_modify(self):
         # GIVEN a logged in user
@@ -594,31 +635,31 @@ class TestAuth(AuthHelper):
 
         # WHEN attempting profile modifications with invalid bodies
         invalid_bodies = [
-            '',
+            "",
             [],
-            {'email': 'foobar'},
-            {'birth_year': 'a'},
-            {'birth_year': 20},
-            {'gender': 0},
-            {'gender': 'a'},
-            {'language': True},
-            {'language': 123},
-            {'keyword_language': True},
-            {'keyword_language': 123},
+            {"email": "foobar"},
+            {"birth_year": "a"},
+            {"birth_year": 20},
+            {"gender": 0},
+            {"gender": "a"},
+            {"language": True},
+            {"language": 123},
+            {"keyword_language": True},
+            {"keyword_language": 123},
         ]
 
         for invalid_body in invalid_bodies:
             # Create a valid body that we overwrite with invalid values
             if isinstance(invalid_body, dict):
                 body = {
-                    'email': self.user['email'],
-                    'language': self.user['language'],
-                    'keyword_language': self.user['keyword_language']
+                    "email": self.user["email"],
+                    "language": self.user["language"],
+                    "keyword_language": self.user["keyword_language"],
                 }
                 body.update(invalid_body)
                 invalid_body = body
             # THEN receive an invalid response code from the server
-            self.post_data('profile', invalid_body, expect_http_code=400)
+            self.post_data("profile", invalid_body, expect_http_code=400)
 
     def test_profile_modify(self):
         # GIVEN a new user
@@ -626,123 +667,98 @@ class TestAuth(AuthHelper):
         self.given_fresh_user_is_logged_in()
 
         # WHEN submitting valid profile changes
-        profile_changes = {
-           'birth_year': 1989,
-           'country': 'NL',
-           'gender': 'o'
-        }
+        profile_changes = {"birth_year": 1989, "country": "NL", "gender": "o"}
 
         body = {
-            'email': self.user['email'],
-            'language': self.user['language'],
-            'keyword_language': self.user['keyword_language']
+            "email": self.user["email"],
+            "language": self.user["language"],
+            "keyword_language": self.user["keyword_language"],
         }
         for key in profile_changes:
             body[key] = profile_changes[key]
             # THEN receive an OK response code from the server
-            self.post_data('profile', body)
+            self.post_data("profile", body)
 
             # WHEN retrieving the profile
-            profile = self.get_data('profile')
+            profile = self.get_data("profile")
             # THEN confirm that our modification has been stored by the server and returned in the latest version of the profile
             self.assertEqual(profile[key], profile_changes[key])
 
         # WHEN updating the user's email
         # (we check email change separately since it involves a flow with a token)
         # THEN receive an OK response code from the server
-        new_email = self.username + '@newhedy.com'
-        body = self.post_data('profile', {'email': new_email, 'language': self.user['language'], 'keyword_language': self.user['keyword_language']})
+        new_email = self.username + "@newhedy.com"
+        body = self.post_data(
+            "profile",
+            {"email": new_email, "language": self.user["language"], "keyword_language": self.user["keyword_language"]},
+        )
 
         # THEN confirm that the server replies with an email verification token
-        self.assertIsInstance(body['token'], str)
+        self.assertIsInstance(body["token"], str)
 
         # FINALLY update the email & email verification token on user
-        self.user['email'] = new_email
-        self.user['verify_token'] = body['token']
+        self.user["email"] = new_email
+        self.user["verify_token"] = body["token"]
 
     def test_invalid_change_language(self):
         # GIVEN a logged in user
         self.given_user_is_logged_in()
 
         # WHEN trying to update the profile with an invalid language
-        body = {
-            'email': self.user['email'],
-            'language': 'abc',
-            'keyword_language': self.user['keyword_language']
-        }
+        body = {"email": self.user["email"], "language": "abc", "keyword_language": self.user["keyword_language"]}
         # THEN receive an invalid response code from the server
-        self.post_data('profile', body, expect_http_code=400)
+        self.post_data("profile", body, expect_http_code=400)
 
     def test_valid_change_language(self):
         # GIVEN a logged in user
         self.given_user_is_logged_in()
 
         # WHEN trying to update the profile with a valid language
-        body = {
-            'email': self.user['email'],
-            'language': 'nl',
-            'keyword_language': 'nl'
-        }
+        body = {"email": self.user["email"], "language": "nl", "keyword_language": "nl"}
         # THEN receive a valid response code from the server
-        self.post_data('profile', body, expect_http_code=200)
+        self.post_data("profile", body, expect_http_code=200)
 
         # WHEN trying to retrieve the current profile
-        profile = self.get_data('profile')
+        profile = self.get_data("profile")
         # THEN verify that the language is successfully changed
-        self.assertEqual(profile['language'], body['language'])
+        self.assertEqual(profile["language"], body["language"])
 
     def test_invalid_keyword_language(self):
         # GIVEN a logged in user
         self.given_user_is_logged_in()
 
         # WHEN trying to update the profile with an invalid keyword language
-        invalid_keyword_language = [
-            'nl',
-            123,
-            'panda'
-        ]
+        invalid_keyword_language = ["nl", 123, "panda"]
 
-        body = {
-            'email': self.user['email'],
-            'language': 'en'
-        }
+        body = {"email": self.user["email"], "language": "en"}
         for invalid_lang in invalid_keyword_language:
-            body['keyword_language'] = invalid_lang
+            body["keyword_language"] = invalid_lang
             # THEN receive an invalid response code from the server
-            self.post_data('profile', body, expect_http_code=400)
+            self.post_data("profile", body, expect_http_code=400)
 
     def test_valid_keyword_language(self):
         # GIVEN a logged in user
         self.given_user_is_logged_in()
 
         # WHEN trying to update the profile with a valid keyword language
-        body = {
-            'email': self.user['email'],
-            'language': 'nl',
-            'keyword_language': 'nl'
-        }
+        body = {"email": self.user["email"], "language": "nl", "keyword_language": "nl"}
         # THEN receive a valid response code from the server
-        self.post_data('profile', body, expect_http_code=200)
+        self.post_data("profile", body, expect_http_code=200)
 
     def test_invalid_recover_password(self):
         # GIVEN an existing user
         self.given_any_user()
 
         # WHEN attempting a password recovery with invalid bodies
-        invalid_bodies = [
-            '',
-            [],
-            {},
-            {'username': 1}
-        ]
+        invalid_bodies = ["", [], {}, {"username": 1}]
 
         for invalid_body in invalid_bodies:
             # THEN receive an invalid response code from the server
-            self.post_data('auth/recover', invalid_body, expect_http_code=400)
+            self.post_data("auth/recover", invalid_body, expect_http_code=400)
 
         # WHEN attempting a password recovery with a non-existing username
         # THEN receive a forbidden response code from the server
-        self.post_data('auth/recover', {'username': self.make_username()}, expect_http_code=403)
+        self.post_data("auth/recover", {"username": self.make_username()}, expect_http_code=403)
 
     def test_recover_password(self):
         # GIVEN an existing user
@@ -750,9 +766,9 @@ class TestAuth(AuthHelper):
 
         # WHEN attempting a password recovery
         # THEN receive an OK response code from the server
-        body = self.post_data('auth/recover', {'username': self.username})
+        body = self.post_data("auth/recover", {"username": self.username})
         # THEN check that we have received a password recovery token from the server
-        self.assertIsInstance(body['token'], str)
+        self.assertIsInstance(body["token"], str)
 
     def test_invalid_reset_password(self):
         # GIVEN an existing user
@@ -760,109 +776,119 @@ class TestAuth(AuthHelper):
 
         # WHEN attempting a password reset with invalid bodies
         invalid_bodies = [
-            '',
+            "",
             [],
             {},
-            {'username': 1},
-            {'username': 'foobar', 'token': 1},
-            {'username': 'foobar', 'token': 'some'},
-            {'username': 'foobar', 'token': 'some', 'password': 1},
-            {'username': 'foobar', 'token': 'some', 'password': 'short'},
-            {'username': 'foobar', 'token': 'some', 'password': 'short', 'password_repeat': 123},
-            {'username': 'foobar', 'token': 'some', 'password_repeat': 'panda123'}
+            {"username": 1},
+            {"username": "foobar", "token": 1},
+            {"username": "foobar", "token": "some"},
+            {"username": "foobar", "token": "some", "password": 1},
+            {"username": "foobar", "token": "some", "password": "short"},
+            {"username": "foobar", "token": "some", "password": "short", "password_repeat": 123},
+            {"username": "foobar", "token": "some", "password_repeat": "panda123"},
         ]
 
         for invalid_body in invalid_bodies:
             # THEN receive an invalid response code from the server
-            self.post_data('auth/reset', invalid_body, expect_http_code=400)
+            self.post_data("auth/reset", invalid_body, expect_http_code=400)
 
         # WHEN attempting a password reset with an invalid token
         # THEN receive a forbidden response code from the server
-        self.post_data('auth/reset', {'username': self.username, 'password': '123456',
-                                      'password_repeat': '123456', 'token': 'foobar'}, expect_http_code=403)
+        self.post_data(
+            "auth/reset",
+            {"username": self.username, "password": "123456", "password_repeat": "123456", "token": "foobar"},
+            expect_http_code=403,
+        )
 
     def test_reset_password(self):
         # GIVEN an existing user
         self.given_any_user()
 
         # WHEN attempting a password reset with a valid username & token combination
-        new_password = 'pas1234'
-        recover_token = self.post_data('auth/recover', {'username': self.username})['token']
+        new_password = "pas1234"
+        recover_token = self.post_data("auth/recover", {"username": self.username})["token"]
         # THEN receive an OK response code from the server
-        self.post_data('auth/reset', {'username': self.username, 'password': new_password,
-                                      'password_repeat': new_password, 'token': recover_token})
+        self.post_data(
+            "auth/reset",
+            {
+                "username": self.username,
+                "password": new_password,
+                "password_repeat": new_password,
+                "token": recover_token,
+            },
+        )
 
         # WHEN attempting a login with the new password
         # THEN receive an OK response code from the server
-        self.post_data('auth/login', {'username': self.username, 'password': new_password})
+        self.post_data("auth/login", {"username": self.username, "password": new_password})
 
         # FINALLY update user's password and attempt login with new password
-        self.user['password'] = new_password
+        self.user["password"] = new_password
 
     def test_invalid_public_profile(self):
         # GIVEN a logged in user
         self.given_user_is_logged_in()
 
         # Create a program -> make sure it is not public
-        program = {'code': 'hello world', 'name': 'program 1', 'level': 1, 'shared': False}
-        program_id = self.post_data('programs', program)['id']
+        program = {"code": "hello world", "name": "program 1", "level": 1, "shared": False}
+        program_id = self.post_data("programs", program)["id"]
 
         # WHEN attempting to create a public profile with invalid bodies
         invalid_bodies = [
-            '',
+            "",
             [],
             {},
-            {'image': 123456},
-            {'image': '123'},
-            {'image': '123', 'personal_text': 123},
-            {'image': '123', 'personal_text': 123},
-            {'image': '123', 'personal_text': 123, 'favourite_program': 123},
-            {'image': '123', 'personal_text': 'Welcome to my profile!', 'favourite_program': 123},
-            {'image': '5', 'personal_text': 'Welcome to my profile!', 'favourite_program': 123},
-            {'image': '5', 'personal_text': 'Welcome to my profile!', 'favourite_program': "abcdefghi"},
-            {'image': '5', 'personal_text': 'Welcome to my profile!', 'favourite_program': program_id},
+            {"image": 123456},
+            {"image": "123"},
+            {"image": "123", "personal_text": 123},
+            {"image": "123", "personal_text": 123},
+            {"image": "123", "personal_text": 123, "favourite_program": 123},
+            {"image": "123", "personal_text": "Welcome to my profile!", "favourite_program": 123},
+            {"image": "5", "personal_text": "Welcome to my profile!", "favourite_program": 123},
+            {"image": "5", "personal_text": "Welcome to my profile!", "favourite_program": "abcdefghi"},
+            {"image": "5", "personal_text": "Welcome to my profile!", "favourite_program": program_id},
         ]
         for invalid_body in invalid_bodies:
             # THEN receive an invalid response code from the server
-            self.post_data('auth/public_profile', invalid_body, expect_http_code=400)
+            self.post_data("auth/public_profile", invalid_body, expect_http_code=400)
 
     def test_public_profile_without_favourite(self):
         # GIVEN a logged in user
         self.given_user_is_logged_in()
 
-        public_profile = {'image': '9', 'personal_text': 'welcome to my profile!'}
+        public_profile = {"image": "9", "personal_text": "welcome to my profile!"}
 
         # WHEN creating a new public profile
         # THEN receive an OK response code from the server
-        self.post_data('auth/public_profile', public_profile, expect_http_code=200)
+        self.post_data("auth/public_profile", public_profile, expect_http_code=200)
 
     def test_public_profile_with_favourite(self):
         # GIVEN a logged in user
         self.given_user_is_logged_in()
 
         # Create a program that is public -> can be set as favourite on the public profile
-        program = {'code': 'hello world', 'name': 'program 1', 'level': 1, 'shared': True}
-        program_id = self.post_data('programs', program)['id']
+        program = {"code": "hello world", "name": "program 1", "level": 1, "shared": True}
+        program_id = self.post_data("programs", program)["id"]
 
-        public_profile = {'image': '9', 'personal_text': 'welcome to my profile!', 'favourite_program': program_id}
+        public_profile = {"image": "9", "personal_text": "welcome to my profile!", "favourite_program": program_id}
 
         # WHEN creating a new public profile with favourite program
         # THEN receive an OK response code from the server
-        self.post_data('auth/public_profile', public_profile, expect_http_code=200)
+        self.post_data("auth/public_profile", public_profile, expect_http_code=200)
 
     def test_destroy_public_profile(self):
         # GIVEN a logged in user
         self.given_user_is_logged_in()
 
-        public_profile = {'image': '9', 'personal_text': 'welcome to my profile!'}
+        public_profile = {"image": "9", "personal_text": "welcome to my profile!"}
 
         # WHEN creating a new public profile with favourite program
         # THEN receive an OK response code from the server
-        self.post_data('auth/public_profile', public_profile, expect_http_code=200)
+        self.post_data("auth/public_profile", public_profile, expect_http_code=200)
 
         # WHEN destroying the public profile
         # THEN receive an OK response from the server
-        self.post_data('auth/destroy_public', public_profile, expect_http_code=200)
+        self.post_data("auth/destroy_public", public_profile, expect_http_code=200)
 
 
 class TestProgram(AuthHelper):
@@ -872,7 +898,7 @@ class TestProgram(AuthHelper):
 
         # WHEN retrieving own programs but without sending a cookie
         # THEN receive a forbidden response code from the server
-        self.get_data('programs_list', expect_http_code=403, no_cookie=True)
+        self.get_data("programs_list", expect_http_code=403, no_cookie=True)
 
     def test_get_programs(self):
         # GIVEN a logged in user
@@ -880,11 +906,11 @@ class TestProgram(AuthHelper):
 
         # WHEN retrieving own programs sending a cookie
         # THEN receive an OK response code from the server
-        body = self.get_data('programs_list')
+        body = self.get_data("programs_list")
 
         # THEN verify that the server sent a body that is an object of the shape `{programs:[...]}`.
         self.assertIsInstance(body, dict)
-        self.assertIsInstance(body['programs'], list)
+        self.assertIsInstance(body["programs"], list)
 
     def test_invalid_create_program(self):
         # GIVEN a logged in user
@@ -892,25 +918,30 @@ class TestProgram(AuthHelper):
 
         # WHEN attempting to create an invalid program
         invalid_bodies = [
-            '',
+            "",
             [],
             {},
-            {'code': 1},
-            {'code':['1']},
-            {'code': 'hello world'},
-            {'code': 'hello world', 'name': 1},
-            {'code': 'hello world', 'name': 'program 1'},
-            {'code': 'hello world', 'name': 'program 1', 'level': '1'},
-            {'code': 'hello world', 'name': 'program 1', 'level': 1, 'adventure_name': 1},
+            {"code": 1},
+            {"code": ["1"]},
+            {"code": "hello world"},
+            {"code": "hello world", "name": 1},
+            {"code": "hello world", "name": "program 1"},
+            {"code": "hello world", "name": "program 1", "level": "1"},
+            {"code": "hello world", "name": "program 1", "level": 1, "adventure_name": 1},
         ]
 
         for invalid_body in invalid_bodies:
             # THEN receive an invalid response code from the server
-            self.post_data('programs', invalid_body, expect_http_code=400)
+            self.post_data("programs", invalid_body, expect_http_code=400)
 
         # WHEN submitting a program without being logged in
         # THEN receive a forbidden response code from the server
-        self.post_data('programs', {'code': 'hello world', 'name': 'program 1', 'level': 1, 'shared': False}, expect_http_code=403, no_cookie=True)
+        self.post_data(
+            "programs",
+            {"code": "hello world", "name": "program 1", "level": 1, "shared": False},
+            expect_http_code=403,
+            no_cookie=True,
+        )
 
     def test_create_program(self):
         # GIVEN a new user
@@ -918,16 +949,16 @@ class TestProgram(AuthHelper):
         self.given_fresh_user_is_logged_in()
 
         # WHEN submitting a valid program
-        program = {'code': 'hello world', 'name': 'program 1', 'level': 1, 'shared': False}
+        program = {"code": "hello world", "name": "program 1", "level": 1, "shared": False}
         # THEN receive an OK response code from the server
-        program = self.post_data('programs', program)
+        program = self.post_data("programs", program)
         # THEN verify that the returned program has both a name and an id
         self.assertIsInstance(program, dict)
-        self.assertIsInstance(program['id'], str)
-        self.assertIsInstance(program['name'], str)
+        self.assertIsInstance(program["id"], str)
+        self.assertIsInstance(program["name"], str)
 
         # WHEN retrieving programs after saving a program
-        saved_programs = self.get_data('programs_list')['programs']
+        saved_programs = self.get_data("programs_list")["programs"]
         print(saved_programs)
 
         # THEN verify that the program we just saved is in the list
@@ -944,108 +975,114 @@ class TestProgram(AuthHelper):
 
         # WHEN attempting to share a program with an invalid body
         invalid_bodies = [
-            '',
+            "",
             [],
             {},
-            {'code': 1},
-            {'code':['1']},
-            {'code': 'hello world'},
-            {'code': 'hello world', 'name': 1},
-            {'code': 'hello world', 'name': 'program 1'},
-            {'code': 'hello world', 'name': 'program 1', 'level': '1'},
-            {'code': 'hello world', 'name': 'program 1', 'level': 1, 'adventure_name': 1},
+            {"code": 1},
+            {"code": ["1"]},
+            {"code": "hello world"},
+            {"code": "hello world", "name": 1},
+            {"code": "hello world", "name": "program 1"},
+            {"code": "hello world", "name": "program 1", "level": "1"},
+            {"code": "hello world", "name": "program 1", "level": 1, "adventure_name": 1},
         ]
 
         for invalid_body in invalid_bodies:
             # THEN receive an invalid response code from the server
-            self.post_data('programs/share', invalid_body, expect_http_code=400)
+            self.post_data("programs/share", invalid_body, expect_http_code=400)
 
         # WHEN sharing a program without being logged in
         # THEN receive a forbidden response code from the server
-        self.post_data('programs/share', {'id': '123456', 'public': True}, expect_http_code=403, no_cookie=True)
+        self.post_data("programs/share", {"id": "123456", "public": True}, expect_http_code=403, no_cookie=True)
 
         # WHEN sharing a program that does not exist
         # THEN receive a not found response code from the server
-        self.post_data('programs/share', {'id': '123456', 'public': True}, expect_http_code=404)
+        self.post_data("programs/share", {"id": "123456", "public": True}, expect_http_code=404)
 
     def test_valid_make_program_public(self):
         # GIVEN a logged in user with at least one program
         self.given_user_is_logged_in()
-        program = {'code': 'hello world', 'name': 'program 1', 'level': 1, 'shared': False}
-        program_id = self.post_data('programs', program)['id']
+        program = {"code": "hello world", "name": "program 1", "level": 1, "shared": False}
+        program_id = self.post_data("programs", program)["id"]
 
         # WHEN making a program public
         # THEN receive an OK response code from the server
-        self.post_data('programs/share', {'id': program_id, 'public': True,})
+        self.post_data(
+            "programs/share",
+            {
+                "id": program_id,
+                "public": True,
+            },
+        )
 
-        saved_programs = self.get_data('programs_list')['programs']
+        saved_programs = self.get_data("programs_list")["programs"]
         for program in saved_programs:
-            if program['id'] != program_id:
+            if program["id"] != program_id:
                 continue
             # THEN the program must have its `public` field enabled
-            self.assertEqual(program['public'], 1)
+            self.assertEqual(program["public"], 1)
 
         # GIVEN another user
         self.given_fresh_user_is_logged_in()
         # WHEN requesting a public program
         # THEN receive an OK response code from the server
-        self.get_data('hedy/1/' + program_id, expect_http_code=200)
+        self.get_data("hedy/1/" + program_id, expect_http_code=200)
 
     def test_valid_make_program_private(self):
         # GIVEN a logged in user with at least one public program
         self.given_user_is_logged_in()
-        program = {'code': 'hello world', 'name': 'program 1', 'level': 1, 'shared': False}
-        program_id = self.post_data('programs', program)['id']
-        self.post_data('programs/share', {'id': program_id, 'public': True})
+        program = {"code": "hello world", "name": "program 1", "level": 1, "shared": False}
+        program_id = self.post_data("programs", program)["id"]
+        self.post_data("programs/share", {"id": program_id, "public": True})
 
         # WHEN making a program private
         # THEN receive an OK response code from the server
-        self.post_data('programs/share', {'id': program_id, 'public': False})
+        self.post_data("programs/share", {"id": program_id, "public": False})
 
-        saved_programs = self.get_data('programs_list')['programs']
+        saved_programs = self.get_data("programs_list")["programs"]
         for program in saved_programs:
-            if program['id'] != program_id:
+            if program["id"] != program_id:
                 continue
             # THEN the program must have a '0' value for Public
-            self.assertEqual(program['public'], 0)
+            self.assertEqual(program["public"], 0)
 
         # GIVEN another user
         self.given_fresh_user_is_logged_in()
         # WHEN requesting a public program
         # THEN receive a not found response code from the server
-        self.get_data('hedy/1/' + program_id, expect_http_code=404)
+        self.get_data("hedy/1/" + program_id, expect_http_code=404)
 
     def test_invalid_delete_program(self):
         # GIVEN a logged in user with at least one program
         self.given_user_is_logged_in()
-        program = {'code': 'hello world', 'name': 'program 1', 'level': 1, 'shared': False}
-        self.post_data('programs', program)['id']
-        program_id = '123456'
+        program = {"code": "hello world", "name": "program 1", "level": 1, "shared": False}
+        self.post_data("programs", program)["id"]
+        program_id = "123456"
 
         # WHEN deleting a program that does not exist
         # THEN receive a not found response code from the server
-        self.post_data('programs/delete/', {'id': program_id}, expect_http_code=404)
+        self.post_data("programs/delete/", {"id": program_id}, expect_http_code=404)
 
     def test_valid_delete_program(self):
         # GIVEN a logged in user with at least one program
         self.given_user_is_logged_in()
-        program = {'code': 'hello world', 'name': 'program 1', 'level': 1, 'shared': False}
-        program_id = self.post_data('programs', program)['id']
+        program = {"code": "hello world", "name": "program 1", "level": 1, "shared": False}
+        program_id = self.post_data("programs", program)["id"]
 
         # WHEN deleting a program
         # THEN receive an OK response code from the server
-        headers = self.post_data('programs/delete/', {'id': program_id}, return_headers=True)
+        headers = self.post_data("programs/delete/", {"id": program_id}, return_headers=True)
 
-        saved_programs = self.get_data('programs_list')['programs']
+        saved_programs = self.get_data("programs_list")["programs"]
         for program in saved_programs:
             # THEN the program should not be any longer in the list of programs
-            self.assertNotEqual(program['id'], program_id)
+            self.assertNotEqual(program["id"], program_id)
 
     def test_destroy_account_with_programs(self):
         # GIVEN a logged in user with at least one program
         self.given_user_is_logged_in()
-        program = {'code': 'hello world', 'name': 'program 1', 'level': 1, 'shared': False}
-        program_id = self.post_data('programs', program)['id']
+        program = {"code": "hello world", "name": "program 1", "level": 1, "shared": False}
+        program_id = self.post_data("programs", program)["id"]
 
         # WHEN deleting the user account
         # THEN receive an OK response code from the server
@@ -1060,7 +1097,7 @@ class TestClasses(AuthHelper):
 
         # WHEN creating a class without teacher permissions
         # THEN receive a forbidden response code from the server
-        self.post_data('class', {'name': 'class1'}, expect_http_code=403)
+        self.post_data("class", {"name": "class1"}, expect_http_code=403)
 
         # WHEN marking the user as teacher
         self.make_current_user_teacher()
@@ -1068,17 +1105,11 @@ class TestClasses(AuthHelper):
         # GIVEN a user with teacher permissions
 
         # WHEN attempting to create a class with an invalid body
-        invalid_bodies = [
-            '',
-            [],
-            {},
-            {'name': 1},
-            {'name': ['foobar']}
-        ]
+        invalid_bodies = ["", [], {}, {"name": 1}, {"name": ["foobar"]}]
 
         for invalid_body in invalid_bodies:
             # THEN receive an invalid response code from the server
-            self.post_data('class', invalid_body, expect_http_code=400)
+            self.post_data("class", invalid_body, expect_http_code=400)
 
     def test_create_class(self):
         # GIVEN a user with teacher permissions
@@ -1086,7 +1117,7 @@ class TestClasses(AuthHelper):
         self.given_fresh_teacher_is_logged_in()
 
         # WHEN retrieving the list of classes
-        class_list = self.get_data('classes')
+        class_list = self.get_data("classes")
 
         # THEN receive a body containing an empty list
         self.assertIsInstance(class_list, list)
@@ -1094,102 +1125,96 @@ class TestClasses(AuthHelper):
 
         # WHEN creating a class
         # THEN receive an OK response code with the server
-        self.post_data('class', {'name': 'class1'})
+        self.post_data("class", {"name": "class1"})
 
         # GIVEN a class already saved
         # WHEN retrieving the list of classes
-        class_list = self.get_data('classes')
+        class_list = self.get_data("classes")
         # THEN receive a body containing an list with one element
         self.assertEqual(len(class_list), 1)
 
         # THEN validate the fields of the class
         Class = class_list[0]
         self.assertIsInstance(Class, dict)
-        self.assertIsInstance(Class['id'], str)
-        self.assertIsInstance(Class['date'], int)
-        self.assertIsInstance(Class['link'], str)
-        self.assertEqual(Class['name'], 'class1')
-        self.assertIsInstance(Class['students'], list)
-        self.assertEqual(len(Class['students']), 0)
-        self.assertEqual(Class['teacher'], self.username)
+        self.assertIsInstance(Class["id"], str)
+        self.assertIsInstance(Class["date"], int)
+        self.assertIsInstance(Class["link"], str)
+        self.assertEqual(Class["name"], "class1")
+        self.assertIsInstance(Class["students"], list)
+        self.assertEqual(len(Class["students"]), 0)
+        self.assertEqual(Class["teacher"], self.username)
 
         # WHEN retrieving the class
         # THEN receive an OK response code from the server
-        Class = self.get_data('for-teachers/class/' + Class['id'])
+        Class = self.get_data("for-teachers/class/" + Class["id"])
 
         # THEN validate the fields of the class
         self.assertIsInstance(Class, dict)
-        self.assertIsInstance(Class['id'], str)
-        self.assertIsInstance(Class['link'], str)
-        self.assertEqual(Class['name'], 'class1')
-        self.assertIsInstance(Class['students'], list)
-        self.assertEqual(len(Class['students']), 0)
+        self.assertIsInstance(Class["id"], str)
+        self.assertIsInstance(Class["link"], str)
+        self.assertEqual(Class["name"], "class1")
+        self.assertIsInstance(Class["students"], list)
+        self.assertEqual(len(Class["students"]), 0)
 
     def test_invalid_update_class(self):
         # GIVEN a user with teacher permissions and a class
         self.given_teacher_is_logged_in()
-        self.post_data('class', {'name': 'class1'})
-        Class = self.get_data('classes') [0]
+        self.post_data("class", {"name": "class1"})
+        Class = self.get_data("classes")[0]
 
         # WHEN attempting to update a class with no cookie
         # THEN receive a forbidden status code from the server
-        self.post_data('class/' + Class['id'], {'name': 'class2'}, expect_http_code=403, put_data=True, no_cookie=True)
+        self.post_data("class/" + Class["id"], {"name": "class2"}, expect_http_code=403, put_data=True, no_cookie=True)
 
         # WHEN attempting to update a class that does not exist
         # THEN receive a not found status code from the server
-        self.post_data('class/foo', {'name': 'class2'}, expect_http_code=404, put_data=True)
+        self.post_data("class/foo", {"name": "class2"}, expect_http_code=404, put_data=True)
 
         # WHEN attempting to update a class with an invalid body
-        invalid_bodies = [
-            '',
-            [],
-            {},
-            {'name': 1},
-            {'name': ['foobar']}
-        ]
+        invalid_bodies = ["", [], {}, {"name": 1}, {"name": ["foobar"]}]
 
         for invalid_body in invalid_bodies:
             # THEN receive an invalid response code from the server
-            self.post_data('class/' + Class['id'], invalid_body, expect_http_code=400, put_data=True)
+            self.post_data("class/" + Class["id"], invalid_body, expect_http_code=400, put_data=True)
 
     def test_update_class(self):
         # GIVEN a user with teacher permissions and a class
         self.given_teacher_is_logged_in()
-        self.post_data('class', {'name': 'class1'})
-        Class = self.get_data('classes') [0]
+        self.post_data("class", {"name": "class1"})
+        Class = self.get_data("classes")[0]
 
         # WHEN attempting to update a class
         # THEN receive an OK status code from the server
-        self.post_data('class/' + Class['id'], {'name': 'class2'}, put_data=True)
+        self.post_data("class/" + Class["id"], {"name": "class2"}, put_data=True)
 
         # WHEN retrieving the class
         # THEN receive an OK response code from the server
-        Class = self.get_data('for-teachers/class/' + Class['id'])
+        Class = self.get_data("for-teachers/class/" + Class["id"])
 
         # THEN the name of the class should be updated
-        self.assertEqual(Class['name'], 'class2')
+        self.assertEqual(Class["name"], "class2")
 
     def test_copy_class(self):
         # GIVEN a user with teacher permissions and a class
         self.given_teacher_is_logged_in()
-        self.post_data('class', {'name': 'class1'})
-        Class = self.get_data('classes')[0]
+        self.post_data("class", {"name": "class1"})
+        Class = self.get_data("classes")[0]
 
         # WHEN attempting to duplicate a class
         # THEN receive an OK status code from the server
-        self.post_data('/duplicate_class', {'id': Class['id'], 'name': 'class2'})
+        self.post_data("/duplicate_class", {"id": Class["id"], "name": "class2"})
 
     def test_join_class(self):
         # GIVEN a teacher
         self.given_teacher_is_logged_in()
 
         # GIVEN a class
-        self.post_data('class', {'name': 'class1'})
-        Class = self.get_data('classes')[0]
+        self.post_data("class", {"name": "class1"})
+        Class = self.get_data("classes")[0]
 
         # WHEN attempting to join a class without being logged in
         # THEN receive a forbidden status code from the server
-        self.post_data('class/join', {'id': Class['id']}, no_cookie=True, expect_http_code=403)
+        self.post_data("class/join", {"id": Class["id"]}, no_cookie=True, expect_http_code=403)
 
         # GIVEN a student (user without teacher permissions)
         self.given_fresh_user_is_logged_in()
@@ -1197,80 +1222,80 @@ class TestClasses(AuthHelper):
 
         # WHEN retrieving the short link of a class
         # THEN receive a redirect to `class/ID/join/LINK`
-        body = self.get_data('hedy/l/' + Class['link'], expect_http_code=302)
-        if not re.search(HOST + 'class/' + Class['id'] + '/prejoin/' + Class['link'], body):
-            raise Exception('Invalid or missing redirect link')
+        body = self.get_data("hedy/l/" + Class["link"], expect_http_code=302)
+        if not re.search(HOST + "class/" + Class["id"] + "/prejoin/" + Class["link"], body):
+            raise Exception("Invalid or missing redirect link")
 
         # WHEN joining a class
         # THEN we receive a 200 code
-        body = self.post_data('class/join', {'id': Class['id']}, expect_http_code=200)
+        body = self.post_data("class/join", {"id": Class["id"]}, expect_http_code=200)
 
         # WHEN getting own profile after joining a class
-        profile = self.get_data('profile')
+        profile = self.get_data("profile")
         # THEN verify that the class is there and contains the right fields
-        self.assertIsInstance(profile['student_classes'], list)
-        self.assertEqual(len(profile['student_classes']), 1)
-        student_class = profile['student_classes'][0]
+        self.assertIsInstance(profile["student_classes"], list)
+        self.assertEqual(len(profile["student_classes"]), 1)
+        student_class = profile["student_classes"][0]
         self.assertIsInstance(student_class, dict)
-        self.assertEqual(student_class['id'], Class['id'])
-        self.assertEqual(student_class['name'], Class['name'])
+        self.assertEqual(student_class["id"], Class["id"])
+        self.assertEqual(student_class["name"], Class["name"])
 
     def test_see_students_in_class(self):
         # GIVEN a teacher (no classes yet)
         self.given_fresh_teacher_is_logged_in()
         teacher = self.user
         # GIVEN a class
-        self.post_data('class', {'name': 'class1'})
-        Class = self.get_data('classes') [0]
+        self.post_data("class", {"name": "class1"})
+        Class = self.get_data("classes")[0]
 
         # GIVEN a student (user without teacher permissions) that has joined the class
         self.given_fresh_user_is_logged_in()
         student = self.user
-        self.post_data('class/join', {'id': Class['id']}, expect_http_code=200)
+        self.post_data("class/join", {"id": Class["id"]}, expect_http_code=200)
 
         # GIVEN the aforementioned teacher
         self.switch_user(teacher)
 
         # WHEN retrieving the class with a student in it
-        Class_data = self.get_data('for-teachers/class/' + Class['id'])
+        Class_data = self.get_data("for-teachers/class/" + Class["id"])
         # THEN the class should contain a student with valid fields
-        self.assertEqual(len(Class_data['students']), 1)
-        class_student = Class_data['students'][0]
-        self.assertEqual(class_student['highest_level'], 0)
-        self.assertEqual(class_student['programs'], 0)
-        self.assertIsInstance(class_student['last_login'], str)
-        self.assertEqual(class_student['username'], student['username'])
+        self.assertEqual(len(Class_data["students"]), 1)
+        class_student = Class_data["students"][0]
+        self.assertEqual(class_student["highest_level"], 0)
+        self.assertEqual(class_student["programs"], 0)
+        self.assertIsInstance(class_student["last_login"], str)
+        self.assertEqual(class_student["username"], student["username"])
 
         # WHEN retrieving the student's programs
         # THEN receive an OK response code from the server
-        body = self.get_data('programs?user=' + student['username'], expect_http_code=200)
+        body = self.get_data("programs?user=" + student["username"], expect_http_code=200)
 
     def test_see_students_with_programs_in_class(self):
         # GIVEN a teacher (no classes yet)
         self.given_fresh_teacher_is_logged_in()
         teacher = self.user
         # GIVEN a class
-        self.post_data('class', {'name': 'class1'})
-        Class = self.get_data('classes') [0]
+        self.post_data("class", {"name": "class1"})
+        Class = self.get_data("classes")[0]
 
         # GIVEN a student (user without teacher permissions) that has joined the class and has a public program
         self.given_fresh_user_is_logged_in()
         student = self.user
-        self.post_data('class/join', {'id': Class['id']}, expect_http_code=200)
+        self.post_data("class/join", {"id": Class["id"]}, expect_http_code=200)
         # GIVEN a student with two programs, one public and one private
-        public_program = {'code': 'hello world', 'name': 'program 1', 'level': 1, 'shared': False}
-        public_program_id = self.post_data('programs', public_program)['id']
-        self.post_data('programs/share', {'id': public_program_id, 'public': True})
-        private_program = {'code': 'hello world', 'name': 'program 2', 'level': 2, 'shared': False}
-        private_program_id = self.post_data('programs', private_program)['id']
+        public_program = {"code": "hello world", "name": "program 1", "level": 1, "shared": False}
+        public_program_id = self.post_data("programs", public_program)["id"]
+        self.post_data("programs/share", {"id": public_program_id, "public": True})
+        private_program = {"code": "hello world", "name": "program 2", "level": 2, "shared": False}
+        private_program_id = self.post_data("programs", private_program)["id"]
 
         # GIVEN the aforementioned teacher
         self.switch_user(teacher)
 
         # WHEN retrieving the class with a student in it
-        Class_data = self.get_data('for-teachers/class/' + Class['id'])
+        Class_data = self.get_data("for-teachers/class/" + Class["id"])
         # THEN the class should contain a student with valid fields
-        self.assertEqual(len(Class_data['students']), 1)
+        self.assertEqual(len(Class_data["students"]), 1)
 
 
 class TestCustomizeClasses(AuthHelper):
@@ -1283,7 +1308,7 @@ class TestCustomizeClasses(AuthHelper):
 
         # WHEN customizing a class without being a teacher
         # THEN receive a forbidden response code from the server
-        self.post_data('for-teachers/customize-class/' + class_id, {}, expect_http_code=403)
+        self.post_data("for-teachers/customize-class/" + class_id, {}, expect_http_code=403)
 
     def test_invalid_customization(self):
         # GIVEN a user with teacher permissions
@@ -1293,29 +1318,29 @@ class TestCustomizeClasses(AuthHelper):
         # WHEN creating a class
         # THEN receive an OK response code with the server
         # AND retrieve the class_id from the first class of your classes
-        self.post_data('class', {'name': 'class1'})
-        class_id = self.get_data('classes')[0].get('id')
+        self.post_data("class", {"name": "class1"})
+        class_id = self.get_data("classes")[0].get("id")
 
         # WHEN attempting to create an invalid customization
         invalid_bodies = [
-            '',
+            "",
             [],
             {},
-            {'levels': 1},
-            {'levels': [1, 2, 3]},
-            {'levels': [1, 2, 3], 'adventures': []},
-            {'levels': [1, 2, 3], 'adventures': {}},
-            {'levels': [1, 2, 3], 'adventures': {}, 'opening_dates': {}},
-            {'levels': [1, 2, 3], 'adventures': {}, 'opening_dates': {}, 'teacher_adventures': []}
+            {"levels": 1},
+            {"levels": [1, 2, 3]},
+            {"levels": [1, 2, 3], "adventures": []},
+            {"levels": [1, 2, 3], "adventures": {}},
+            {"levels": [1, 2, 3], "adventures": {}, "opening_dates": {}},
+            {"levels": [1, 2, 3], "adventures": {}, "opening_dates": {}, "teacher_adventures": []},
         ]
 
         for invalid_body in invalid_bodies:
             # THEN receive an invalid response code from the server
-            self.post_data('for-teachers/customize-class/' + class_id, invalid_body, expect_http_code=400)
+            self.post_data("for-teachers/customize-class/" + class_id, invalid_body, expect_http_code=400)
 
         # WHEN customizing a class that doesn't exist
         # THEN receive a not found response code from the server
-        self.post_data('for-teachers/customize-class/123' + class_id, {}, expect_http_code=404)
+        self.post_data("for-teachers/customize-class/123" + class_id, {}, expect_http_code=404)
 
     def test_valid_customization(self):
         # GIVEN a user with teacher permissions
@@ -1325,29 +1350,71 @@ class TestCustomizeClasses(AuthHelper):
         # WHEN creating a class
         # THEN receive an OK response code with the server
         # AND retrieve the class_id from the first class of your classes
-        self.post_data('class', {'name': 'class1'})
-        class_id = self.get_data('classes')[0].get('id')
+        self.post_data("class", {"name": "class1"})
+        class_id = self.get_data("classes")[0].get("id")
 
         valid_bodies = [
-            {'levels': [], 'adventures': {}, 'opening_dates': {}, 'teacher_adventures': [], 'other_settings': []},
-            {'levels': ['1'], 'adventures': {'story': ['1']}, 'opening_dates': {'1': '2022-03-16'}, 'teacher_adventures': [], 'other_settings': []},
-            {'levels': ['1', '2', '3'], 'opening_dates': {'1': '', '2': '', '3': ''},
-             'adventures': {'story': [], 'parrot': [], 'songs': [], 'turtle': [], 'dishes': [], 'dice': [], 'rock': [],
-                            'calculator': [], 'restaurant': [], 'fortune': [], 'haunted': [], 'piggybank': [],
-                            'quizmaster': [], 'language': [], 'next': [], 'end': []}, 'teacher_adventures': [],
-             'other_settings': []},
-            {'levels': ['1', '2', '3'], 'opening_dates': {'1': '', '2': '', '3': ''},
-             'adventures': {'story': ['1', '2', '3'], 'parrot': ['1', '2', '3'], 'songs': [], 'turtle': ['1', '2', '3'],
-                            'dishes': ['3'], 'dice': ['3'], 'rock': ['1', '2', '3'], 'calculator': [],
-                            'restaurant': ['1', '2', '3'], 'fortune': ['1', '3'], 'haunted': ['1', '2', '3'],
-                            'piggybank': [], 'quizmaster': [], 'language': [], 'next': ['1', '2', '3'],
-                            'end': ['1', '2', '3']}, 'teacher_adventures': [],
-             'other_settings': ['developers_mode', 'hide_cheatsheet']}
+            {"levels": [], "adventures": {}, "opening_dates": {}, "teacher_adventures": [], "other_settings": []},
+            {
+                "levels": ["1"],
+                "adventures": {"story": ["1"]},
+                "opening_dates": {"1": "2022-03-16"},
+                "teacher_adventures": [],
+                "other_settings": [],
+            },
+            {
+                "levels": ["1", "2", "3"],
+                "opening_dates": {"1": "", "2": "", "3": ""},
+                "adventures": {
+                    "story": [],
+                    "parrot": [],
+                    "songs": [],
+                    "turtle": [],
+                    "dishes": [],
+                    "dice": [],
+                    "rock": [],
+                    "calculator": [],
+                    "restaurant": [],
+                    "fortune": [],
+                    "haunted": [],
+                    "piggybank": [],
+                    "quizmaster": [],
+                    "language": [],
+                    "next": [],
+                    "end": [],
+                },
+                "teacher_adventures": [],
+                "other_settings": [],
+            },
+            {
+                "levels": ["1", "2", "3"],
+                "opening_dates": {"1": "", "2": "", "3": ""},
+                "adventures": {
+                    "story": ["1", "2", "3"],
+                    "parrot": ["1", "2", "3"],
+                    "songs": [],
+                    "turtle": ["1", "2", "3"],
+                    "dishes": ["3"],
+                    "dice": ["3"],
+                    "rock": ["1", "2", "3"],
+                    "calculator": [],
+                    "restaurant": ["1", "2", "3"],
+                    "fortune": ["1", "3"],
+                    "haunted": ["1", "2", "3"],
+                    "piggybank": [],
+                    "quizmaster": [],
+                    "language": [],
+                    "next": ["1", "2", "3"],
+                    "end": ["1", "2", "3"],
+                },
+                "teacher_adventures": [],
+                "other_settings": ["developers_mode", "hide_cheatsheet"],
+            },
         ]
 
         for valid_body in valid_bodies:
             # THEN receive an invalid response code from the server
-            self.post_data('for-teachers/customize-class/' + class_id, valid_body, expect_http_code=200)
+            self.post_data("for-teachers/customize-class/" + class_id, valid_body, expect_http_code=200)
 
     def test_remove_customization(self):
         # GIVEN a user with teacher permissions
@@ -1357,17 +1424,17 @@ class TestCustomizeClasses(AuthHelper):
         # WHEN creating a class
         # THEN receive an OK response code with the server
         # AND retrieve the class_id from the first class of your classes
-        self.post_data('class', {'name': 'class1'})
-        class_id = self.get_data('classes')[0].get('id')
+        self.post_data("class", {"name": "class1"})
+        class_id = self.get_data("classes")[0].get("id")
 
         # WHEN creating class customizations
         # THEN receive an OK response code with the server
-        body = {'levels': [], 'adventures': {}, 'opening_dates': {}, 'teacher_adventures': [], 'other_settings': []}
-        self.post_data('for-teachers/customize-class/' + class_id, body, expect_http_code=200)
+        body = {"levels": [], "adventures": {}, "opening_dates": {}, "teacher_adventures": [], "other_settings": []}
+        self.post_data("for-teachers/customize-class/" + class_id, body, expect_http_code=200)
 
         # WHEN deleting class customizations
         # THEN receive an OK response code with the server
-        self.delete_data('for-teachers/customize-class/' + class_id, expect_http_code=200)
+        self.delete_data("for-teachers/customize-class/" + class_id, expect_http_code=200)
 
 
 class TestCustomAdventures(AuthHelper):
@@ -1377,27 +1444,22 @@ class TestCustomAdventures(AuthHelper):
 
         # WHEN trying to create a custom adventure
         # THEN receive a forbidden response code from the server
-        self.post_data('for-teachers/create_adventure', {}, expect_http_code=403)
+        self.post_data("for-teachers/create_adventure", {}, expect_http_code=403)
 
     def test_invalid_create_adventure(self):
         # GIVEN a new teacher
         self.given_fresh_teacher_is_logged_in()
 
         # WHEN attempting to create an invalid adventure
-        invalid_bodies = [
-            '',
-            [],
-            {},
-            {'name': 123}
-        ]
+        invalid_bodies = ["", [], {}, {"name": 123}]
 
         for invalid_body in invalid_bodies:
-            self.post_data('for-teachers/create_adventure', invalid_body, expect_http_code=400)
+            self.post_data("for-teachers/create_adventure", invalid_body, expect_http_code=400)
 
         # WHEN attempting to create an adventure that already exists
         # THEN receive an 400 error from the server
-        self.post_data('for-teachers/create_adventure', {'name': 'test_adventure'}, expect_http_code=200)
-        self.post_data('for-teachers/create_adventure', {'name': 'test_adventure'}, expect_http_code=400)
+        self.post_data("for-teachers/create_adventure", {"name": "test_adventure"}, expect_http_code=200)
+        self.post_data("for-teachers/create_adventure", {"name": "test_adventure"}, expect_http_code=400)
 
     def test_create_adventure(self):
         # GIVEN a new teacher
@@ -1405,7 +1467,7 @@ class TestCustomAdventures(AuthHelper):
 
         # WHEN attempting to create a valid adventure
         # THEN receive an OK response with the server
-        self.post_data('for-teachers/create_adventure', {'name': 'test_adventure'}, expect_http_code=200)
+        self.post_data("for-teachers/create_adventure", {"name": "test_adventure"}, expect_http_code=200)
 
     def test_invalid_view_adventure(self):
         # GIVEN a new user
@@ -1413,14 +1475,14 @@ class TestCustomAdventures(AuthHelper):
 
         # WHEN attempting to view a custom adventure
         # THEN receive a 403 error from the server
-        self.get_data('for-teachers/customize-adventure/view/123', expect_http_code=403)
+        self.get_data("for-teachers/customize-adventure/view/123", expect_http_code=403)
 
         # GIVEN a new teacher
         self.given_fresh_teacher_is_logged_in()
 
         # WHEN attempting to view a custom adventure that doesn't exist
         # THEN receive a 404 error from the server
-        self.get_data('for-teachers/customize-adventure/view/123', expect_http_code=404)
+        self.get_data("for-teachers/customize-adventure/view/123", expect_http_code=404)
 
     def test_valid_view_adventure(self):
         # GIVEN a new teacher
@@ -1428,11 +1490,13 @@ class TestCustomAdventures(AuthHelper):
 
         # WHEN attempting to create a valid adventure
         # THEN receive an OK response with the server
-        adventure_id = self.post_data('for-teachers/create_adventure', {'name': 'test_adventure'}, expect_http_code=200).get("id")
+        adventure_id = self.post_data(
+            "for-teachers/create_adventure", {"name": "test_adventure"}, expect_http_code=200
+        ).get("id")
 
         # WHEN attempting to view the adventure using the id from the returned body
         # THEN receive an OK response with the server
-        self.get_data('for-teachers/customize-adventure/view/' + adventure_id)
+        self.get_data("for-teachers/customize-adventure/view/" + adventure_id)
 
     def test_invalid_update_adventure(self):
         # GIVEN a new teacher
@@ -1440,31 +1504,47 @@ class TestCustomAdventures(AuthHelper):
 
         # WHEN attempting to create a valid adventure
         # THEN receive an OK response with the server
-        adventure_id = self.post_data('for-teachers/create_adventure', {'name': 'test_adventure'}, expect_http_code=200).get("id")
+        adventure_id = self.post_data(
+            "for-teachers/create_adventure", {"name": "test_adventure"}, expect_http_code=200
+        ).get("id")
 
         # WHEN attempting to updating an adventure with invalid data
         invalid_bodies = [
-            '',
+            "",
             [],
             {},
-            {'id': 123},
-            {'id': 123, 'name': 123},
-            {'id': '123', 'name': 123},
-            {'id': '123', 'name': 123, 'classes': []},
-            {'id': '123', 'name': 123, 'classes': [], 'level': 5},
-            {'id': '123', 'name': 123, 'classes': [], 'level': 5, 'content': 123},
-            {'id': adventure_id, 'name': 'panda', 'classes': [], 'level': '5', 'content': 'too short!'},
-            {'id': adventure_id, 'name': 'panda', 'classes': [], 'level': '5', 'content': 'This is just long enough!', 'public': 'panda'},
+            {"id": 123},
+            {"id": 123, "name": 123},
+            {"id": "123", "name": 123},
+            {"id": "123", "name": 123, "classes": []},
+            {"id": "123", "name": 123, "classes": [], "level": 5},
+            {"id": "123", "name": 123, "classes": [], "level": 5, "content": 123},
+            {"id": adventure_id, "name": "panda", "classes": [], "level": "5", "content": "too short!"},
+            {
+                "id": adventure_id,
+                "name": "panda",
+                "classes": [],
+                "level": "5",
+                "content": "This is just long enough!",
+                "public": "panda",
+            },
         ]
 
         # THEN receive a 400 error from the server
         for invalid_body in invalid_bodies:
-            self.post_data('for-teachers/customize-adventure', invalid_body, expect_http_code=400)
+            self.post_data("for-teachers/customize-adventure", invalid_body, expect_http_code=400)
 
         # WHEN attempting to update a non-existing adventure
         # THEN receive a 404 error from the server
-        body = {'id': '123', 'name': 'panda', 'classes': [], 'level': '5', 'content': 'This is just long enough!', 'public': True}
-        self.post_data('for-teachers/customize-adventure', body, expect_http_code=404)
+        body = {
+            "id": "123",
+            "name": "panda",
+            "classes": [],
+            "level": "5",
+            "content": "This is just long enough!",
+            "public": True,
+        }
+        self.post_data("for-teachers/customize-adventure", body, expect_http_code=404)
 
     def test_valid_update_adventure(self):
         # GIVEN a new teacher
@@ -1472,12 +1552,21 @@ class TestCustomAdventures(AuthHelper):
 
         # WHEN attempting to create a valid adventure
         # THEN receive an OK response from the server
-        adventure_id = self.post_data('for-teachers/create_adventure', {'name': 'test_adventure'}, expect_http_code=200).get("id")
+        adventure_id = self.post_data(
+            "for-teachers/create_adventure", {"name": "test_adventure"}, expect_http_code=200
+        ).get("id")
 
         # WHEN attempting to update an adventure with a valid body
         # THEN receive an OK response from the server
-        body = {'id': adventure_id, 'name': 'test_adventure', 'classes': [], 'level': '5', 'content': 'This is just long enough!', 'public': True}
-        self.post_data('for-teachers/customize-adventure', body, expect_http_code=200)
+        body = {
+            "id": adventure_id,
+            "name": "test_adventure",
+            "classes": [],
+            "level": "5",
+            "content": "This is just long enough!",
+            "public": True,
+        }
+        self.post_data("for-teachers/customize-adventure", body, expect_http_code=200)
 
     def test_valid_update_adventure_with_class(self):
         # GIVEN a new teacher
@@ -1485,25 +1574,27 @@ class TestCustomAdventures(AuthHelper):
 
         # WHEN attempting to create a valid adventure
         # THEN receive an OK response from the server
-        adventure_id = self.post_data('for-teachers/create_adventure', {'name': 'test_adventure'}, expect_http_code=200).get("id")
+        adventure_id = self.post_data(
+            "for-teachers/create_adventure", {"name": "test_adventure"}, expect_http_code=200
+        ).get("id")
 
         # WHEN attempting to create a valid adventure
         # THEN receive an OK response from the server AND retrieve the class_id
-        self.post_data('class', {'name': 'class1'})
-        class_id = self.get_data('classes')[0].get('id')
+        self.post_data("class", {"name": "class1"})
+        class_id = self.get_data("classes")[0].get("id")
 
         # WHEN attempting to update an adventure with a valid body
         # THEN receive an OK response from the server
         body = {
-            'id': adventure_id,
-            'name': 'test_adventure',
-            'classes': [class_id],
-            'level': '5',
-            'content': 'This is just long enough!',
-            'public': True
+            "id": adventure_id,
+            "name": "test_adventure",
+            "classes": [class_id],
+            "level": "5",
+            "content": "This is just long enough!",
+            "public": True,
         }
 
-        self.post_data('for-teachers/customize-adventure', body, expect_http_code=200)
+        self.post_data("for-teachers/customize-adventure", body, expect_http_code=200)
 
     def test_destroy_adventure(self):
         # GIVEN a user with teacher permissions
@@ -1512,11 +1603,11 @@ class TestCustomAdventures(AuthHelper):
 
         # WHEN attempting to create a valid adventure
         # THEN receive an OK response from the server
-        body = self.post_data('for-teachers/create_adventure', {'name': 'test_adventure'}, expect_http_code=200)
+        body = self.post_data("for-teachers/create_adventure", {"name": "test_adventure"}, expect_http_code=200)
 
         # WHEN attempting to remove the adventure
         # THEN receive an OK response from the server
-        self.delete_data('for-teachers/customize-adventure/' + body.get('id', ""), expect_http_code=200)
+        self.delete_data("for-teachers/customize-adventure/" + body.get("id", ""), expect_http_code=200)
 
 
 class TestMultipleAccounts(AuthHelper):
@@ -1526,7 +1617,7 @@ class TestMultipleAccounts(AuthHelper):
 
         # WHEN trying to create multiple accounts
         # THEN receive a forbidden response code from the server
-        self.post_data('for-teachers/create-accounts', {}, expect_http_code=403)
+        self.post_data("for-teachers/create-accounts", {}, expect_http_code=403)
 
     def test_invalid_create_accounts(self):
         # GIVEN a new teacher
@@ -1534,18 +1625,18 @@ class TestMultipleAccounts(AuthHelper):
 
         # WHEN attempting to create invalid accounts
         invalid_bodies = [
-            '',
+            "",
             [],
             {},
-            {'accounts': []},
-            {'accounts': [{'username': 123}]},
-            {'accounts': [{'username': 'panda', 'password': 123}]},
-            {'accounts': [{'username': '@', 'password': 'test123'}]},
-            {'accounts': [{'username': 'panda', 'password': 'test123'}, {'username': 'panda2', 'password': 123}]}
+            {"accounts": []},
+            {"accounts": [{"username": 123}]},
+            {"accounts": [{"username": "panda", "password": 123}]},
+            {"accounts": [{"username": "@", "password": "test123"}]},
+            {"accounts": [{"username": "panda", "password": "test123"}, {"username": "panda2", "password": 123}]},
         ]
 
         for invalid_body in invalid_bodies:
-            self.post_data('for-teachers/create-accounts', invalid_body, expect_http_code=400)
+            self.post_data("for-teachers/create-accounts", invalid_body, expect_http_code=400)
 
     def test_create_accounts(self):
         # GIVEN a new teacher
@@ -1554,16 +1645,15 @@ class TestMultipleAccounts(AuthHelper):
         # WHEN attempting to create a valid adventure
         # THEN receive an OK response with the server
         body = {
-            'accounts': [
-                {'username': 'panda', 'password': 'test123'},
-                {'username': 'panda2', 'password': 'test321'}
-            ]
+            "accounts": [{"username": "panda", "password": "test123"}, {"username": "panda2", "password": "test321"}]
         }
-        self.post_data('for-teachers/create-accounts', body, expect_http_code=200)
+        self.post_data("for-teachers/create-accounts", body, expect_http_code=200)
+
 
 # *** CLEANUP OF USERS CREATED DURING THE TESTS ***
 
-def tearDownModule ():
+
+def tearDownModule():
     auth_helper = AuthHelper()
     auth_helper.setUp()
     for username in USERS.copy():

--- a/utils.py
+++ b/utils.py
@@ -11,14 +11,13 @@ import uuid
 
 from flask_babel import gettext, format_date, format_datetime, format_timedelta
 from ruamel import yaml
-from website import querylog
 import commonmark
 
 commonmark_parser = commonmark.Parser()
 commonmark_renderer = commonmark.HtmlRenderer()
 from bs4 import BeautifulSoup
 from flask_helpers import render_template
-from flask import g, session, request
+from flask import session, request
 
 IS_WINDOWS = os.name == "nt"
 

--- a/utils.py
+++ b/utils.py
@@ -13,16 +13,18 @@ from flask_babel import gettext, format_date, format_datetime, format_timedelta
 from ruamel import yaml
 from website import querylog
 import commonmark
+
 commonmark_parser = commonmark.Parser()
 commonmark_renderer = commonmark.HtmlRenderer()
 from bs4 import BeautifulSoup
 from flask_helpers import render_template
 from flask import g, session, request
 
-IS_WINDOWS = os.name == 'nt'
+IS_WINDOWS = os.name == "nt"
 
 # Define code that will be used if some turtle command is present
-TURTLE_PREFIX_CODE = textwrap.dedent("""\
+TURTLE_PREFIX_CODE = textwrap.dedent(
+    """\
     # coding=utf8
     import random, time, turtle
     t = turtle.Turtle()
@@ -32,12 +34,14 @@ TURTLE_PREFIX_CODE = textwrap.dedent("""\
     t.pendown()
     t.speed(3)
     t.showturtle()
- """)
+ """
+)
 
 # Preamble that will be used for non-Turtle programs
 # numerals list generated from: https://replit.com/@mevrHermans/multilangnumerals
 
-NORMAL_PREFIX_CODE = textwrap.dedent("""\
+NORMAL_PREFIX_CODE = textwrap.dedent(
+    """\
     # coding=utf8
     import random, time
     global int_saver
@@ -82,28 +86,33 @@ NORMAL_PREFIX_CODE = textwrap.dedent("""\
             return ''.join(all_numerals_converted)
         else:
             return number
-        """)
+        """
+)
+
 
 class Timer:
-  """A quick and dirty timer."""
-  def __init__(self, name):
-    self.name = name
+    """A quick and dirty timer."""
 
-  def __enter__(self):
-    self.start = time.time()
+    def __init__(self, name):
+        self.name = name
 
-  def __exit__(self, type, value, tb):
-    delta = time.time() - self.start
-    print(f'{self.name}: {delta}s')
+    def __enter__(self):
+        self.start = time.time()
+
+    def __exit__(self, type, value, tb):
+        delta = time.time() - self.start
+        print(f"{self.name}: {delta}s")
 
 
 def timer(fn):
-  """Decoractor for fn."""
-  @functools.wraps(fn)
-  def wrapper(*args, **kwargs):
-    with Timer(fn.__name__):
-      return fn(*args, **kwargs)
-  return wrapper
+    """Decoractor for fn."""
+
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        with Timer(fn.__name__):
+            return fn(*args, **kwargs)
+
+    return wrapper
 
 
 def timems():
@@ -115,6 +124,7 @@ def timems():
     """
     return int(round(time.time() * 1000))
 
+
 def times():
     """Return the UNIX timestamp in seconds.
 
@@ -123,9 +133,8 @@ def times():
     return int(round(time.time()))
 
 
-
-
 DEBUG_MODE = False
+
 
 def is_debug_mode():
     """Return whether or not we're in debug mode.
@@ -144,7 +153,7 @@ def set_debug_mode(debug_mode):
 def load_yaml_rt(filename):
     """Load YAML with the round trip loader."""
     try:
-        with open(filename, 'r', encoding='utf-8') as f:
+        with open(filename, "r", encoding="utf-8") as f:
             return yaml.round_trip_load(f, preserve_quotes=True)
     except IOError:
         return {}
@@ -154,15 +163,18 @@ def dump_yaml_rt(data):
     """Dump round-tripped YAML."""
     return yaml.round_trip_dump(data, indent=4, width=999)
 
-def slash_join(*args):
-    ret =[]
-    for arg in args:
-        if not arg: continue
 
-        if ret and not ret[-1].endswith('/'):
-            ret.append('/')
-        ret.append(arg.lstrip('/') if ret else arg)
-    return ''.join(ret)
+def slash_join(*args):
+    ret = []
+    for arg in args:
+        if not arg:
+            continue
+
+        if ret and not ret[-1].endswith("/"):
+            ret.append("/")
+        ret.append(arg.lstrip("/") if ret else arg)
+    return "".join(ret)
+
 
 def is_testing_request(request):
     """Whether the current request is a test request.
@@ -172,20 +184,22 @@ def is_testing_request(request):
 
     Test requests are only allowed on non-Heroku instances.
     """
-    return not is_heroku() and bool('X-Testing' in request.headers and request.headers['X-Testing'])
+    return not is_heroku() and bool("X-Testing" in request.headers and request.headers["X-Testing"])
+
 
 def extract_bcrypt_rounds(hash):
-    return int(re.match(r'\$2b\$\d+', hash)[0].replace('$2b$', ''))
+    return int(re.match(r"\$2b\$\d+", hash)[0].replace("$2b$", ""))
+
 
 def isoformat(timestamp):
     """Turn a timestamp into an ISO formatted string."""
     dt = datetime.datetime.utcfromtimestamp(timestamp)
-    return dt.isoformat() + 'Z'
+    return dt.isoformat() + "Z"
 
 
 def is_production():
     """Whether we are serving production traffic."""
-    return os.getenv('IS_PRODUCTION', '') != ''
+    return os.getenv("IS_PRODUCTION", "") != ""
 
 
 def is_heroku():
@@ -203,27 +217,28 @@ def is_heroku():
       to optimize for developer productivity.
 
     """
-    return os.getenv('DYNO', '') != ''
+    return os.getenv("DYNO", "") != ""
 
 
 def version():
 
     # """Get the version from the Heroku environment variables."""
     if not is_heroku():
-        return 'DEV'
+        return "DEV"
 
-    vrz = os.getenv('HEROKU_RELEASE_CREATED_AT')
+    vrz = os.getenv("HEROKU_RELEASE_CREATED_AT")
     the_date = datetime.date.fromisoformat(vrz[:10]) if vrz else datetime.date.today()
 
-    commit = os.getenv('HEROKU_SLUG_COMMIT', '????')[0:6]
-    return the_date.strftime('%Y %b %d') + f'({commit})'
+    commit = os.getenv("HEROKU_SLUG_COMMIT", "????")[0:6]
+    return the_date.strftime("%Y %b %d") + f"({commit})"
+
 
 def valid_email(s):
-    return bool(re.match(r'^(([a-zA-Z0-9_+\.\-]+)@([\da-zA-Z\.\-]+)\.([a-zA-Z\.]{2,6})\s*)$', s))
+    return bool(re.match(r"^(([a-zA-Z0-9_+\.\-]+)@([\da-zA-Z\.\-]+)\.([a-zA-Z\.]{2,6})\s*)$", s))
 
 
 @contextlib.contextmanager
-def atomic_write_file(filename, mode='wb'):
+def atomic_write_file(filename, mode="wb"):
     """Write to a filename atomically.
 
     First write to a unique tempfile, then rename the tempfile into
@@ -236,7 +251,7 @@ def atomic_write_file(filename, mode='wb'):
     on Windows. We now just swallow the exception, someone else already wrote the file?)
     """
 
-    tmp_file = f'{filename}.{os.getpid()}'
+    tmp_file = f"{filename}.{os.getpid()}"
     with open(tmp_file, mode) as f:
         yield f
 
@@ -245,14 +260,17 @@ def atomic_write_file(filename, mode='wb'):
     except IOError:
         pass
 
+
 # This function takes a date in milliseconds from the Unix epoch and transforms it into a printable date
 # It operates by converting the date to a string, removing its last 3 digits, converting it back to an int
 # and then invoking the `isoformat` date function on it
 def mstoisostring(date):
     return datetime.datetime.fromtimestamp(int(str(date)[:-3])).isoformat()
 
+
 def string_date_to_date(date):
     return datetime.datetime.strptime(date, "%Y-%m-%d")
+
 
 def timestamp_to_date(timestamp, short_format=False):
     try:
@@ -271,8 +289,10 @@ def delta_timestamp(date, short_format=False):
         delta = datetime.datetime.now() - datetime.datetime.fromtimestamp(int(str(date)[:-3]))
     return format_timedelta(delta)
 
+
 def stoisostring(date):
     return datetime.datetime.fromtimestamp(date)
+
 
 def localized_date_format(date, short_format=False):
     # Improve the date by using the Flask Babel library and return timestamp as expected by language
@@ -280,41 +300,53 @@ def localized_date_format(date, short_format=False):
         timestamp = datetime.datetime.fromtimestamp(int(str(date)))
     else:
         timestamp = datetime.datetime.fromtimestamp(int(str(date)[:-3]))
-    return format_date(timestamp, format='medium') + " " + format_datetime(timestamp, "H:mm")
+    return format_date(timestamp, format="medium") + " " + format_datetime(timestamp, "H:mm")
+
 
 def datetotimeordate(date):
     print(date)
     return date.replace("T", " ")
 
+
 # https://stackoverflow.com/a/2257449
 def random_id_generator(size=6, chars=string.ascii_uppercase + string.ascii_lowercase + string.digits):
-    return ''.join(random.choice(chars) for _ in range(size))
+    return "".join(random.choice(chars) for _ in range(size))
+
 
 # This function takes a Markdown string and returns a list with each of the HTML elements obtained
 # by rendering the Markdown into HTML.
 def markdown_to_html_tags(markdown):
     _html = commonmark_renderer.render(commonmark_parser.parse(markdown))
-    soup = BeautifulSoup(_html, 'html.parser')
+    soup = BeautifulSoup(_html, "html.parser")
     return soup.find_all()
 
 
 def error_page(error=404, page_error=None, ui_message=None, menu=True, iframe=None):
     if error not in [403, 404, 500]:
         error = 404
-    default = gettext('default_404')
+    default = gettext("default_404")
     if error == 403:
-        default = gettext('default_403')
+        default = gettext("default_403")
     elif error == 500:
-        default = gettext('default_500')
-    return render_template("error-page.html", menu=menu, error=error, iframe=iframe,
-                           page_error=page_error or ui_message or '', default=default), error
+        default = gettext("default_500")
+    return (
+        render_template(
+            "error-page.html",
+            menu=menu,
+            error=error,
+            iframe=iframe,
+            page_error=page_error or ui_message or "",
+            default=default,
+        ),
+        error,
+    )
 
 
 def session_id():
     """Returns or sets the current session ID."""
-    if 'session_id' not in session:
-        if os.getenv('IS_TEST_ENV') and 'X-session_id' in request.headers:
-            session['session_id'] = request.headers['X-session_id']
+    if "session_id" not in session:
+        if os.getenv("IS_TEST_ENV") and "X-session_id" in request.headers:
+            session["session_id"] = request.headers["X-session_id"]
         else:
-            session['session_id'] = uuid.uuid4().hex
-    return session['session_id']
+            session["session_id"] = uuid.uuid4().hex
+    return session["session_id"]

--- a/website/ab_proxying.py
+++ b/website/ab_proxying.py
@@ -12,8 +12,10 @@ import itsdangerous
 from .auth import current_user
 import utils
 
+
 class ABProxying:
     """Proxy some requests to another server."""
+
     def __init__(self, app, target_host, secret_key):
         self.target_host = target_host
         self.secret_key = secret_key
@@ -23,66 +25,66 @@ class ABProxying:
     def before_request_proxy(self):
         # If it is an auth route, we do not reverse proxy it to the PROXY_TO_TEST_HOST environment
         # We want to keep all cookie setting in the main environment, not the test one.
-        if re.match ('.*/auth/.*', request.url):
+        if re.match(".*/auth/.*", request.url):
             pass
         # This route is meant to return the session from the main environment, for testing purposes.
-        elif re.match ('.*/session_main', request.url):
+        elif re.match(".*/session_main", request.url):
             pass
         # If we enter this block, we will reverse proxy the request to the PROXY_TO_TEST_HOST environment.
         # /session_test is meant to return the session from the test environment, for testing purposes.
-        elif re.match ('.*/session_test', request.url) or redirect_ab (request):
+        elif re.match(".*/session_test", request.url) or redirect_ab(request):
             url = self.target_host + request.full_path
-            logging.debug('Proxying %s %s %s to %s', request.method, request.url, dict (session), url)
+            logging.debug("Proxying %s %s %s to %s", request.method, request.url, dict(session), url)
 
             request_headers = {}
             for header in request.headers:
-                if (header [0].lower () in ['host']):
+                if header[0].lower() in ["host"]:
                     continue
-                request_headers [header [0]] = header [1]
+                request_headers[header[0]] = header[1]
             # In case the session_id is not yet set in the cookie, pass it in a special header
-            request_headers ['X-session_id'] = session ['session_id']
+            request_headers["X-session_id"] = session["session_id"]
 
-            r = getattr (requests, request.method.lower ()) (url, headers=request_headers, data=request.data)
+            r = getattr(requests, request.method.lower())(url, headers=request_headers, data=request.data)
 
-            response = make_response (r.content)
+            response = make_response(r.content)
             for header in r.headers:
                 # With great help from https://medium.com/customorchestrator/simple-reverse-proxy-server-using-flask-936087ce0afb
-                if header.lower () in ['content-encoding', 'content-length', 'transfer-encoding', 'connection']:
+                if header.lower() in ["content-encoding", "content-length", "transfer-encoding", "connection"]:
                     continue
                 # Setting the session cookie returned by the test environment into the response won't work because it will be overwritten by Flask, so we need to read the cookie into the session so that then the session cookie can be updated by Flask
-                if header.lower () == 'set-cookie':
-                    proxied_session = extract_session_from_cookie (r.headers [header], self.secret_key)
+                if header.lower() == "set-cookie":
+                    proxied_session = extract_session_from_cookie(r.headers[header], self.secret_key)
                     for key in proxied_session:
-                        session [key] = proxied_session [key]
+                        session[key] = proxied_session[key]
                     continue
-                response.headers [header] = r.headers [header]
+                response.headers[header] = r.headers[header]
 
             return response, r.status_code
 
 
-def redirect_ab (request):
+def redirect_ab(request):
     # If this is a testing request, we return True
-    if utils.is_testing_request (request):
+    if utils.is_testing_request(request):
         return True
     # If the user is logged in, we use their username as identifier, otherwise we use the session id
-    user_identifier = current_user()['username'] or str(session['session_id'])
+    user_identifier = current_user()["username"] or str(session["session_id"])
 
     # This will send either % PROXY_TO_TEST_PROPORTION of the requests into redirect, or 50% if that variable is not specified.
-    redirect_proportion = int (os.getenv ('PROXY_TO_TEST_PROPORTION', '50'))
-    redirect_flag = (hash_user_or_session (user_identifier) % 100) < redirect_proportion
+    redirect_proportion = int(os.getenv("PROXY_TO_TEST_PROPORTION", "50"))
+    redirect_flag = (hash_user_or_session(user_identifier) % 100) < redirect_proportion
     return redirect_flag
 
 
-def hash_user_or_session (string):
-    hash = hashlib.md5 (string.encode ('utf-8')).hexdigest ()
-    return int (hash, 16)
+def hash_user_or_session(string):
+    hash = hashlib.md5(string.encode("utf-8")).hexdigest()
+    return int(hash, 16)
 
 
 # Used by A/B testing to extract a session from a set-cookie header.
 # The signature is ignored. The source of the session should be trusted.
-def extract_session_from_cookie (cookie_header, secret_key):
-    parsed_cookie = SimpleCookie (cookie_header)
-    if not 'session' in parsed_cookie:
+def extract_session_from_cookie(cookie_header, secret_key):
+    parsed_cookie = SimpleCookie(cookie_header)
+    if not "session" in parsed_cookie:
         return {}
 
     cookie_interface = flask.sessions.SecureCookieSessionInterface()
@@ -93,12 +95,12 @@ def extract_session_from_cookie (cookie_header, secret_key):
         salt=cookie_interface.salt,
         serializer=cookie_interface.serializer,
         signer_kwargs=dict(
-            key_derivation=cookie_interface.key_derivation,
-            digest_method=cookie_interface.digest_method
-       ))
+            key_derivation=cookie_interface.key_derivation, digest_method=cookie_interface.digest_method
+        ),
+    )
 
     try:
-        cookie_value = parsed_cookie['session'].value
+        cookie_value = parsed_cookie["session"].value
         return serializer.loads(cookie_value)
     except itsdangerous.exc.BadSignature as e:
         # If the signature is wrong, we can still decode the cookie.
@@ -111,4 +113,3 @@ def extract_session_from_cookie (cookie_header, secret_key):
             except itsdangerous.exc.BadData:
                 pass
         return {}
-

--- a/website/achievements.py
+++ b/website/achievements.py
@@ -8,7 +8,6 @@ import hedy
 
 
 class Achievements:
-
     def __init__(self):
         self.DATABASE = database.Database()
         self.TRANSLATIONS = AchievementTranslations()
@@ -18,12 +17,12 @@ class Achievements:
 
     def get_all_commands(self):
         commands = []
-        for i in range(1, hedy.HEDY_MAX_LEVEL+1):
+        for i in range(1, hedy.HEDY_MAX_LEVEL + 1):
             for command in hedy.commands_per_level.get(i):
                 commands.append(command)
         commands = set(commands)
         # We manually remove the redundant commands, these are stored in the commands_per_level but not returned by the parser via AllCommands()
-        redundant_commands = {'at', 'from', 'times', 'range', 'to'}
+        redundant_commands = {"at", "from", "times", "range", "to"}
         return commands - redundant_commands
 
     def get_global_statistics(self):
@@ -39,64 +38,70 @@ class Achievements:
         return statistics
 
     def initialize_user_data_if_necessary(self):
-        if 'achieved' not in session:
-            achievements_data = self.DATABASE.progress_by_username(current_user()['username'])
-            session['new_achieved'] = []
-            session['new_commands'] = []
-            session['previous_code'] = None
-            session['identical_consecutive_errors'] = 0
-            session['consecutive_errors'] = 0
+        if "achieved" not in session:
+            achievements_data = self.DATABASE.progress_by_username(current_user()["username"])
+            session["new_achieved"] = []
+            session["new_commands"] = []
+            session["previous_code"] = None
+            session["identical_consecutive_errors"] = 0
+            session["consecutive_errors"] = 0
             if not achievements_data:
                 achievements_data = {}
-            if 'achieved' in achievements_data:
-                session['achieved'] = achievements_data['achieved']
+            if "achieved" in achievements_data:
+                session["achieved"] = achievements_data["achieved"]
             else:
-                session['achieved'] = []
-            if 'commands' in achievements_data:
+                session["achieved"] = []
+            if "commands" in achievements_data:
                 # We convert the list to a set perform intersection with all commands and convert to set again
                 # This to prevent "faulty" commands being kept from relic code (such as "multiplication")
-                session['commands'] = list(set(achievements_data['commands']).intersection(self.all_commands))
+                session["commands"] = list(set(achievements_data["commands"]).intersection(self.all_commands))
             else:
-                session['commands'] = []
-            if 'run_programs' in achievements_data:
-                session['run_programs'] = achievements_data['run_programs']
+                session["commands"] = []
+            if "run_programs" in achievements_data:
+                session["run_programs"] = achievements_data["run_programs"]
             else:
-                session['run_programs'] = 0
-            if 'saved_programs' in achievements_data:
-                session['saved_programs'] = achievements_data['saved_programs']
+                session["run_programs"] = 0
+            if "saved_programs" in achievements_data:
+                session["saved_programs"] = achievements_data["saved_programs"]
             else:
-                session['saved_programs'] = 0
-            if 'submitted_programs' in achievements_data:
-                session['submitted_programs'] = achievements_data['submitted_programs']
+                session["saved_programs"] = 0
+            if "submitted_programs" in achievements_data:
+                session["submitted_programs"] = achievements_data["submitted_programs"]
             else:
-                session['submitted_programs'] = 0
+                session["submitted_programs"] = 0
 
     def routes(self, app, database):
         global DATABASE
         DATABASE = database
 
-        @app.route('/achievements', methods=['POST'])
+        @app.route("/achievements", methods=["POST"])
         @requires_login
         def push_new_achievement(user):
             body = request.json
             if "achievement" in body:
                 self.initialize_user_data_if_necessary()
-                if body['achievement'] not in session['achieved'] and body['achievement'] in self.TRANSLATIONS.get_translations(session['lang']).get('achievements'):
-                    return jsonify({"achievements": self.verify_pushed_achievement(user.get('username'), body['achievement'])})
+                if body["achievement"] not in session["achieved"] and body[
+                    "achievement"
+                ] in self.TRANSLATIONS.get_translations(session["lang"]).get("achievements"):
+                    return jsonify(
+                        {"achievements": self.verify_pushed_achievement(user.get("username"), body["achievement"])}
+                    )
             return jsonify({})
 
     def increase_count(self, category):
         self.initialize_user_data_if_necessary()
         if category == "run":
-            session['run_programs'] += 1
+            session["run_programs"] += 1
         elif category == "saved":
-            session['saved_programs'] += 1
+            session["saved_programs"] += 1
         elif category == "submitted":
-            session['submitted_programs'] += 1
+            session["submitted_programs"] += 1
 
     def add_single_achievement(self, username, achievement):
         self.initialize_user_data_if_necessary()
-        if achievement not in session['achieved'] and achievement in self.TRANSLATIONS.get_translations(session['lang']).get("achievements"):
+        if achievement not in session["achieved"] and achievement in self.TRANSLATIONS.get_translations(
+            session["lang"]
+        ).get("achievements"):
             return self.verify_pushed_achievement(username, achievement)
         else:
             return None
@@ -109,33 +114,33 @@ class Achievements:
         if code and response:
             self.check_response_achievements(code, response)
 
-        if len(session['new_commands']) > 0:
-            for command in session['new_commands']:
-                session['commands'].append(command)
-            session['new_commands'] = []
+        if len(session["new_commands"]) > 0:
+            for command in session["new_commands"]:
+                session["commands"].append(command)
+            session["new_commands"] = []
             # Only update commands to database if we used new onces
-            self.DATABASE.add_commands_to_username(username, session['commands'])
+            self.DATABASE.add_commands_to_username(username, session["commands"])
 
-        if len(session['new_achieved']) > 0:
-            if self.DATABASE.add_achievements_to_username(username, session['new_achieved']):
+        if len(session["new_achieved"]) > 0:
+            if self.DATABASE.add_achievements_to_username(username, session["new_achieved"]):
                 self.total_users += 1
-            for achievement in session['new_achieved']:
+            for achievement in session["new_achieved"]:
                 self.statistics[achievement] += 1
-                session['achieved'].append(achievement)
+                session["achieved"].append(achievement)
             return True
         return False
 
     def verify_save_achievements(self, username, adventure=None):
         self.initialize_user_data_if_necessary()
         self.check_programs_saved()
-        if adventure and 'adventure_is_worthwhile' not in session['achieved']:
-            session['new_achieved'].append("adventure_is_worthwhile")
-        if len(session['new_achieved']) > 0:
-            if self.DATABASE.add_achievements_to_username(username, session['new_achieved']):
+        if adventure and "adventure_is_worthwhile" not in session["achieved"]:
+            session["new_achieved"].append("adventure_is_worthwhile")
+        if len(session["new_achieved"]) > 0:
+            if self.DATABASE.add_achievements_to_username(username, session["new_achieved"]):
                 self.total_users += 1
-            for achievement in session['new_achieved']:
+            for achievement in session["new_achieved"]:
                 self.statistics[achievement] += 1
-                session['achieved'].append(achievement)
+                session["achieved"].append(achievement)
             return True
         return False
 
@@ -143,114 +148,116 @@ class Achievements:
         self.initialize_user_data_if_necessary()
         self.check_programs_submitted()
 
-        if len(session['new_achieved']) > 0:
-            if self.DATABASE.add_achievements_to_username(username, session['new_achieved']):
+        if len(session["new_achieved"]) > 0:
+            if self.DATABASE.add_achievements_to_username(username, session["new_achieved"]):
                 self.total_users += 1
-            for achievement in session['new_achieved']:
+            for achievement in session["new_achieved"]:
                 self.statistics[achievement] += 1
-                session['achieved'].append(achievement)
+                session["achieved"].append(achievement)
             return True
         return False
 
     def verify_pushed_achievement(self, username, achievement):
         self.initialize_user_data_if_necessary()
-        session['new_achieved'] = [achievement]
+        session["new_achieved"] = [achievement]
         if self.DATABASE.add_achievement_to_username(username, achievement):
             self.total_users += 1
-        session['achieved'].append(achievement)
+        session["achieved"].append(achievement)
         self.statistics[achievement] += 1
         return self.get_earned_achievements()
 
     def get_earned_achievements(self):
         self.initialize_user_data_if_necessary()
-        translations = self.TRANSLATIONS.get_translations(session['lang']).get('achievements')
+        translations = self.TRANSLATIONS.get_translations(session["lang"]).get("achievements")
         translated_achievements = []
-        for achievement in session['new_achieved']:
+        for achievement in session["new_achieved"]:
             percentage = round(((self.statistics[achievement] / self.total_users) * 100), 2)
-            stats = gettext('percentage_achieved').format(**{'percentage': percentage})
-            translated_achievements.append([translations[achievement]['title'], translations[achievement]['text'], stats])
-        session['new_achieved'] = [] # Once we get earned achievements -> empty the array with "waiting" ones
+            stats = gettext("percentage_achieved").format(**{"percentage": percentage})
+            translated_achievements.append(
+                [translations[achievement]["title"], translations[achievement]["text"], stats]
+            )
+        session["new_achieved"] = []  # Once we get earned achievements -> empty the array with "waiting" ones
         return translated_achievements
 
     def check_programs_run(self):
         self.initialize_user_data_if_necessary()
-        if 'getting_started_I' not in session['achieved'] and session['run_programs'] >= 1:
-            session['new_achieved'].append("getting_started_I")
-        if 'getting_started_II' not in session['achieved'] and session['run_programs'] >= 10:
-            session['new_achieved'].append("getting_started_II")
-        if 'getting_started_III' not in session['achieved'] and session['run_programs'] >= 50:
-            session['new_achieved'].append("getting_started_III")
-        if 'getting_started_IV' not in session['achieved'] and session['run_programs'] >= 200:
-            session['new_achieved'].append("getting_started_IV")
-        if 'getting_started_V' not in session['achieved'] and session['run_programs'] >= 500:
-            session['new_achieved'].append("getting_started_V")
+        if "getting_started_I" not in session["achieved"] and session["run_programs"] >= 1:
+            session["new_achieved"].append("getting_started_I")
+        if "getting_started_II" not in session["achieved"] and session["run_programs"] >= 10:
+            session["new_achieved"].append("getting_started_II")
+        if "getting_started_III" not in session["achieved"] and session["run_programs"] >= 50:
+            session["new_achieved"].append("getting_started_III")
+        if "getting_started_IV" not in session["achieved"] and session["run_programs"] >= 200:
+            session["new_achieved"].append("getting_started_IV")
+        if "getting_started_V" not in session["achieved"] and session["run_programs"] >= 500:
+            session["new_achieved"].append("getting_started_V")
 
     def check_programs_saved(self):
         self.initialize_user_data_if_necessary()
-        if 'one_to_remember_I' not in session['achieved'] and session['saved_programs'] >= 1:
-            session['new_achieved'].append("one_to_remember_I")
-        if 'one_to_remember_II' not in session['achieved'] and session['saved_programs'] >= 5:
-            session['new_achieved'].append("one_to_remember_II")
-        if 'one_to_remember_III' not in session['achieved'] and session['saved_programs'] >= 10:
-            session['new_achieved'].append("one_to_remember_III")
-        if 'one_to_remember_IV' not in session['achieved'] and session['saved_programs'] >= 25:
-            session['new_achieved'].append("one_to_remember_IV")
-        if 'one_to_remember_V' not in session['achieved'] and session['saved_programs'] >= 50:
-            session['new_achieved'].append("one_to_remember_V")
+        if "one_to_remember_I" not in session["achieved"] and session["saved_programs"] >= 1:
+            session["new_achieved"].append("one_to_remember_I")
+        if "one_to_remember_II" not in session["achieved"] and session["saved_programs"] >= 5:
+            session["new_achieved"].append("one_to_remember_II")
+        if "one_to_remember_III" not in session["achieved"] and session["saved_programs"] >= 10:
+            session["new_achieved"].append("one_to_remember_III")
+        if "one_to_remember_IV" not in session["achieved"] and session["saved_programs"] >= 25:
+            session["new_achieved"].append("one_to_remember_IV")
+        if "one_to_remember_V" not in session["achieved"] and session["saved_programs"] >= 50:
+            session["new_achieved"].append("one_to_remember_V")
 
     def check_programs_submitted(self):
         self.initialize_user_data_if_necessary()
-        if 'deadline_daredevil_I' not in session['achieved'] and session['submitted_programs'] >= 1:
-            session['new_achieved'].append("deadline_daredevil_I")
-        if 'deadline_daredevil_II' not in session['achieved'] and session['submitted_programs'] >= 3:
-            session['new_achieved'].append("deadline_daredevil_II")
-        if 'deadline_daredevil_III' not in session['achieved'] and session['submitted_programs'] >= 10:
-            session['new_achieved'].append("deadline_daredevil_III")
+        if "deadline_daredevil_I" not in session["achieved"] and session["submitted_programs"] >= 1:
+            session["new_achieved"].append("deadline_daredevil_I")
+        if "deadline_daredevil_II" not in session["achieved"] and session["submitted_programs"] >= 3:
+            session["new_achieved"].append("deadline_daredevil_II")
+        if "deadline_daredevil_III" not in session["achieved"] and session["submitted_programs"] >= 10:
+            session["new_achieved"].append("deadline_daredevil_III")
 
     def check_code_achievements(self, code, level):
         self.initialize_user_data_if_necessary()
-        commands_in_code = hedy.all_commands(code, level, session['lang'])
-        if 'trying_is_key' not in session['achieved']:
+        commands_in_code = hedy.all_commands(code, level, session["lang"])
+        if "trying_is_key" not in session["achieved"]:
             for command in list(set(commands_in_code)):  # To remove duplicates
-                if command not in session['commands'] and command in self.all_commands:
-                    session['new_commands'].append(command)
-            if set(session['commands']).union(set(session['new_commands'])) == self.all_commands:
-                session['new_achieved'].append("trying_is_key")
-        if 'did_you_say_please' not in session['achieved'] and "ask" in hedy.all_commands(code, level, session['lang']):
-            session['new_achieved'].append("did_you_say_please")
-        if 'talk-talk-talk' not in session['achieved'] and hedy.all_commands(code, level, session['lang']).count("ask") >= 5:
-            session['new_achieved'].append("talk-talk-talk")
-        if 'hedy_honor' not in session['achieved'] and "Hedy" in code:
-            session['new_achieved'].append("hedy_honor")
-        if 'hedy-ious' not in session['achieved']:
-            all_print_arguments = hedy.all_print_arguments(code, level, session['lang'])
+                if command not in session["commands"] and command in self.all_commands:
+                    session["new_commands"].append(command)
+            if set(session["commands"]).union(set(session["new_commands"])) == self.all_commands:
+                session["new_achieved"].append("trying_is_key")
+        if "did_you_say_please" not in session["achieved"] and "ask" in hedy.all_commands(code, level, session["lang"]):
+            session["new_achieved"].append("did_you_say_please")
+        if (
+            "talk-talk-talk" not in session["achieved"]
+            and hedy.all_commands(code, level, session["lang"]).count("ask") >= 5
+        ):
+            session["new_achieved"].append("talk-talk-talk")
+        if "hedy_honor" not in session["achieved"] and "Hedy" in code:
+            session["new_achieved"].append("hedy_honor")
+        if "hedy-ious" not in session["achieved"]:
+            all_print_arguments = hedy.all_print_arguments(code, level, session["lang"])
             for argument in all_print_arguments:
                 if all_print_arguments.count(argument) >= 10:
-                    session['new_achieved'].append("hedy-ious")
+                    session["new_achieved"].append("hedy-ious")
                     break
 
     def check_response_achievements(self, code, response):
         self.initialize_user_data_if_necessary()
-        if 'ninja_turtle' not in session['achieved'] and 'has_turtle' in response and response['has_turtle']:
-            session['new_achieved'].append("ninja_turtle")
-        if 'watch_out' not in session['achieved'] and 'Warning' in response and response['Warning']:
-            session['new_achieved'].append("watch_out")
-        if 'Error' in response and response['Error']:
-            session['consecutive_errors'] += 1
-            if session['previous_code'] == code:
-                if session['identical_consecutive_errors'] == 0:
-                    session['identical_consecutive_errors'] += 2 #We have to count the first one too!
+        if "ninja_turtle" not in session["achieved"] and "has_turtle" in response and response["has_turtle"]:
+            session["new_achieved"].append("ninja_turtle")
+        if "watch_out" not in session["achieved"] and "Warning" in response and response["Warning"]:
+            session["new_achieved"].append("watch_out")
+        if "Error" in response and response["Error"]:
+            session["consecutive_errors"] += 1
+            if session["previous_code"] == code:
+                if session["identical_consecutive_errors"] == 0:
+                    session["identical_consecutive_errors"] += 2  # We have to count the first one too!
                 else:
-                    session['identical_consecutive_errors'] += 1
-            if session['identical_consecutive_errors'] >= 3:
-                if 'programming_panic' not in session['achieved']:
-                    session['new_achieved'].append("programming_panic")
-            session['previous_code'] = code
+                    session["identical_consecutive_errors"] += 1
+            if session["identical_consecutive_errors"] >= 3:
+                if "programming_panic" not in session["achieved"]:
+                    session["new_achieved"].append("programming_panic")
+            session["previous_code"] = code
         else:
-            if 'programming_protagonist' not in session['achieved'] and session['consecutive_errors'] >= 1:
-                session['new_achieved'].append("programming_protagonist")
-            session['consecutive_errors'] = 0
-            session['identical_consecutive_errors'] = 0
-
-
-
+            if "programming_protagonist" not in session["achieved"] and session["consecutive_errors"] >= 1:
+                session["new_achieved"].append("programming_protagonist")
+            session["consecutive_errors"] = 0
+            session["identical_consecutive_errors"] = 0

--- a/website/admin.py
+++ b/website/admin.py
@@ -1,26 +1,41 @@
 from flask_babel import gettext
+from flask import request, g
 import hedyweb
 from website import statistics
-from website.auth import requires_login, current_user, is_admin, pick, requires_admin
+from website.auth import (
+    create_verify_link,
+    current_user,
+    is_admin,
+    is_teacher,
+    make_salt,
+    password_hash,
+    pick,
+    requires_admin,
+    send_email_template,
+    password_hash,
+)
+from .database import Database
 import utils
-from flask import request
 from flask_helpers import render_template
+from .website_module import WebsiteModule, route
 
 
-def routes(app, database):
-    global DATABASE
-    DATABASE = database
+class AdminModule(WebsiteModule):
+    def __init__(self, db: Database):
+        super().__init__("admin", __name__, url_prefix="/admin")
 
-    @app.route("/admin", methods=["GET"])
-    def get_admin_page():
+        self.db = db
+
+    @route("/", methods=["GET"])
+    def get_admin_page(self):
         # Todo TB: Why do we check for the testing_request here? (09-22)
         if not utils.is_testing_request(request) and not is_admin(current_user()):
             return utils.error_page(error=403, ui_message=gettext("unauthorized"))
         return render_template("admin/admin.html", page_title=gettext("title_admin"))
 
-    @app.route("/admin/users", methods=["GET"])
+    @route("/users", methods=["GET"])
     @requires_admin
-    def get_admin_users_page(user):
+    def get_admin_users_page(self, user):
         category = request.args.get("filter", default=None, type=str)
         category = None if category == "null" else category
 
@@ -38,7 +53,7 @@ def routes(app, database):
 
         pagination_token = request.args.get("page", default=None, type=str)
 
-        users = DATABASE.all_users(pagination_token)
+        users = self.db.all_users(pagination_token)
 
         userdata = []
         fields = [
@@ -107,9 +122,9 @@ def routes(app, database):
             next_page_token=users.next_page_token,
         )
 
-    @app.route("/admin/classes", methods=["GET"])
+    @route("/classes", methods=["GET"])
     @requires_admin
-    def get_admin_classes_page(user):
+    def get_admin_classes_page(self, user):
         classes = [
             {
                 "name": Class.get("name"),
@@ -119,17 +134,21 @@ def routes(app, database):
                 "stats": statistics.get_general_class_stats(Class.get("students", [])),
                 "id": Class.get("id"),
             }
-            for Class in DATABASE.all_classes()
+            for Class in self.db.all_classes()
         ]
 
         classes = sorted(classes, key=lambda d: d.get("stats").get("week").get("runs"), reverse=True)
 
-        return render_template("admin/admin-classes.html", classes=classes, page_title=gettext("title_admin"))
+        return render_template(
+            "admin/admin-classes.html",
+            classes=classes,
+            page_title=gettext("title_admin"),
+        )
 
-    @app.route("/admin/adventures", methods=["GET"])
+    @route("/adventures", methods=["GET"])
     @requires_admin
-    def get_admin_adventures_page(user):
-        all_adventures = sorted(DATABASE.all_adventures(), key=lambda d: d.get("date", 0), reverse=True)
+    def get_admin_adventures_page(self, user):
+        all_adventures = sorted(self.db.all_adventures(), key=lambda d: d.get("date", 0), reverse=True)
         adventures = [
             {
                 "id": adventure.get("id"),
@@ -142,21 +161,25 @@ def routes(app, database):
             for adventure in all_adventures
         ]
 
-        return render_template("admin/admin-adventures.html", adventures=adventures, page_title=gettext("title_admin"))
+        return render_template(
+            "admin/admin-adventures.html",
+            adventures=adventures,
+            page_title=gettext("title_admin"),
+        )
 
-    @app.route("/admin/stats", methods=["GET"])
+    @route("/stats", methods=["GET"])
     @requires_admin
-    def get_admin_stats_page(user):
+    def get_admin_stats_page(self, user):
         return render_template("admin/admin-stats.html", page_title=gettext("title_admin"))
 
-    @app.route("/admin/logs", methods=["GET"])
+    @route("/logs", methods=["GET"])
     @requires_admin
-    def get_admin_logs_page(user):
+    def get_admin_logs_page(self, user):
         return render_template("admin/admin-logs.html", page_title=gettext("title_admin"))
 
-    @app.route("/admin/achievements", methods=["GET"])
+    @route("/achievements", methods=["GET"])
     @requires_admin
-    def get_admin_achievements_page(user):
+    def get_admin_achievements_page(self, user):
         stats = {}
         achievements = hedyweb.AchievementTranslations().get_translations("en").get("achievements")
         for achievement in achievements.keys():
@@ -165,12 +188,135 @@ def routes(app, database):
             stats[achievement]["description"] = achievements.get(achievement).get("text")
             stats[achievement]["count"] = 0
 
-        user_achievements = DATABASE.get_all_achievements()
+        user_achievements = self.db.get_all_achievements()
         total = len(user_achievements)
         for user in user_achievements:
             for achieved in user.get("achieved", []):
                 stats[achieved]["count"] += 1
 
         return render_template(
-            "admin/admin-achievements.html", stats=stats, total=total, page_title=gettext("title_admin")
+            "admin/admin-achievements.html",
+            stats=stats,
+            total=total,
+            page_title=gettext("title_admin"),
         )
+
+    @route("/markAsTeacher", methods=["POST"])
+    def mark_as_teacher(self):
+        user = current_user()
+        if not is_admin(user) and not utils.is_testing_request(request):
+            return utils.error_page(error=403, ui_message=gettext("unauthorized"))
+
+        body = request.json
+
+        # Validations
+        if not isinstance(body, dict):
+            return gettext("ajax_error"), 400
+        if not isinstance(body.get("username"), str):
+            return gettext("username_invalid"), 400
+        if not isinstance(body.get("is_teacher"), bool):
+            return gettext("teacher_invalid"), 400
+
+        user = self.db.user_by_username(body["username"].strip().lower())
+
+        if not user:
+            return gettext("username_invalid"), 400
+
+        is_teacher_value = 1 if body["is_teacher"] else 0
+        update_is_teacher(self.db, user, is_teacher_value)
+
+        # Todo TB feb 2022 -> Return the success message here instead of fixing in the front-end
+        return "", 200
+
+    @route("/changeUserEmail", methods=["POST"])
+    @requires_admin
+    def change_user_email(self, user):
+        body = request.json
+
+        # Validations
+        if not isinstance(body, dict):
+            return gettext("ajax_error"), 400
+        if not isinstance(body.get("username"), str):
+            return gettext("username_invalid"), 400
+        if not isinstance(body.get("email"), str) or not utils.valid_email(body["email"]):
+            return gettext("email_invalid"), 400
+
+        user = self.db.user_by_username(body["username"].strip().lower())
+
+        if not user:
+            return gettext("email_invalid"), 400
+
+        token = make_salt()
+        hashed_token = password_hash(token, make_salt())
+
+        # We assume that this email is not in use by any other users. In other words, we trust the admin to enter a valid, not yet used email address.
+        self.db.update_user(
+            user["username"],
+            {"email": body["email"], "verification_pending": hashed_token},
+        )
+
+        # If this is an e2e test, we return the email verification token directly instead of emailing it.
+        if utils.is_testing_request(request):
+            resp = {"username": user["username"], "token": hashed_token}
+        else:
+            try:
+                send_email_template(
+                    template="welcome_verify",
+                    email=body["email"],
+                    link=create_verify_link(user["username"], hashed_token),
+                    username=user["username"],
+                )
+            except:
+                return gettext("mail_error_change_processed"), 400
+
+        return {}, 200
+
+    @route("/getUserTags", methods=["POST"])
+    @requires_admin
+    def get_user_tags(self, user):
+        body = request.json
+        user = self.db.get_public_profile_settings(body["username"].strip().lower())
+        if not user:
+            return "User doesn't have a public profile", 400
+        return {"tags": user.get("tags", [])}, 200
+
+    @route("/updateUserTags", methods=["POST"])
+    @requires_admin
+    def update_user_tags(self, user):
+        body = request.json
+        user = self.db.get_public_profile_settings(body["username"].strip().lower())
+        if not user:
+            return "User doesn't have a public profile", 400
+
+        tags = []
+        if "admin" in user.get("tags", []):
+            tags.append("admin")
+        if "teacher" in user.get("tags", []):
+            tags.append("teacher")
+        if body.get("certified"):
+            tags.append("certified_teacher")
+        if body.get("distinguished"):
+            tags.append("distinguished_user")
+        if body.get("contributor"):
+            tags.append("contributor")
+
+        user["tags"] = tags
+        self.db.update_public_profile(user["username"], user)
+        return {}, 200
+
+
+def update_is_teacher(db: Database, user, is_teacher_value=1):
+    user_is_teacher = is_teacher(user)
+    user_becomes_teacher = is_teacher_value and not user_is_teacher
+
+    db.update_user(user["username"], {"is_teacher": is_teacher_value, "teacher_request": None})
+
+    if user_becomes_teacher and not utils.is_testing_request(request):
+        try:
+            send_email_template(
+                template="welcome_teacher",
+                email=user["email"],
+                username=user["username"],
+            )
+        except:
+            print(f"An error occurred when sending a welcome teacher mail to {user['email']}, changes still processed")

--- a/website/admin.py
+++ b/website/admin.py
@@ -11,24 +11,24 @@ def routes(app, database):
     global DATABASE
     DATABASE = database
 
-    @app.route('/admin', methods=['GET'])
+    @app.route("/admin", methods=["GET"])
     def get_admin_page():
         # Todo TB: Why do we check for the testing_request here? (09-22)
         if not utils.is_testing_request(request) and not is_admin(current_user()):
-            return utils.error_page(error=403, ui_message=gettext('unauthorized'))
-        return render_template('admin/admin.html', page_title=gettext('title_admin'))
+            return utils.error_page(error=403, ui_message=gettext("unauthorized"))
+        return render_template("admin/admin.html", page_title=gettext("title_admin"))
 
-    @app.route('/admin/users', methods=['GET'])
+    @app.route("/admin/users", methods=["GET"])
     @requires_admin
     def get_admin_users_page(user):
-        category = request.args.get('filter', default=None, type=str)
+        category = request.args.get("filter", default=None, type=str)
         category = None if category == "null" else category
 
-        substring = request.args.get('substring', default=None, type=str)
-        start_date = request.args.get('start', default=None, type=str)
-        end_date = request.args.get('end', default=None, type=str)
-        language = request.args.get('language', default=None, type=str)
-        keyword_language = request.args.get('keyword_language', default=None, type=str)
+        substring = request.args.get("substring", default=None, type=str)
+        start_date = request.args.get("start", default=None, type=str)
+        end_date = request.args.get("end", default=None, type=str)
+        language = request.args.get("language", default=None, type=str)
+        keyword_language = request.args.get("keyword_language", default=None, type=str)
 
         substring = None if substring == "null" else substring
         start_date = None if start_date == "null" else start_date
@@ -36,100 +36,125 @@ def routes(app, database):
         language = None if language == "null" else language
         keyword_language = None if keyword_language == "null" else keyword_language
 
-        pagination_token = request.args.get('page', default=None, type=str)
+        pagination_token = request.args.get("page", default=None, type=str)
 
         users = DATABASE.all_users(pagination_token)
 
         userdata = []
         fields = [
-            'username', 'email', 'birth_year', 'country',
-            'gender', 'created', 'last_login', 'verification_pending',
-            'is_teacher', 'program_count', 'prog_experience', 'teacher_request',
-            'experience_languages', 'language', 'keyword_language', 'third_party'
+            "username",
+            "email",
+            "birth_year",
+            "country",
+            "gender",
+            "created",
+            "last_login",
+            "verification_pending",
+            "is_teacher",
+            "program_count",
+            "prog_experience",
+            "teacher_request",
+            "experience_languages",
+            "language",
+            "keyword_language",
+            "third_party",
         ]
 
         for user in users:
             data = pick(user, *fields)
-            data['email_verified'] = not bool(data['verification_pending'])
-            data['is_teacher'] = bool(data['is_teacher'])
-            data['teacher_request'] = True if data['teacher_request'] else None
-            data['third_party'] = True if data['third_party'] else None
-            data['created'] = utils.timestamp_to_date(data['created'])
-            data['last_login'] = utils.timestamp_to_date(data['last_login']) if data.get('last_login') else None
+            data["email_verified"] = not bool(data["verification_pending"])
+            data["is_teacher"] = bool(data["is_teacher"])
+            data["teacher_request"] = True if data["teacher_request"] else None
+            data["third_party"] = True if data["third_party"] else None
+            data["created"] = utils.timestamp_to_date(data["created"])
+            data["last_login"] = utils.timestamp_to_date(data["last_login"]) if data.get("last_login") else None
             if category == "language":
-                if language != data['language']:
+                if language != data["language"]:
                     continue
             if category == "keyword_language":
-                if keyword_language != data['keyword_language']:
+                if keyword_language != data["keyword_language"]:
                     continue
             if category == "username":
-                if substring and substring not in data.get('username'):
+                if substring and substring not in data.get("username"):
                     continue
             if category == "email":
-                if not data.get('email') or (substring and substring not in data.get('email')):
+                if not data.get("email") or (substring and substring not in data.get("email")):
                     continue
             if category == "created":
-                if start_date and utils.string_date_to_date(start_date) > data['created']:
+                if start_date and utils.string_date_to_date(start_date) > data["created"]:
                     continue
-                if end_date and utils.string_date_to_date(end_date) < data['created']:
+                if end_date and utils.string_date_to_date(end_date) < data["created"]:
                     continue
             if category == "last_login":
-                if not data.get('last_login'):
+                if not data.get("last_login"):
                     continue
-                if start_date and utils.string_date_to_date(start_date) > data['last_login']:
+                if start_date and utils.string_date_to_date(start_date) > data["last_login"]:
                     continue
-                if end_date and utils.string_date_to_date(end_date) < data['last_login']:
+                if end_date and utils.string_date_to_date(end_date) < data["last_login"]:
                     continue
             userdata.append(data)
 
-        return render_template('admin/admin-users.html', users=userdata, page_title=gettext('title_admin'),
-                               filter=category, start_date=start_date, end_date=end_date, text_filter=substring,
-                               language_filter=language, keyword_language_filter=keyword_language,
-                               next_page_token=users.next_page_token)
+        return render_template(
+            "admin/admin-users.html",
+            users=userdata,
+            page_title=gettext("title_admin"),
+            filter=category,
+            start_date=start_date,
+            end_date=end_date,
+            text_filter=substring,
+            language_filter=language,
+            keyword_language_filter=keyword_language,
+            next_page_token=users.next_page_token,
+        )
 
-    @app.route('/admin/classes', methods=['GET'])
+    @app.route("/admin/classes", methods=["GET"])
     @requires_admin
     def get_admin_classes_page(user):
-        classes = [{
-            "name": Class.get('name'),
-            "teacher": Class.get('teacher'),
-            "created": utils.localized_date_format(Class.get('date')),
-            "students": len(Class.get('students')) if 'students' in Class else 0,
-            "stats": statistics.get_general_class_stats(Class.get('students', [])),
-            "id": Class.get('id')
-        } for Class in DATABASE.all_classes()]
+        classes = [
+            {
+                "name": Class.get("name"),
+                "teacher": Class.get("teacher"),
+                "created": utils.localized_date_format(Class.get("date")),
+                "students": len(Class.get("students")) if "students" in Class else 0,
+                "stats": statistics.get_general_class_stats(Class.get("students", [])),
+                "id": Class.get("id"),
+            }
+            for Class in DATABASE.all_classes()
+        ]
 
-        classes = sorted(classes, key=lambda d: d.get('stats').get('week').get('runs'), reverse=True)
+        classes = sorted(classes, key=lambda d: d.get("stats").get("week").get("runs"), reverse=True)
 
-        return render_template('admin/admin-classes.html', classes=classes, page_title=gettext('title_admin'))
+        return render_template("admin/admin-classes.html", classes=classes, page_title=gettext("title_admin"))
 
-    @app.route('/admin/adventures', methods=['GET'])
+    @app.route("/admin/adventures", methods=["GET"])
     @requires_admin
     def get_admin_adventures_page(user):
-        all_adventures = sorted(DATABASE.all_adventures(), key=lambda d: d.get('date', 0), reverse=True)
-        adventures = [{
-            "id": adventure.get('id'),
-            "creator": adventure.get('creator'),
-            "name": adventure.get('name'),
-            "level": adventure.get('level'),
-            "public": "Yes" if adventure.get('public') else "No",
-            "date": utils.localized_date_format(adventure.get('date'))
-        } for adventure in all_adventures]
+        all_adventures = sorted(DATABASE.all_adventures(), key=lambda d: d.get("date", 0), reverse=True)
+        adventures = [
+            {
+                "id": adventure.get("id"),
+                "creator": adventure.get("creator"),
+                "name": adventure.get("name"),
+                "level": adventure.get("level"),
+                "public": "Yes" if adventure.get("public") else "No",
+                "date": utils.localized_date_format(adventure.get("date")),
+            }
+            for adventure in all_adventures
+        ]
 
+        return render_template("admin/admin-adventures.html", adventures=adventures, page_title=gettext("title_admin"))
 
-        return render_template('admin/admin-adventures.html', adventures=adventures, page_title=gettext('title_admin'))
-
-    @app.route('/admin/stats', methods=['GET'])
+    @app.route("/admin/stats", methods=["GET"])
     @requires_admin
     def get_admin_stats_page(user):
-        return render_template('admin/admin-stats.html', page_title=gettext('title_admin'))
+        return render_template("admin/admin-stats.html", page_title=gettext("title_admin"))
 
-    @app.route('/admin/logs', methods=['GET'])
+    @app.route("/admin/logs", methods=["GET"])
     @requires_admin
     def get_admin_logs_page(user):
-        return render_template('admin/admin-logs.html', page_title=gettext('title_admin'))
+        return render_template("admin/admin-logs.html", page_title=gettext("title_admin"))
 
-    @app.route('/admin/achievements', methods=['GET'])
+    @app.route("/admin/achievements", methods=["GET"])
     @requires_admin
     def get_admin_achievements_page(user):
         stats = {}
@@ -146,6 +171,6 @@ def routes(app, database):
             for achieved in user.get("achieved", []):
                 stats[achieved]["count"] += 1
 
-        return render_template('admin/admin-achievements.html', stats=stats,
-                               total=total, page_title=gettext('title_admin'))
-
+        return render_template(
+            "admin/admin-achievements.html", stats=stats, total=total, page_title=gettext("title_admin")
+        )

--- a/website/auth.py
+++ b/website/auth.py
@@ -20,54 +20,64 @@ import requests
 from website import querylog, database
 import hashlib
 
-TOKEN_COOKIE_NAME = config['session']['cookie_name']
+TOKEN_COOKIE_NAME = config["session"]["cookie_name"]
 # The session_length in the session is set to 60 * 24 * 14 (in minutes) config.py#13
 # The reset_length in the session is set to 60 * 4 (in minutes) config.py#14
 # We multiply this by 60 to set the session_length to 14 days and reset_length to 4 hours
-session_length = config['session']['session_length'] * 60
-reset_length = config['session']['reset_length'] * 60
+session_length = config["session"]["session_length"] * 60
+reset_length = config["session"]["reset_length"] * 60
 
-env = os.getenv('HEROKU_APP_NAME')
+env = os.getenv("HEROKU_APP_NAME")
 
 DATABASE: database.Database = None
 
 MAILCHIMP_API_URL = None
-if os.getenv('MAILCHIMP_API_KEY') and os.getenv('MAILCHIMP_AUDIENCE_ID'):
+if os.getenv("MAILCHIMP_API_KEY") and os.getenv("MAILCHIMP_AUDIENCE_ID"):
     # The domain in the path is the server name, which is contained in the Mailchimp API key
-    MAILCHIMP_API_URL = 'https://' + os.getenv('MAILCHIMP_API_KEY').split('-')[
-        1] + '.api.mailchimp.com/3.0/lists/' + os.getenv('MAILCHIMP_AUDIENCE_ID')
-    MAILCHIMP_API_HEADERS = {'Content-Type': 'application/json',
-                             'Authorization': 'apikey ' + os.getenv('MAILCHIMP_API_KEY')}
+    MAILCHIMP_API_URL = (
+        "https://"
+        + os.getenv("MAILCHIMP_API_KEY").split("-")[1]
+        + ".api.mailchimp.com/3.0/lists/"
+        + os.getenv("MAILCHIMP_AUDIENCE_ID")
+    )
+    MAILCHIMP_API_HEADERS = {
+        "Content-Type": "application/json",
+        "Authorization": "apikey " + os.getenv("MAILCHIMP_API_KEY"),
+    }
 
 
 def mailchimp_subscribe_user(email):
-    request_body = {'email_address': email, 'status': 'subscribed'}
-    r = requests.post(MAILCHIMP_API_URL + '/members', headers=MAILCHIMP_API_HEADERS, data=json.dumps(request_body))
+    request_body = {"email_address": email, "status": "subscribed"}
+    r = requests.post(MAILCHIMP_API_URL + "/members", headers=MAILCHIMP_API_HEADERS, data=json.dumps(request_body))
 
     subscription_error = None
     if r.status_code != 200 and r.status_code != 400:
         subscription_error = True
     # We can get a 400 if the email is already subscribed to the list. We should ignore this error.
-    if r.status_code == 400 and not re.match('.*already a list member', r.text):
+    if r.status_code == 400 and not re.match(".*already a list member", r.text):
         subscription_error = True
     # If there's an error in subscription through the API, we report it to the main email address
     if subscription_error:
-        send_email(config['email']['sender'], 'ERROR - Subscription to Hedy newsletter on signup', email,
-                   '<p>' + email + '</p><pre>Status:' + str(r.status_code) + '    Body:' + r.text + '</pre>')
+        send_email(
+            config["email"]["sender"],
+            "ERROR - Subscription to Hedy newsletter on signup",
+            email,
+            "<p>" + email + "</p><pre>Status:" + str(r.status_code) + "    Body:" + r.text + "</pre>",
+        )
 
 
 @querylog.timed
 def check_password(password, hash):
-    return bcrypt.checkpw(bytes(password, 'utf-8'), bytes(hash, 'utf-8'))
+    return bcrypt.checkpw(bytes(password, "utf-8"), bytes(hash, "utf-8"))
 
 
 def make_salt():
-    return bcrypt.gensalt(rounds=config['bcrypt_rounds']).decode('utf-8')
+    return bcrypt.gensalt(rounds=config["bcrypt_rounds"]).decode("utf-8")
 
 
 @querylog.timed
 def hash(password, salt):
-    return bcrypt.hashpw(bytes(password, 'utf-8'), bytes(salt, 'utf-8')).decode('utf-8')
+    return bcrypt.hashpw(bytes(password, "utf-8"), bytes(salt, "utf-8")).decode("utf-8")
 
 
 # The current user is a slice of the user information from the database and placed on the Flask session.
@@ -81,10 +91,10 @@ def hash(password, salt):
 # The current user should be retrieved with `current_user` function since it will return a sane default.
 # You can remove the current user from the Flask session with the `forget_current_user`.
 def remember_current_user(db_user):
-    session['user-ttl'] = times() + 5 * 60
-    session['user'] = pick(db_user, 'username', 'email', 'is_teacher')
-    session['lang'] = db_user.get('language', 'en')
-    session['keyword_lang'] = db_user.get('keyword_language', 'en')
+    session["user-ttl"] = times() + 5 * 60
+    session["user"] = pick(db_user, "username", "email", "is_teacher")
+    session["lang"] = db_user.get("language", "en")
+    session["keyword_lang"] = db_user.get("keyword_language", "en")
 
 
 def pick(d, *requested_keys):
@@ -96,14 +106,14 @@ def pick(d, *requested_keys):
 # If the current user is to old, as determined by the time-to-live, we repopulate from the database.
 def current_user():
     now = times()
-    user = session.get('user', {'username': '', 'email': ''})
-    ttl = session.get('user-ttl', None)
+    user = session.get("user", {"username": "", "email": ""})
+    ttl = session.get("user-ttl", None)
     if ttl == None or now >= ttl:
-        username = user['username']
+        username = user["username"]
         if username:
             db_user = DATABASE.user_by_username(username)
             if not db_user:
-                raise RuntimeError(f'Cannot find current user in db anymore: {username}')
+                raise RuntimeError(f"Cannot find current user in db anymore: {username}")
             remember_current_user(db_user)
 
     return user
@@ -111,16 +121,16 @@ def current_user():
 
 def is_user_logged_in():
     """Return whether or not a user is currently logged in."""
-    return bool(current_user()['username'])
+    return bool(current_user()["username"])
 
 
 # Remove the current info from the Flask session.
 def forget_current_user():
-    session.pop('user', None)  # We are not interested in the value of the use key.
-    session.pop('messages', None)  # Delete messages counter for current user if existed
-    session.pop('achieved', None)  # Delete session achievements if existing
-    session.pop('keyword_lang', None)  # Delete session keyword language if existing
-    session.pop('profile_image', None)  # Delete profile image id if existing
+    session.pop("user", None)  # We are not interested in the value of the use key.
+    session.pop("messages", None)  # Delete messages counter for current user if existed
+    session.pop("achieved", None)  # Delete session achievements if existing
+    session.pop("keyword_lang", None)  # Delete session keyword language if existing
+    session.pop("profile_image", None)  # Delete profile image id if existing
 
 
 def is_admin(user):
@@ -129,28 +139,28 @@ def is_admin(user):
     Shecks the configuration in environment variables $ADMIN_USER and $ADMIN_USERS.
     """
     admin_users = []
-    if os.getenv('ADMIN_USER'):
-        admin_users.append(os.getenv('ADMIN_USER'))
-    if os.getenv('ADMIN_USERS'):
-        admin_users.extend(os.getenv('ADMIN_USERS').split(','))
+    if os.getenv("ADMIN_USER"):
+        admin_users.append(os.getenv("ADMIN_USER"))
+    if os.getenv("ADMIN_USERS"):
+        admin_users.extend(os.getenv("ADMIN_USERS").split(","))
 
-    return user.get('username') in admin_users or user.get('email') in admin_users
+    return user.get("username") in admin_users or user.get("email") in admin_users
 
 
 def is_teacher(user):
     # the `is_teacher` field is either `0`, `1` or not present.
-    return bool(user.get('is_teacher', False))
+    return bool(user.get("is_teacher", False))
 
 
 def update_is_teacher(user, is_teacher_value=1):
     user_is_teacher = is_teacher(user)
     user_becomes_teacher = is_teacher_value and not user_is_teacher
 
-    DATABASE.update_user(user['username'], {'is_teacher': is_teacher_value, 'teacher_request': None})
+    DATABASE.update_user(user["username"], {"is_teacher": is_teacher_value, "teacher_request": None})
 
     if user_becomes_teacher and not is_testing_request(request):
         try:
-            send_email_template(template='welcome_teacher', email=user['email'], username=user['username'])
+            send_email_template(template="welcome_teacher", email=user["email"], username=user["username"])
         except:
             print(f"An error occurred when sending a welcome teacher mail to {user['email']}, changes still processed")
 
@@ -170,7 +180,7 @@ def requires_admin(f):
     @wraps(f)
     def inner(*args, **kws):
         if not is_user_logged_in() or not is_admin(current_user()):
-            return utils.error_page(error=403, ui_message=gettext('unauthorized'))
+            return utils.error_page(error=403, ui_message=gettext("unauthorized"))
         return f(current_user(), *args, **kws)
 
     return inner
@@ -189,8 +199,8 @@ def login_user_from_token_cookie():
         return
 
     # We update the login record with the current time -> this way the last login is closer to correct
-    DATABASE.record_login(token['username'])
-    user = DATABASE.user_by_username(token['username'])
+    DATABASE.record_login(token["username"])
+    user = DATABASE.user_by_username(token["username"])
     if user:
         remember_current_user(user)
 
@@ -206,69 +216,69 @@ def prepare_user_db(username, password):
 
 
 def validate_student_signup_data(account):
-    if not isinstance(account.get('username'), str):
-        return gettext('username_invalid')
-    if '@' in account.get('username') or ':' in account.get('username'):
-        return gettext('username_special')
-    if len(account.get('username').strip()) < 3:
-        return gettext('username_three')
-    if not isinstance(account.get('password'), str):
-        return gettext('password_invalid')
-    if len(account.get('password')) < 6:
-        return gettext('passwords_six')
+    if not isinstance(account.get("username"), str):
+        return gettext("username_invalid")
+    if "@" in account.get("username") or ":" in account.get("username"):
+        return gettext("username_special")
+    if len(account.get("username").strip()) < 3:
+        return gettext("username_three")
+    if not isinstance(account.get("password"), str):
+        return gettext("password_invalid")
+    if len(account.get("password")) < 6:
+        return gettext("passwords_six")
     return None
 
 
 def validate_signup_data(account):
-    if not isinstance(account.get('username'), str):
-        return gettext('username_invalid')
-    if '@' in account.get('username') or ':' in account.get('username'):
-        return gettext('username_special')
-    if len(account.get('username').strip()) < 3:
-        return gettext('username_three')
-    if not isinstance(account.get('email'), str) or not utils.valid_email(account.get('email')):
-        return gettext('email_invalid')
-    if not isinstance(account.get('password'), str):
-        return gettext('password_invalid')
-    if len(account.get('password')) < 6:
-        return gettext('passwords_six')
+    if not isinstance(account.get("username"), str):
+        return gettext("username_invalid")
+    if "@" in account.get("username") or ":" in account.get("username"):
+        return gettext("username_special")
+    if len(account.get("username").strip()) < 3:
+        return gettext("username_three")
+    if not isinstance(account.get("email"), str) or not utils.valid_email(account.get("email")):
+        return gettext("email_invalid")
+    if not isinstance(account.get("password"), str):
+        return gettext("password_invalid")
+    if len(account.get("password")) < 6:
+        return gettext("passwords_six")
     return None
 
 
 def store_new_student_account(account, teacher_username):
-    username, hashed, hashed_token = prepare_user_db(account['username'], account['password'])
+    username, hashed, hashed_token = prepare_user_db(account["username"], account["password"])
     user = {
-        'username': username,
-        'password': hashed,
-        'language': account['language'],
-        'keyword_language': account['keyword_language'],
-        'created': timems(),
-        'teacher': teacher_username,
-        'verification_pending': hashed_token,
-        'last_login': timems()
+        "username": username,
+        "password": hashed,
+        "language": account["language"],
+        "keyword_language": account["keyword_language"],
+        "created": timems(),
+        "teacher": teacher_username,
+        "verification_pending": hashed_token,
+        "last_login": timems(),
     }
     DATABASE.store_user(user)
     return user
 
 
 def store_new_account(account, email):
-    username, hashed, hashed_token = prepare_user_db(account['username'], account['password'])
+    username, hashed, hashed_token = prepare_user_db(account["username"], account["password"])
     user = {
-        'username': username,
-        'password': hashed,
-        'email': email,
-        'language': account['language'],
-        'keyword_language': account['keyword_language'],
-        'created': timems(),
-        'teacher_request': True if account.get('is_teacher') else None,
-        'third_party': True if account.get('agree_third_party') else None,
-        'verification_pending': hashed_token,
-        'last_login': timems()
+        "username": username,
+        "password": hashed,
+        "email": email,
+        "language": account["language"],
+        "keyword_language": account["keyword_language"],
+        "created": timems(),
+        "teacher_request": True if account.get("is_teacher") else None,
+        "third_party": True if account.get("agree_third_party") else None,
+        "verification_pending": hashed_token,
+        "last_login": timems(),
     }
 
-    for field in ['country', 'birth_year', 'gender', 'language', 'prog_experience', 'experience_languages']:
+    for field in ["country", "birth_year", "gender", "language", "prog_experience", "experience_languages"]:
         if field in account:
-            if field == 'experience_languages' and len(account[field]) == 0:
+            if field == "experience_languages" and len(account[field]) == 0:
                 continue
             user[field] = account[field]
 
@@ -276,100 +286,112 @@ def store_new_account(account, email):
 
     # If this is an e2e test, we return the email verification token directly instead of emailing it.
     if is_testing_request(request):
-        resp = make_response({'username': username, 'token': hashed_token})
+        resp = make_response({"username": username, "token": hashed_token})
     # Otherwise, we send an email with a verification link and we return an empty body
     else:
         try:
-            send_email_template(template='welcome_verify', email=email,
-                            link=create_verify_link(username, hashed_token), username=user['username'])
+            send_email_template(
+                template="welcome_verify",
+                email=email,
+                link=create_verify_link(username, hashed_token),
+                username=user["username"],
+            )
         except:
-            return user, make_response({gettext('mail_error_change_processed')}, 400)
+            return user, make_response({gettext("mail_error_change_processed")}, 400)
         resp = make_response({})
     return user, resp
 
 
 def create_recover_link(username, token):
-    email = email_base_url() + '/reset?username='
-    email += urllib.parse.quote_plus(username) + '&token=' + urllib.parse.quote_plus(token)
+    email = email_base_url() + "/reset?username="
+    email += urllib.parse.quote_plus(username) + "&token=" + urllib.parse.quote_plus(token)
     return email
 
 
 def create_verify_link(username, token):
-    email = email_base_url() + '/auth/verify?username='
-    email += urllib.parse.quote_plus(username) + '&token=' + urllib.parse.quote_plus(token)
+    email = email_base_url() + "/auth/verify?username="
+    email += urllib.parse.quote_plus(username) + "&token=" + urllib.parse.quote_plus(token)
     return email
+
 
 # Note: translations are used only for texts that will be seen by a GUI user.
 def routes(app, database):
     global DATABASE
     DATABASE = database
 
-    @app.route('/auth/login', methods=['POST'])
+    @app.route("/auth/login", methods=["POST"])
     def login():
         body = request.json
         # Validations
         if not isinstance(body, dict):
-            return gettext('ajax_error'), 400
-        if not isinstance(body.get('username'), str):
-            return gettext('username_invalid'), 400
-        if not isinstance(body.get('password'), str):
-            return gettext('password_invalid'), 400
+            return gettext("ajax_error"), 400
+        if not isinstance(body.get("username"), str):
+            return gettext("username_invalid"), 400
+        if not isinstance(body.get("password"), str):
+            return gettext("password_invalid"), 400
 
         # If username has an @-sign, then it's an email
-        if '@' in body['username']:
-            user = DATABASE.user_by_email(body['username'])
+        if "@" in body["username"]:
+            user = DATABASE.user_by_email(body["username"])
         else:
-            user = DATABASE.user_by_username(body['username'])
+            user = DATABASE.user_by_username(body["username"])
 
-        if not user or not check_password(body['password'], user['password']):
-            return gettext('invalid_username_password') + " " + gettext('no_account'), 403
+        if not user or not check_password(body["password"], user["password"]):
+            return gettext("invalid_username_password") + " " + gettext("no_account"), 403
 
         # If the number of bcrypt rounds has changed, create a new hash.
         new_hash = None
-        if config['bcrypt_rounds'] != extract_bcrypt_rounds(user['password']):
-            new_hash = hash(body['password'], make_salt())
+        if config["bcrypt_rounds"] != extract_bcrypt_rounds(user["password"]):
+            new_hash = hash(body["password"], make_salt())
 
         cookie = make_salt()
-        DATABASE.store_token({'id': cookie, 'username': user['username'], 'ttl': times() + session_length})
+        DATABASE.store_token({"id": cookie, "username": user["username"], "ttl": times() + session_length})
         if new_hash:
-            DATABASE.record_login(user['username'], new_hash)
+            DATABASE.record_login(user["username"], new_hash)
         else:
-            DATABASE.record_login(user['username'])
+            DATABASE.record_login(user["username"])
 
         # Check if the user has a public profile, if so -> retrieve the profile image
-        public_profile = DATABASE.get_public_profile_settings(user['username'])
+        public_profile = DATABASE.get_public_profile_settings(user["username"])
         if public_profile:
-            session['profile_image'] = public_profile.get('image', 1)
+            session["profile_image"] = public_profile.get("image", 1)
 
         # Make an empty response to make sure we have one
         resp = make_response()
 
         if is_admin(user):
-            resp = make_response({'admin': True})
-        elif user.get('is_teacher'):
-            resp = make_response({'teacher': True})
+            resp = make_response({"admin": True})
+        elif user.get("is_teacher"):
+            resp = make_response({"teacher": True})
 
         # If the user is a student (and has a related teacher) and the verification is still pending -> first login
-        if user.get('teacher') and user.get('verification_pending'):
-            DATABASE.update_user(user['username'], {'verification_pending': None})
-            resp = make_response({'first_time': True})
+        if user.get("teacher") and user.get("verification_pending"):
+            DATABASE.update_user(user["username"], {"verification_pending": None})
+            resp = make_response({"first_time": True})
 
         # We set the cookie to expire in a year, just so that the browser won't invalidate it if the same cookie gets renewed by constant use.
         # The server will decide whether the cookie expires.
-        resp.set_cookie(TOKEN_COOKIE_NAME, value=cookie, httponly=True, secure=is_heroku(), samesite='Lax', path='/',
-                        max_age=365 * 24 * 60 * 60)
+        resp.set_cookie(
+            TOKEN_COOKIE_NAME,
+            value=cookie,
+            httponly=True,
+            secure=is_heroku(),
+            samesite="Lax",
+            path="/",
+            max_age=365 * 24 * 60 * 60,
+        )
 
         # Remember the current user on the session. This is "new style" logins, which should ultimately
         # replace "old style" logins (with the cookie above), as it requires fewer database calls.
         remember_current_user(user)
         return resp
 
-    @app.route('/auth/signup', methods=['POST'])
+    @app.route("/auth/signup", methods=["POST"])
     def signup():
         body = request.json
         # Validations, mandatory fields
         if not isinstance(body, dict):
-            return gettext('ajax_error'), 400
+            return gettext("ajax_error"), 400
 
         # Validate the essential data using a function -> also used for multiple account creation
         validation = validate_signup_data(body)
@@ -377,231 +399,251 @@ def routes(app, database):
             return validation, 400
 
         # Validate fields only relevant when creating a single user account
-        if not isinstance(body.get('password_repeat'), str) or body['password'] != body['password_repeat']:
-            return gettext('repeat_match_password'), 400
-        if not isinstance(body.get('language'), str) or body.get('language') not in ALL_LANGUAGES.keys():
-            return gettext('language_invalid'), 400
-        if not isinstance(body.get('agree_terms'), str) or not body.get('agree_terms'):
-            return gettext('agree_invalid'), 400
-        if not isinstance(body.get('keyword_language'), str) or body.get('keyword_language') not in ['en', body.get('language')]:
-            return gettext('keyword_language_invalid'), 400
+        if not isinstance(body.get("password_repeat"), str) or body["password"] != body["password_repeat"]:
+            return gettext("repeat_match_password"), 400
+        if not isinstance(body.get("language"), str) or body.get("language") not in ALL_LANGUAGES.keys():
+            return gettext("language_invalid"), 400
+        if not isinstance(body.get("agree_terms"), str) or not body.get("agree_terms"):
+            return gettext("agree_invalid"), 400
+        if not isinstance(body.get("keyword_language"), str) or body.get("keyword_language") not in [
+            "en",
+            body.get("language"),
+        ]:
+            return gettext("keyword_language_invalid"), 400
 
         # Validations, optional fields
-        if 'birth_year' in body:
+        if "birth_year" in body:
             year = datetime.datetime.now().year
             try:
-                body['birth_year'] = int(body.get('birth_year'))
+                body["birth_year"] = int(body.get("birth_year"))
             except ValueError:
-                return gettext('year_invalid').format(**{'current_year': str(year)}), 400
-            if not isinstance(body.get('birth_year'), int) or body['birth_year'] <= 1900 or body['birth_year'] > year:
-                return gettext('year_invalid').format(**{'current_year': str(year)}), 400
-        if 'gender' in body:
-            if body['gender'] != 'm' and body['gender'] != 'f' and body['gender'] != 'o':
-                return gettext('gender_invalid'), 400
-        if 'country' in body:
-            if not body['country'] in COUNTRIES:
-                return gettext('country_invalid'), 400
-        if 'prog_experience' in body and body['prog_experience'] not in ['yes', 'no']:
-            return gettext('experience_invalid'), 400
-        if 'experience_languages' in body:
-            if not isinstance(body['experience_languages'], list):
-                return gettext('experience_invalid'), 400
-            for language in body['experience_languages']:
-                if language not in['scratch', 'other_block', 'python', 'other_text']:
-                    return gettext('programming_invalid'), 400
+                return gettext("year_invalid").format(**{"current_year": str(year)}), 400
+            if not isinstance(body.get("birth_year"), int) or body["birth_year"] <= 1900 or body["birth_year"] > year:
+                return gettext("year_invalid").format(**{"current_year": str(year)}), 400
+        if "gender" in body:
+            if body["gender"] != "m" and body["gender"] != "f" and body["gender"] != "o":
+                return gettext("gender_invalid"), 400
+        if "country" in body:
+            if not body["country"] in COUNTRIES:
+                return gettext("country_invalid"), 400
+        if "prog_experience" in body and body["prog_experience"] not in ["yes", "no"]:
+            return gettext("experience_invalid"), 400
+        if "experience_languages" in body:
+            if not isinstance(body["experience_languages"], list):
+                return gettext("experience_invalid"), 400
+            for language in body["experience_languages"]:
+                if language not in ["scratch", "other_block", "python", "other_text"]:
+                    return gettext("programming_invalid"), 400
 
-        if DATABASE.user_by_username(body['username'].strip().lower()):
-            return gettext('exists_username'), 403
-        if DATABASE.user_by_email(body['email'].strip().lower()):
-            return gettext('exists_email'), 403
+        if DATABASE.user_by_username(body["username"].strip().lower()):
+            return gettext("exists_username"), 403
+        if DATABASE.user_by_email(body["email"].strip().lower()):
+            return gettext("exists_email"), 403
 
         # We receive the pre-processed user and response package from the function
-        user, resp = store_new_account(body, body['email'].strip().lower())
+        user, resp = store_new_account(body, body["email"].strip().lower())
 
-        if not is_testing_request(request) and 'subscribe' in body and body['subscribe'] is True:
+        if not is_testing_request(request) and "subscribe" in body and body["subscribe"] is True:
             # If we have a Mailchimp API key, we use it to add the subscriber through the API
             if MAILCHIMP_API_URL:
-                mailchimp_subscribe_user(user['email'])
+                mailchimp_subscribe_user(user["email"])
             # Otherwise, we send an email to notify about the subscription to the main email address
             else:
-                send_email(config['email']['sender'], 'Subscription to Hedy newsletter on signup', user['email'],
-                           '<p>' + user['email'] + '</p>')
+                send_email(
+                    config["email"]["sender"],
+                    "Subscription to Hedy newsletter on signup",
+                    user["email"],
+                    "<p>" + user["email"] + "</p>",
+                )
 
         # We automatically login the user
         cookie = make_salt()
-        DATABASE.store_token({'id': cookie, 'username': user['username'], 'ttl': times() + session_length})
+        DATABASE.store_token({"id": cookie, "username": user["username"], "ttl": times() + session_length})
         # We set the cookie to expire in a year, just so that the browser won't invalidate it if the same cookie gets renewed by constant use.
         # The server will decide whether the cookie expires.
-        resp.set_cookie(TOKEN_COOKIE_NAME, value=cookie, httponly=True, secure=is_heroku(), samesite='Lax', path='/',
-                        max_age=365 * 24 * 60 * 60)
+        resp.set_cookie(
+            TOKEN_COOKIE_NAME,
+            value=cookie,
+            httponly=True,
+            secure=is_heroku(),
+            samesite="Lax",
+            path="/",
+            max_age=365 * 24 * 60 * 60,
+        )
 
         remember_current_user(user)
         return resp
 
-    @app.route('/auth/verify', methods=['GET'])
+    @app.route("/auth/verify", methods=["GET"])
     def verify_email():
-        username = request.args.get('username', None)
-        token = request.args.get('token', None)
+        username = request.args.get("username", None)
+        token = request.args.get("token", None)
         if not token:
-            return gettext('token_invalid'), 400
+            return gettext("token_invalid"), 400
         if not username:
-            return gettext('username_invalid'), 400
+            return gettext("username_invalid"), 400
 
         # Verify that user actually exists
         user = DATABASE.user_by_username(username)
         if not user:
-            return gettext('username_invalid'), 403
+            return gettext("username_invalid"), 403
 
         # If user is already verified -> re-direct to landing-page anyway
-        if not 'verification_pending' in user:
-            return redirect('/landing-page')
+        if not "verification_pending" in user:
+            return redirect("/landing-page")
 
         # Verify the token
-        if token != user['verification_pending']:
-            return gettext('token_invalid'), 403
+        if token != user["verification_pending"]:
+            return gettext("token_invalid"), 403
 
         # Remove the token from the user
-        DATABASE.update_user(username, {'verification_pending': None})
+        DATABASE.update_user(username, {"verification_pending": None})
 
         # We automatically login the user
         cookie = make_salt()
-        DATABASE.store_token({'id': cookie, 'username': user['username'], 'ttl': times() + session_length})
+        DATABASE.store_token({"id": cookie, "username": user["username"], "ttl": times() + session_length})
         remember_current_user(user)
 
-        return redirect('/landing-page')
+        return redirect("/landing-page")
 
-    @app.route('/auth/logout', methods=['POST'])
+    @app.route("/auth/logout", methods=["POST"])
     def logout():
         forget_current_user()
         if request.cookies.get(TOKEN_COOKIE_NAME):
             DATABASE.forget_token(request.cookies.get(TOKEN_COOKIE_NAME))
-        return '', 200
+        return "", 200
 
-    @app.route('/auth/destroy', methods=['POST'])
+    @app.route("/auth/destroy", methods=["POST"])
     @requires_login
     def destroy(user):
         forget_current_user()
         DATABASE.forget_token(request.cookies.get(TOKEN_COOKIE_NAME))
-        DATABASE.forget_user(user['username'])
-        return '', 200
+        DATABASE.forget_user(user["username"])
+        return "", 200
 
-    @app.route('/auth/destroy_public', methods=['POST'])
+    @app.route("/auth/destroy_public", methods=["POST"])
     @requires_login
     def destroy_public(user):
-        DATABASE.forget_public_profile(user['username'])
-        session.pop('profile_image', None)  # Delete profile image id if existing
-        return '', 200
+        DATABASE.forget_public_profile(user["username"])
+        session.pop("profile_image", None)  # Delete profile image id if existing
+        return "", 200
 
-    @app.route('/auth/change_student_password', methods=['POST'])
+    @app.route("/auth/change_student_password", methods=["POST"])
     @requires_login
     def change_student_password(user):
         body = request.json
         if not isinstance(body, dict):
-            return gettext('ajax_error'), 400
-        if not isinstance(body.get('username'), str):
-            return gettext('username_invalid'), 400
-        if not isinstance(body.get('password'), str):
-            return gettext('password_invalid'), 400
-        if len(body['password']) < 6:
-            return gettext('password_six'), 400
+            return gettext("ajax_error"), 400
+        if not isinstance(body.get("username"), str):
+            return gettext("username_invalid"), 400
+        if not isinstance(body.get("password"), str):
+            return gettext("password_invalid"), 400
+        if len(body["password"]) < 6:
+            return gettext("password_six"), 400
 
         if not is_teacher(user):
             return gettext("password_change_not_allowed"), 400
-        students = DATABASE.get_teacher_students(user['username'])
-        if body['username'] not in students:
+        students = DATABASE.get_teacher_students(user["username"])
+        if body["username"] not in students:
             return gettext("password_change_not_allowed"), 400
 
-        hashed = hash(body['password'], make_salt())
-        DATABASE.update_user(body['username'], {'password': hashed})
+        hashed = hash(body["password"], make_salt())
+        DATABASE.update_user(body["username"], {"password": hashed})
 
-        return {'success': gettext("password_change_success")}, 200
+        return {"success": gettext("password_change_success")}, 200
 
-    @app.route('/auth/change_password', methods=['POST'])
+    @app.route("/auth/change_password", methods=["POST"])
     @requires_login
     def change_password(user):
         body = request.json
 
         if not isinstance(body, dict):
-            return gettext('ajax_error'), 400
-        if not isinstance(body.get('old_password'), str) or not isinstance(body.get('password'), str):
-            return gettext('password_invalid'), 400
-        if not isinstance(body.get( 'password_repeat'), str):
-            return gettext('repeat_match_password'), 400
-        if len(body['password']) < 6:
-            return gettext('password_six'), 400
-        if body['password'] != body['password_repeat']:
-            return gettext('repeat_match_password'), 400
+            return gettext("ajax_error"), 400
+        if not isinstance(body.get("old_password"), str) or not isinstance(body.get("password"), str):
+            return gettext("password_invalid"), 400
+        if not isinstance(body.get("password_repeat"), str):
+            return gettext("repeat_match_password"), 400
+        if len(body["password"]) < 6:
+            return gettext("password_six"), 400
+        if body["password"] != body["password_repeat"]:
+            return gettext("repeat_match_password"), 400
 
         # The user object we got from 'requires_login' doesn't have the password, so look that up in the database
-        user = DATABASE.user_by_username(user['username'])
+        user = DATABASE.user_by_username(user["username"])
 
-        if not check_password(body['old_password'], user['password']):
-            return gettext('password_invalid'), 403
+        if not check_password(body["old_password"], user["password"]):
+            return gettext("password_invalid"), 403
 
-        hashed = hash(body['password'], make_salt())
+        hashed = hash(body["password"], make_salt())
 
-        DATABASE.update_user(user['username'], {'password': hashed})
+        DATABASE.update_user(user["username"], {"password": hashed})
         # We are not updating the user in the Flask session, because we should not rely on the password in anyway.
         if not is_testing_request(request):
             try:
-                send_email_template(template='change_password', email=user['email'], username=user['username'])
+                send_email_template(template="change_password", email=user["email"], username=user["username"])
             except:
-                return gettext('mail_error_change_processed'), 400
+                return gettext("mail_error_change_processed"), 400
 
-        return jsonify({'message': gettext('password_updated')}), 200
+        return jsonify({"message": gettext("password_updated")}), 200
 
-    @app.route('/profile', methods=['POST'])
+    @app.route("/profile", methods=["POST"])
     @requires_login
     def update_profile(user):
         body = request.json
         if not isinstance(body, dict):
-            return gettext('ajax_error'), 400
-        if not isinstance(body.get('language'), str) or body.get('language') not in ALL_LANGUAGES.keys():
-            return gettext('language_invalid'), 400
-        if not isinstance(body.get('keyword_language'), str) or body.get('keyword_language') not in ['en', body.get(
-                'language')] or body.get('keyword_language') not in ALL_KEYWORD_LANGUAGES.keys():
-            return gettext('keyword_language_invalid'), 400
+            return gettext("ajax_error"), 400
+        if not isinstance(body.get("language"), str) or body.get("language") not in ALL_LANGUAGES.keys():
+            return gettext("language_invalid"), 400
+        if (
+            not isinstance(body.get("keyword_language"), str)
+            or body.get("keyword_language") not in ["en", body.get("language")]
+            or body.get("keyword_language") not in ALL_KEYWORD_LANGUAGES.keys()
+        ):
+            return gettext("keyword_language_invalid"), 400
 
         # Mail is a unique field, only mandatory if the user doesn't have a related teacher (and no mail address)
-        user = DATABASE.user_by_username(user['username'])
-        if not user.get('teacher') or 'email' in body:
-            if not isinstance(body.get('email'), str) or not valid_email(body['email']):
-                return gettext('email_invalid'), 400
+        user = DATABASE.user_by_username(user["username"])
+        if not user.get("teacher") or "email" in body:
+            if not isinstance(body.get("email"), str) or not valid_email(body["email"]):
+                return gettext("email_invalid"), 400
 
         # Validations, optional fields
-        if 'birth_year' in body:
+        if "birth_year" in body:
             year = datetime.datetime.now().year
             try:
-                body['birth_year'] = int(body.get('birth_year'))
+                body["birth_year"] = int(body.get("birth_year"))
             except ValueError:
-                return gettext('year_invalid').format(**{'current_year': str(year)}), 400
-            if not isinstance(body.get('birth_year'), int) or body['birth_year'] <= 1900 or body['birth_year'] > year:
-                return gettext('year_invalid').format(**{'current_year': str(year)}), 400
-        if 'gender' in body:
-            if body['gender'] not in ["m", "f", "o"]:
-                return gettext('gender_invalid'), 400
-        if 'country' in body:
-            if not body['country'] in COUNTRIES:
-                return gettext('country_invalid'), 400
+                return gettext("year_invalid").format(**{"current_year": str(year)}), 400
+            if not isinstance(body.get("birth_year"), int) or body["birth_year"] <= 1900 or body["birth_year"] > year:
+                return gettext("year_invalid").format(**{"current_year": str(year)}), 400
+        if "gender" in body:
+            if body["gender"] not in ["m", "f", "o"]:
+                return gettext("gender_invalid"), 400
+        if "country" in body:
+            if not body["country"] in COUNTRIES:
+                return gettext("country_invalid"), 400
 
         resp = {}
-        if 'email' in body:
-            email = body['email'].strip().lower()
-            if email != user.get('email'):
+        if "email" in body:
+            email = body["email"].strip().lower()
+            if email != user.get("email"):
                 exists = DATABASE.user_by_email(email)
                 if exists:
-                    return gettext('exists_email'), 403
+                    return gettext("exists_email"), 403
                 token = make_salt()
                 hashed_token = hash(token, make_salt())
-                DATABASE.update_user(user['username'], {'email': email, 'verification_pending': hashed_token})
+                DATABASE.update_user(user["username"], {"email": email, "verification_pending": hashed_token})
                 # If this is an e2e test, we return the email verification token directly instead of emailing it.
                 if is_testing_request(request):
-                    resp = {'username': user['username'], 'token': hashed_token}
+                    resp = {"username": user["username"], "token": hashed_token}
                 else:
                     try:
-                        send_email_template(template='welcome_verify', email=email,
-                                        link=create_verify_link(user['username'], hashed_token),
-                                        username=user['username'])
+                        send_email_template(
+                            template="welcome_verify",
+                            email=email,
+                            link=create_verify_link(user["username"], hashed_token),
+                            username=user["username"],
+                        )
                     except:
                         # Todo TB: Now we only log to the back-end, would be nice to also return the user some info
                         # We have two options: return an error at this point (don't process changes)
@@ -611,252 +653,256 @@ def routes(app, database):
                 # We check whether the user is in the Mailchimp list.
                 if not is_testing_request(request) and MAILCHIMP_API_URL:
                     # We hash the email with md5 to avoid emails with unescaped characters triggering errors
-                    request_path = MAILCHIMP_API_URL + '/members/' + hashlib.md5(
-                        user['email'].encode('utf-8')).hexdigest()
+                    request_path = (
+                        MAILCHIMP_API_URL + "/members/" + hashlib.md5(user["email"].encode("utf-8")).hexdigest()
+                    )
                     r = requests.get(request_path, headers=MAILCHIMP_API_HEADERS)
                     # If user is subscribed, we remove the old email from the list and add the new one
                     if r.status_code == 200:
                         r = requests.delete(request_path, headers=MAILCHIMP_API_HEADERS)
                         mailchimp_subscribe_user(email)
 
-        username = user['username']
+        username = user["username"]
 
         updates = {}
-        for field in ['country', 'birth_year', 'gender', 'language', 'keyword_language']:
+        for field in ["country", "birth_year", "gender", "language", "keyword_language"]:
             if field in body:
                 updates[field] = body[field]
             else:
                 updates[field] = None
-        if body.get('agree_third_party'):
-            updates['third_party'] = True
+        if body.get("agree_third_party"):
+            updates["third_party"] = True
         else:
-            updates['third_party'] = None
+            updates["third_party"] = None
 
         if updates:
             DATABASE.update_user(username, updates)
 
         # Always make sure that the country stored on the public profile is identical to the profile one
-        DATABASE.update_country_public_profile(username, body.get('country', None))
+        DATABASE.update_country_public_profile(username, body.get("country", None))
 
         # We want to check if the user choose a new language, if so -> reload
         # We can use g.lang for this to reduce the db calls
-        resp['reload'] = False
-        if session['lang'] != body['language'] or session['keyword_lang'] != body['keyword_language']:
-            resp['message'] = gettext('profile_updated_reload')
-            resp['reload'] = True
+        resp["reload"] = False
+        if session["lang"] != body["language"] or session["keyword_lang"] != body["keyword_language"]:
+            resp["message"] = gettext("profile_updated_reload")
+            resp["reload"] = True
         else:
-            resp['message'] = gettext('profile_updated')
+            resp["message"] = gettext("profile_updated")
 
-        remember_current_user(DATABASE.user_by_username(user['username']))
+        remember_current_user(DATABASE.user_by_username(user["username"]))
         return jsonify(resp)
 
-    @app.route('/profile', methods=['GET'])
+    @app.route("/profile", methods=["GET"])
     @requires_login
     def get_profile(user):
         # The user object we got from 'requires_login' is not fully hydrated yet. Look up the database user.
-        user = DATABASE.user_by_username(user['username'])
+        user = DATABASE.user_by_username(user["username"])
 
-        output = {
-            'username': user['username'],
-            'email': user['email'],
-            'language': user.get('language', 'en')
-        }
-        for field in ['birth_year', 'country', 'gender', 'prog_experience', 'experience_languages', 'third_party']:
+        output = {"username": user["username"], "email": user["email"], "language": user.get("language", "en")}
+        for field in ["birth_year", "country", "gender", "prog_experience", "experience_languages", "third_party"]:
             if field in user:
                 output[field] = user[field]
-        if 'verification_pending' in user:
-            output['verification_pending'] = True
+        if "verification_pending" in user:
+            output["verification_pending"] = True
 
-        output['student_classes'] = DATABASE.get_student_classes(user['username'])
+        output["student_classes"] = DATABASE.get_student_classes(user["username"])
 
-        output['session_expires_at'] = timems() + session_length * 1000
+        output["session_expires_at"] = timems() + session_length * 1000
 
         return jsonify(output), 200
 
-    @app.route('/auth/recover', methods=['POST'])
+    @app.route("/auth/recover", methods=["POST"])
     def recover():
         body = request.json
         # Validations
         if not isinstance(body, dict):
-            return gettext('ajax_error'), 400
-        if not isinstance(body.get('username'), str):
-            return gettext('username_invalid'), 400
+            return gettext("ajax_error"), 400
+        if not isinstance(body.get("username"), str):
+            return gettext("username_invalid"), 400
 
         # If username has an @-sign, then it's an email
-        if '@' in body['username']:
-            user = DATABASE.user_by_email(body['username'].strip().lower())
+        if "@" in body["username"]:
+            user = DATABASE.user_by_email(body["username"].strip().lower())
         else:
-            user = DATABASE.user_by_username(body['username'].strip().lower())
+            user = DATABASE.user_by_username(body["username"].strip().lower())
 
         if not user:
-            return gettext('username_invalid'), 403
+            return gettext("username_invalid"), 403
 
         # In this case -> account has a related teacher (and is a student)
         # We still store the token, but sent the mail to the teacher instead
-        if user.get('teacher') and not user.get('email'):
-            email = DATABASE.user_by_username(user.get('teacher')).get('email')
+        if user.get("teacher") and not user.get("email"):
+            email = DATABASE.user_by_username(user.get("teacher")).get("email")
         else:
-            email = user['email']
+            email = user["email"]
 
         # Create a token -> use the reset_length value as we don't want the token to live as long as a login one
         token = make_salt()
         # Todo TB -> Don't we want to use a hashed token here as well?
-        DATABASE.store_token({'id': token, 'username': user['username'], 'ttl': times() + reset_length})
+        DATABASE.store_token({"id": token, "username": user["username"], "ttl": times() + reset_length})
 
         if is_testing_request(request):
             # If this is an e2e test, we return the email verification token directly instead of emailing it.
-            return jsonify({'username': user['username'], 'token': token}), 200
+            return jsonify({"username": user["username"], "token": token}), 200
         else:
             try:
-                send_email_template(template='recover_password', email=email,
-                                link=create_recover_link(user['username'], token), username=user['username'])
+                send_email_template(
+                    template="recover_password",
+                    email=email,
+                    link=create_recover_link(user["username"], token),
+                    username=user["username"],
+                )
             except:
-                return gettext('mail_error_change_processed'), 400
+                return gettext("mail_error_change_processed"), 400
 
-            return jsonify({'message': gettext('sent_password_recovery')}), 200
+            return jsonify({"message": gettext("sent_password_recovery")}), 200
 
-    @app.route('/auth/reset', methods=['POST'])
+    @app.route("/auth/reset", methods=["POST"])
     def reset():
         body = request.json
         # Validations
         if not isinstance(body, dict):
-            return gettext('ajax_error'), 400
-        if not isinstance(body.get('username'), str):
-            return gettext('username_invalid'), 400
-        if not isinstance(body.get('token'), str):
-            return gettext('token_invalid'), 400
-        if not isinstance(body.get('password'), str):
-            return gettext('password_invalid'), 400
-        if len(body['password']) < 6:
-            return gettext('password_six'), 400
-        if not isinstance(body.get('password_repeat'), str) or body['password'] != body['password_repeat']:
-            return gettext('repeat_match_password'), 400
+            return gettext("ajax_error"), 400
+        if not isinstance(body.get("username"), str):
+            return gettext("username_invalid"), 400
+        if not isinstance(body.get("token"), str):
+            return gettext("token_invalid"), 400
+        if not isinstance(body.get("password"), str):
+            return gettext("password_invalid"), 400
+        if len(body["password"]) < 6:
+            return gettext("password_six"), 400
+        if not isinstance(body.get("password_repeat"), str) or body["password"] != body["password_repeat"]:
+            return gettext("repeat_match_password"), 400
 
-        token = DATABASE.get_token(body['token'])
-        if not token or body['token'] != token.get('id') or body['username'] != token.get('username'):
-            return gettext('token_invalid'), 403
+        token = DATABASE.get_token(body["token"])
+        if not token or body["token"] != token.get("id") or body["username"] != token.get("username"):
+            return gettext("token_invalid"), 403
 
-        hashed = hash(body['password'], make_salt())
-        DATABASE.update_user(body['username'], {'password': hashed})
-        user = DATABASE.user_by_username(body['username'])
+        hashed = hash(body["password"], make_salt())
+        DATABASE.update_user(body["username"], {"password": hashed})
+        user = DATABASE.user_by_username(body["username"])
 
         # Delete all tokens of the user -> automatically logout all long-lived sessions
-        DATABASE.delete_all_tokens(body['username'])
+        DATABASE.delete_all_tokens(body["username"])
 
         # In this case -> account has a related teacher (and is a student)
         # We mail the teacher instead
-        if user.get('teacher') and not user.get('email'):
-            email = DATABASE.user_by_username(user.get('teacher')).get('email')
+        if user.get("teacher") and not user.get("email"):
+            email = DATABASE.user_by_username(user.get("teacher")).get("email")
         else:
-            email = user['email']
+            email = user["email"]
 
         if not is_testing_request(request):
             try:
-                send_email_template(template='reset_password', email=email, username=user['username'])
+                send_email_template(template="reset_password", email=email, username=user["username"])
             except:
-                return gettext('mail_error_change_processed'), 400
+                return gettext("mail_error_change_processed"), 400
 
-        return jsonify({'message': gettext('password_resetted')}), 200
+        return jsonify({"message": gettext("password_resetted")}), 200
 
-    @app.route('/auth/request_teacher', methods=['GET'])
+    @app.route("/auth/request_teacher", methods=["GET"])
     @requires_login
     def request_teacher_account(user):
-        account = DATABASE.user_by_username(user['username'])
-        if account.get('is_teacher'):
-            return gettext('already_teacher'), 400
-        if account.get('teacher_request'):
-            return gettext('already_teacher_request'), 400
+        account = DATABASE.user_by_username(user["username"])
+        if account.get("is_teacher"):
+            return gettext("already_teacher"), 400
+        if account.get("teacher_request"):
+            return gettext("already_teacher_request"), 400
 
-        DATABASE.update_user(user['username'], {'teacher_request': True})
-        return jsonify({'message': gettext('teacher_account_success')}), 200
+        DATABASE.update_user(user["username"], {"teacher_request": True})
+        return jsonify({"message": gettext("teacher_account_success")}), 200
 
     # *** ADMIN ROUTES ***
 
-    @app.route('/admin/markAsTeacher', methods=['POST'])
+    @app.route("/admin/markAsTeacher", methods=["POST"])
     def mark_as_teacher():
         user = current_user()
         if not is_admin(user) and not is_testing_request(request):
-            return utils.error_page(error=403, ui_message=gettext('unauthorized'))
+            return utils.error_page(error=403, ui_message=gettext("unauthorized"))
 
         body = request.json
 
         # Validations
         if not isinstance(body, dict):
-            return gettext('ajax_error'), 400
-        if not isinstance(body.get('username'), str):
-            return gettext('username_invalid'), 400
-        if not isinstance(body.get('is_teacher'), bool):
-            return gettext('teacher_invalid'), 400
+            return gettext("ajax_error"), 400
+        if not isinstance(body.get("username"), str):
+            return gettext("username_invalid"), 400
+        if not isinstance(body.get("is_teacher"), bool):
+            return gettext("teacher_invalid"), 400
 
-        user = DATABASE.user_by_username(body['username'].strip().lower())
+        user = DATABASE.user_by_username(body["username"].strip().lower())
 
         if not user:
-            return gettext('username_invalid'), 400
+            return gettext("username_invalid"), 400
 
-        is_teacher_value = 1 if body['is_teacher'] else 0
+        is_teacher_value = 1 if body["is_teacher"] else 0
         update_is_teacher(user, is_teacher_value)
 
         # Todo TB feb 2022 -> Return the success message here instead of fixing in the front-end
-        return '', 200
+        return "", 200
 
-    @app.route('/admin/changeUserEmail', methods=['POST'])
+    @app.route("/admin/changeUserEmail", methods=["POST"])
     @requires_admin
     def change_user_email(user):
         body = request.json
 
         # Validations
         if not isinstance(body, dict):
-            return gettext('ajax_error'), 400
-        if not isinstance(body.get('username'), str):
-            return gettext('username_invalid'), 400
-        if not isinstance(body.get('email'), str) or not valid_email(body['email']):
-            return gettext('email_invalid'), 400
+            return gettext("ajax_error"), 400
+        if not isinstance(body.get("username"), str):
+            return gettext("username_invalid"), 400
+        if not isinstance(body.get("email"), str) or not valid_email(body["email"]):
+            return gettext("email_invalid"), 400
 
-        user = DATABASE.user_by_username(body['username'].strip().lower())
+        user = DATABASE.user_by_username(body["username"].strip().lower())
 
         if not user:
-            return gettext('email_invalid'), 400
+            return gettext("email_invalid"), 400
 
         token = make_salt()
         hashed_token = hash(token, make_salt())
 
         # We assume that this email is not in use by any other users. In other words, we trust the admin to enter a valid, not yet used email address.
-        DATABASE.update_user(user['username'], {'email': body['email'], 'verification_pending': hashed_token})
+        DATABASE.update_user(user["username"], {"email": body["email"], "verification_pending": hashed_token})
 
         # If this is an e2e test, we return the email verification token directly instead of emailing it.
         if is_testing_request(request):
-            resp = {'username': user['username'], 'token': hashed_token}
+            resp = {"username": user["username"], "token": hashed_token}
         else:
             try:
-                send_email_template(template='welcome_verify', email=body['email'],
-                                    link=create_verify_link(user['username'], hashed_token),
-                                    username=user['username'])
+                send_email_template(
+                    template="welcome_verify",
+                    email=body["email"],
+                    link=create_verify_link(user["username"], hashed_token),
+                    username=user["username"],
+                )
             except:
-                return gettext('mail_error_change_processed'), 400
+                return gettext("mail_error_change_processed"), 400
 
         return {}, 200
 
-    @app.route('/admin/getUserTags', methods=['POST'])
+    @app.route("/admin/getUserTags", methods=["POST"])
     @requires_admin
     def get_user_tags(user):
         body = request.json
-        user = DATABASE.get_public_profile_settings(body['username'].strip().lower())
+        user = DATABASE.get_public_profile_settings(body["username"].strip().lower())
         if not user:
             return "User doesn't have a public profile", 400
-        return {'tags': user.get('tags', [])}, 200
+        return {"tags": user.get("tags", [])}, 200
 
-    @app.route('/admin/updateUserTags', methods=['POST'])
+    @app.route("/admin/updateUserTags", methods=["POST"])
     @requires_admin
     def update_user_tags(user):
         body = request.json
-        user = DATABASE.get_public_profile_settings(body['username'].strip().lower())
+        user = DATABASE.get_public_profile_settings(body["username"].strip().lower())
         if not user:
             return "User doesn't have a public profile", 400
 
         tags = []
-        if "admin" in user.get('tags', []):
+        if "admin" in user.get("tags", []):
             tags.append("admin")
-        if "teacher" in user.get('tags', []):
+        if "teacher" in user.get("tags", []):
             tags.append("teacher")
         if body.get("certified"):
             tags.append("certified_teacher")
@@ -865,90 +911,97 @@ def routes(app, database):
         if body.get("contributor"):
             tags.append("contributor")
 
-        user['tags'] = tags
-        DATABASE.update_public_profile(user['username'], user)
+        user["tags"] = tags
+        DATABASE.update_public_profile(user["username"], user)
         return {}, 200
+
 
 # Turn off verbose logs from boto/SES, thanks to https://github.com/boto/boto3/issues/521
 import logging
 
 for name in logging.Logger.manager.loggerDict.keys():
-    if ('boto' in name) or ('urllib3' in name) or ('s3transfer' in name) or ('boto3' in name) or (
-            'botocore' in name) or ('nose' in name):
+    if (
+        ("boto" in name)
+        or ("urllib3" in name)
+        or ("s3transfer" in name)
+        or ("boto3" in name)
+        or ("botocore" in name)
+        or ("nose" in name)
+    ):
         logging.getLogger(name).setLevel(logging.CRITICAL)
 
 # https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-using-sdk-python.html
-email_client = boto3.client('ses', region_name=config['email']['region'])
+email_client = boto3.client("ses", region_name=config["email"]["region"])
 
 
 @querylog.timed
 def send_email(recipient, subject, body_plain, body_html):
     try:
         result = email_client.send_email(
-            Source=config['email']['sender'],
-            Destination={'ToAddresses': [recipient]},
+            Source=config["email"]["sender"],
+            Destination={"ToAddresses": [recipient]},
             Message={
-                'Subject': {'Data': subject, 'Charset': 'UTF-8'},
-                'Body': {
-                    'Text': {'Data': body_plain, 'Charset': 'UTF-8'},
-                    'Html': {'Data': body_html, 'Charset': 'UTF-8'},
-                }
-            }
+                "Subject": {"Data": subject, "Charset": "UTF-8"},
+                "Body": {
+                    "Text": {"Data": body_plain, "Charset": "UTF-8"},
+                    "Html": {"Data": body_html, "Charset": "UTF-8"},
+                },
+            },
         )
     except email_error as error:
-        print('Email send error', error.response['Error']['Message'])
+        print("Email send error", error.response["Error"]["Message"])
     except NoCredentialsError as e:
         if not is_debug_mode():
             raise e
     else:
-        print('Email sent to ' + recipient)
+        print("Email sent to " + recipient)
 
 
 def get_template_translation(template):
-    if template == 'welcome_verify':
-        return gettext('mail_welcome_verify_body')
-    elif template == 'change_password':
-        return gettext('mail_change_password_body')
-    elif template == 'recover_password':
-        return gettext('mail_recover_password_body')
-    elif template == 'reset_password':
-        return gettext('mail_reset_password_body')
-    elif template == 'welcome_teacher':
-        return gettext('mail_welcome_teacher_body')
+    if template == "welcome_verify":
+        return gettext("mail_welcome_verify_body")
+    elif template == "change_password":
+        return gettext("mail_change_password_body")
+    elif template == "recover_password":
+        return gettext("mail_recover_password_body")
+    elif template == "reset_password":
+        return gettext("mail_reset_password_body")
+    elif template == "welcome_teacher":
+        return gettext("mail_welcome_teacher_body")
     return None
 
 
 def get_subject_translation(template):
-    if template == 'welcome_verify':
-        return gettext('mail_welcome_verify_subject')
-    elif template == 'change_password':
-        return gettext('mail_change_password_subject')
-    elif template == 'recover_password':
-        return gettext('mail_recover_password_subject')
-    elif template == 'reset_password':
-        return gettext('mail_reset_password_subject')
-    elif template == 'welcome_teacher':
-        return gettext('mail_welcome_teacher_subject')
+    if template == "welcome_verify":
+        return gettext("mail_welcome_verify_subject")
+    elif template == "change_password":
+        return gettext("mail_change_password_subject")
+    elif template == "recover_password":
+        return gettext("mail_recover_password_subject")
+    elif template == "reset_password":
+        return gettext("mail_reset_password_subject")
+    elif template == "welcome_teacher":
+        return gettext("mail_welcome_teacher_subject")
     return None
 
 
-def send_email_template(template, email, link=None, username=gettext('user')):
+def send_email_template(template, email, link=None, username=gettext("user")):
     subject = get_subject_translation(template)
     if not subject:
         print("Something went wrong, mail template could not be found...")
         return
-    body = gettext('mail_hello').format(username=username) + "\n\n"
+    body = gettext("mail_hello").format(username=username) + "\n\n"
     body += get_template_translation(template) + "\n\n"
-    body += gettext('mail_goodbye')
+    body += gettext("mail_goodbye")
 
-    with open('templates/base_email.html', 'r', encoding='utf-8') as f:
+    with open("templates/base_email.html", "r", encoding="utf-8") as f:
         body_html = f.read()
 
     body_html = body_html.format(content=body)
     body_plain = body
     if link:
-        body_plain = body_plain.format(link=gettext('copy_mail_link') + " " + link)
-        body_html = body_html.format(link='<a href="' + link + '">{link}</a>').format(link=gettext('link'))
+        body_plain = body_plain.format(link=gettext("copy_mail_link") + " " + link)
+        body_html = body_html.format(link='<a href="' + link + '">{link}</a>').format(link=gettext("link"))
 
     send_email(email, subject, body_plain, body_html)
 
@@ -963,7 +1016,7 @@ def email_base_url():
     Will use the environment variable BASE_URL if set, otherwise will guess using
     the current Flask request.
     """
-    from_env = os.getenv('BASE_URL')
+    from_env = os.getenv("BASE_URL")
     if from_env:
-        return from_env.rstrip('/')
+        return from_env.rstrip("/")
     return request.host_url

--- a/website/auth.py
+++ b/website/auth.py
@@ -1,37 +1,34 @@
-import ast
-import collections
+import json
 import os
-from flask_babel import gettext
-import utils
-from hedy_content import COUNTRIES, ALL_LANGUAGES, ALL_KEYWORD_LANGUAGES
-from website.yaml_file import YamlFile
 import bcrypt
 import re
 import urllib
-from flask import request, session, make_response, jsonify, redirect
-from utils import timems, times, extract_bcrypt_rounds, is_testing_request, is_debug_mode, valid_email, is_heroku
-import datetime
 from functools import wraps
-from config import config
+
 import boto3
 from botocore.exceptions import ClientError as email_error, NoCredentialsError
-import json
+from flask import g, request, session
+from flask_babel import gettext
 import requests
-from website import querylog, database
-import hashlib
+
+import utils
+from utils import timems, times, is_debug_mode
+from config import config
+from website import querylog
 
 TOKEN_COOKIE_NAME = config["session"]["cookie_name"]
+
 # The session_length in the session is set to 60 * 24 * 14 (in minutes) config.py#13
 # The reset_length in the session is set to 60 * 4 (in minutes) config.py#14
 # We multiply this by 60 to set the session_length to 14 days and reset_length to 4 hours
-session_length = config["session"]["session_length"] * 60
-reset_length = config["session"]["reset_length"] * 60
+SESSION_LENGTH = config["session"]["session_length"] * 60
+RESET_LENGTH = config["session"]["reset_length"] * 60
+
 
 env = os.getenv("HEROKU_APP_NAME")
 
-DATABASE: database.Database = None
-
 MAILCHIMP_API_URL = None
+MAILCHIMP_API_HEADERS = {}
 if os.getenv("MAILCHIMP_API_KEY") and os.getenv("MAILCHIMP_AUDIENCE_ID"):
     # The domain in the path is the server name, which is contained in the Mailchimp API key
     MAILCHIMP_API_URL = (
@@ -48,7 +45,11 @@ if os.getenv("MAILCHIMP_API_KEY") and os.getenv("MAILCHIMP_AUDIENCE_ID"):
 
 def mailchimp_subscribe_user(email):
     request_body = {"email_address": email, "status": "subscribed"}
-    r = requests.post(MAILCHIMP_API_URL + "/members", headers=MAILCHIMP_API_HEADERS, data=json.dumps(request_body))
+    r = requests.post(
+        MAILCHIMP_API_URL + "/members",
+        headers=MAILCHIMP_API_HEADERS,
+        data=json.dumps(request_body),
+    )
 
     subscription_error = None
     if r.status_code != 200 and r.status_code != 400:
@@ -76,7 +77,7 @@ def make_salt():
 
 
 @querylog.timed
-def hash(password, salt):
+def password_hash(password, salt):
     return bcrypt.hashpw(bytes(password, "utf-8"), bytes(salt, "utf-8")).decode("utf-8")
 
 
@@ -111,7 +112,7 @@ def current_user():
     if ttl == None or now >= ttl:
         username = user["username"]
         if username:
-            db_user = DATABASE.user_by_username(username)
+            db_user = g.db.user_by_username(username)
             if not db_user:
                 raise RuntimeError(f"Cannot find current user in db anymore: {username}")
             remember_current_user(db_user)
@@ -152,36 +153,48 @@ def is_teacher(user):
     return bool(user.get("is_teacher", False))
 
 
-def update_is_teacher(user, is_teacher_value=1):
-    user_is_teacher = is_teacher(user)
-    user_becomes_teacher = is_teacher_value and not user_is_teacher
-
-    DATABASE.update_user(user["username"], {"is_teacher": is_teacher_value, "teacher_request": None})
-
-    if user_becomes_teacher and not is_testing_request(request):
-        try:
-            send_email_template(template="welcome_teacher", email=user["email"], username=user["username"])
-        except:
-            print(f"An error occurred when sending a welcome teacher mail to {user['email']}, changes still processed")
-
-
 # Thanks to https://stackoverflow.com/a/34499643
 def requires_login(f):
+    """Decoractor to indicate that a particular route requires the user to be logged in.
+
+    If the user is not logged in, an error page will be shown. If they are, the
+    function is executed as normal with the user information passed to it.
+
+    The function MUST take an argument named 'user', which will contain the
+    minimal user object from the session (containing 'username', 'email' and
+    'is_teacher').
+
+    Example:
+
+        @app.route('/bla', method=['GET'])
+        @requires_login
+        def show_bla(user):
+            pass
+    """
+
     @wraps(f)
     def inner(*args, **kws):
         if not is_user_logged_in():
             return utils.error_page(error=403)
-        return f(current_user(), *args, **kws)
+        # The reason we pass by keyword argument is to make this
+        # work logically both for free-floating functions as well
+        # as [unbound] class methods.
+        return f(*args, user=current_user(), **kws)
 
     return inner
 
 
 def requires_admin(f):
+    """Similar to 'requires_login', but also tests that the user is an admin.
+
+    The decorated function MUST declare an argument named 'user'.
+    """
+
     @wraps(f)
     def inner(*args, **kws):
         if not is_user_logged_in() or not is_admin(current_user()):
             return utils.error_page(error=403, ui_message=gettext("unauthorized"))
-        return f(current_user(), *args, **kws)
+        return f(*args, user=current_user(), **kws)
 
     return inner
 
@@ -194,25 +207,15 @@ def login_user_from_token_cookie():
     if not request.cookies.get(TOKEN_COOKIE_NAME):
         return
 
-    token = DATABASE.get_token(request.cookies.get(TOKEN_COOKIE_NAME))
+    token = g.db.get_token(request.cookies.get(TOKEN_COOKIE_NAME))
     if not token:
         return
 
     # We update the login record with the current time -> this way the last login is closer to correct
-    DATABASE.record_login(token["username"])
-    user = DATABASE.user_by_username(token["username"])
+    g.db.record_login(token["username"])
+    user = g.db.user_by_username(token["username"])
     if user:
         remember_current_user(user)
-
-
-def prepare_user_db(username, password):
-    hashed = hash(password, make_salt())
-
-    token = make_salt()
-    hashed_token = hash(token, make_salt())
-    username = username.strip().lower()
-
-    return username, hashed, hashed_token
 
 
 def validate_student_signup_data(account):
@@ -243,677 +246,6 @@ def validate_signup_data(account):
     if len(account.get("password")) < 6:
         return gettext("passwords_six")
     return None
-
-
-def store_new_student_account(account, teacher_username):
-    username, hashed, hashed_token = prepare_user_db(account["username"], account["password"])
-    user = {
-        "username": username,
-        "password": hashed,
-        "language": account["language"],
-        "keyword_language": account["keyword_language"],
-        "created": timems(),
-        "teacher": teacher_username,
-        "verification_pending": hashed_token,
-        "last_login": timems(),
-    }
-    DATABASE.store_user(user)
-    return user
-
-
-def store_new_account(account, email):
-    username, hashed, hashed_token = prepare_user_db(account["username"], account["password"])
-    user = {
-        "username": username,
-        "password": hashed,
-        "email": email,
-        "language": account["language"],
-        "keyword_language": account["keyword_language"],
-        "created": timems(),
-        "teacher_request": True if account.get("is_teacher") else None,
-        "third_party": True if account.get("agree_third_party") else None,
-        "verification_pending": hashed_token,
-        "last_login": timems(),
-    }
-
-    for field in ["country", "birth_year", "gender", "language", "prog_experience", "experience_languages"]:
-        if field in account:
-            if field == "experience_languages" and len(account[field]) == 0:
-                continue
-            user[field] = account[field]
-
-    DATABASE.store_user(user)
-
-    # If this is an e2e test, we return the email verification token directly instead of emailing it.
-    if is_testing_request(request):
-        resp = make_response({"username": username, "token": hashed_token})
-    # Otherwise, we send an email with a verification link and we return an empty body
-    else:
-        try:
-            send_email_template(
-                template="welcome_verify",
-                email=email,
-                link=create_verify_link(username, hashed_token),
-                username=user["username"],
-            )
-        except:
-            return user, make_response({gettext("mail_error_change_processed")}, 400)
-        resp = make_response({})
-    return user, resp
-
-
-def create_recover_link(username, token):
-    email = email_base_url() + "/reset?username="
-    email += urllib.parse.quote_plus(username) + "&token=" + urllib.parse.quote_plus(token)
-    return email
-
-
-def create_verify_link(username, token):
-    email = email_base_url() + "/auth/verify?username="
-    email += urllib.parse.quote_plus(username) + "&token=" + urllib.parse.quote_plus(token)
-    return email
-
-
-# Note: translations are used only for texts that will be seen by a GUI user.
-def routes(app, database):
-    global DATABASE
-    DATABASE = database
-
-    @app.route("/auth/login", methods=["POST"])
-    def login():
-        body = request.json
-        # Validations
-        if not isinstance(body, dict):
-            return gettext("ajax_error"), 400
-        if not isinstance(body.get("username"), str):
-            return gettext("username_invalid"), 400
-        if not isinstance(body.get("password"), str):
-            return gettext("password_invalid"), 400
-
-        # If username has an @-sign, then it's an email
-        if "@" in body["username"]:
-            user = DATABASE.user_by_email(body["username"])
-        else:
-            user = DATABASE.user_by_username(body["username"])
-
-        if not user or not check_password(body["password"], user["password"]):
-            return gettext("invalid_username_password") + " " + gettext("no_account"), 403
-
-        # If the number of bcrypt rounds has changed, create a new hash.
-        new_hash = None
-        if config["bcrypt_rounds"] != extract_bcrypt_rounds(user["password"]):
-            new_hash = hash(body["password"], make_salt())
-
-        cookie = make_salt()
-        DATABASE.store_token({"id": cookie, "username": user["username"], "ttl": times() + session_length})
-        if new_hash:
-            DATABASE.record_login(user["username"], new_hash)
-        else:
-            DATABASE.record_login(user["username"])
-
-        # Check if the user has a public profile, if so -> retrieve the profile image
-        public_profile = DATABASE.get_public_profile_settings(user["username"])
-        if public_profile:
-            session["profile_image"] = public_profile.get("image", 1)
-
-        # Make an empty response to make sure we have one
-        resp = make_response()
-
-        if is_admin(user):
-            resp = make_response({"admin": True})
-        elif user.get("is_teacher"):
-            resp = make_response({"teacher": True})
-
-        # If the user is a student (and has a related teacher) and the verification is still pending -> first login
-        if user.get("teacher") and user.get("verification_pending"):
-            DATABASE.update_user(user["username"], {"verification_pending": None})
-            resp = make_response({"first_time": True})
-
-        # We set the cookie to expire in a year, just so that the browser won't invalidate it if the same cookie gets renewed by constant use.
-        # The server will decide whether the cookie expires.
-        resp.set_cookie(
-            TOKEN_COOKIE_NAME,
-            value=cookie,
-            httponly=True,
-            secure=is_heroku(),
-            samesite="Lax",
-            path="/",
-            max_age=365 * 24 * 60 * 60,
-        )
-
-        # Remember the current user on the session. This is "new style" logins, which should ultimately
-        # replace "old style" logins (with the cookie above), as it requires fewer database calls.
-        remember_current_user(user)
-        return resp
-
-    @app.route("/auth/signup", methods=["POST"])
-    def signup():
-        body = request.json
-        # Validations, mandatory fields
-        if not isinstance(body, dict):
-            return gettext("ajax_error"), 400
-
-        # Validate the essential data using a function -> also used for multiple account creation
-        validation = validate_signup_data(body)
-        if validation:
-            return validation, 400
-
-        # Validate fields only relevant when creating a single user account
-        if not isinstance(body.get("password_repeat"), str) or body["password"] != body["password_repeat"]:
-            return gettext("repeat_match_password"), 400
-        if not isinstance(body.get("language"), str) or body.get("language") not in ALL_LANGUAGES.keys():
-            return gettext("language_invalid"), 400
-        if not isinstance(body.get("agree_terms"), str) or not body.get("agree_terms"):
-            return gettext("agree_invalid"), 400
-        if not isinstance(body.get("keyword_language"), str) or body.get("keyword_language") not in [
-            "en",
-            body.get("language"),
-        ]:
-            return gettext("keyword_language_invalid"), 400
-
-        # Validations, optional fields
-        if "birth_year" in body:
-            year = datetime.datetime.now().year
-            try:
-                body["birth_year"] = int(body.get("birth_year"))
-            except ValueError:
-                return gettext("year_invalid").format(**{"current_year": str(year)}), 400
-            if not isinstance(body.get("birth_year"), int) or body["birth_year"] <= 1900 or body["birth_year"] > year:
-                return gettext("year_invalid").format(**{"current_year": str(year)}), 400
-        if "gender" in body:
-            if body["gender"] != "m" and body["gender"] != "f" and body["gender"] != "o":
-                return gettext("gender_invalid"), 400
-        if "country" in body:
-            if not body["country"] in COUNTRIES:
-                return gettext("country_invalid"), 400
-        if "prog_experience" in body and body["prog_experience"] not in ["yes", "no"]:
-            return gettext("experience_invalid"), 400
-        if "experience_languages" in body:
-            if not isinstance(body["experience_languages"], list):
-                return gettext("experience_invalid"), 400
-            for language in body["experience_languages"]:
-                if language not in ["scratch", "other_block", "python", "other_text"]:
-                    return gettext("programming_invalid"), 400
-
-        if DATABASE.user_by_username(body["username"].strip().lower()):
-            return gettext("exists_username"), 403
-        if DATABASE.user_by_email(body["email"].strip().lower()):
-            return gettext("exists_email"), 403
-
-        # We receive the pre-processed user and response package from the function
-        user, resp = store_new_account(body, body["email"].strip().lower())
-
-        if not is_testing_request(request) and "subscribe" in body and body["subscribe"] is True:
-            # If we have a Mailchimp API key, we use it to add the subscriber through the API
-            if MAILCHIMP_API_URL:
-                mailchimp_subscribe_user(user["email"])
-            # Otherwise, we send an email to notify about the subscription to the main email address
-            else:
-                send_email(
-                    config["email"]["sender"],
-                    "Subscription to Hedy newsletter on signup",
-                    user["email"],
-                    "<p>" + user["email"] + "</p>",
-                )
-
-        # We automatically login the user
-        cookie = make_salt()
-        DATABASE.store_token({"id": cookie, "username": user["username"], "ttl": times() + session_length})
-        # We set the cookie to expire in a year, just so that the browser won't invalidate it if the same cookie gets renewed by constant use.
-        # The server will decide whether the cookie expires.
-        resp.set_cookie(
-            TOKEN_COOKIE_NAME,
-            value=cookie,
-            httponly=True,
-            secure=is_heroku(),
-            samesite="Lax",
-            path="/",
-            max_age=365 * 24 * 60 * 60,
-        )
-
-        remember_current_user(user)
-        return resp
-
-    @app.route("/auth/verify", methods=["GET"])
-    def verify_email():
-        username = request.args.get("username", None)
-        token = request.args.get("token", None)
-        if not token:
-            return gettext("token_invalid"), 400
-        if not username:
-            return gettext("username_invalid"), 400
-
-        # Verify that user actually exists
-        user = DATABASE.user_by_username(username)
-        if not user:
-            return gettext("username_invalid"), 403
-
-        # If user is already verified -> re-direct to landing-page anyway
-        if not "verification_pending" in user:
-            return redirect("/landing-page")
-
-        # Verify the token
-        if token != user["verification_pending"]:
-            return gettext("token_invalid"), 403
-
-        # Remove the token from the user
-        DATABASE.update_user(username, {"verification_pending": None})
-
-        # We automatically login the user
-        cookie = make_salt()
-        DATABASE.store_token({"id": cookie, "username": user["username"], "ttl": times() + session_length})
-        remember_current_user(user)
-
-        return redirect("/landing-page")
-
-    @app.route("/auth/logout", methods=["POST"])
-    def logout():
-        forget_current_user()
-        if request.cookies.get(TOKEN_COOKIE_NAME):
-            DATABASE.forget_token(request.cookies.get(TOKEN_COOKIE_NAME))
-        return "", 200
-
-    @app.route("/auth/destroy", methods=["POST"])
-    @requires_login
-    def destroy(user):
-        forget_current_user()
-        DATABASE.forget_token(request.cookies.get(TOKEN_COOKIE_NAME))
-        DATABASE.forget_user(user["username"])
-        return "", 200
-
-    @app.route("/auth/destroy_public", methods=["POST"])
-    @requires_login
-    def destroy_public(user):
-        DATABASE.forget_public_profile(user["username"])
-        session.pop("profile_image", None)  # Delete profile image id if existing
-        return "", 200
-
-    @app.route("/auth/change_student_password", methods=["POST"])
-    @requires_login
-    def change_student_password(user):
-        body = request.json
-        if not isinstance(body, dict):
-            return gettext("ajax_error"), 400
-        if not isinstance(body.get("username"), str):
-            return gettext("username_invalid"), 400
-        if not isinstance(body.get("password"), str):
-            return gettext("password_invalid"), 400
-        if len(body["password"]) < 6:
-            return gettext("password_six"), 400
-
-        if not is_teacher(user):
-            return gettext("password_change_not_allowed"), 400
-        students = DATABASE.get_teacher_students(user["username"])
-        if body["username"] not in students:
-            return gettext("password_change_not_allowed"), 400
-
-        hashed = hash(body["password"], make_salt())
-        DATABASE.update_user(body["username"], {"password": hashed})
-
-        return {"success": gettext("password_change_success")}, 200
-
-    @app.route("/auth/change_password", methods=["POST"])
-    @requires_login
-    def change_password(user):
-        body = request.json
-
-        if not isinstance(body, dict):
-            return gettext("ajax_error"), 400
-        if not isinstance(body.get("old_password"), str) or not isinstance(body.get("password"), str):
-            return gettext("password_invalid"), 400
-        if not isinstance(body.get("password_repeat"), str):
-            return gettext("repeat_match_password"), 400
-        if len(body["password"]) < 6:
-            return gettext("password_six"), 400
-        if body["password"] != body["password_repeat"]:
-            return gettext("repeat_match_password"), 400
-
-        # The user object we got from 'requires_login' doesn't have the password, so look that up in the database
-        user = DATABASE.user_by_username(user["username"])
-
-        if not check_password(body["old_password"], user["password"]):
-            return gettext("password_invalid"), 403
-
-        hashed = hash(body["password"], make_salt())
-
-        DATABASE.update_user(user["username"], {"password": hashed})
-        # We are not updating the user in the Flask session, because we should not rely on the password in anyway.
-        if not is_testing_request(request):
-            try:
-                send_email_template(template="change_password", email=user["email"], username=user["username"])
-            except:
-                return gettext("mail_error_change_processed"), 400
-
-        return jsonify({"message": gettext("password_updated")}), 200
-
-    @app.route("/profile", methods=["POST"])
-    @requires_login
-    def update_profile(user):
-        body = request.json
-        if not isinstance(body, dict):
-            return gettext("ajax_error"), 400
-        if not isinstance(body.get("language"), str) or body.get("language") not in ALL_LANGUAGES.keys():
-            return gettext("language_invalid"), 400
-        if (
-            not isinstance(body.get("keyword_language"), str)
-            or body.get("keyword_language") not in ["en", body.get("language")]
-            or body.get("keyword_language") not in ALL_KEYWORD_LANGUAGES.keys()
-        ):
-            return gettext("keyword_language_invalid"), 400
-
-        # Mail is a unique field, only mandatory if the user doesn't have a related teacher (and no mail address)
-        user = DATABASE.user_by_username(user["username"])
-        if not user.get("teacher") or "email" in body:
-            if not isinstance(body.get("email"), str) or not valid_email(body["email"]):
-                return gettext("email_invalid"), 400
-
-        # Validations, optional fields
-        if "birth_year" in body:
-            year = datetime.datetime.now().year
-            try:
-                body["birth_year"] = int(body.get("birth_year"))
-            except ValueError:
-                return gettext("year_invalid").format(**{"current_year": str(year)}), 400
-            if not isinstance(body.get("birth_year"), int) or body["birth_year"] <= 1900 or body["birth_year"] > year:
-                return gettext("year_invalid").format(**{"current_year": str(year)}), 400
-        if "gender" in body:
-            if body["gender"] not in ["m", "f", "o"]:
-                return gettext("gender_invalid"), 400
-        if "country" in body:
-            if not body["country"] in COUNTRIES:
-                return gettext("country_invalid"), 400
-
-        resp = {}
-        if "email" in body:
-            email = body["email"].strip().lower()
-            if email != user.get("email"):
-                exists = DATABASE.user_by_email(email)
-                if exists:
-                    return gettext("exists_email"), 403
-                token = make_salt()
-                hashed_token = hash(token, make_salt())
-                DATABASE.update_user(user["username"], {"email": email, "verification_pending": hashed_token})
-                # If this is an e2e test, we return the email verification token directly instead of emailing it.
-                if is_testing_request(request):
-                    resp = {"username": user["username"], "token": hashed_token}
-                else:
-                    try:
-                        send_email_template(
-                            template="welcome_verify",
-                            email=email,
-                            link=create_verify_link(user["username"], hashed_token),
-                            username=user["username"],
-                        )
-                    except:
-                        # Todo TB: Now we only log to the back-end, would be nice to also return the user some info
-                        # We have two options: return an error at this point (don't process changes)
-                        # Add a notification to the response, still process the changes
-                        print(f"Profile changes processed for {user['username']}, mail sending invalid")
-
-                # We check whether the user is in the Mailchimp list.
-                if not is_testing_request(request) and MAILCHIMP_API_URL:
-                    # We hash the email with md5 to avoid emails with unescaped characters triggering errors
-                    request_path = (
-                        MAILCHIMP_API_URL + "/members/" + hashlib.md5(user["email"].encode("utf-8")).hexdigest()
-                    )
-                    r = requests.get(request_path, headers=MAILCHIMP_API_HEADERS)
-                    # If user is subscribed, we remove the old email from the list and add the new one
-                    if r.status_code == 200:
-                        r = requests.delete(request_path, headers=MAILCHIMP_API_HEADERS)
-                        mailchimp_subscribe_user(email)
-
-        username = user["username"]
-
-        updates = {}
-        for field in ["country", "birth_year", "gender", "language", "keyword_language"]:
-            if field in body:
-                updates[field] = body[field]
-            else:
-                updates[field] = None
-        if body.get("agree_third_party"):
-            updates["third_party"] = True
-        else:
-            updates["third_party"] = None
-
-        if updates:
-            DATABASE.update_user(username, updates)
-
-        # Always make sure that the country stored on the public profile is identical to the profile one
-        DATABASE.update_country_public_profile(username, body.get("country", None))
-
-        # We want to check if the user choose a new language, if so -> reload
-        # We can use g.lang for this to reduce the db calls
-        resp["reload"] = False
-        if session["lang"] != body["language"] or session["keyword_lang"] != body["keyword_language"]:
-            resp["message"] = gettext("profile_updated_reload")
-            resp["reload"] = True
-        else:
-            resp["message"] = gettext("profile_updated")
-
-        remember_current_user(DATABASE.user_by_username(user["username"]))
-        return jsonify(resp)
-
-    @app.route("/profile", methods=["GET"])
-    @requires_login
-    def get_profile(user):
-        # The user object we got from 'requires_login' is not fully hydrated yet. Look up the database user.
-        user = DATABASE.user_by_username(user["username"])
-
-        output = {"username": user["username"], "email": user["email"], "language": user.get("language", "en")}
-        for field in ["birth_year", "country", "gender", "prog_experience", "experience_languages", "third_party"]:
-            if field in user:
-                output[field] = user[field]
-        if "verification_pending" in user:
-            output["verification_pending"] = True
-
-        output["student_classes"] = DATABASE.get_student_classes(user["username"])
-
-        output["session_expires_at"] = timems() + session_length * 1000
-
-        return jsonify(output), 200
-
-    @app.route("/auth/recover", methods=["POST"])
-    def recover():
-        body = request.json
-        # Validations
-        if not isinstance(body, dict):
-            return gettext("ajax_error"), 400
-        if not isinstance(body.get("username"), str):
-            return gettext("username_invalid"), 400
-
-        # If username has an @-sign, then it's an email
-        if "@" in body["username"]:
-            user = DATABASE.user_by_email(body["username"].strip().lower())
-        else:
-            user = DATABASE.user_by_username(body["username"].strip().lower())
-
-        if not user:
-            return gettext("username_invalid"), 403
-
-        # In this case -> account has a related teacher (and is a student)
-        # We still store the token, but sent the mail to the teacher instead
-        if user.get("teacher") and not user.get("email"):
-            email = DATABASE.user_by_username(user.get("teacher")).get("email")
-        else:
-            email = user["email"]
-
-        # Create a token -> use the reset_length value as we don't want the token to live as long as a login one
-        token = make_salt()
-        # Todo TB -> Don't we want to use a hashed token here as well?
-        DATABASE.store_token({"id": token, "username": user["username"], "ttl": times() + reset_length})
-
-        if is_testing_request(request):
-            # If this is an e2e test, we return the email verification token directly instead of emailing it.
-            return jsonify({"username": user["username"], "token": token}), 200
-        else:
-            try:
-                send_email_template(
-                    template="recover_password",
-                    email=email,
-                    link=create_recover_link(user["username"], token),
-                    username=user["username"],
-                )
-            except:
-                return gettext("mail_error_change_processed"), 400
-
-            return jsonify({"message": gettext("sent_password_recovery")}), 200
-
-    @app.route("/auth/reset", methods=["POST"])
-    def reset():
-        body = request.json
-        # Validations
-        if not isinstance(body, dict):
-            return gettext("ajax_error"), 400
-        if not isinstance(body.get("username"), str):
-            return gettext("username_invalid"), 400
-        if not isinstance(body.get("token"), str):
-            return gettext("token_invalid"), 400
-        if not isinstance(body.get("password"), str):
-            return gettext("password_invalid"), 400
-        if len(body["password"]) < 6:
-            return gettext("password_six"), 400
-        if not isinstance(body.get("password_repeat"), str) or body["password"] != body["password_repeat"]:
-            return gettext("repeat_match_password"), 400
-
-        token = DATABASE.get_token(body["token"])
-        if not token or body["token"] != token.get("id") or body["username"] != token.get("username"):
-            return gettext("token_invalid"), 403
-
-        hashed = hash(body["password"], make_salt())
-        DATABASE.update_user(body["username"], {"password": hashed})
-        user = DATABASE.user_by_username(body["username"])
-
-        # Delete all tokens of the user -> automatically logout all long-lived sessions
-        DATABASE.delete_all_tokens(body["username"])
-
-        # In this case -> account has a related teacher (and is a student)
-        # We mail the teacher instead
-        if user.get("teacher") and not user.get("email"):
-            email = DATABASE.user_by_username(user.get("teacher")).get("email")
-        else:
-            email = user["email"]
-
-        if not is_testing_request(request):
-            try:
-                send_email_template(template="reset_password", email=email, username=user["username"])
-            except:
-                return gettext("mail_error_change_processed"), 400
-
-        return jsonify({"message": gettext("password_resetted")}), 200
-
-    @app.route("/auth/request_teacher", methods=["GET"])
-    @requires_login
-    def request_teacher_account(user):
-        account = DATABASE.user_by_username(user["username"])
-        if account.get("is_teacher"):
-            return gettext("already_teacher"), 400
-        if account.get("teacher_request"):
-            return gettext("already_teacher_request"), 400
-
-        DATABASE.update_user(user["username"], {"teacher_request": True})
-        return jsonify({"message": gettext("teacher_account_success")}), 200
-
-    # *** ADMIN ROUTES ***
-
-    @app.route("/admin/markAsTeacher", methods=["POST"])
-    def mark_as_teacher():
-        user = current_user()
-        if not is_admin(user) and not is_testing_request(request):
-            return utils.error_page(error=403, ui_message=gettext("unauthorized"))
-
-        body = request.json
-
-        # Validations
-        if not isinstance(body, dict):
-            return gettext("ajax_error"), 400
-        if not isinstance(body.get("username"), str):
-            return gettext("username_invalid"), 400
-        if not isinstance(body.get("is_teacher"), bool):
-            return gettext("teacher_invalid"), 400
-
-        user = DATABASE.user_by_username(body["username"].strip().lower())
-
-        if not user:
-            return gettext("username_invalid"), 400
-
-        is_teacher_value = 1 if body["is_teacher"] else 0
-        update_is_teacher(user, is_teacher_value)
-
-        # Todo TB feb 2022 -> Return the success message here instead of fixing in the front-end
-        return "", 200
-
-    @app.route("/admin/changeUserEmail", methods=["POST"])
-    @requires_admin
-    def change_user_email(user):
-        body = request.json
-
-        # Validations
-        if not isinstance(body, dict):
-            return gettext("ajax_error"), 400
-        if not isinstance(body.get("username"), str):
-            return gettext("username_invalid"), 400
-        if not isinstance(body.get("email"), str) or not valid_email(body["email"]):
-            return gettext("email_invalid"), 400
-
-        user = DATABASE.user_by_username(body["username"].strip().lower())
-
-        if not user:
-            return gettext("email_invalid"), 400
-
-        token = make_salt()
-        hashed_token = hash(token, make_salt())
-
-        # We assume that this email is not in use by any other users. In other words, we trust the admin to enter a valid, not yet used email address.
-        DATABASE.update_user(user["username"], {"email": body["email"], "verification_pending": hashed_token})
-
-        # If this is an e2e test, we return the email verification token directly instead of emailing it.
-        if is_testing_request(request):
-            resp = {"username": user["username"], "token": hashed_token}
-        else:
-            try:
-                send_email_template(
-                    template="welcome_verify",
-                    email=body["email"],
-                    link=create_verify_link(user["username"], hashed_token),
-                    username=user["username"],
-                )
-            except:
-                return gettext("mail_error_change_processed"), 400
-
-        return {}, 200
-
-    @app.route("/admin/getUserTags", methods=["POST"])
-    @requires_admin
-    def get_user_tags(user):
-        body = request.json
-        user = DATABASE.get_public_profile_settings(body["username"].strip().lower())
-        if not user:
-            return "User doesn't have a public profile", 400
-        return {"tags": user.get("tags", [])}, 200
-
-    @app.route("/admin/updateUserTags", methods=["POST"])
-    @requires_admin
-    def update_user_tags(user):
-        body = request.json
-        user = DATABASE.get_public_profile_settings(body["username"].strip().lower())
-        if not user:
-            return "User doesn't have a public profile", 400
-
-        tags = []
-        if "admin" in user.get("tags", []):
-            tags.append("admin")
-        if "teacher" in user.get("tags", []):
-            tags.append("teacher")
-        if body.get("certified"):
-            tags.append("certified_teacher")
-        if body.get("distinguished"):
-            tags.append("distinguished_user")
-        if body.get("contributor"):
-            tags.append("contributor")
-
-        user["tags"] = tags
-        DATABASE.update_public_profile(user["username"], user)
-        return {}, 200
 
 
 # Turn off verbose logs from boto/SES, thanks to https://github.com/boto/boto3/issues/521
@@ -1006,6 +338,38 @@ def send_email_template(template, email, link=None, username=gettext("user")):
     send_email(email, subject, body_plain, body_html)
 
 
+def store_new_student_account(db, account, teacher_username):
+    username, hashed, hashed_token = prepare_user_db(account["username"], account["password"])
+    user = {
+        "username": username,
+        "password": hashed,
+        "language": account["language"],
+        "keyword_language": account["keyword_language"],
+        "created": timems(),
+        "teacher": teacher_username,
+        "verification_pending": hashed_token,
+        "last_login": timems(),
+    }
+    db.store_user(user)
+    return user
+
+
+def prepare_user_db(username, password):
+    hashed = password_hash(password, make_salt())
+
+    token = make_salt()
+    hashed_token = password_hash(token, make_salt())
+    username = username.strip().lower()
+
+    return username, hashed, hashed_token
+
+
+def create_verify_link(username, token):
+    email = email_base_url() + "/auth/verify?username="
+    email += urllib.parse.quote_plus(username) + "&token=" + urllib.parse.quote_plus(token)
+    return email
+
+
 def email_base_url():
     """Return the base URL for the current site, without trailing slash.
 
@@ -1020,3 +384,9 @@ def email_base_url():
     if from_env:
         return from_env.rstrip("/")
     return request.host_url
+
+
+def create_recover_link(username, token):
+    email = email_base_url() + "/reset?username="
+    email += urllib.parse.quote_plus(username) + "&token=" + urllib.parse.quote_plus(token)
+    return email

--- a/website/auth_pages.py
+++ b/website/auth_pages.py
@@ -1,0 +1,395 @@
+from flask_babel import gettext
+from hedy_content import COUNTRIES, ALL_LANGUAGES
+from website.auth import MAILCHIMP_API_URL, RESET_LENGTH, SESSION_LENGTH, TOKEN_COOKIE_NAME, check_password, create_recover_link, create_verify_link, forget_current_user, is_admin, is_teacher, mailchimp_subscribe_user, make_salt, prepare_user_db, remember_current_user, requires_login, send_email, send_email_template, validate_signup_data, password_hash
+from flask import request, session, make_response, jsonify, redirect
+from utils import times, timems, extract_bcrypt_rounds, is_testing_request, is_heroku
+import datetime
+from config import config
+from .database import Database
+from .website_module import WebsiteModule, route
+
+class AuthModule(WebsiteModule):
+    def __init__(self, db: Database):
+        super().__init__('auth', __name__, url_prefix='/auth')
+
+        self.db = db
+
+    @route('/login', methods=['POST'])
+    def login(self):
+        body = request.json
+        # Validations
+        if not isinstance(body, dict):
+            return gettext('ajax_error'), 400
+        if not isinstance(body.get('username'), str):
+            return gettext('username_invalid'), 400
+        if not isinstance(body.get('password'), str):
+            return gettext('password_invalid'), 400
+
+        # If username has an @-sign, then it's an email
+        if '@' in body['username']:
+            user = self.db.user_by_email(body['username'])
+        else:
+            user = self.db.user_by_username(body['username'])
+
+        if not user or not check_password(body['password'], user['password']):
+            return gettext('invalid_username_password') + " " + gettext('no_account'), 403
+
+        # If the number of bcrypt rounds has changed, create a new hash.
+        new_hash = None
+        if config['bcrypt_rounds'] != extract_bcrypt_rounds(user['password']):
+            new_hash = password_hash(body['password'], make_salt())
+
+        cookie = make_salt()
+        self.db.store_token({'id': cookie, 'username': user['username'], 'ttl': times() + SESSION_LENGTH})
+        if new_hash:
+            self.db.record_login(user['username'], new_hash)
+        else:
+            self.db.record_login(user['username'])
+
+        # Check if the user has a public profile, if so -> retrieve the profile image
+        public_profile = self.db.get_public_profile_settings(user['username'])
+        if public_profile:
+            session['profile_image'] = public_profile.get('image', 1)
+
+        # Make an empty response to make sure we have one
+        resp = make_response()
+
+        if is_admin(user):
+            resp = make_response({'admin': True})
+        elif user.get('is_teacher'):
+            resp = make_response({'teacher': True})
+
+        # If the user is a student (and has a related teacher) and the verification is still pending -> first login
+        if user.get('teacher') and user.get('verification_pending'):
+            self.db.update_user(user['username'], {'verification_pending': None})
+            resp = make_response({'first_time': True})
+
+        # We set the cookie to expire in a year, just so that the browser won't invalidate it if the same cookie gets renewed by constant use.
+        # The server will decide whether the cookie expires.
+        resp.set_cookie(TOKEN_COOKIE_NAME, value=cookie, httponly=True, secure=is_heroku(), samesite='Lax', path='/',
+                        max_age=365 * 24 * 60 * 60)
+
+        # Remember the current user on the session. This is "new style" logins, which should ultimately
+        # replace "old style" logins (with the cookie above), as it requires fewer database calls.
+        remember_current_user(user)
+        return resp
+
+    @route('/signup', methods=['POST'])
+    def signup(self):
+        body = request.json
+        # Validations, mandatory fields
+        if not isinstance(body, dict):
+            return gettext('ajax_error'), 400
+
+        # Validate the essential data using a function -> also used for multiple account creation
+        validation = validate_signup_data(body)
+        if validation:
+            return validation, 400
+
+        # Validate fields only relevant when creating a single user account
+        if not isinstance(body.get('password_repeat'), str) or body['password'] != body['password_repeat']:
+            return gettext('repeat_match_password'), 400
+        if not isinstance(body.get('language'), str) or body.get('language') not in ALL_LANGUAGES.keys():
+            return gettext('language_invalid'), 400
+        if not isinstance(body.get('agree_terms'), str) or not body.get('agree_terms'):
+            return gettext('agree_invalid'), 400
+        if not isinstance(body.get('keyword_language'), str) or body.get('keyword_language') not in ['en', body.get('language')]:
+            return gettext('keyword_language_invalid'), 400
+
+        # Validations, optional fields
+        if 'birth_year' in body:
+            year = datetime.datetime.now().year
+            try:
+                body['birth_year'] = int(body.get('birth_year'))
+            except ValueError:
+                return gettext('year_invalid').format(**{'current_year': str(year)}), 400
+            if not isinstance(body.get('birth_year'), int) or body['birth_year'] <= 1900 or body['birth_year'] > year:
+                return gettext('year_invalid').format(**{'current_year': str(year)}), 400
+        if 'gender' in body:
+            if body['gender'] != 'm' and body['gender'] != 'f' and body['gender'] != 'o':
+                return gettext('gender_invalid'), 400
+        if 'country' in body:
+            if not body['country'] in COUNTRIES:
+                return gettext('country_invalid'), 400
+        if 'prog_experience' in body and body['prog_experience'] not in ['yes', 'no']:
+            return gettext('experience_invalid'), 400
+        if 'experience_languages' in body:
+            if not isinstance(body['experience_languages'], list):
+                return gettext('experience_invalid'), 400
+            for language in body['experience_languages']:
+                if language not in['scratch', 'other_block', 'python', 'other_text']:
+                    return gettext('programming_invalid'), 400
+
+        if self.db.user_by_username(body['username'].strip().lower()):
+            return gettext('exists_username'), 403
+        if self.db.user_by_email(body['email'].strip().lower()):
+            return gettext('exists_email'), 403
+
+        # We receive the pre-processed user and response package from the function
+        user, resp = self.store_new_account(body, body['email'].strip().lower())
+
+        if not is_testing_request(request) and 'subscribe' in body and body['subscribe'] is True:
+            # If we have a Mailchimp API key, we use it to add the subscriber through the API
+            if MAILCHIMP_API_URL:
+                mailchimp_subscribe_user(user['email'])
+            # Otherwise, we send an email to notify about the subscription to the main email address
+            else:
+                send_email(config['email']['sender'], 'Subscription to Hedy newsletter on signup', user['email'],
+                            '<p>' + user['email'] + '</p>')
+
+        # We automatically login the user
+        cookie = make_salt()
+        self.db.store_token({'id': cookie, 'username': user['username'], 'ttl': times() + SESSION_LENGTH})
+        # We set the cookie to expire in a year, just so that the browser won't invalidate it if the same cookie gets renewed by constant use.
+        # The server will decide whether the cookie expires.
+        resp.set_cookie(TOKEN_COOKIE_NAME, value=cookie, httponly=True, secure=is_heroku(), samesite='Lax', path='/',
+                        max_age=365 * 24 * 60 * 60)
+
+        remember_current_user(user)
+        return resp
+
+    @route('/verify', methods=['GET'])
+    def verify_email(self):
+        username = request.args.get('username', None)
+        token = request.args.get('token', None)
+        if not token:
+            return gettext('token_invalid'), 400
+        if not username:
+            return gettext('username_invalid'), 400
+
+        # Verify that user actually exists
+        user = self.db.user_by_username(username)
+        if not user:
+            return gettext('username_invalid'), 403
+
+        # If user is already verified -> re-direct to landing-page anyway
+        if not 'verification_pending' in user:
+            return redirect('/landing-page')
+
+        # Verify the token
+        if token != user['verification_pending']:
+            return gettext('token_invalid'), 403
+
+        # Remove the token from the user
+        self.db.update_user(username, {'verification_pending': None})
+
+        # We automatically login the user
+        cookie = make_salt()
+        self.db.store_token({'id': cookie, 'username': user['username'], 'ttl': times() + SESSION_LENGTH})
+        remember_current_user(user)
+
+        return redirect('/landing-page')
+
+    @route('/logout', methods=['POST'])
+    def logout(self):
+        forget_current_user()
+        if request.cookies.get(TOKEN_COOKIE_NAME):
+            self.db.forget_token(request.cookies.get(TOKEN_COOKIE_NAME))
+        return '', 200
+
+    @route('/destroy', methods=['POST'])
+    @requires_login
+    def destroy(self, user):
+        forget_current_user()
+        self.db.forget_token(request.cookies.get(TOKEN_COOKIE_NAME))
+        self.db.forget_user(user['username'])
+        return '', 200
+
+    @route('/destroy_public', methods=['POST'])
+    @requires_login
+    def destroy_public(self, user):
+        self.db.forget_public_profile(user['username'])
+        session.pop('profile_image', None)  # Delete profile image id if existing
+        return '', 200
+
+    @route('/change_student_password', methods=['POST'])
+    @requires_login
+    def change_student_password(self, user):
+        body = request.json
+        if not isinstance(body, dict):
+            return gettext('ajax_error'), 400
+        if not isinstance(body.get('username'), str):
+            return gettext('username_invalid'), 400
+        if not isinstance(body.get('password'), str):
+            return gettext('password_invalid'), 400
+        if len(body['password']) < 6:
+            return gettext('password_six'), 400
+
+        if not is_teacher(user):
+            return gettext("password_change_not_allowed"), 400
+        students = self.db.get_teacher_students(user['username'])
+        if body['username'] not in students:
+            return gettext("password_change_not_allowed"), 400
+
+        hashed = password_hash(body['password'], make_salt())
+        self.db.update_user(body['username'], {'password': hashed})
+
+        return {'success': gettext("password_change_success")}, 200
+
+    @route('/change_password', methods=['POST'])
+    @requires_login
+    def change_password(self, user):
+        body = request.json
+
+        if not isinstance(body, dict):
+            return gettext('ajax_error'), 400
+        if not isinstance(body.get('old_password'), str) or not isinstance(body.get('password'), str):
+            return gettext('password_invalid'), 400
+        if not isinstance(body.get( 'password_repeat'), str):
+            return gettext('repeat_match_password'), 400
+        if len(body['password']) < 6:
+            return gettext('password_six'), 400
+        if body['password'] != body['password_repeat']:
+            return gettext('repeat_match_password'), 400
+
+        # The user object we got from 'requires_login' doesn't have the password, so look that up in the database
+        user = self.db.user_by_username(user['username'])
+
+        if not check_password(body['old_password'], user['password']):
+            return gettext('password_invalid'), 403
+
+        hashed = password_hash(body['password'], make_salt())
+
+        self.db.update_user(user['username'], {'password': hashed})
+        # We are not updating the user in the Flask session, because we should not rely on the password in anyway.
+        if not is_testing_request(request):
+            try:
+                send_email_template(template='change_password', email=user['email'], username=user['username'])
+            except:
+                return gettext('mail_error_change_processed'), 400
+
+        return jsonify({'message': gettext('password_updated')}), 200
+
+    @route('/recover', methods=['POST'])
+    def recover(self):
+        body = request.json
+        # Validations
+        if not isinstance(body, dict):
+            return gettext('ajax_error'), 400
+        if not isinstance(body.get('username'), str):
+            return gettext('username_invalid'), 400
+
+        # If username has an @-sign, then it's an email
+        if '@' in body['username']:
+            user = self.db.user_by_email(body['username'].strip().lower())
+        else:
+            user = self.db.user_by_username(body['username'].strip().lower())
+
+        if not user:
+            return gettext('username_invalid'), 403
+
+        # In this case -> account has a related teacher (and is a student)
+        # We still store the token, but sent the mail to the teacher instead
+        if user.get('teacher') and not user.get('email'):
+            email = self.db.user_by_username(user.get('teacher')).get('email')
+        else:
+            email = user['email']
+
+        # Create a token -> use the reset_length value as we don't want the token to live as long as a login one
+        token = make_salt()
+        # Todo TB -> Don't we want to use a hashed token here as well?
+        self.db.store_token({'id': token, 'username': user['username'], 'ttl': times() + RESET_LENGTH})
+
+        if is_testing_request(request):
+            # If this is an e2e test, we return the email verification token directly instead of emailing it.
+            return jsonify({'username': user['username'], 'token': token}), 200
+        else:
+            try:
+                send_email_template(template='recover_password', email=email,
+                                link=create_recover_link(user['username'], token), username=user['username'])
+            except:
+                return gettext('mail_error_change_processed'), 400
+
+            return jsonify({'message': gettext('sent_password_recovery')}), 200
+
+    @route('/reset', methods=['POST'])
+    def reset(self):
+        body = request.json
+        # Validations
+        if not isinstance(body, dict):
+            return gettext('ajax_error'), 400
+        if not isinstance(body.get('username'), str):
+            return gettext('username_invalid'), 400
+        if not isinstance(body.get('token'), str):
+            return gettext('token_invalid'), 400
+        if not isinstance(body.get('password'), str):
+            return gettext('password_invalid'), 400
+        if len(body['password']) < 6:
+            return gettext('password_six'), 400
+        if not isinstance(body.get('password_repeat'), str) or body['password'] != body['password_repeat']:
+            return gettext('repeat_match_password'), 400
+
+        token = self.db.get_token(body['token'])
+        if not token or body['token'] != token.get('id') or body['username'] != token.get('username'):
+            return gettext('token_invalid'), 403
+
+        hashed = password_hash(body['password'], make_salt())
+        self.db.update_user(body['username'], {'password': hashed})
+        user = self.db.user_by_username(body['username'])
+
+        # Delete all tokens of the user -> automatically logout all long-lived sessions
+        self.db.delete_all_tokens(body['username'])
+
+        # In this case -> account has a related teacher (and is a student)
+        # We mail the teacher instead
+        if user.get('teacher') and not user.get('email'):
+            email = self.db.user_by_username(user.get('teacher')).get('email')
+        else:
+            email = user['email']
+
+        if not is_testing_request(request):
+            try:
+                send_email_template(template='reset_password', email=email, username=user['username'])
+            except:
+                return gettext('mail_error_change_processed'), 400
+
+        return jsonify({'message': gettext('password_resetted')}), 200
+
+    @route('/request_teacher', methods=['GET'])
+    @requires_login
+    def request_teacher_account(self, user):
+        account = self.db.user_by_username(user['username'])
+        if account.get('is_teacher'):
+            return gettext('already_teacher'), 400
+        if account.get('teacher_request'):
+            return gettext('already_teacher_request'), 400
+
+        self.db.update_user(user['username'], {'teacher_request': True})
+        return jsonify({'message': gettext('teacher_account_success')}), 200
+
+    def store_new_account(self, account, email):
+        username, hashed, hashed_token = prepare_user_db(account['username'], account['password'])
+        user = {
+            'username': username,
+            'password': hashed,
+            'email': email,
+            'language': account['language'],
+            'keyword_language': account['keyword_language'],
+            'created': timems(),
+            'teacher_request': True if account.get('is_teacher') else None,
+            'third_party': True if account.get('agree_third_party') else None,
+            'verification_pending': hashed_token,
+            'last_login': timems()
+        }
+
+        for field in ['country', 'birth_year', 'gender', 'language', 'prog_experience', 'experience_languages']:
+            if field in account:
+                if field == 'experience_languages' and len(account[field]) == 0:
+                    continue
+                user[field] = account[field]
+
+        self.db.store_user(user)
+
+        # If this is an e2e test, we return the email verification token directly instead of emailing it.
+        if is_testing_request(request):
+            resp = make_response({'username': username, 'token': hashed_token})
+        # Otherwise, we send an email with a verification link and we return an empty body
+        else:
+            try:
+                send_email_template(template='welcome_verify', email=email,
+                                link=create_verify_link(username, hashed_token), username=user['username'])
+            except:
+                return user, make_response({gettext('mail_error_change_processed')}, 400)
+            resp = make_response({})
+        return user, resp
+

--- a/website/aws_helpers.py
+++ b/website/aws_helpers.py
@@ -10,25 +10,24 @@ import threading
 
 def s3_querylog_transmitter_from_env():
     """Return an S3 transmitter, or return None."""
-    have_aws_creds = os.getenv('AWS_ACCESS_KEY_ID') and os.getenv('AWS_SECRET_ACCESS_KEY')
+    have_aws_creds = os.getenv("AWS_ACCESS_KEY_ID") and os.getenv("AWS_SECRET_ACCESS_KEY")
 
     if not have_aws_creds:
-        logging.warning('Unable to initialize S3 querylogger (missing AWS_ACCESS_KEY_ID or AWS_SECRET_ACCESS_KEY)')
+        logging.warning("Unable to initialize S3 querylogger (missing AWS_ACCESS_KEY_ID or AWS_SECRET_ACCESS_KEY)")
         return None
 
-    return make_s3_transmitter(config.config['s3-query-logs'])
+    return make_s3_transmitter(config.config["s3-query-logs"])
 
 
 def s3_parselog_transmitter_from_env():
     """Return an S3 transmitter, or return None."""
-    have_aws_creds = os.getenv('AWS_ACCESS_KEY_ID') and os.getenv('AWS_SECRET_ACCESS_KEY')
+    have_aws_creds = os.getenv("AWS_ACCESS_KEY_ID") and os.getenv("AWS_SECRET_ACCESS_KEY")
 
     if not have_aws_creds:
-        logging.warning('Unable to initialize S3 parse logger (missing AWS_ACCESS_KEY_ID or AWS_SECRET_ACCESS_KEY)')
+        logging.warning("Unable to initialize S3 parse logger (missing AWS_ACCESS_KEY_ID or AWS_SECRET_ACCESS_KEY)")
         return None
 
-    return make_s3_transmitter(config.config['s3-parse-logs'])
-
+    return make_s3_transmitter(config.config["s3-parse-logs"])
 
 
 # The 'boto3.client' method is not thread safe: https://github.com/boto/boto3/issues/1592
@@ -37,26 +36,32 @@ def s3_parselog_transmitter_from_env():
 # same time, they don't trample on each other.
 BOTO3_LOCK = threading.Lock()
 
+
 def make_s3_transmitter(s3config):
     """Make a transmitter function (for use with a LogQueue) which will save records to S3."""
+
     def transmit_to_s3(timestamp, records):
         """Transmit logfiles to S3 with default config."""
 
         # No need to configure credentials, we've already confirmed they are in the environment.
         with BOTO3_LOCK:
-            s3 = boto3.client('s3', region_name=s3config['region'])
+            s3 = boto3.client("s3", region_name=s3config["region"])
 
         # Grouping in the key is important, we need this to zoom into an interesting
         # log period.
-        key = s3config.get('prefix', '') + utils.isoformat(timestamp).replace('T', '/') + s3config.get('postfix', '') + '.jsonl'
+        key = (
+            s3config.get("prefix", "")
+            + utils.isoformat(timestamp).replace("T", "/")
+            + s3config.get("postfix", "")
+            + ".jsonl"
+        )
 
         # Store as json-lines format
-        body = '\n'.join(json.dumps(r) for r in records)
+        body = "\n".join(json.dumps(r) for r in records)
 
         s3.put_object(
-            Bucket=s3config['bucket'],
-            Key=key,
-            StorageClass='STANDARD_IA', # Cheaper, applicable for logs
-            Body=body)
+            Bucket=s3config["bucket"], Key=key, StorageClass="STANDARD_IA", Body=body  # Cheaper, applicable for logs
+        )
         logging.debug(f'Wrote {len(records)} query logs to s3://{s3config["bucket"]}/{key}')
+
     return transmit_to_s3

--- a/website/cdn.py
+++ b/website/cdn.py
@@ -1,5 +1,6 @@
 import utils
 
+
 class Cdn:
     """Set up CDN configuration.
 
@@ -22,10 +23,11 @@ class Cdn:
     Because the commit number is in the URL, it can be extremely aggressively
     cached by the CDN.
     """
+
     def __init__(self, app, cdn_prefix, commit):
-        self.cdn_prefix = cdn_prefix or ''
+        self.cdn_prefix = cdn_prefix or ""
         self.commit = commit
-        self.static_prefix = '/'
+        self.static_prefix = "/"
         self.app = app
 
         if self.cdn_prefix:
@@ -39,12 +41,12 @@ class Cdn:
             #
             # We still keep on hosting static assets in the "old" location as well for images in
             # emails and content we forgot to replace or are unable to replace (like in Markdowns).
-            self.static_prefix = '/static-' + commit
-            app.add_url_rule(self.static_prefix + '/<path:filename>',
-                    endpoint='cdn_static',
-                    view_func=self._send_static_file)
+            self.static_prefix = "/static-" + commit
+            app.add_url_rule(
+                self.static_prefix + "/<path:filename>", endpoint="cdn_static", view_func=self._send_static_file
+            )
 
-        app.add_template_global(self.static, name='static')
+        app.add_template_global(self.static, name="static")
 
     def static(self, url):
         """Return cacheable links to static resources."""
@@ -62,7 +64,6 @@ class Cdn:
         2. Set caching to indefinite.
         """
         response = self.app.send_static_file(filename)
-        response.headers['Access-Control-Allow-Origin'] = '*'
-        response.cache_control.max_age = 24 * 3600 # A day
+        response.headers["Access-Control-Allow-Origin"] = "*"
+        response.cache_control.max_age = 24 * 3600  # A day
         return response
-

--- a/website/classes.py
+++ b/website/classes.py
@@ -1,0 +1,294 @@
+from flask_babel import gettext
+from .achievements import Achievements
+from website.auth import requires_login, is_teacher, current_user
+import utils
+import uuid
+from flask import g, request, jsonify, redirect, session
+from flask_helpers import render_template
+from config import config
+from .database import Database
+from .website_module import WebsiteModule, route
+
+cookie_name = config['session']['cookie_name']
+invite_length = config['session']['invite_length'] * 60
+
+class ClassModule(WebsiteModule):
+    """The /class/... pages."""
+    def __init__(self, db: Database, achievements: Achievements):
+        super().__init__('class', __name__, url_prefix='/class')
+
+        self.db = db
+        self.achievements = achievements
+
+    @route('/', methods=['POST'])
+    @requires_login
+    def create_class(self, user):
+        if not is_teacher(user):
+            return gettext('only_teacher_create_class'), 403
+
+        body = request.json
+        # Validations
+        if not isinstance(body, dict):
+            return gettext('ajax_error'), 400
+        if not isinstance(body.get('name'), str):
+            return gettext('class_name_invalid'), 400
+        if len(body.get('name')) < 1:
+            return gettext('class_name_empty'), 400
+
+        # We use this extra call to verify if the class name doesn't already exist, if so it's a duplicate
+        Classes = self.db.get_teacher_classes(user['username'], True)
+        for Class in Classes:
+            if Class['name'] == body['name']:
+                return gettext('class_name_duplicate'), 200
+
+        Class = {
+            'id': uuid.uuid4().hex,
+            'date': utils.timems(),
+            'teacher': user['username'],
+            'link': utils.random_id_generator(7),
+            'name': body['name']
+        }
+
+        self.db.store_class(Class)
+        achievement = self.achievements.add_single_achievement(user['username'], "ready_set_education")
+        if achievement:
+            return {'id': Class['id'], 'achievement': achievement}, 200
+        return {'id': Class['id']}, 200
+
+    @route('/<class_id>', methods=['PUT'])
+    @requires_login
+    def update_class(self, user, class_id):
+        if not is_teacher(user):
+            return 'Only teachers can update classes', 403
+
+        body = request.json
+        # Validations
+        if not isinstance(body, dict):
+            return gettext('ajax_error'), 400
+        if not isinstance(body.get('name'), str):
+            return gettext('class_name_invalid'), 400
+        if len(body.get('name')) < 1:
+            return gettext('class_name_empty'), 400
+
+        Class = self.db.get_class (class_id)
+        if not Class or Class['teacher'] != user['username']:
+            return gettext('no_such_class'), 404
+
+        # We use this extra call to verify if the class name doesn't already exist, if so it's a duplicate
+        Classes = self.db.get_teacher_classes(user['username'], True)
+        for Class in Classes:
+            if Class['name'] == body['name']:
+                return "duplicate", 200 # Todo TB: Will have to look into this, but not sure why we return a 200?
+
+        self.db.update_class(class_id, body['name'])
+        achievement = self.achievements.add_single_achievement(user['username'], "on_second_thoughts")
+        if achievement:
+            return {'achievement': achievement}, 200
+        return {}, 200
+
+    @route('/<class_id>', methods=['DELETE'])
+    @requires_login
+    def delete_class(self, user, class_id):
+        Class = self.db.get_class(class_id)
+        if not Class or Class['teacher'] != user['username']:
+            return gettext('no_such_class'), 404
+
+        self.db.delete_class(Class)
+        achievement = self.achievements.add_single_achievement(user['username'], "end_of_semester")
+        if achievement:
+            return {'achievement': achievement}, 200
+        return {}, 200
+
+    @route('/<class_id>/prejoin/<link>', methods=['GET'])
+    def prejoin_class(self, class_id, link):
+        Class = self.db.get_class(class_id)
+        if not Class or Class['link'] != link:
+            return utils.error_page(error=404, ui_message=gettext('invalid_class_link'))
+        if request.cookies.get(cookie_name):
+            token = self.db.get_token(request.cookies.get(cookie_name))
+            if token and token.get('username') in Class.get('students', []):
+                    return render_template('class-prejoin.html', joined=True, page_title=gettext('title_join-class'),
+                                            current_page='my-profile', class_info={'name': Class ['name']})
+        return render_template('class-prejoin.html', joined=False, page_title=gettext('title_join-class'),
+                               current_page='my-profile', class_info={'id': Class ['id'], 'name': Class ['name']})
+
+    @route('/join', methods=['POST'])
+    def join_class(self):
+        body = request.json
+        Class = None
+        if 'id' in body:
+            Class = self.db.get_class(body['id'])
+        if not Class or Class['id'] != body['id']:
+            return utils.error_page(error=404, ui_message=gettext('invalid_class_link'))
+
+        if not current_user()['username']:
+            return gettext('join_prompt'), 403
+
+        self.db.add_student_to_class(Class['id'], current_user()['username'])
+        # We only want to remove the invite if the user joins the class with an actual pending invite
+        invite = self.db.get_username_invite(current_user()['username'])
+        if invite and invite.get('class_id') == body['id']:
+            self.db.remove_class_invite(current_user()['username'])
+            # Also remove the pending message in this case
+            session['messages'] = 0
+
+        achievement = self.achievements.add_single_achievement(current_user()['username'], "epic_education")
+        if achievement:
+            return {'achievement': achievement}, 200
+        return {}, 200
+
+    @route('/<class_id>/student/<student_id>', methods=['DELETE'])
+    @requires_login
+    def leave_class(self, user, class_id, student_id):
+        Class = self.db.get_class(class_id)
+        if not Class or (Class['teacher'] != user['username'] and student_id != user['username']):
+            return gettext('ajax_error'), 400
+
+        self.db.remove_student_from_class(Class['id'], student_id)
+        achievement = None
+        if Class['teacher'] == user['username']:
+            achievement = self.achievements.add_single_achievement(user['username'], "detention")
+        if achievement:
+            return {'achievement': achievement}, 200
+        return {}, 200
+
+class MiscClassPages(WebsiteModule):
+    """All the pages that have to do with the teacher interface or classes, but
+    are not mounted under the '/class' URL space.
+    """
+
+    def __init__(self, db: Database, achievements: Achievements):
+        # Note: explicitly no 'url_prefix'
+        super().__init__('miscclass', __name__)
+        self.db = db
+        self.achievements = achievements
+
+    @route('/classes', methods=['GET'])
+    @requires_login
+    def get_classes(self, user):
+        if not is_teacher(user):
+            return utils.error_page(error=403, ui_message=gettext('retrieve_class_error'))
+        return jsonify (self.db.get_teacher_classes(user['username'], True))
+
+    @route('/duplicate_class', methods=['POST'])
+    @requires_login
+    def duplicate_class(self, user):
+        if not is_teacher(user):
+            return gettext('only_teacher_create_class'), 403
+
+        body = request.json
+        # Validations
+        if not isinstance(body, dict):
+            return gettext('ajax_error'), 400
+        if not isinstance(body.get('name'), str):
+            return gettext('class_name_invalid'), 400
+        if len(body.get('name')) < 1:
+            return gettext('class_name_empty'), 400
+
+        Class = self.db.get_class(body.get('id'))
+        if not Class or Class['teacher'] != user['username']:
+            return gettext('no_such_class'), 404
+
+        # We use this extra call to verify if the class name doesn't already exist, if so it's a duplicate
+        # Todo TB: This is a duplicate function, might be nice to perform some clean-up to reduce these parts
+        Classes = self.db.get_teacher_classes(user['username'], True)
+        for Class in Classes:
+            if Class['name'] == body.get('name'):
+                return gettext('class_name_duplicate'), 400
+
+        # All the class settings are still unique, we are only concerned with copying the customizations
+        # Shortly: Create a class like normal: concern with copying the customizations
+        class_id = uuid.uuid4().hex
+
+        new_class = {
+            'id': class_id,
+            'date': utils.timems(),
+            'teacher': user['username'],
+            'link': utils.random_id_generator(7),
+            'name': body.get('name')
+        }
+
+        self.db.store_class(new_class)
+
+        # Get the customizations of the current class -> if they exist, update id and store again
+        customizations = self.db.get_class_customizations(body.get('id'))
+        if customizations:
+            customizations['id'] = class_id
+            self.db.update_class_customizations(customizations)
+
+        achievement = self.achievements.add_single_achievement(current_user()['username'], "one_for_money")
+        if achievement:
+            return {'achievement': achievement}, 200
+
+
+    @route('/invite_student', methods=['POST'])
+    @requires_login
+    def invite_student(self, user):
+        body = request.json
+        # Validations
+        if not isinstance(body, dict):
+            return gettext('ajax_error'), 400
+        if not isinstance(body.get('username'), str):
+            return gettext('username_invalid'), 400
+        if not isinstance(body.get('class_id'), str):
+            return 'class id must be a string', 400
+        if len(body.get('username')) < 1:
+            return gettext('username_empty'), 400
+
+        username = body.get('username').lower()
+        class_id = body.get('class_id')
+
+        if not is_teacher(user):
+            return utils.error_page(error=403, ui_message=gettext('retrieve_class_error'))
+        Class = self.db.get_class(class_id)
+        if not Class or Class['teacher'] != user['username']:
+            return utils.error_page(error=404, ui_message=gettext('no_such_class'))
+
+        user = self.db.user_by_username(username)
+        if not user:
+            return gettext('student_not_existing'), 400
+        if 'students' in Class and user['username'] in Class['students']:
+            return gettext('student_already_in_class'), 400
+        if self.db.get_username_invite(user['username']):
+            return gettext('student_already_invite'), 400
+
+        # So: The class and student exist and are currently not a combination -> invite!
+        data = {
+            'username': username,
+            'class_id': class_id,
+            'timestamp': utils.times(),
+            'ttl': utils.times() + invite_length
+        }
+        self.db.add_class_invite(data)
+        return {}, 200
+
+    @route('/remove_student_invite', methods=['POST'])
+    @requires_login
+    def remove_invite(self, user):
+        body = request.json
+        # Validations
+        if not isinstance(body, dict):
+            return gettext('ajax_error'), 400
+        if not isinstance(body.get('username'), str):
+            return gettext('username_invalid'), 400
+        if not isinstance(body.get('class_id'), str):
+            return 'class id must be a string', 400
+
+        username = body.get('username')
+        class_id = body.get('class_id')
+
+        if not is_teacher(user) and username != user.get('username'):
+            return utils.error_page(error=403, ui_message=gettext('retrieve_class_error'))
+        Class = self.db.get_class(class_id)
+        if not Class or (Class['teacher'] != user['username'] and username != user.get('username')):
+            return utils.error_page(error=404, ui_message=gettext('no_such_class'))
+
+        self.db.remove_class_invite(username)
+        return {}, 200
+
+    @route('/hedy/l/<link_id>', methods=['GET'])
+    def resolve_class_link(self, link_id):
+        Class = self.db.resolve_class_link(link_id)
+        if not Class:
+            return utils.error_page(error=404, ui_message=gettext('invalid_class_link'))
+        return redirect(request.url.replace('/hedy/l/' + link_id, '/class/' + Class ['id'] + '/prejoin/' + link_id), code=302)

--- a/website/database.py
+++ b/website/database.py
@@ -5,19 +5,24 @@ import functools
 import operator
 
 
+storage = dynamo.AwsDynamoStorage.from_env() or dynamo.MemoryStorage("dev_database.json")
 
-storage = dynamo.AwsDynamoStorage.from_env() or dynamo.MemoryStorage('dev_database.json')
-
-USERS = dynamo.Table(storage, 'users', 'username', indexed_fields=[dynamo.IndexKey('email'), dynamo.IndexKey('epoch', 'created')])
-TOKENS = dynamo.Table(storage, 'tokens', 'id', indexed_fields=[dynamo.IndexKey(v) for v in ['id', 'username']])
-PROGRAMS = dynamo.Table(storage, 'programs', 'id', indexed_fields=[dynamo.IndexKey(v) for v in ['username', 'public', 'hedy_choice']])
-CLASSES = dynamo.Table(storage, 'classes', 'id', indexed_fields=[dynamo.IndexKey(v) for v in ['teacher', 'link']])
-ADVENTURES = dynamo.Table(storage, 'adventures', 'id', indexed_fields=[dynamo.IndexKey('creator')])
-INVITATIONS = dynamo.Table(storage, 'class_invitations', partition_key='username', indexed_fields=[dynamo.IndexKey('class_id')])
-CUSTOMIZATIONS = dynamo.Table(storage, 'class_customizations', partition_key='id')
-ACHIEVEMENTS = dynamo.Table(storage, 'achievements', partition_key='username')
-PUBLIC_PROFILES = dynamo.Table(storage, 'public_profiles', partition_key='username')
-PARSONS = dynamo.Table(storage, 'parsons', 'id')
+USERS = dynamo.Table(
+    storage, "users", "username", indexed_fields=[dynamo.IndexKey("email"), dynamo.IndexKey("epoch", "created")]
+)
+TOKENS = dynamo.Table(storage, "tokens", "id", indexed_fields=[dynamo.IndexKey(v) for v in ["id", "username"]])
+PROGRAMS = dynamo.Table(
+    storage, "programs", "id", indexed_fields=[dynamo.IndexKey(v) for v in ["username", "public", "hedy_choice"]]
+)
+CLASSES = dynamo.Table(storage, "classes", "id", indexed_fields=[dynamo.IndexKey(v) for v in ["teacher", "link"]])
+ADVENTURES = dynamo.Table(storage, "adventures", "id", indexed_fields=[dynamo.IndexKey("creator")])
+INVITATIONS = dynamo.Table(
+    storage, "class_invitations", partition_key="username", indexed_fields=[dynamo.IndexKey("class_id")]
+)
+CUSTOMIZATIONS = dynamo.Table(storage, "class_customizations", partition_key="id")
+ACHIEVEMENTS = dynamo.Table(storage, "achievements", partition_key="username")
+PUBLIC_PROFILES = dynamo.Table(storage, "public_profiles", partition_key="username")
+PARSONS = dynamo.Table(storage, "parsons", "id")
 
 
 # We use the epoch field to make an index on the users table, sorted by a different
@@ -51,7 +56,7 @@ CURRENT_USER_EPOCH = 1
 # 'levelAttempt' is a combination of level and attemptId, to distinguish attempts
 # by a user. 'level' is padded to 4 characters, then attemptId is added.
 #
-QUIZ_ANSWERS = dynamo.Table(storage, 'quizAnswers', partition_key='user', sort_key='levelAttempt')
+QUIZ_ANSWERS = dynamo.Table(storage, "quizAnswers", partition_key="user", sort_key="levelAttempt")
 
 # Holds information about program runs: success/failure and produced exceptions. Entries are created per user per level
 # per week and updated in place. Uses a composite partition key 'id#level' and 'week' as a sort key. Structure:
@@ -63,11 +68,14 @@ QUIZ_ANSWERS = dynamo.Table(storage, 'quizAnswers', partition_key='user', sort_k
 #   "InvalidSpaceException": 2
 # }
 #
-PROGRAM_STATS = dynamo.Table(storage, 'program-stats', partition_key='id#level', sort_key='week',
-                             indexed_fields=[dynamo.IndexKey('id', 'week')])
+PROGRAM_STATS = dynamo.Table(
+    storage, "program-stats", partition_key="id#level", sort_key="week", indexed_fields=[dynamo.IndexKey("id", "week")]
+)
 
-QUIZ_STATS = dynamo.Table(storage, 'quiz-stats', partition_key='id#level', sort_key='week',
-                          indexed_fields=[dynamo.IndexKey('id', 'week')])
+QUIZ_STATS = dynamo.Table(
+    storage, "quiz-stats", partition_key="id#level", sort_key="week", indexed_fields=[dynamo.IndexKey("id", "week")]
+)
+
 
 class Database:
     def record_quiz_answer(self, attempt_id, username, level, question_number, answer, is_correct):
@@ -77,7 +85,7 @@ class Database:
         """
         key = {
             "user": username,
-            "levelAttempt": str(level).zfill(4) + '_' + attempt_id,
+            "levelAttempt": str(level).zfill(4) + "_" + attempt_id,
         }
 
         updates = {
@@ -88,14 +96,14 @@ class Database:
         }
 
         if is_correct:
-            updates['correct'] = dynamo.DynamoAddToNumberSet(int(question_number))
+            updates["correct"] = dynamo.DynamoAddToNumberSet(int(question_number))
 
         return QUIZ_ANSWERS.update(key, updates)
 
     def get_quiz_answer(self, username, level, attempt_id):
         """Load a quiz answer from the database."""
 
-        quizAnswers = QUIZ_ANSWERS.get({'user': username, 'levelAttempt': str(level).zfill(4) + '_' + attempt_id})
+        quizAnswers = QUIZ_ANSWERS.get({"user": username, "levelAttempt": str(level).zfill(4) + "_" + attempt_id})
 
         array_quiz_answers = []
         for question_number in range(len(quizAnswers)):
@@ -108,39 +116,39 @@ class Database:
 
         Returns: [{ code, name, program, level, adventure_name, date }]
         """
-        programs = PROGRAMS.get_many({'username': username}, reverse=True)
-        return [x for x in programs if x.get('level') == int(level)]
+        programs = PROGRAMS.get_many({"username": username}, reverse=True)
+        return [x for x in programs if x.get("level") == int(level)]
 
     def programs_for_user(self, username):
         """List programs for the given user, newest first.
 
         Returns: [{ code, name, program, level, adventure_name, date }]
         """
-        return PROGRAMS.get_many({'username': username}, reverse=True)
+        return PROGRAMS.get_many({"username": username}, reverse=True)
 
     def filtered_programs_for_user(self, username, level, adventure):
-        programs = PROGRAMS.get_many({'username': username}, reverse=True)
+        programs = PROGRAMS.get_many({"username": username}, reverse=True)
         if level:
-            programs = [x for x in programs if x.get('level') == int(level)]
+            programs = [x for x in programs if x.get("level") == int(level)]
         if adventure:
             # If the adventure we filter on is called 'default' -> return all programs WITHOUT an adventure
             if adventure == "default":
-                programs = [x for x in programs if x.get('adventure_name') == ""]
+                programs = [x for x in programs if x.get("adventure_name") == ""]
             else:
-                programs = [x for x in programs if x.get('adventure_name') == adventure]
+                programs = [x for x in programs if x.get("adventure_name") == adventure]
         return programs
 
     def public_programs_for_user(self, username):
         # Only return programs that are public but not submitted
-        programs = PROGRAMS.get_many({'username': username}, reverse=True)
-        return [p for p in programs if p.get('public') == 1 and not p.get('submitted', False)]
+        programs = PROGRAMS.get_many({"username": username}, reverse=True)
+        return [p for p in programs if p.get("public") == 1 and not p.get("submitted", False)]
 
     def program_by_id(self, id):
         """Get program by ID.
 
         Returns: { code, name, program, level, adventure_name, date }
         """
-        return PROGRAMS.get({'id': id})
+        return PROGRAMS.get({"id": id})
 
     def store_program(self, program):
         """Store a program."""
@@ -148,32 +156,30 @@ class Database:
 
     def set_program_public_by_id(self, id, public):
         """Store a program."""
-        PROGRAMS.update({'id': id}, {'public': 1 if public else 0})
+        PROGRAMS.update({"id": id}, {"public": 1 if public else 0})
 
     def submit_program_by_id(self, id):
-        PROGRAMS.update({'id': id}, {'submitted': True})
+        PROGRAMS.update({"id": id}, {"submitted": True})
 
     def delete_program_by_id(self, id):
         """Delete a program by id."""
-        PROGRAMS.delete({'id': id})
+        PROGRAMS.delete({"id": id})
 
     def increase_user_program_count(self, username, delta=1):
         """Increase the program count of a user by the given delta."""
-        return USERS.update({ 'username': username }, {
-            'program_count': dynamo.DynamoIncrement(delta)
-        })
+        return USERS.update({"username": username}, {"program_count": dynamo.DynamoIncrement(delta)})
 
     def user_by_username(self, username):
         """Return a user object from the username."""
-        return USERS.get({'username': username.strip().lower()})
+        return USERS.get({"username": username.strip().lower()})
 
     def user_by_email(self, email):
         """Return a user object from the email address."""
-        return USERS.get({'email': email.strip().lower()})
+        return USERS.get({"email": email.strip().lower()})
 
     def get_token(self, token_id):
         """Load a token from the database."""
-        return TOKENS.get({'id': token_id})
+        return TOKENS.get({"id": token_id})
 
     def store_token(self, token):
         """Store a token in the database."""
@@ -184,23 +190,23 @@ class Database:
 
         Returns the Token that was deleted.
         """
-        return TOKENS.delete({'id': token_id})
+        return TOKENS.delete({"id": token_id})
 
     def delete_all_tokens(self, username):
         """Forget all Tokens from a user."""
-        TOKENS.del_many({'username': username})
+        TOKENS.del_many({"username": username})
 
     def store_user(self, user):
         """Store a user in the database."""
-        user['epoch'] = CURRENT_USER_EPOCH
+        user["epoch"] = CURRENT_USER_EPOCH
         USERS.create(user)
 
     def record_login(self, username, new_password_hash=None):
         """Record the fact that the user logged in, potentially updating their password hash."""
         if new_password_hash:
-            self.update_user(username, {'password': new_password_hash, 'last_login': timems ()})
+            self.update_user(username, {"password": new_password_hash, "last_login": timems()})
         else:
-            self.update_user(username, {'last_login': timems ()})
+            self.update_user(username, {"last_login": timems()})
 
     def update_user(self, username, userdata):
         """Update the user data with the given fields.
@@ -209,24 +215,24 @@ class Database:
         slight variants of tweaking some fields on the user in the code to
         turn each of them into a separate method here.
         """
-        USERS.update({'username': username}, userdata)
+        USERS.update({"username": username}, userdata)
 
     def forget_user(self, username):
         """Forget the given user."""
-        classes = USERS.get({'username': username}).get ('classes') or []
-        USERS.delete({'username': username})
-        INVITATIONS.delete({'username': username})
+        classes = USERS.get({"username": username}).get("classes") or []
+        USERS.delete({"username": username})
+        INVITATIONS.delete({"username": username})
         # The recover password token may exist, so we delete it
-        TOKENS.delete({'id': username})
-        PROGRAMS.del_many({'username': username})
+        TOKENS.delete({"id": username})
+        PROGRAMS.del_many({"username": username})
 
         # Remove user from classes of which they are a student
         for class_id in classes:
-            self.remove_student_from_class (class_id, username)
+            self.remove_student_from_class(class_id, username)
 
         # Delete classes owned by the user
-        for Class in self.get_teacher_classes (username, False):
-            self.delete_class (Class)
+        for Class in self.get_teacher_classes(username, False):
+            self.delete_class(Class)
 
     def all_users(self, page_token=None):
         """Return a page from the users table.
@@ -238,7 +244,9 @@ class Database:
         """
         limit = 500
 
-        epoch, pagination_token = page_token.split(':', maxsplit=1) if page_token is not None else (CURRENT_USER_EPOCH, None)
+        epoch, pagination_token = (
+            page_token.split(":", maxsplit=1) if page_token is not None else (CURRENT_USER_EPOCH, None)
+        )
         epoch = int(epoch)
 
         page = USERS.get_many(dict(epoch=epoch), pagination_token=pagination_token, limit=limit, reverse=True)
@@ -254,12 +262,12 @@ class Database:
 
         # Prepend the epoch to the next pagination token
         if page.next_page_token:
-            page.next_page_token = f'{epoch}:{page.next_page_token}'
+            page.next_page_token = f"{epoch}:{page.next_page_token}"
         return page
 
     def get_all_public_programs(self):
-        programs = PROGRAMS.get_many({'public': 1}, reverse=True)
-        return [x for x in programs if not x.get('submitted', False)]
+        programs = PROGRAMS.get_many({"public": 1}, reverse=True)
+        return [x for x in programs if not x.get("submitted", False)]
 
     def get_highscores(self, username, filter, filter_value=None):
         profiles = []
@@ -270,64 +278,63 @@ class Database:
         # If it's a class, only get the ones from your class
         elif filter == "class":
             Class = self.get_class(filter_value)
-            for student in Class.get('students', []):
+            for student in Class.get("students", []):
                 profile = self.get_public_profile_settings(student)
                 if profile:
                     profiles.append(profile)
 
         for profile in profiles:
-            if not profile.get('country'):
+            if not profile.get("country"):
                 # This seems to crash on production even if it shouldn't (all profiles should have a username)
                 # To be sure, surround with a try catch
                 try:
-                    country = self.user_by_username(profile.get('username')).get('country')
-                    self.update_country_public_profile(profile.get('username'), country)
+                    country = self.user_by_username(profile.get("username")).get("country")
+                    self.update_country_public_profile(profile.get("username"), country)
                 except AttributeError:
                     print("This profile username is invalid...")
                     country = None
-                profile['country'] = country
-            if not profile.get('achievements'):
-                achievements = self.achievements_by_username(profile.get('username'))
-                self.update_achievements_public_profile(profile.get('username'), len(achievements) or 0)
-                profile['achievements'] = len(achievements) or 0
+                profile["country"] = country
+            if not profile.get("achievements"):
+                achievements = self.achievements_by_username(profile.get("username"))
+                self.update_achievements_public_profile(profile.get("username"), len(achievements) or 0)
+                profile["achievements"] = len(achievements) or 0
 
         # If we filter on country, make sure to filter out all non-country values
         if filter == "country":
-            profiles = [x for x in profiles if x.get('country') == filter_value]
+            profiles = [x for x in profiles if x.get("country") == filter_value]
 
         # Perform a double sorting: first by achievements (high-low), then by timestamp (low-high)
-        profiles = sorted(profiles, key=lambda k: (k.get('achievements'), -k.get('last_achievement')), reverse=True)
+        profiles = sorted(profiles, key=lambda k: (k.get("achievements"), -k.get("last_achievement")), reverse=True)
 
         # Add ranking for each profile
         ranking = 1
         for profile in profiles:
-            profile['ranking'] = ranking
+            profile["ranking"] = ranking
             ranking += 1
 
         # If the user is not in the current top 50: still append to the results
-        if not any(d['username'] == username for d in profiles[:50]):
-            return profiles[:50] + [i for i in profiles if i['username'] == username]
+        if not any(d["username"] == username for d in profiles[:50]):
+            return profiles[:50] + [i for i in profiles if i["username"] == username]
         return profiles[:50]
 
-
     def get_all_hedy_choices(self):
-        return PROGRAMS.get_many({'hedy_choice': 1}, reverse=True)
+        return PROGRAMS.get_many({"hedy_choice": 1}, reverse=True)
 
     def get_hedy_choices(self):
-        return PROGRAMS.get_many({'hedy_choice': 1}, limit=4, reverse=True)
+        return PROGRAMS.get_many({"hedy_choice": 1}, limit=4, reverse=True)
 
     def set_program_as_hedy_choice(self, id, favourite):
-        PROGRAMS.update({'id': id}, {'hedy_choice': 1 if favourite else None})
+        PROGRAMS.update({"id": id}, {"hedy_choice": 1 if favourite else None})
 
     def get_class(self, id):
         """Return the classes with given id."""
-        return CLASSES.get({'id': id})
+        return CLASSES.get({"id": id})
 
     def get_teacher_classes(self, username, students_to_list=False):
         """Return all the classes belonging to a teacher."""
         classes = None
         if isinstance(storage, dynamo.AwsDynamoStorage):
-            classes = CLASSES.get_many({'teacher': username}, reverse=True)
+            classes = CLASSES.get_many({"teacher": username}, reverse=True)
 
         # If we're using the in-memory database, we need to make a shallow copy
         # of the classes before changing the `students` key from a set to list,
@@ -338,63 +345,62 @@ class Database:
         # skeptical that it's accurate.
         else:
             classes = []
-            for Class in CLASSES.get_many({'teacher': username}, reverse=True):
-                classes.append (Class.copy())
+            for Class in CLASSES.get_many({"teacher": username}, reverse=True):
+                classes.append(Class.copy())
         if students_to_list:
             for Class in classes:
-                if not 'students' in Class:
-                    Class ['students'] = []
+                if not "students" in Class:
+                    Class["students"] = []
                 else:
-                    Class ['students'] = list (Class ['students'])
+                    Class["students"] = list(Class["students"])
         return classes
 
     def get_teacher_students(self, username):
         """Return all the students belonging to a teacher."""
         students = []
-        classes = CLASSES.get_many({'teacher': username}, reverse=True)
+        classes = CLASSES.get_many({"teacher": username}, reverse=True)
         for Class in classes:
-            for student in Class.get ('students', []):
+            for student in Class.get("students", []):
                 if student not in students:
-                    students.append (student)
+                    students.append(student)
         return students
 
     def get_adventure(self, adventure_id):
-        return ADVENTURES.get({'id': adventure_id})
+        return ADVENTURES.get({"id": adventure_id})
 
     def delete_adventure(self, adventure_id):
         # If we delete an adventure -> also delete is from possible class customizations
-        teacher = self.get_adventure(adventure_id).get('creator', '')
-        ADVENTURES.delete({'id': adventure_id})
+        teacher = self.get_adventure(adventure_id).get("creator", "")
+        ADVENTURES.delete({"id": adventure_id})
         for Class in self.get_teacher_classes(teacher, True):
-            customizations = self.get_class_customizations(Class.get('id'))
-            if customizations and adventure_id in customizations.get('teacher_adventures',[]):
-                customizations['teacher_adventures'].remove(adventure_id)
+            customizations = self.get_class_customizations(Class.get("id"))
+            if customizations and adventure_id in customizations.get("teacher_adventures", []):
+                customizations["teacher_adventures"].remove(adventure_id)
                 self.update_class_customizations(customizations)
-
 
     def store_adventure(self, adventure):
         """Store an adventure."""
         ADVENTURES.create(adventure)
 
     def update_adventure(self, adventure_id, adventure):
-        ADVENTURES.update({'id': adventure_id}, adventure)
+        ADVENTURES.update({"id": adventure_id}, adventure)
 
     def get_teacher_adventures(self, username):
-        return ADVENTURES.get_many({'creator': username})
+        return ADVENTURES.get_many({"creator": username})
 
     def all_adventures(self):
         return ADVENTURES.scan()
 
     def get_student_classes_ids(self, username):
-        ids = USERS.get({'username': username}).get('classes')
+        ids = USERS.get({"username": username}).get("classes")
         return list(ids) if ids else []
 
     def get_student_classes(self, username):
         """Return all the classes of which the user is a student."""
         classes = []
         for class_id in self.get_student_classes_ids(username):
-            Class = self.get_class (class_id)
-            classes.append ({'id': Class ['id'], 'name': Class ['name']})
+            Class = self.get_class(class_id)
+            classes.append({"id": Class["id"], "name": Class["name"]})
 
         return classes
 
@@ -404,54 +410,54 @@ class Database:
 
     def update_class(self, id, name):
         """Updates a class."""
-        CLASSES.update({'id': id}, {'name': name})
+        CLASSES.update({"id": id}, {"name": name})
 
     def add_student_to_class(self, class_id, student_id):
         """Adds a student to a class."""
-        CLASSES.update ({'id': class_id}, {'students': dynamo.DynamoAddToStringSet (student_id)})
-        USERS.update({'username': student_id}, {'classes': dynamo.DynamoAddToStringSet (class_id)})
+        CLASSES.update({"id": class_id}, {"students": dynamo.DynamoAddToStringSet(student_id)})
+        USERS.update({"username": student_id}, {"classes": dynamo.DynamoAddToStringSet(class_id)})
 
     def remove_student_from_class(self, class_id, student_id):
         """Removes a student from a class."""
-        CLASSES.update ({'id': class_id}, {'students': dynamo.DynamoRemoveFromStringSet (student_id)})
-        USERS.update({'username': student_id}, {'classes': dynamo.DynamoRemoveFromStringSet (class_id)})
+        CLASSES.update({"id": class_id}, {"students": dynamo.DynamoRemoveFromStringSet(student_id)})
+        USERS.update({"username": student_id}, {"classes": dynamo.DynamoRemoveFromStringSet(class_id)})
 
     def delete_class(self, Class):
-        for student_id in Class.get ('students', []):
-            Database.remove_student_from_class (self, Class ['id'], student_id)
+        for student_id in Class.get("students", []):
+            Database.remove_student_from_class(self, Class["id"], student_id)
 
-        CUSTOMIZATIONS.del_many({'id': Class['id']})
-        INVITATIONS.del_many({'class_id': Class['id']})
-        CUSTOMIZATIONS.delete({'id': Class['id']})
-        CLASSES.delete({'id': Class['id']})
+        CUSTOMIZATIONS.del_many({"id": Class["id"]})
+        INVITATIONS.del_many({"class_id": Class["id"]})
+        CUSTOMIZATIONS.delete({"id": Class["id"]})
+        CLASSES.delete({"id": Class["id"]})
 
     def resolve_class_link(self, link_id):
-        return CLASSES.get({'link': link_id})
+        return CLASSES.get({"link": link_id})
 
     def get_username_invite(self, username):
-        return INVITATIONS.get({'username': username}) or None
+        return INVITATIONS.get({"username": username}) or None
 
     def add_class_invite(self, data):
         INVITATIONS.put(data)
 
     def remove_class_invite(self, username):
-        INVITATIONS.delete({'username': username})
+        INVITATIONS.delete({"username": username})
 
     def get_class_invites(self, class_id):
-        return INVITATIONS.get_many({'class_id': class_id}) or []
+        return INVITATIONS.get_many({"class_id": class_id}) or []
 
     def all_classes(self):
         return CLASSES.scan()
 
     def delete_class_customizations(self, class_id):
-        CUSTOMIZATIONS.delete({'id': class_id})
+        CUSTOMIZATIONS.delete({"id": class_id})
 
     def add_adventure_to_class_customizations(self, class_id, adventure_id):
         customizations = self.get_class_customizations(class_id)
         if not customizations:
-            customizations = {'id': class_id, 'teacher_adventures': [adventure_id]}
-        elif adventure_id not in customizations.get('teacher_adventures', []):
-            customizations['teacher_adventures'] = customizations.get('teacher_adventures', []) + [adventure_id]
+            customizations = {"id": class_id, "teacher_adventures": [adventure_id]}
+        elif adventure_id not in customizations.get("teacher_adventures", []):
+            customizations["teacher_adventures"] = customizations.get("teacher_adventures", []) + [adventure_id]
         # If both cases don't return valid the adventure is already in the customizations -> save a PUT operation
         else:
             return None
@@ -462,31 +468,31 @@ class Database:
         # If there are no customizations, leave as it is -> only perform an action if it is already stored on the class
         if not customizations:
             return None
-        elif adventure_id in customizations.get('teacher_adventures', []):
-            customizations['teacher_adventures'].remove(adventure_id)
+        elif adventure_id in customizations.get("teacher_adventures", []):
+            customizations["teacher_adventures"].remove(adventure_id)
             CUSTOMIZATIONS.put(customizations)
 
     def update_class_customizations(self, customizations):
         CUSTOMIZATIONS.put(customizations)
 
     def get_class_customizations(self, class_id):
-        customizations = CUSTOMIZATIONS.get({'id': class_id})
+        customizations = CUSTOMIZATIONS.get({"id": class_id})
         return customizations
 
     def get_student_class_customizations(self, user):
         student_classes = self.get_student_classes(user)
         if student_classes:
-            class_customizations = self.get_class_customizations(student_classes[0]['id'])
+            class_customizations = self.get_class_customizations(student_classes[0]["id"])
             return class_customizations or {}
         return {}
 
     def progress_by_username(self, username):
-        return ACHIEVEMENTS.get({'username': username})
+        return ACHIEVEMENTS.get({"username": username})
 
     def achievements_by_username(self, username):
-        progress_data = ACHIEVEMENTS.get({'username': username})
-        if progress_data and 'achieved' in progress_data:
-            return progress_data['achieved']
+        progress_data = ACHIEVEMENTS.get({"username": username})
+        if progress_data and "achieved" in progress_data:
+            return progress_data["achieved"]
         else:
             return None
 
@@ -495,87 +501,89 @@ class Database:
 
     def add_achievement_to_username(self, username, achievement):
         new_user = False
-        user_achievements = ACHIEVEMENTS.get({'username': username})
+        user_achievements = ACHIEVEMENTS.get({"username": username})
         if not user_achievements:
             new_user = True
-            user_achievements = {'username': username}
-        if 'achieved' not in user_achievements:
-            user_achievements['achieved'] = []
-        if achievement not in user_achievements['achieved']:
-            user_achievements['achieved'].append(achievement)
+            user_achievements = {"username": username}
+        if "achieved" not in user_achievements:
+            user_achievements["achieved"] = []
+        if achievement not in user_achievements["achieved"]:
+            user_achievements["achieved"].append(achievement)
             ACHIEVEMENTS.put(user_achievements)
         # Update the amount of achievements on the public profile (if exists)
-        self.update_achievements_public_profile(username, len(user_achievements['achieved']))
+        self.update_achievements_public_profile(username, len(user_achievements["achieved"]))
         if new_user:
             return True
         return False
 
     def add_achievements_to_username(self, username, achievements):
         new_user = False
-        user_achievements = ACHIEVEMENTS.get({'username': username})
+        user_achievements = ACHIEVEMENTS.get({"username": username})
         if not user_achievements:
             new_user = True
-            user_achievements = {'username': username}
-        if 'achieved' not in user_achievements:
-            user_achievements['achieved'] = []
+            user_achievements = {"username": username}
+        if "achieved" not in user_achievements:
+            user_achievements["achieved"] = []
         for achievement in achievements:
-            if achievement not in user_achievements['achieved']:
-                user_achievements['achieved'].append(achievement)
-        user_achievements['achieved'] = list(dict.fromkeys(user_achievements['achieved']))
+            if achievement not in user_achievements["achieved"]:
+                user_achievements["achieved"].append(achievement)
+        user_achievements["achieved"] = list(dict.fromkeys(user_achievements["achieved"]))
         ACHIEVEMENTS.put(user_achievements)
 
         # Update the amount of achievements on the public profile (if exists)
-        self.update_achievements_public_profile(username, len(user_achievements['achieved']))
+        self.update_achievements_public_profile(username, len(user_achievements["achieved"]))
         if new_user:
             return True
         return False
 
     def add_commands_to_username(self, username, commands):
-        user_achievements = ACHIEVEMENTS.get({'username': username})
+        user_achievements = ACHIEVEMENTS.get({"username": username})
         if not user_achievements:
-            user_achievements = {'username': username}
-        user_achievements['commands'] = commands
+            user_achievements = {"username": username}
+        user_achievements["commands"] = commands
         ACHIEVEMENTS.put(user_achievements)
 
     def increase_user_run_count(self, username):
-        ACHIEVEMENTS.update({'username': username}, {'run_programs': dynamo.DynamoIncrement(1)})
+        ACHIEVEMENTS.update({"username": username}, {"run_programs": dynamo.DynamoIncrement(1)})
 
     def increase_user_save_count(self, username):
-        ACHIEVEMENTS.update({'username': username}, {'saved_programs': dynamo.DynamoIncrement(1)})
+        ACHIEVEMENTS.update({"username": username}, {"saved_programs": dynamo.DynamoIncrement(1)})
 
     def increase_user_submit_count(self, username):
-        ACHIEVEMENTS.update({'username': username}, {'submitted_programs': dynamo.DynamoIncrement(1)})
+        ACHIEVEMENTS.update({"username": username}, {"submitted_programs": dynamo.DynamoIncrement(1)})
 
     def update_public_profile(self, username, data):
-        PUBLIC_PROFILES.update({'username': username}, data)
+        PUBLIC_PROFILES.update({"username": username}, data)
 
     def update_achievements_public_profile(self, username, amount_achievements):
-        data = PUBLIC_PROFILES.get({'username': username})
+        data = PUBLIC_PROFILES.get({"username": username})
         # In the case that we make this call but there is no public profile -> don't do anything
         if data:
-            PUBLIC_PROFILES.update({'username': username}, {'achievements': amount_achievements, 'last_achievement': timems()})
+            PUBLIC_PROFILES.update(
+                {"username": username}, {"achievements": amount_achievements, "last_achievement": timems()}
+            )
 
     def update_country_public_profile(self, username, country):
-        data = PUBLIC_PROFILES.get({'username': username})
+        data = PUBLIC_PROFILES.get({"username": username})
         # If there is no data -> we might have made this request from the /update_profile route without a public profile
         # In this case don't do anything
         if data:
-            PUBLIC_PROFILES.update({'username': username}, {'country': country})
+            PUBLIC_PROFILES.update({"username": username}, {"country": country})
 
     def set_favourite_program(self, username, program_id):
         # We can only set a favourite program is there is already a public profile
-        data = PUBLIC_PROFILES.get({'username': username})
+        data = PUBLIC_PROFILES.get({"username": username})
         if data:
-            data['favourite_program'] = program_id
+            data["favourite_program"] = program_id
             self.update_public_profile(username, data)
             return True
         return False
 
     def get_public_profile_settings(self, username):
-        return PUBLIC_PROFILES.get({'username': username})
+        return PUBLIC_PROFILES.get({"username": username})
 
     def forget_public_profile(self, username):
-        PUBLIC_PROFILES.delete({'username': username})
+        PUBLIC_PROFILES.delete({"username": username})
 
     def get_all_public_profiles(self):
         return PUBLIC_PROFILES.scan()
@@ -584,18 +592,21 @@ class Database:
         PARSONS.create(attempt)
 
     def add_quiz_started(self, id, level):
-        key = {"id#level": f'{id}#{level}', 'week': self.to_year_week(date.today())}
+        key = {"id#level": f"{id}#{level}", "week": self.to_year_week(date.today())}
 
-        add_attributes = {'id': id, 'level': level, 'started': dynamo.DynamoIncrement()}
+        add_attributes = {"id": id, "level": level, "started": dynamo.DynamoIncrement()}
 
         return QUIZ_STATS.update(key, add_attributes)
 
     def add_quiz_finished(self, id, level, score):
-        key = {"id#level": f'{id}#{level}', 'week': self.to_year_week(date.today())}
+        key = {"id#level": f"{id}#{level}", "week": self.to_year_week(date.today())}
 
-        add_attributes = {'id': id, 'level': level,
-                          'finished': dynamo.DynamoIncrement(),
-                          'scores': dynamo.DynamoAddToList(score)}
+        add_attributes = {
+            "id": id,
+            "level": level,
+            "finished": dynamo.DynamoIncrement(),
+            "scores": dynamo.DynamoAddToList(score),
+        }
 
         return QUIZ_STATS.update(key, add_attributes)
 
@@ -603,17 +614,17 @@ class Database:
         start_week = self.to_year_week(self.parse_date(start, date(2022, 1, 1)))
         end_week = self.to_year_week(self.parse_date(end, date.today()))
 
-        data = [QUIZ_STATS.get_many({'id': i, 'week': dynamo.Between(start_week, end_week)}) for i in ids]
+        data = [QUIZ_STATS.get_many({"id": i, "week": dynamo.Between(start_week, end_week)}) for i in ids]
         return functools.reduce(operator.iconcat, data, [])
 
     def add_program_stats(self, id, level, exception):
-        key = {"id#level": f'{id}#{level}', 'week': self.to_year_week(date.today())}
+        key = {"id#level": f"{id}#{level}", "week": self.to_year_week(date.today())}
 
-        add_attributes = {'id': id, 'level': level}
+        add_attributes = {"id": id, "level": level}
         if exception:
             add_attributes[exception] = dynamo.DynamoIncrement()
         else:
-            add_attributes['successful_runs'] = dynamo.DynamoIncrement()
+            add_attributes["successful_runs"] = dynamo.DynamoIncrement()
 
         return PROGRAM_STATS.update(key, add_attributes)
 
@@ -621,12 +632,12 @@ class Database:
         start_week = self.to_year_week(self.parse_date(start, date(2022, 1, 1)))
         end_week = self.to_year_week(self.parse_date(end, date.today()))
 
-        data = [PROGRAM_STATS.get_many({'id': i, 'week': dynamo.Between(start_week, end_week)}) for i in ids]
+        data = [PROGRAM_STATS.get_many({"id": i, "week": dynamo.Between(start_week, end_week)}) for i in ids]
         return functools.reduce(operator.iconcat, data, [])
 
     def parse_date(self, d, default):
-        return date(*map(int, d.split('-'))) if d else default
+        return date(*map(int, d.split("-"))) if d else default
 
     def to_year_week(self, d):
         cal = d.isocalendar()
-        return f'{cal[0]}-{cal[1]:02d}'
+        return f"{cal[0]}-{cal[1]:02d}"

--- a/website/dynamo.py
+++ b/website/dynamo.py
@@ -16,17 +16,31 @@ from typing import List, Optional
 
 
 class TableStorage(metaclass=ABCMeta):
-    def get_item(self, table_name, key): ...
+    def get_item(self, table_name, key):
+        ...
 
     # The 'sort_key' argument for query and query_index is used to indicate that one of the keys is a sort_key
     # This is now needed because we can query by index sort key too. Still hacky hacky :).
-    def query(self, table_name, key, sort_key, reverse, limit, pagination_token): ...
-    def query_index(self, table_name, index_name, keys, sort_key, reverse=False, limit=None, pagination_token=None): ...
-    def put(self, table_name, key, data): ...
-    def update(self, table_name, key, updates): ...
-    def delete(self, table_name, key): ...
-    def item_count(self, table_name): ...
-    def scan(self, table_name, limit, pagination_token): ...
+    def query(self, table_name, key, sort_key, reverse, limit, pagination_token):
+        ...
+
+    def query_index(self, table_name, index_name, keys, sort_key, reverse=False, limit=None, pagination_token=None):
+        ...
+
+    def put(self, table_name, key, data):
+        ...
+
+    def update(self, table_name, key, updates):
+        ...
+
+    def delete(self, table_name, key):
+        ...
+
+    def item_count(self, table_name):
+        ...
+
+    def scan(self, table_name, limit, pagination_token):
+        ...
 
 
 @dataclass
@@ -47,6 +61,7 @@ class ResultPage:
 
         result_list = list(table.get_many(...))
     """
+
     records: List[dict]
     next_page_token: Optional[str]
 
@@ -65,6 +80,7 @@ class ResultPage:
 
     def __nonzero__(self):
         return bool(self.records)
+
     __bool__ = __nonzero__
 
 
@@ -81,6 +97,7 @@ class Table:
           own sort keys.
         - sort_key: a field that is the sort key for the table.
     """
+
     def __init__(self, storage: TableStorage, table_name, partition_key, sort_key=None, indexed_fields=None):
         self.storage = storage
         self.table_name = table_name
@@ -88,24 +105,26 @@ class Table:
         self.sort_key = sort_key
         self.indexed_fields = indexed_fields or []
 
-    @querylog.timed_as('db_get')
+    @querylog.timed_as("db_get")
     def get(self, key):
         """Gets an item by key from the database.
 
         The key must be a dict with a single entry which references the
         partition key or an index key.
         """
-        querylog.log_counter(f'db_get:{self.table_name}')
+        querylog.log_counter(f"db_get:{self.table_name}")
         lookup = self._determine_lookup(key, many=False)
         if isinstance(lookup, TableLookup):
             return self.storage.get_item(lookup.table_name, lookup.key)
         if isinstance(lookup, IndexLookup):
             return first_or_none(
-                self.storage.query_index(lookup.table_name, lookup.index_name, lookup.key, sort_key=lookup.sort_key, limit=1)[0]
+                self.storage.query_index(
+                    lookup.table_name, lookup.index_name, lookup.key, sort_key=lookup.sort_key, limit=1
+                )[0]
             )
         assert False
 
-    @querylog.timed_as('db_get_many')
+    @querylog.timed_as("db_get_many")
     def get_many(self, key, reverse=False, limit=None, pagination_token=None):
         """Gets a list of items by key from the database.
 
@@ -115,27 +134,34 @@ class Table:
         `get_many` reads up to 1MB of data from the database, or a maximum of `limit`
         records, whichever one is hit first.
         """
-        querylog.log_counter(f'db_get_many:{self.table_name}')
+        querylog.log_counter(f"db_get_many:{self.table_name}")
 
         lookup = self._determine_lookup(key, many=True)
         if isinstance(lookup, TableLookup):
-            items, next_page_token = self.storage.query(lookup.table_name, lookup.key,
+            items, next_page_token = self.storage.query(
+                lookup.table_name,
+                lookup.key,
                 sort_key=self.sort_key,
                 reverse=reverse,
                 limit=limit,
-                pagination_token=decode_page_token(pagination_token))
+                pagination_token=decode_page_token(pagination_token),
+            )
         elif isinstance(lookup, IndexLookup):
-            items, next_page_token = self.storage.query_index(lookup.table_name, lookup.index_name, lookup.key,
+            items, next_page_token = self.storage.query_index(
+                lookup.table_name,
+                lookup.index_name,
+                lookup.key,
                 sort_key=lookup.sort_key,
                 reverse=reverse,
                 limit=limit,
-                pagination_token=decode_page_token(pagination_token))
+                pagination_token=decode_page_token(pagination_token),
+            )
         else:
             assert False
-        querylog.log_counter('db_get_many_items', len(items))
+        querylog.log_counter("db_get_many_items", len(items))
         return ResultPage(items, encode_page_token(next_page_token))
 
-    @querylog.timed_as('db_create')
+    @querylog.timed_as("db_create")
     def create(self, data):
         """Put a single complete record into the database."""
         if self.partition_key not in data:
@@ -143,14 +169,14 @@ class Table:
         if self.sort_key and self.sort_key not in data:
             raise ValueError(f"Expecting '{self.sort_key}' field in create() call, got: {data}")
 
-        querylog.log_counter(f'db_create:{self.table_name}')
+        querylog.log_counter(f"db_create:{self.table_name}")
         self.storage.put(self.table_name, self._extract_key(data), data)
 
     def put(self, data):
         """An alias for 'create', if calling create reads uncomfortably."""
         return self.create(data)
 
-    @querylog.timed_as('db_update')
+    @querylog.timed_as("db_update")
     def update(self, key, updates):
         """Update select fields of a given record.
 
@@ -158,31 +184,31 @@ class Table:
         one of the subclasses of DynamoUpdate which represent
         updates that aren't representable as plain values.
         """
-        querylog.log_counter(f'db_update:{self.table_name}')
+        querylog.log_counter(f"db_update:{self.table_name}")
         self._validate_key(key)
 
         return self.storage.update(self.table_name, key, updates)
 
-    @querylog.timed_as('db_del')
+    @querylog.timed_as("db_del")
     def delete(self, key):
         """Delete an item by primary key.
 
         Returns the delete item.
         """
-        querylog.log_counter('db_del:' + self.table_name)
+        querylog.log_counter("db_del:" + self.table_name)
         self._validate_key(key)
 
         return self.storage.delete(self.table_name, key)
 
-    @querylog.timed_as('db_del_many')
-    def del_many (self, key):
+    @querylog.timed_as("db_del_many")
+    def del_many(self, key):
         """Delete all items matching a key.
 
         DynamoDB does not support this operation natively, so we have to turn
         it into a fetch+batch delete (and since our N is small, we do
         repeated "single" deletes instead of doing a proper batch delete).
         """
-        querylog.log_counter('db_del_many:' + self.table_name)
+        querylog.log_counter("db_del_many:" + self.table_name)
 
         # The result of get_many is paged, so we might need to do this more than once.
         to_delete = self.get_many(key)
@@ -192,21 +218,23 @@ class Table:
                 self.delete(key)
             to_delete = self.get_many(key)
 
-    @querylog.timed_as('db_scan')
+    @querylog.timed_as("db_scan")
     def scan(self, limit=None, pagination_token=None):
         """Reads the entire table into memory."""
-        querylog.log_counter('db_scan:' + self.table_name)
-        items, next_page_token = self.storage.scan(self.table_name, limit=limit, pagination_token=decode_page_token(pagination_token))
+        querylog.log_counter("db_scan:" + self.table_name)
+        items, next_page_token = self.storage.scan(
+            self.table_name, limit=limit, pagination_token=decode_page_token(pagination_token)
+        )
         return ResultPage(items, encode_page_token(next_page_token))
 
-    @querylog.timed_as('db_describe')
+    @querylog.timed_as("db_describe")
     def item_count(self):
-        querylog.log_counter('db_describe:' + self.table_name)
+        querylog.log_counter("db_describe:" + self.table_name)
         return self.storage.item_count(self.table_name)
 
     def _determine_lookup(self, key_data, many):
         if any(not v for v in key_data.values()):
-            raise ValueError(f'Key data cannot have empty values: {key_data}')
+            raise ValueError(f"Key data cannot have empty values: {key_data}")
 
         keys = set(key_data.keys())
         table_keys = self._key_names()
@@ -220,23 +248,19 @@ class Table:
         for index in self.indexed_fields:
             index_key_names = [x for x in [index.partition_key, index.sort_key] if x is not None]
             if keys == set(index_key_names) or one_key == index.partition_key:
-                return IndexLookup(
-                    self.table_name,
-                    f'{"-".join(index_key_names)}-index',
-                    key_data,
-                    index.sort_key)
+                return IndexLookup(self.table_name, f'{"-".join(index_key_names)}-index', key_data, index.sort_key)
 
         if len(keys) != 1:
-            raise RuntimeError(f'Getting key data: {key_data}, but expecting: {table_keys}')
+            raise RuntimeError(f"Getting key data: {key_data}, but expecting: {table_keys}")
 
         # If the one key matches the partition key, it must be because we also have a
         # sort key, but that's allowed because we are looking for 'many' records.
         if one_key == self.partition_key:
             if not many:
-                raise RuntimeError(f'Looking up one value, but missing sort key: {self.sort_key} in {key_data}')
+                raise RuntimeError(f"Looking up one value, but missing sort key: {self.sort_key} in {key_data}")
             return TableLookup(self.table_name, key_data)
 
-        raise RuntimeError(f'Field not partition key or index: {one_key}')
+        raise RuntimeError(f"Field not partition key or index: {one_key}")
 
     def _extract_key(self, data):
         """
@@ -247,16 +271,17 @@ class Table:
         if self.sort_key and self.sort_key not in data:
             raise RuntimeError(f"Sort key '{self.sort_key}' missing from data: {data}")
 
-        return { k: data[k] for k in self._key_names() }
+        return {k: data[k] for k in self._key_names()}
 
     def _key_names(self):
         return set(x for x in [self.partition_key, self.sort_key] if x is not None)
 
     def _validate_key(self, key):
         if key.keys() != self._key_names():
-            raise RuntimeError(f'key fields incorrect: {key} != {self._key_names()}')
+            raise RuntimeError(f"key fields incorrect: {key} != {self._key_names()}")
         if any(not v for v in key.values()):
-            raise RuntimeError(f'key fields cannot be empty: {key}')
+            raise RuntimeError(f"key fields cannot be empty: {key}")
+
 
 DDB_SERIALIZER = TypeSerializer()
 DDB_DESERIALIZER = TypeDeserializer()
@@ -266,9 +291,9 @@ class AwsDynamoStorage(TableStorage):
     @staticmethod
     def from_env():
         # If we have AWS credentials, use the real DynamoDB
-        if os.getenv('AWS_ACCESS_KEY_ID'):
-            db = boto3.client ('dynamodb', region_name = config ['dynamodb'] ['region'])
-            db_prefix = os.getenv ('AWS_DYNAMODB_TABLE_PREFIX', '')
+        if os.getenv("AWS_ACCESS_KEY_ID"):
+            db = boto3.client("dynamodb", region_name=config["dynamodb"]["region"])
+            db_prefix = os.getenv("AWS_DYNAMODB_TABLE_PREFIX", "")
             return AwsDynamoStorage(db, db_prefix)
         return None
 
@@ -277,41 +302,49 @@ class AwsDynamoStorage(TableStorage):
         self.db_prefix = db_prefix
 
     def get_item(self, table_name, key):
-        result = self.db.get_item(
-            TableName=make_table_name(self.db_prefix, table_name),
-            Key = self._encode(key))
-        return self._decode(result.get('Item', None))
+        result = self.db.get_item(TableName=make_table_name(self.db_prefix, table_name), Key=self._encode(key))
+        return self._decode(result.get("Item", None))
 
     def query(self, table_name, key, sort_key, reverse, limit, pagination_token):
         key_expression, attr_values, attr_names = self._prep_query_data(key, sort_key)
-        result = self.db.query(**notnone(
-            TableName=make_table_name(self.db_prefix, table_name),
-            KeyConditionExpression=key_expression,
-            ExpressionAttributeValues=attr_values,
-            ScanIndexForward=not reverse,
-            ExpressionAttributeNames=attr_names,
-            Limit=limit,
-            ExclusiveStartKey=self._encode(pagination_token) if pagination_token else None))
+        result = self.db.query(
+            **notnone(
+                TableName=make_table_name(self.db_prefix, table_name),
+                KeyConditionExpression=key_expression,
+                ExpressionAttributeValues=attr_values,
+                ScanIndexForward=not reverse,
+                ExpressionAttributeNames=attr_names,
+                Limit=limit,
+                ExclusiveStartKey=self._encode(pagination_token) if pagination_token else None,
+            )
+        )
 
-        items = [self._decode(x) for x in result.get('Items', [])]
-        next_page_token = self._decode(result.get('LastEvaluatedKey', None)) if result.get('LastEvaluatedKey', None) else None
+        items = [self._decode(x) for x in result.get("Items", [])]
+        next_page_token = (
+            self._decode(result.get("LastEvaluatedKey", None)) if result.get("LastEvaluatedKey", None) else None
+        )
         return items, next_page_token
 
     def query_index(self, table_name, index_name, keys, sort_key, reverse=False, limit=None, pagination_token=None):
         key_expression, attr_values, attr_names = self._prep_query_data(keys, sort_key)
 
-        result = self.db.query(**notnone(
-            TableName=make_table_name(self.db_prefix, table_name),
-            IndexName=index_name,
-            KeyConditionExpression=key_expression,
-            ExpressionAttributeValues=attr_values,
-            ScanIndexForward=not reverse,
-            ExpressionAttributeNames=attr_names,
-            Limit=limit,
-            ExclusiveStartKey=self._encode(pagination_token) if pagination_token else None))
+        result = self.db.query(
+            **notnone(
+                TableName=make_table_name(self.db_prefix, table_name),
+                IndexName=index_name,
+                KeyConditionExpression=key_expression,
+                ExpressionAttributeValues=attr_values,
+                ScanIndexForward=not reverse,
+                ExpressionAttributeNames=attr_names,
+                Limit=limit,
+                ExclusiveStartKey=self._encode(pagination_token) if pagination_token else None,
+            )
+        )
 
-        items = [self._decode(x) for x in result.get('Items', [])]
-        next_page_token = self._decode(result.get('LastEvaluatedKey', None)) if result.get('LastEvaluatedKey', None) else None
+        items = [self._decode(x) for x in result.get("Items", [])]
+        next_page_token = (
+            self._decode(result.get("LastEvaluatedKey", None)) if result.get("LastEvaluatedKey", None) else None
+        )
         return items, next_page_token
 
     def _prep_query_data(self, key, sort_key=None):
@@ -322,22 +355,21 @@ class AwsDynamoStorage(TableStorage):
         # with fields called 'level' etc: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ReservedWords.html
         # This escapes too much, but at least it's easy.
 
-        key_expression = ' AND '.join(
-            [f'#{field} = :{field}' for field in eq_conditions.keys()] +
-            [cond.to_dynamo_expression(field) for field, cond in special_conditions.items()])
+        key_expression = " AND ".join(
+            [f"#{field} = :{field}" for field in eq_conditions.keys()]
+            + [cond.to_dynamo_expression(field) for field, cond in special_conditions.items()]
+        )
 
-        attr_values = {f':{field}': DDB_SERIALIZER.serialize(key[field]) for field in eq_conditions.keys()}
+        attr_values = {f":{field}": DDB_SERIALIZER.serialize(key[field]) for field in eq_conditions.keys()}
         for field, cond in special_conditions.items():
             attr_values.update(cond.to_dynamo_values(field))
 
-        attr_names = {'#' + field: field for field in key.keys()}
+        attr_names = {"#" + field: field for field in key.keys()}
 
         return key_expression, attr_values, attr_names
 
     def put(self, table_name, _key, data):
-        return self.db.put_item(
-            TableName=make_table_name(self.db_prefix, table_name),
-            Item = self._encode(data))
+        return self.db.put_item(TableName=make_table_name(self.db_prefix, table_name), Item=self._encode(data))
 
     def update(self, table_name, key, updates):
         value_updates = {k: v for k, v in updates.items() if not isinstance(v, DynamoUpdate)}
@@ -345,44 +377,48 @@ class AwsDynamoStorage(TableStorage):
 
         return self.db.update_item(
             TableName=make_table_name(self.db_prefix, table_name),
-            Key = self._encode(key),
-            AttributeUpdates = {
+            Key=self._encode(key),
+            AttributeUpdates={
                 **self._encode_updates(value_updates),
                 **special_updates,
-            })
+            },
+        )
 
     def delete(self, table_name, key):
-        return self.db.delete_item(
-            TableName=make_table_name(self.db_prefix, table_name),
-            Key = self._encode(key))
+        return self.db.delete_item(TableName=make_table_name(self.db_prefix, table_name), Key=self._encode(key))
 
     def item_count(self, table_name):
-        result = self.db.describe_table (
-            TableName=make_table_name(self.db_prefix, table_name))
-        return result['Table']['ItemCount']
+        result = self.db.describe_table(TableName=make_table_name(self.db_prefix, table_name))
+        return result["Table"]["ItemCount"]
 
     def scan(self, table_name, limit, pagination_token):
-        result = self.db.scan(**notnone(
-            TableName=make_table_name(self.db_prefix, table_name),
-            Limit=limit,
-            ExclusiveStartKey=self._encode(pagination_token) if pagination_token else None))
-        items = [self._decode(x) for x in result.get('Items', [])]
-        next_page_token = self._decode(result.get('LastEvaluatedKey', None)) if result.get('LastEvaluatedKey', None) else None
+        result = self.db.scan(
+            **notnone(
+                TableName=make_table_name(self.db_prefix, table_name),
+                Limit=limit,
+                ExclusiveStartKey=self._encode(pagination_token) if pagination_token else None,
+            )
+        )
+        items = [self._decode(x) for x in result.get("Items", [])]
+        next_page_token = (
+            self._decode(result.get("LastEvaluatedKey", None)) if result.get("LastEvaluatedKey", None) else None
+        )
         return items, next_page_token
 
-    def _encode (self, data):
+    def _encode(self, data):
         return {k: DDB_SERIALIZER.serialize(v) for k, v in data.items()}
 
-    def _encode_updates (self, data):
+    def _encode_updates(self, data):
         def encode_update(value):
             # None is special, we use it to remove a field from a record
             if value is None:
-                return {'Action': 'DELETE'}
+                return {"Action": "DELETE"}
             else:
-                return {'Value': DDB_SERIALIZER.serialize(value)}
+                return {"Value": DDB_SERIALIZER.serialize(value)}
+
         return {k: encode_update(v) for k, v in data.items()}
 
-    def _decode (self, data):
+    def _decode(self, data):
         if data is None:
             return None
 
@@ -398,7 +434,9 @@ class Lock:
         def _wrapper(*args, **kwargs):
             with self.lock:
                 return fn(*args, **kwargs)
+
         return _wrapper
+
 
 lock = Lock()
 
@@ -415,12 +453,14 @@ class MemoryStorage(TableStorage):
 
         if filename:
             try:
-                with open(filename, 'r', encoding='utf-8') as f:
+                with open(filename, "r", encoding="utf-8") as f:
                     self.tables = json.load(f, object_hook=CustomEncoder.decode_object)
             except IOError:
                 pass
             except json.decoder.JSONDecodeError as e:
-                logging.warning(f'Error loading {filename}. The next write operation will overwrite the database with a clean copy: {e}')
+                logging.warning(
+                    f"Error loading {filename}. The next write operation will overwrite the database with a clean copy: {e}"
+                )
 
     # NOTE: on purpose not @synchronized here
     def get_item(self, table_name, key):
@@ -443,9 +483,9 @@ class MemoryStorage(TableStorage):
 
         # Pagination token
         def extract_key(i, record):
-            ret = { k: record[k] for k in key.keys() }
+            ret = {k: record[k] for k in key.keys()}
             if sort_key is None:
-                ret['offset'] = i
+                ret["offset"] = i
             else:
                 ret[sort_key] = record[sort_key]
             return ret
@@ -473,7 +513,9 @@ class MemoryStorage(TableStorage):
 
     # NOTE: on purpose not @synchronized here
     def query_index(self, table_name, index_name, keys, sort_key, reverse=False, limit=None, pagination_token=None):
-        return self.query(table_name, keys, sort_key=sort_key, reverse=reverse, limit=limit, pagination_token=pagination_token)
+        return self.query(
+            table_name, keys, sort_key=sort_key, reverse=reverse, limit=limit, pagination_token=pagination_token
+        )
 
     @lock.synchronized
     def put(self, table_name, key, data):
@@ -501,25 +543,25 @@ class MemoryStorage(TableStorage):
                 elif isinstance(update, DynamoAddToStringSet):
                     existing = record.get(name, set())
                     if not isinstance(existing, set):
-                        raise TypeError(f'Expected a set in {name}, got: {existing}')
+                        raise TypeError(f"Expected a set in {name}, got: {existing}")
                     record[name] = existing | set(update.elements)
                 elif isinstance(update, DynamoRemoveFromStringSet):
                     existing = record.get(name, set())
                     if not isinstance(existing, set):
-                        raise TypeError(f'Expected a set in {name}, got: {existing}')
+                        raise TypeError(f"Expected a set in {name}, got: {existing}")
                     record[name] = existing - set(update.elements)
                 elif isinstance(update, DynamoAddToList):
                     existing = record.get(name, [])
                     if not isinstance(existing, list):
-                        raise TypeError(f'Expected a list in {name}, got: {existing}')
+                        raise TypeError(f"Expected a list in {name}, got: {existing}")
                     record[name] = existing + list(update.elements)
                 elif isinstance(update, DynamoAddToNumberSet):
                     existing = record.get(name, set())
                     if not isinstance(existing, set):
-                        raise TypeError(f'Expected a set in {name}, got: {existing}')
+                        raise TypeError(f"Expected a set in {name}, got: {existing}")
                     record[name] = existing | set(update.elements)
                 else:
-                    raise RuntimeError(f'Unsupported update type for in-memory database: {update}')
+                    raise RuntimeError(f"Unsupported update type for in-memory database: {update}")
             elif update is None:
                 if name in record:
                     del record[name]
@@ -550,12 +592,12 @@ class MemoryStorage(TableStorage):
 
         start_index = 0
         if pagination_token:
-            start_index = pagination_token['offset']
-            items = items[pagination_token['offset']:]
+            start_index = pagination_token["offset"]
+            items = items[pagination_token["offset"] :]
 
         next_page_token = None
         if limit and limit < len(items):
-            next_page_token = {'offset': start_index + limit}
+            next_page_token = {"offset": start_index + limit}
             items = items[:limit]
 
         items = copy.copy(items)
@@ -571,24 +613,28 @@ class MemoryStorage(TableStorage):
         return all(record.get(k) == v for k, v in key.items())
 
     def _query_matches(self, record, eq, conds):
-        return (all(record.get(k) == v for k, v in eq.items())
-            and all(cond.matches(record.get(k)) for k, cond in conds.items()))
+        return all(record.get(k) == v for k, v in eq.items()) and all(
+            cond.matches(record.get(k)) for k, cond in conds.items()
+        )
 
     def _flush(self):
         if self.filename:
             try:
-                with open(self.filename, 'w', encoding='utf-8') as f:
+                with open(self.filename, "w", encoding="utf-8") as f:
                     json.dump(self.tables, f, indent=2, cls=CustomEncoder)
             except IOError:
                 pass
 
+
 def first_or_none(xs):
     return xs[0] if xs else None
+
 
 @dataclass
 class TableLookup:
     table_name: str
     key: dict
+
 
 @dataclass
 class IndexLookup:
@@ -609,58 +655,64 @@ class DynamoIncrement(DynamoUpdate):
 
     def to_dynamo(self):
         return {
-                'Action': 'ADD',
-                'Value': { 'N': str(self.delta) },
-            }
+            "Action": "ADD",
+            "Value": {"N": str(self.delta)},
+        }
+
 
 class DynamoAddToStringSet(DynamoUpdate):
     """Add one or more elements to a string set."""
+
     def __init__(self, *elements):
         self.elements = elements
 
     def to_dynamo(self):
         return {
-                'Action': 'ADD',
-                'Value': { 'SS': list(self.elements) },
-            }
+            "Action": "ADD",
+            "Value": {"SS": list(self.elements)},
+        }
+
 
 class DynamoAddToNumberSet(DynamoUpdate):
     """Add one or more elements to a number set."""
+
     def __init__(self, *elements):
         for el in elements:
             if not isinstance(el, numbers.Real):
-                raise ValueError(f'Must be a number, got: {el}')
+                raise ValueError(f"Must be a number, got: {el}")
         self.elements = elements
 
     def to_dynamo(self):
         return {
-                'Action': 'ADD',
-                'Value': { 'NS': [str(x) for x in self.elements] },
-            }
+            "Action": "ADD",
+            "Value": {"NS": [str(x) for x in self.elements]},
+        }
 
 
 class DynamoAddToList(DynamoUpdate):
     """Add one or more elements to a list."""
+
     def __init__(self, *elements):
         self.elements = elements
 
     def to_dynamo(self):
         return {
-                'Action': 'ADD',
-                'Value': { 'L': [DDB_SERIALIZER.serialize(x) for x in self.elements] },
-            }
+            "Action": "ADD",
+            "Value": {"L": [DDB_SERIALIZER.serialize(x) for x in self.elements]},
+        }
 
 
 class DynamoRemoveFromStringSet(DynamoUpdate):
     """Remove one or more elements to a string set."""
+
     def __init__(self, *elements):
         self.elements = elements
 
     def to_dynamo(self):
         return {
-                'Action': 'DELETE',
-                'Value': { 'SS': list(self.elements) },
-            }
+            "Action": "DELETE",
+            "Value": {"SS": list(self.elements)},
+        }
 
 
 class DynamoCondition:
@@ -670,6 +722,7 @@ class DynamoCondition:
 
     Conditions only apply to sort keys.
     """
+
     def to_dynamo_expression(self, _field_name):
         """Render expression part of Dynamo query."""
         raise NotImplementedError()
@@ -690,8 +743,8 @@ class DynamoCondition:
         NOT of type DynamoCondition. The other one will contain all the elements
         for which the value ARE DynamoConditions.
         """
-        eq_conditions = { k: v for k, v in key.items() if not isinstance(v, DynamoCondition) }
-        special_conditions = { k: v for k, v in key.items() if isinstance(v, DynamoCondition) }
+        eq_conditions = {k: v for k, v in key.items() if not isinstance(v, DynamoCondition)}
+        special_conditions = {k: v for k, v in key.items() if isinstance(v, DynamoCondition)}
 
         return (eq_conditions, special_conditions)
 
@@ -704,12 +757,12 @@ class Between(DynamoCondition):
         self.maxval = maxval
 
     def to_dynamo_expression(self, field_name):
-        return f'#{field_name} BETWEEN :{field_name}_min AND :{field_name}_max'
+        return f"#{field_name} BETWEEN :{field_name}_min AND :{field_name}_max"
 
     def to_dynamo_values(self, field_name):
         return {
-            f':{field_name}_min': DDB_SERIALIZER.serialize(self.minval),
-            f':{field_name}_max': DDB_SERIALIZER.serialize(self.maxval),
+            f":{field_name}_min": DDB_SERIALIZER.serialize(self.minval),
+            f":{field_name}_max": DDB_SERIALIZER.serialize(self.maxval),
         }
 
     def matches(self, value):
@@ -744,36 +797,38 @@ def replace_decimals(obj):
 
 class CustomEncoder(json.JSONEncoder):
     """An encoder that serializes non-standard types like sets."""
+
     def default(self, obj):
         if isinstance(obj, set):
             return {"$type": "set", "elements": list(obj)}
         return json.JSONEncoder.default(self, obj)
 
-
     @staticmethod
     def decode_object(obj):
         """The decoding for the encoding above."""
-        if obj.get('$type') == 'set':
-            return set(obj['elements'])
+        if obj.get("$type") == "set":
+            return set(obj["elements"])
         return obj
 
 
 def validate_only_sort_key(conds, sort_key):
     """Check that only the sort key is used in the given key conditions."""
     if sort_key and set(conds.keys()) - {sort_key}:
-        raise RuntimeError(f'Conditions only allowed on sort key {sort_key}, got: {list(conds)}')
+        raise RuntimeError(f"Conditions only allowed on sort key {sort_key}, got: {list(conds)}")
 
 
 def encode_page_token(x):
     """Encode a compound key page token (dict) to a string."""
-    if x is None: return None
-    return base64.urlsafe_b64encode(json.dumps(x).encode('utf-8')).decode('ascii')
+    if x is None:
+        return None
+    return base64.urlsafe_b64encode(json.dumps(x).encode("utf-8")).decode("ascii")
 
 
 def decode_page_token(x):
     """Decode string page token to compound key (dict)."""
-    if x is None: return None
-    return json.loads(base64.urlsafe_b64decode(x.encode('ascii')).decode('utf-8'))
+    if x is None:
+        return None
+    return json.loads(base64.urlsafe_b64decode(x.encode("ascii")).decode("utf-8"))
 
 
 def notnone(**kwargs):
@@ -781,4 +836,4 @@ def notnone(**kwargs):
 
 
 def make_table_name(prefix, name):
-    return f'{prefix}-{name}' if prefix else name
+    return f"{prefix}-{name}" if prefix else name

--- a/website/for_teachers.py
+++ b/website/for_teachers.py
@@ -1,0 +1,403 @@
+import json
+from flask_babel import gettext
+import hedy
+import hedyweb
+from .achievements import Achievements
+from website.auth import requires_login, is_teacher, is_admin, current_user, validate_student_signup_data, store_new_student_account
+import utils
+import uuid
+from flask import g, request, jsonify, session
+from flask_helpers import render_template
+import os
+import hedy_content
+from .database import Database
+from .website_module import WebsiteModule, route
+
+class ForTeachersModule(WebsiteModule):
+    def __init__(self, db: Database, achievements: Achievements):
+        super().__init__('teachers', __name__, url_prefix='/for-teachers')
+        self.db = db
+        self.achievements = achievements
+
+    @route('/', methods=['GET'])
+    @requires_login
+    def for_teachers_page(self, user):
+        if not is_teacher(user):
+            return utils.error_page(error=403, ui_message=gettext('not_teacher'))
+
+        welcome_teacher = session.get('welcome-teacher') or False
+        session.pop('welcome-teacher', None)
+
+        teacher_classes = self.db.get_teacher_classes(current_user()['username'], True)
+        adventures = []
+        for adventure in self.db.get_teacher_adventures(current_user()['username']):
+            adventures.append(
+                {'id': adventure.get('id'),
+                 'name': adventure.get('name'),
+                 'date': utils.localized_date_format(adventure.get('date')),
+                 'level': adventure.get('level')
+                 }
+            )
+
+        return render_template('for-teachers.html', current_page='my-profile', page_title=gettext('title_for-teacher'),
+                               teacher_classes=teacher_classes,
+                               teacher_adventures=adventures, welcome_teacher=welcome_teacher)
+
+
+    @route('/manual', methods=['GET'])
+    @requires_login
+    def get_teacher_manual(self, user):
+        page_translations = hedyweb.PageTranslations('for-teachers').get_page_translations(g.lang)
+        return render_template('teacher-manual.html', current_page='my-profile', content=page_translations)
+
+    @route('/class/<class_id>', methods=['GET'])
+    @requires_login
+    def get_class(self, user, class_id):
+        if not is_teacher(user) and not is_admin(user):
+            return utils.error_page(error=403, ui_message=gettext('retrieve_class_error'))
+        Class = self.db.get_class(class_id)
+        if not Class or (Class['teacher'] != user['username'] and not is_admin(user)):
+            return utils.error_page(error=404, ui_message=gettext('no_such_class'))
+        students = []
+
+        for student_username in Class.get('students', []):
+            student = self.db.user_by_username(student_username)
+            programs = self.db.programs_for_user(student_username)
+            highest_level = max(program['level'] for program in programs) if len(programs) else 0
+            students.append({
+                'username': student_username,
+                'last_login': student['last_login'],
+                'programs': len(programs),
+                'highest_level': highest_level
+            })
+
+        # Sort the students by their last login
+        students = sorted(students, key=lambda d: d.get('last_login', 0), reverse=True)
+        # After sorting: replace the number value by a string format date
+        for student in students:
+            student['last_login'] = utils.localized_date_format(student.get('last_login', 0))
+
+        if utils.is_testing_request(request):
+            return jsonify({'students': students, 'link': Class['link'], 'name': Class['name'], 'id': Class['id']})
+
+        achievement = None
+        if len(students) > 20:
+            achievement = self.achievements.add_single_achievement(user['username'], "full_house")
+        if achievement:
+            achievement = json.dumps(achievement)
+
+        invites = []
+        for invite in self.db.get_class_invites(Class['id']):
+            invites.append({'username': invite['username'],
+                            'timestamp': utils.localized_date_format(invite['timestamp'], short_format=True),
+                            'expire_timestamp': utils.localized_date_format(invite['ttl'], short_format=True)})
+
+        return render_template('class-overview.html', current_page='my-profile',
+                                page_title=gettext('title_class-overview'),
+                                achievement=achievement, invites=invites,
+                                class_info={'students': students, 'link': os.getenv('BASE_URL') + '/hedy/l/' + Class['link'],
+                                            'teacher': Class['teacher'], 'name': Class['name'], 'id': Class['id']})
+
+    @route('/customize-class/<class_id>', methods=['GET'])
+    @requires_login
+    def get_class_info(self, user, class_id):
+        if not is_teacher(user) and not is_admin(user):
+            return utils.error_page(error=403, ui_message=gettext('retrieve_class_error'))
+        Class = self.db.get_class(class_id)
+        if not Class or (Class['teacher'] != user['username'] and not is_admin(user)):
+            return utils.error_page(error=404, ui_message=gettext('no_such_class'))
+
+        if hedy_content.Adventures(g.lang).has_adventures():
+            adventures = hedy_content.Adventures(g.lang).get_adventure_keyname_name_levels()
+        else:
+            adventures = hedy_content.Adventures("en").get_adventure_keyname_name_levels()
+
+        teacher_adventures = self.db.get_teacher_adventures(user['username'])
+        customizations = self.db.get_class_customizations(class_id)
+
+        return render_template('customize-class.html', page_title=gettext('title_customize-class'),
+                               class_info={'name': Class['name'], 'id': Class['id']}, max_level=hedy.HEDY_MAX_LEVEL,
+                               adventures=adventures, teacher_adventures=teacher_adventures,
+                               customizations=customizations, current_page='my-profile')
+
+    @route('/customize-class/<class_id>', methods=['DELETE'])
+    @requires_login
+    def delete_customizations(self, user, class_id):
+        if not is_teacher(user):
+            return utils.error_page(error=403, ui_message=gettext('retrieve_class_error'))
+        Class = self.db.get_class(class_id)
+        if not Class or Class['teacher'] != user['username']:
+            return utils.error_page(error=404, ui_message=gettext('no_such_class'))
+
+        self.db.delete_class_customizations(class_id)
+        return {'success': gettext('customization_deleted')}, 200
+
+    @route('/customize-class/<class_id>', methods=['POST'])
+    @requires_login
+    def update_customizations(self, user, class_id):
+        if not is_teacher(user):
+            return utils.error_page(error=403, ui_message=gettext('retrieve_class_error'))
+        Class = self.db.get_class(class_id)
+        if not Class or Class['teacher'] != user['username']:
+            return utils.error_page(error=404, ui_message=gettext('no_such_class'))
+
+        body = request.json
+        # Validations
+        if not isinstance(body, dict):
+            return gettext('ajax_error'), 400
+        if not isinstance(body.get('levels'), list):
+            return "Levels must be a list", 400
+        if not isinstance(body.get('adventures'), dict):
+            return 'Adventures must be a dict', 400
+        if not isinstance(body.get('teacher_adventures'), list):
+            return 'Teacher adventures must be a list', 400
+        if not isinstance(body.get('other_settings'), list):
+            return 'Other settings must be a list', 400
+        if not isinstance(body.get('opening_dates'), dict):
+            return 'Opening dates must be a dict', 400
+
+        # Values are always strings from the front-end -> convert to numbers
+        levels = [int(i) for i in body['levels']]
+
+        opening_dates = body['opening_dates'].copy()
+        for level, timestamp in body.get('opening_dates').items():
+            if len(timestamp) < 1:
+                opening_dates.pop(level)
+            else:
+                try:
+                    opening_dates[level] = utils.datetotimeordate(timestamp)
+                except:
+                    return 'One or more of your opening dates is invalid', 400
+
+        adventures = {}
+        for name, adventure_levels in body['adventures'].items():
+            adventures[name] = [int(i) for i in adventure_levels]
+
+        customizations = {
+            'id': class_id,
+            'levels': levels,
+            'opening_dates': opening_dates,
+            'adventures': adventures,
+            'teacher_adventures': body['teacher_adventures'],
+            'other_settings': body['other_settings']
+        }
+
+        self.db.update_class_customizations(customizations)
+        return {'success': gettext('class_customize_success')}, 200
+
+    @route('/create-accounts/<class_id>', methods=['GET'])
+    @requires_login
+    def create_accounts(self, user, class_id):
+        if not is_teacher(user):
+            return utils.error_page(error=403, ui_message=gettext('not_teacher'))
+        current_class = self.db.get_class(class_id)
+        if not current_class or current_class.get('teacher') != user.get('username'):
+            return utils.error_page(error=403, ui_message=gettext('no_such_class'))
+
+        return render_template('create-accounts.html', current_class = current_class)
+
+    @route('/create-accounts', methods=['POST'])
+    @requires_login
+    def store_accounts(self, user):
+        if not is_teacher(user):
+            return utils.error_page(error=403, ui_message=gettext('not_teacher'))
+        body = request.json
+
+        # Validations
+        if not isinstance(body, dict):
+            return gettext('ajax_error'), 400
+        if not isinstance(body.get('accounts'), list):
+            return "accounts should be a list!", 400
+
+        if len(body.get('accounts', [])) < 1:
+            return gettext('no_accounts'), 400
+
+        usernames = []
+
+        # Validation for correct types and duplicates
+        for account in body.get('accounts', []):
+            validation = validate_student_signup_data(account)
+            if validation:
+                return validation, 400
+            if account.get('username').strip().lower() in usernames:
+                return {'error': gettext('unique_usernames'), 'value': account.get('username')}, 200
+            usernames.append(account.get('username').strip().lower())
+
+        # Validation for duplicates in the db
+        classes = self.db.get_teacher_classes(user['username'], False)
+        for account in body.get('accounts', []):
+            if account.get('class') and account['class'] not in [i.get('name') for i in classes]:
+                return "not your class", 404
+            if self.db.user_by_username(account.get('username').strip().lower()):
+                return {'error': gettext('usernames_exist'), 'value': account.get('username').strip().lower()}, 200
+
+        # Now -> actually store the users in the db
+        for account in body.get('accounts', []):
+            # Set the current teacher language and keyword language as new account language
+            account['language'] = g.lang
+            account['keyword_language'] = g.keyword_lang
+            store_new_student_account(self.db, account, user['username'])
+            if account.get('class'):
+                class_id = [i.get('id') for i in classes if i.get('name') == account.get('class')][0]
+                self.db.add_student_to_class(class_id, account.get('username').strip().lower())
+        return {'success': gettext('accounts_created')}, 200
+
+    @route('/customize-adventure/view/<adventure_id>', methods=['GET'])
+    @requires_login
+    def view_adventure(self, user, adventure_id):
+        if not is_teacher(user) and not is_admin(user):
+            return utils.error_page(error=403, ui_message=gettext('retrieve_adventure_error'))
+        adventure = self.db.get_adventure(adventure_id)
+        if not adventure:
+            return utils.error_page(error=404, ui_message=gettext('no_such_adventure'))
+        if adventure['creator'] != user['username'] and not is_admin(user):
+            return utils.error_page(error=403, ui_message=gettext('retrieve_adventure_error'))
+
+        # Add level to the <pre> tag to let syntax highlighting know which highlighting we need!
+        adventure['content'] = adventure['content'].replace("<pre>", "<pre class='no-copy-button' level='" + str(adventure['level']) + "'>")
+        adventure['content'] = adventure['content'].format(**hedy_content.KEYWORDS.get(g.keyword_lang))
+
+        return render_template('view-adventure.html', adventure=adventure,
+                               page_title=gettext('title_view-adventure'), current_page='my-profile')
+
+    @route('/customize-adventure/<adventure_id>', methods=['GET'])
+    @requires_login
+    def get_adventure_info(self, user, adventure_id):
+        if not is_teacher(user):
+            return utils.error_page(error=403, ui_message=gettext('retrieve_adventure_error'))
+        adventure = self.db.get_adventure(adventure_id)
+        if not adventure or adventure['creator'] != user['username']:
+            return utils.error_page(error=404, ui_message=gettext('no_such_adventure'))
+
+        # Now it gets a bit complex, we want to get the teacher classes as well as the customizations
+        # This is a quite expensive retrieval, but we should be fine as this page is not called often
+        # We only need the name, id and if it already has the adventure set as data to the front-end
+        Classes = self.db.get_teacher_classes(user['username'])
+        class_data = []
+        for Class in Classes:
+            temp = {'name': Class.get('name'), 'id': Class.get('id'), 'checked': False}
+            customizations = self.db.get_class_customizations(Class.get('id'))
+            if customizations and adventure_id in customizations.get('teacher_adventures', []):
+                temp['checked'] = True
+            class_data.append(temp)
+
+        return render_template('customize-adventure.html', page_title=gettext('title_customize-adventure'),
+                               adventure=adventure, class_data=class_data,
+                               max_level=hedy.HEDY_MAX_LEVEL, current_page='my-profile')
+
+    @route('/customize-adventure', methods=['POST'])
+    @requires_login
+    def update_adventure(self, user):
+        body = request.json
+        # Validations
+        if not isinstance(body, dict):
+            return gettext('ajax_error'), 400
+        if not isinstance(body.get('id'), str):
+            return gettext('adventure_id_invalid'), 400
+        if not isinstance(body.get('name'), str):
+            return gettext('adventure_name_invalid'), 400
+        if not isinstance(body.get('level'), str):
+            return gettext('level_invalid'), 400
+        if not isinstance(body.get('content'), str):
+            return gettext('content_invalid'), 400
+        if len(body.get('content')) < 20:
+            return gettext('adventure_length'), 400
+        if not isinstance(body.get('public'), bool):
+            return gettext('public_invalid'), 400
+        if not isinstance(body.get('classes'), list):
+            return gettext('classes_invalid'), 400
+
+        if not is_teacher(user):
+            return utils.error_page(error=403, ui_message=gettext('retrieve_adventure_error'))
+        current_adventure = self.db.get_adventure(body['id'])
+        if not current_adventure or current_adventure['creator'] != user['username']:
+            return utils.error_page(error=404, ui_message=gettext('no_such_adventure'))
+
+        adventures = self.db.get_teacher_adventures(user['username'])
+        for adventure in adventures:
+            if adventure['name'] == body['name'] and adventure['id'] != body['id']:
+                return gettext('adventure_duplicate'), 400
+
+        # We want to make sure the adventure is valid and only contains correct placeholders
+        # Try to parse with our current language, if it fails -> return an error to the user
+        try:
+            body['content'].format(**hedy_content.KEYWORDS.get(g.keyword_lang))
+        except:
+            return gettext('something_went_wrong_keyword_parsing'), 400
+
+        adventure = {
+            'date': utils.timems(),
+            'creator': user['username'],
+            'name': body['name'],
+            'level': body['level'],
+            'content': body['content'],
+            'public': body['public']
+        }
+
+        self.db.update_adventure(body['id'], adventure)
+
+        # Once the adventure is correctly stored we have to update all class customizations
+        # This is once again an expensive operation, we have to retrieve all teacher customizations
+        # Then check if something is changed with the current situation, if so -> update in database
+        Classes = self.db.get_teacher_classes(user['username'])
+        for Class in Classes:
+            # If so, the adventure should be in the class
+            if Class.get('id') in body.get('classes', []):
+                self.db.add_adventure_to_class_customizations(Class.get('id'), body.get('id'))
+            else:
+                self.db.remove_adventure_from_class_customizations(Class.get('id'), body.get('id'))
+
+        return {'success': gettext('adventure_updated')}, 200
+
+    @route('/customize-adventure/<adventure_id>', methods=['DELETE'])
+    @requires_login
+    def delete_adventure(self, user, adventure_id):
+        if not is_teacher(user):
+            return utils.error_page(error=403, ui_message=gettext('retrieve_adventure_error'))
+        adventure = self.db.get_adventure(adventure_id)
+        if not adventure or adventure['creator'] != user['username']:
+            return utils.error_page(error=404, ui_message=gettext('no_such_adventure'))
+
+        self.db.delete_adventure(adventure_id)
+        return {}, 200
+
+    @route('/preview-adventure', methods=['POST'])
+    def parse_preview_adventure(self):
+        body = request.json
+        try:
+            code = body.get('code').format(**hedy_content.KEYWORDS.get(g.keyword_lang))
+        except:
+            return gettext('something_went_wrong_keyword_parsing'), 400
+        return {'code': code}, 200
+
+    @route('/create_adventure', methods=['POST'])
+    @requires_login
+    def create_adventure(self, user):
+        if not is_teacher(user):
+            return utils.error_page(error=403, ui_message=gettext('create_adventure'))
+
+        body = request.json
+        # Validations
+        if not isinstance(body, dict):
+            return gettext('ajax_error'), 400
+        if not isinstance(body.get('name'), str):
+            return gettext('adventure_name_invalid'), 400
+        if len(body.get('name')) < 1:
+            return gettext('adventure_empty'), 400
+
+        adventures = self.db.get_teacher_adventures(user['username'])
+        for adventure in adventures:
+            if adventure['name'] == body['name']:
+                return gettext('adventure_duplicate'), 400
+
+        adventure = {
+            'id': uuid.uuid4().hex,
+            'date': utils.timems(),
+            'creator': user['username'],
+            'name': body['name'],
+            'level': 1,
+            'content': ""
+        }
+
+        self.db.store_adventure(adventure)
+        return {'id': adventure['id']}, 200

--- a/website/jsonbin.py
+++ b/website/jsonbin.py
@@ -8,7 +8,8 @@ import logging
 from . import log_queue
 from . import aws_helpers
 
-logger = logging.getLogger('jsonbin')
+logger = logging.getLogger("jsonbin")
+
 
 class JsonBinLogger:
     """Logger for jsonbin.io
@@ -21,11 +22,11 @@ class JsonBinLogger:
     @staticmethod
     def from_env_vars():
         """Create a new JsonBinLogger using standard environment variables."""
-        key = os.getenv('JSONBIN_SECRET_KEY')
-        collection = os.getenv('JSONBIN_COLLECTION_ID')
+        key = os.getenv("JSONBIN_SECRET_KEY")
+        collection = os.getenv("JSONBIN_COLLECTION_ID")
 
         if key is None or collection is None:
-            logger.warn('Set JSONBIN_SECRET_KEY and JSONBIN_COLLECTION_ID if you want to log (disabled for now)')
+            logger.warn("Set JSONBIN_SECRET_KEY and JSONBIN_COLLECTION_ID if you want to log (disabled for now)")
             return NullJsonbinLogger()
         return JsonBinLogger(key, collection)
 
@@ -34,7 +35,7 @@ class JsonBinLogger:
         self.collection_id = collection_id
         self.queue = queue.Queue()
 
-        self.thread = threading.Thread(target=self._run, daemon=True, name='jsonbin_logger')
+        self.thread = threading.Thread(target=self._run, daemon=True, name="jsonbin_logger")
         self.thread.start()
 
     def log(self, obj):
@@ -44,43 +45,49 @@ class JsonBinLogger:
         # Let's start off by printing warnings. If this turns out to be an
         # issue in the future, we might start dropping work.
         if self.queue.qsize() > 20:
-            logger.warn(f'jsonbin logging queue is backing up, contains {self.queue.qsize()} items')
+            logger.warn(f"jsonbin logging queue is backing up, contains {self.queue.qsize()} items")
 
     def _run(self):
-        logger.debug('jsonbin logger started')
+        logger.debug("jsonbin logger started")
         while True:
             obj = self.queue.get()
 
             try:
-                response = requests.post('https://api.jsonbin.io/v3/b', json=obj, headers={
-                    'Content-Type': 'application/json',
-                    'X-Master-Key': self.secret_key,
-                    'X-Collection-Id': self.collection_id,
-                })
+                response = requests.post(
+                    "https://api.jsonbin.io/v3/b",
+                    json=obj,
+                    headers={
+                        "Content-Type": "application/json",
+                        "X-Master-Key": self.secret_key,
+                        "X-Collection-Id": self.collection_id,
+                    },
+                )
 
                 # Try to read the response as JSON
                 try:
                     resp = json.loads(response.text)
 
                     if response.status_code == 200:
-                        logger.info('Posted to jsonbin')
+                        logger.info("Posted to jsonbin")
                     else:
                         logger.warning(f'Posting to jsonbin failed: {response.status_code} {resp["message"]}')
                 except Exception:
                     # Not JSON or no success field
-                    logger.exception(f'Posting to jsonbin failed: {response.text}')
+                    logger.exception(f"Posting to jsonbin failed: {response.text}")
             except Exception:
-                logger.exception(f'Error posting to jsonbin.')
+                logger.exception(f"Error posting to jsonbin.")
 
 
-class NullJsonbinLogger():
+class NullJsonbinLogger:
     """A jsonbin logger that doesn't actually do anything."""
+
     def log(self, obj):
         pass
 
 
-class MultiParseLogger():
+class MultiParseLogger:
     """A logger that forwards to other loggers."""
+
     def __init__(self, *loggers):
         self.loggers = loggers
 
@@ -89,13 +96,14 @@ class MultiParseLogger():
             logger.log(obj)
 
 
-class S3ParseLogger():
+class S3ParseLogger:
     """A logger that logs to S3.
 
     - Well then why is it in a file called 'jsonbin.py'?
 
     - Legacy, young grasshopper. Legacy.
     """
+
     @staticmethod
     def from_env_vars():
         transmitter = aws_helpers.s3_parselog_transmitter_from_env()
@@ -109,8 +117,9 @@ class S3ParseLogger():
         S3_LOG_QUEUE.add(obj)
 
 
-S3_LOG_QUEUE = log_queue.LogQueue('parse', batch_window_s=300)
+S3_LOG_QUEUE = log_queue.LogQueue("parse", batch_window_s=300)
 S3_LOG_QUEUE.try_load_emergency_saves()
+
 
 def emergency_shutdown():
     """The process is being killed. Do whatever needs to be done to save the logs."""

--- a/website/log_fetcher.py
+++ b/website/log_fetcher.py
@@ -10,18 +10,18 @@ def _get_value(filters, name, default):
     return f"'{filters.get(name, default) or default}'"
 
 
-QueryResult = namedtuple('QueryResult', ['id', 'status'])
+QueryResult = namedtuple("QueryResult", ["id", "status"])
 
 
 class AwsAthenaClient:
     @staticmethod
     def from_env():
-        if os.getenv('AWS_ACCESS_KEY_ID'):
-            db = boto3.client('athena', region_name=config['athena']['region'])
-            database = config['athena']['database']
-            s3_output = config['athena']['s3_output']
+        if os.getenv("AWS_ACCESS_KEY_ID"):
+            db = boto3.client("athena", region_name=config["athena"]["region"])
+            database = config["athena"]["database"]
+            s3_output = config["athena"]["s3_output"]
             return AwsAthenaClient(db, database, s3_output)
-        logging.warning('Unable to initialize Athena client (missing AWS_ACCESS_KEY_ID or AWS_SECRET_ACCESS_KEY)')
+        logging.warning("Unable to initialize Athena client (missing AWS_ACCESS_KEY_ID or AWS_SECRET_ACCESS_KEY)")
         return None
 
     def __init__(self, client, database, s3_output):
@@ -32,25 +32,26 @@ class AwsAthenaClient:
     @retry(stop_max_attempt_number=5, wait_exponential_multiplier=1000, wait_exponential_max=10 * 1000)
     def poll_query_status(self, query_execution_id):
         result = self.client.get_query_execution(QueryExecutionId=query_execution_id)
-        state = result['QueryExecution']['Status']['State']
-        if state == 'SUCCEEDED':
+        state = result["QueryExecution"]["Status"]["State"]
+        if state == "SUCCEEDED":
             return result
-        if state == 'FAILED':
+        if state == "FAILED":
             return result
         raise Exception
 
     def start_query(self, query):
         response = self.client.start_query_execution(
             QueryString=query,
-            QueryExecutionContext={'Database': self.database},
-            ResultConfiguration={'OutputLocation': self.s3_output})
+            QueryExecutionContext={"Database": self.database},
+            ResultConfiguration={"OutputLocation": self.s3_output},
+        )
 
-        return response['QueryExecutionId']
+        return response["QueryExecutionId"]
 
     def get_query_results(self, query_execution_id, next_token=None, max_results=50):
-        params = {'QueryExecutionId': query_execution_id, 'MaxResults': max_results}
+        params = {"QueryExecutionId": query_execution_id, "MaxResults": max_results}
         if next_token:
-            params['NextToken'] = next_token
+            params["NextToken"] = next_token
 
         return self.client.get_query_results(**params)
 
@@ -64,24 +65,24 @@ class LogFetcher:
         query_exec_id = self.client.start_query(query)
         query_status = self.client.poll_query_status(query_exec_id)
 
-        return QueryResult(query_exec_id, query_status['QueryExecution']['Status']['State'])
+        return QueryResult(query_exec_id, query_status["QueryExecution"]["Status"]["State"])
 
     def get_query_results(self, query_execution_id, next_token=None):
-        max_results = config['athena']['max_results']
+        max_results = config["athena"]["max_results"]
         data = self.client.get_query_results(query_execution_id, next_token, max_results)
-        return self._result_to_response(data, next_token is None), data.get('NextToken')
+        return self._result_to_response(data, next_token is None), data.get("NextToken")
 
     def _build_query(self, filters):
         # For now we use a pre-created Athena prepared statement, re-evaluate after feedback about the query options
         filters_with_values = {k: v for k, v in filters.items() if v is not None}
 
-        start = _get_value(filters_with_values, 'start', '2022-01-01')
-        end = _get_value(filters_with_values, 'end', '2099-12-31')
-        exception = _get_value(filters_with_values, 'exception', '%')
-        level = _get_value(filters_with_values, 'level', '%')
-        username = _get_value(filters_with_values, 'username', '%')
+        start = _get_value(filters_with_values, "start", "2022-01-01")
+        end = _get_value(filters_with_values, "end", "2099-12-31")
+        exception = _get_value(filters_with_values, "exception", "%")
+        level = _get_value(filters_with_values, "level", "%")
+        username = _get_value(filters_with_values, "username", "%")
 
-        prep_statement = config['athena']['prepare_statement']
+        prep_statement = config["athena"]["prepare_statement"]
         return f"EXECUTE {prep_statement} USING {start}, {end}, {exception}, {level}, {username};"
 
     def _result_to_response(self, data, is_first_batch):
@@ -93,21 +94,24 @@ class LogFetcher:
 
     def _get_rows_and_headers(self, data):
         try:
-            data_rows = data['ResultSet']['Rows']
-            rows = [r.get('Data') for r in data_rows if r.get('Data')]
-            data_columns = data['ResultSet']['ResultSetMetadata']['ColumnInfo']
-            headers = [c['Name'] for c in data_columns]
+            data_rows = data["ResultSet"]["Rows"]
+            rows = [r.get("Data") for r in data_rows if r.get("Data")]
+            data_columns = data["ResultSet"]["ResultSetMetadata"]["ColumnInfo"]
+            headers = [c["Name"] for c in data_columns]
             return headers, rows
         except KeyError or TypeError:
             return [], []
 
     def _to_row_response(self, headers, data):
-        row = [d.get('VarCharValue') for d in data]
-        return {} if len(row) != len(headers) else \
-            {headers[i]: self._format_if_date(headers[i], row[i]) for i in range(0, len(headers))}
+        row = [d.get("VarCharValue") for d in data]
+        return (
+            {}
+            if len(row) != len(headers)
+            else {headers[i]: self._format_if_date(headers[i], row[i]) for i in range(0, len(headers))}
+        )
 
     def _format_if_date(self, header, value):
-        return value.split('.')[0] if header == 'date' else value
+        return value.split(".")[0] if header == "date" else value
 
 
 athena_client = AwsAthenaClient.from_env()

--- a/website/parsons.py
+++ b/website/parsons.py
@@ -14,10 +14,10 @@ def routes(app, database, achievements, parsons):
     ACHIEVEMENTS = achievements
     PARSONS = parsons
 
-    @app.route('/parsons/get-exercise/<int:level>/<int:exercise>', methods=['GET'])
+    @app.route("/parsons/get-exercise/<int:level>/<int:exercise>", methods=["GET"])
     def get_parsons_exercise(level, exercise):
         if exercise > PARSONS[g.lang].get_highest_exercise_level(level) or exercise < 1:
-            return gettext('exercise_doesnt_exist'), 400
+            return gettext("exercise_doesnt_exist"), 400
 
         exercise = PARSONS[g.lang].get_parsons_data_for_level_exercise(level, exercise, g.keyword_lang)
         return jsonify(exercise), 200

--- a/website/parsons.py
+++ b/website/parsons.py
@@ -1,23 +1,18 @@
-import copy
-import random
-
-from flask import g, jsonify
+from flask import jsonify, g
 from flask_babel import gettext
+from .website_module import WebsiteModule, route
 
 
-def routes(app, database, achievements, parsons):
-    global DATABASE
-    global ACHIEVEMENTS
-    global PARSONS
+class ParsonsModule(WebsiteModule):
+    def __init__(self, parsons):
+        super().__init__("parsons", __name__, url_prefix="/parsons")
 
-    DATABASE = database
-    ACHIEVEMENTS = achievements
-    PARSONS = parsons
+        self.parsons = parsons
 
-    @app.route("/parsons/get-exercise/<int:level>/<int:exercise>", methods=["GET"])
-    def get_parsons_exercise(level, exercise):
-        if exercise > PARSONS[g.lang].get_highest_exercise_level(level) or exercise < 1:
+    @route("/get-exercise/<int:level>/<int:exercise>", methods=["GET"])
+    def get_parsons_exercise(self, level, exercise):
+        if exercise > self.parsons[g.lang].get_highest_exercise_level(level) or exercise < 1:
             return gettext("exercise_doesnt_exist"), 400
 
-        exercise = PARSONS[g.lang].get_parsons_data_for_level_exercise(level, exercise, g.keyword_lang)
+        exercise = self.parsons[g.lang].get_parsons_data_for_level_exercise(level, exercise, g.keyword_lang)
         return jsonify(exercise), 200

--- a/website/profile.py
+++ b/website/profile.py
@@ -1,0 +1,139 @@
+import datetime
+import hashlib
+import requests
+from flask_babel import gettext
+from hedy_content import COUNTRIES, ALL_LANGUAGES, ALL_KEYWORD_LANGUAGES
+from website.auth import MAILCHIMP_API_HEADERS, MAILCHIMP_API_URL, SESSION_LENGTH, create_verify_link, mailchimp_subscribe_user, make_salt, remember_current_user, requires_login, send_email_template, password_hash
+from flask import request, session, jsonify
+from utils import timems, is_testing_request, valid_email
+from .database import Database
+from .website_module import WebsiteModule, route
+
+class ProfileModule(WebsiteModule):
+    def __init__(self, db: Database):
+        super().__init__('profile', __name__, url_prefix='/profile')
+        self.db = db
+
+    @route('/', methods=['POST'])
+    @requires_login
+    def update_profile(self, user):
+        body = request.json
+        if not isinstance(body, dict):
+            return gettext('ajax_error'), 400
+        if not isinstance(body.get('language'), str) or body.get('language') not in ALL_LANGUAGES.keys():
+            return gettext('language_invalid'), 400
+        if not isinstance(body.get('keyword_language'), str) or body.get('keyword_language') not in ['en', body.get(
+                'language')] or body.get('keyword_language') not in ALL_KEYWORD_LANGUAGES.keys():
+            return gettext('keyword_language_invalid'), 400
+
+        # Mail is a unique field, only mandatory if the user doesn't have a related teacher (and no mail address)
+        user = self.db.user_by_username(user['username'])
+        if not user.get('teacher') or 'email' in body:
+            if not isinstance(body.get('email'), str) or not valid_email(body['email']):
+                return gettext('email_invalid'), 400
+
+        # Validations, optional fields
+        if 'birth_year' in body:
+            year = datetime.datetime.now().year
+            try:
+                body['birth_year'] = int(body.get('birth_year'))
+            except ValueError:
+                return gettext('year_invalid').format(**{'current_year': str(year)}), 400
+            if not isinstance(body.get('birth_year'), int) or body['birth_year'] <= 1900 or body['birth_year'] > year:
+                return gettext('year_invalid').format(**{'current_year': str(year)}), 400
+        if 'gender' in body:
+            if body['gender'] not in ["m", "f", "o"]:
+                return gettext('gender_invalid'), 400
+        if 'country' in body:
+            if not body['country'] in COUNTRIES:
+                return gettext('country_invalid'), 400
+
+        resp = {}
+        if 'email' in body:
+            email = body['email'].strip().lower()
+            if email != user.get('email'):
+                exists = self.db.user_by_email(email)
+                if exists:
+                    return gettext('exists_email'), 403
+                token = make_salt()
+                hashed_token = password_hash(token, make_salt())
+                self.db.update_user(user['username'], {'email': email, 'verification_pending': hashed_token})
+                # If this is an e2e test, we return the email verification token directly instead of emailing it.
+                if is_testing_request(request):
+                    resp = {'username': user['username'], 'token': hashed_token}
+                else:
+                    try:
+                        send_email_template(template='welcome_verify', email=email,
+                                        link=create_verify_link(user['username'], hashed_token),
+                                        username=user['username'])
+                    except:
+                        # Todo TB: Now we only log to the back-end, would be nice to also return the user some info
+                        # We have two options: return an error at this point (don't process changes)
+                        # Add a notification to the response, still process the changes
+                        print(f"Profile changes processed for {user['username']}, mail sending invalid")
+
+                # We check whether the user is in the Mailchimp list.
+                if not is_testing_request(request) and MAILCHIMP_API_URL:
+                    # We hash the email with md5 to avoid emails with unescaped characters triggering errors
+                    request_path = MAILCHIMP_API_URL + '/members/' + hashlib.md5(
+                        user['email'].encode('utf-8')).hexdigest()
+                    r = requests.get(request_path, headers=MAILCHIMP_API_HEADERS)
+                    # If user is subscribed, we remove the old email from the list and add the new one
+                    if r.status_code == 200:
+                        r = requests.delete(request_path, headers=MAILCHIMP_API_HEADERS)
+                        mailchimp_subscribe_user(email)
+
+        username = user['username']
+
+        updates = {}
+        for field in ['country', 'birth_year', 'gender', 'language', 'keyword_language']:
+            if field in body:
+                updates[field] = body[field]
+            else:
+                updates[field] = None
+        if body.get('agree_third_party'):
+            updates['third_party'] = True
+        else:
+            updates['third_party'] = None
+
+        if updates:
+            self.db.update_user(username, updates)
+
+        # Always make sure that the country stored on the public profile is identical to the profile one
+        self.db.update_country_public_profile(username, body.get('country', None))
+
+        # We want to check if the user choose a new language, if so -> reload
+        # We can use g.lang for this to reduce the db calls
+        resp['reload'] = False
+        if session['lang'] != body['language'] or session['keyword_lang'] != body['keyword_language']:
+            resp['message'] = gettext('profile_updated_reload')
+            resp['reload'] = True
+        else:
+            resp['message'] = gettext('profile_updated')
+
+        remember_current_user(self.db.user_by_username(user['username']))
+        return jsonify(resp)
+
+    @route('/', methods=['GET'])
+    @requires_login
+    def get_profile(self, user):
+        print(self, user)
+        # The user object we got from 'requires_login' is not fully hydrated yet. Look up the database user.
+        user = self.db.user_by_username(user['username'])
+
+        output = {
+            'username': user['username'],
+            'email': user['email'],
+            'language': user.get('language', 'en')
+        }
+        for field in ['birth_year', 'country', 'gender', 'prog_experience', 'experience_languages', 'third_party']:
+            if field in user:
+                output[field] = user[field]
+        if 'verification_pending' in user:
+            output['verification_pending'] = True
+
+        output['student_classes'] = self.db.get_student_classes(user['username'])
+
+        output['session_expires_at'] = timems() + SESSION_LENGTH * 1000
+
+        return jsonify(output), 200

--- a/website/programs.py
+++ b/website/programs.py
@@ -13,231 +13,248 @@ def routes(app, database, achievements):
     DATABASE = database
     ACHIEVEMENTS = achievements
 
-    @app.route('/programs_list', methods=['GET'])
+    @app.route("/programs_list", methods=["GET"])
     @requires_login
     def list_programs(user):
-        return {'programs': DATABASE.programs_for_user(user['username']).records}
+        return {"programs": DATABASE.programs_for_user(user["username"]).records}
 
-    @app.route('/programs/delete/', methods=['POST'])
+    @app.route("/programs/delete/", methods=["POST"])
     @requires_login
     def delete_program(user):
         body = request.json
-        if not isinstance(body.get('id'), str):
-            return 'program id must be a string', 400
+        if not isinstance(body.get("id"), str):
+            return "program id must be a string", 400
 
-        result = DATABASE.program_by_id(body['id'])
+        result = DATABASE.program_by_id(body["id"])
 
-        if not result or (result['username'] != user['username'] and not is_admin(user)):
+        if not result or (result["username"] != user["username"] and not is_admin(user)):
             return "", 404
-        DATABASE.delete_program_by_id(body['id'])
-        DATABASE.increase_user_program_count(user['username'], -1)
+        DATABASE.delete_program_by_id(body["id"])
+        DATABASE.increase_user_program_count(user["username"], -1)
 
         # This only happens in the situation were a user deletes their favourite program -> Delete from public profile
-        public_profile = DATABASE.get_public_profile_settings(current_user()['username'])
-        if public_profile and 'favourite_program' in public_profile and public_profile['favourite_program'] == body['id']:
-            DATABASE.set_favourite_program(user['username'], None)
+        public_profile = DATABASE.get_public_profile_settings(current_user()["username"])
+        if (
+            public_profile
+            and "favourite_program" in public_profile
+            and public_profile["favourite_program"] == body["id"]
+        ):
+            DATABASE.set_favourite_program(user["username"], None)
 
-        achievement = ACHIEVEMENTS.add_single_achievement(user['username'], "do_you_have_copy")
-        resp = {'message': gettext('delete_success')}
+        achievement = ACHIEVEMENTS.add_single_achievement(user["username"], "do_you_have_copy")
+        resp = {"message": gettext("delete_success")}
         if achievement:
-            resp['achievement'] = achievement
+            resp["achievement"] = achievement
         return jsonify(resp)
 
-    @app.route('/programs/duplicate-check', methods=['POST'])
+    @app.route("/programs/duplicate-check", methods=["POST"])
     def check_duplicate_program():
         body = request.json
         if not isinstance(body, dict):
-            return 'body must be an object', 400
-        if not isinstance(body.get('name'), str):
-            return 'name must be a string', 400
+            return "body must be an object", 400
+        if not isinstance(body.get("name"), str):
+            return "name must be a string", 400
 
-        if not current_user()['username']:
-            return gettext('save_prompt'), 403
+        if not current_user()["username"]:
+            return gettext("save_prompt"), 403
 
-        programs = DATABASE.programs_for_user(current_user()['username'])
+        programs = DATABASE.programs_for_user(current_user()["username"])
         for program in programs:
-            if program['name'] == body['name']:
-                return jsonify({'duplicate': True, 'message': gettext('overwrite_warning')})
-        return jsonify({'duplicate': False})
+            if program["name"] == body["name"]:
+                return jsonify({"duplicate": True, "message": gettext("overwrite_warning")})
+        return jsonify({"duplicate": False})
 
-    @app.route('/programs', methods=['POST'])
+    @app.route("/programs", methods=["POST"])
     @requires_login
     def save_program(user):
         body = request.json
         if not isinstance(body, dict):
-            return 'body must be an object', 400
-        if not isinstance(body.get('code'), str):
-            return 'code must be a string', 400
-        if not isinstance(body.get('name'), str):
-            return 'name must be a string', 400
-        if not isinstance(body.get('level'), int):
-            return 'level must be an integer', 400
-        if not isinstance(body.get('shared'), bool):
-            return 'shared must be a boolean', 400
-        if 'adventure_name' in body:
-            if not isinstance(body.get('adventure_name'), str):
-                return 'if present, adventure_name must be a string', 400
+            return "body must be an object", 400
+        if not isinstance(body.get("code"), str):
+            return "code must be a string", 400
+        if not isinstance(body.get("name"), str):
+            return "name must be a string", 400
+        if not isinstance(body.get("level"), int):
+            return "level must be an integer", 400
+        if not isinstance(body.get("shared"), bool):
+            return "shared must be a boolean", 400
+        if "adventure_name" in body:
+            if not isinstance(body.get("adventure_name"), str):
+                return "if present, adventure_name must be a string", 400
 
         error = False
         try:
-            hedy.transpile(body.get('code'), body.get('level'), g.lang)
+            hedy.transpile(body.get("code"), body.get("level"), g.lang)
         except:
             error = True
-            if not body.get('force_save', True):
-                return jsonify({'parse_error': True, 'message': gettext('save_parse_warning')})
+            if not body.get("force_save", True):
+                return jsonify({"parse_error": True, "message": gettext("save_parse_warning")})
 
         # We check if a program with a name `xyz` exists in the database for the username.
         # It'd be ideal to search by username & program name, but since DynamoDB doesn't allow searching for two indexes at the same time, this would require to create a special index to that effect, which is cumbersome.
         # For now, we bring all existing programs for the user and then search within them for repeated names.
-        programs = DATABASE.programs_for_user(user['username']).records
+        programs = DATABASE.programs_for_user(user["username"]).records
         program_id = uuid.uuid4().hex
-        program_public = body.get('shared')
+        program_public = body.get("shared")
         overwrite = False
         for program in programs:
-            if program['name'] == body['name']:
+            if program["name"] == body["name"]:
                 overwrite = True
-                program_id = program['id']
+                program_id = program["id"]
                 # If a program was already shared, keep it that way
-                if program.get('public', False):
+                if program.get("public", False):
                     program_public = True
                 break
 
         stored_program = {
-            'id': program_id,
-            'session': utils.session_id(),
-            'date': utils.timems(),
-            'lang': g.lang,
-            'version': utils.version(),
-            'level': body['level'],
-            'code': body['code'],
-            'name': body['name'],
-            'username': user['username'],
-            'public': 1 if program_public else 0,
-            'error': error
+            "id": program_id,
+            "session": utils.session_id(),
+            "date": utils.timems(),
+            "lang": g.lang,
+            "version": utils.version(),
+            "level": body["level"],
+            "code": body["code"],
+            "name": body["name"],
+            "username": user["username"],
+            "public": 1 if program_public else 0,
+            "error": error,
         }
 
-        if 'adventure_name' in body:
-            stored_program['adventure_name'] = body['adventure_name']
+        if "adventure_name" in body:
+            stored_program["adventure_name"] = body["adventure_name"]
 
         DATABASE.store_program(stored_program)
         if not overwrite:
-            DATABASE.increase_user_program_count(user['username'])
-        DATABASE.increase_user_save_count(user['username'])
+            DATABASE.increase_user_program_count(user["username"])
+        DATABASE.increase_user_save_count(user["username"])
         ACHIEVEMENTS.increase_count("saved")
 
-        if ACHIEVEMENTS.verify_save_achievements(user['username'],
-                                                 'adventure_name' in body and len(body['adventure_name']) > 2):
+        if ACHIEVEMENTS.verify_save_achievements(
+            user["username"], "adventure_name" in body and len(body["adventure_name"]) > 2
+        ):
             return jsonify(
-                {'message': gettext('save_success_detail'), 'name': body['name'], 'id': program_id, "achievements": ACHIEVEMENTS.get_earned_achievements()})
-        return jsonify({'message': gettext('save_success_detail'), 'name': body['name'], 'id': program_id})
+                {
+                    "message": gettext("save_success_detail"),
+                    "name": body["name"],
+                    "id": program_id,
+                    "achievements": ACHIEVEMENTS.get_earned_achievements(),
+                }
+            )
+        return jsonify({"message": gettext("save_success_detail"), "name": body["name"], "id": program_id})
 
-    @app.route('/programs/share', methods=['POST'])
+    @app.route("/programs/share", methods=["POST"])
     @requires_login
     def share_unshare_program(user):
         body = request.json
         if not isinstance(body, dict):
-            return 'body must be an object', 400
-        if not isinstance(body.get('id'), str):
-            return 'id must be a string', 400
-        if not isinstance(body.get('public'), bool):
-            return 'public must be a boolean', 400
+            return "body must be an object", 400
+        if not isinstance(body.get("id"), str):
+            return "id must be a string", 400
+        if not isinstance(body.get("public"), bool):
+            return "public must be a boolean", 400
 
-        result = DATABASE.program_by_id(body['id'])
-        if not result or result['username'] != user['username']:
-            return 'No such program!', 404
+        result = DATABASE.program_by_id(body["id"])
+        if not result or result["username"] != user["username"]:
+            return "No such program!", 404
 
         # This only happens in the situation were a user un-shares their favourite program -> Delete from public profile
-        public_profile = DATABASE.get_public_profile_settings(current_user()['username'])
-        if public_profile and 'favourite_program' in public_profile and public_profile['favourite_program'] == body[
-            'id']:
-            DATABASE.set_favourite_program(user['username'], None)
+        public_profile = DATABASE.get_public_profile_settings(current_user()["username"])
+        if (
+            public_profile
+            and "favourite_program" in public_profile
+            and public_profile["favourite_program"] == body["id"]
+        ):
+            DATABASE.set_favourite_program(user["username"], None)
 
-        DATABASE.set_program_public_by_id(body['id'], bool(body['public']))
-        achievement = ACHIEVEMENTS.add_single_achievement(user['username'], "sharing_is_caring")
+        DATABASE.set_program_public_by_id(body["id"], bool(body["public"]))
+        achievement = ACHIEVEMENTS.add_single_achievement(user["username"], "sharing_is_caring")
 
-        resp = {'id': body['id']}
-        if bool(body['public']):
-            resp['message'] = gettext('share_success_detail')
+        resp = {"id": body["id"]}
+        if bool(body["public"]):
+            resp["message"] = gettext("share_success_detail")
         else:
-            resp['message'] = gettext('unshare_success_detail')
+            resp["message"] = gettext("unshare_success_detail")
         if achievement:
-            resp['achievement'] = achievement
+            resp["achievement"] = achievement
         return jsonify(resp)
 
-    @app.route('/programs/submit', methods=['POST'])
+    @app.route("/programs/submit", methods=["POST"])
     @requires_login
     def submit_program(user):
         body = request.json
         if not isinstance(body, dict):
-            return 'body must be an object', 400
-        if not isinstance(body.get('id'), str):
-            return 'id must be a string', 400
+            return "body must be an object", 400
+        if not isinstance(body.get("id"), str):
+            return "id must be a string", 400
 
-        result = DATABASE.program_by_id(body['id'])
-        if not result or result['username'] != user['username']:
-            return 'No such program!', 404
+        result = DATABASE.program_by_id(body["id"])
+        if not result or result["username"] != user["username"]:
+            return "No such program!", 404
 
-        DATABASE.submit_program_by_id(body['id'])
-        DATABASE.increase_user_submit_count(user['username'])
+        DATABASE.submit_program_by_id(body["id"])
+        DATABASE.increase_user_submit_count(user["username"])
         ACHIEVEMENTS.increase_count("submitted")
 
-        if ACHIEVEMENTS.verify_submit_achievements(user['username']):
+        if ACHIEVEMENTS.verify_submit_achievements(user["username"]):
             return jsonify({"achievements": ACHIEVEMENTS.get_earned_achievements()})
         return jsonify({})
 
-    @app.route('/programs/set_favourite', methods=['POST'])
+    @app.route("/programs/set_favourite", methods=["POST"])
     @requires_login
     def set_favourite_program(user):
         body = request.json
         if not isinstance(body, dict):
-            return 'body must be an object', 400
-        if not isinstance(body.get('id'), str):
-            return 'id must be a string', 400
+            return "body must be an object", 400
+        if not isinstance(body.get("id"), str):
+            return "id must be a string", 400
 
-        result = DATABASE.program_by_id(body['id'])
-        if not result or result['username'] != user['username']:
-            return 'No such program!', 404
+        result = DATABASE.program_by_id(body["id"])
+        if not result or result["username"] != user["username"]:
+            return "No such program!", 404
 
-        if DATABASE.set_favourite_program(user['username'], body['id']):
-            return jsonify({'message': gettext('favourite_success')})
+        if DATABASE.set_favourite_program(user["username"], body["id"]):
+            return jsonify({"message": gettext("favourite_success")})
         else:
             return "You can't set a favourite program without a public profile", 400
 
-    @app.route('/programs/set_hedy_choice', methods=['POST'])
+    @app.route("/programs/set_hedy_choice", methods=["POST"])
     @requires_admin
     def set_hedy_choice(user):
         body = request.json
         if not isinstance(body, dict):
-            return 'body must be an object', 400
-        if not isinstance(body.get('id'), str):
-            return 'id must be a string', 400
-        if not isinstance(body.get('favourite'), int):
-            return 'favourite must be a integer', 400
+            return "body must be an object", 400
+        if not isinstance(body.get("id"), str):
+            return "id must be a string", 400
+        if not isinstance(body.get("favourite"), int):
+            return "favourite must be a integer", 400
 
-        favourite = True if body.get('favourite') == 1 else False
+        favourite = True if body.get("favourite") == 1 else False
 
-        result = DATABASE.program_by_id(body['id'])
+        result = DATABASE.program_by_id(body["id"])
         if not result:
-            return 'No such program!', 404
+            return "No such program!", 404
 
-        DATABASE.set_program_as_hedy_choice(body['id'], favourite)
+        DATABASE.set_program_as_hedy_choice(body["id"], favourite)
         if favourite:
-            return jsonify({'message': 'Program successfully set as a "Hedy choice" program.'}), 200
-        return jsonify({'message': 'Program successfully removed as a "Hedy choice" program.'}), 200
+            return jsonify({"message": 'Program successfully set as a "Hedy choice" program.'}), 200
+        return jsonify({"message": 'Program successfully removed as a "Hedy choice" program.'}), 200
 
-    @app.route('/programs/report', methods=['POST'])
+    @app.route("/programs/report", methods=["POST"])
     @requires_login
     def report_program(user):
         body = request.json
 
         # Make sure the program actually exists and is public
-        program = DATABASE.program_by_id(body.get('id'))
-        if not program or program.get('public') != 1:
-            return gettext('report_failure'), 400
+        program = DATABASE.program_by_id(body.get("id"))
+        if not program or program.get("public") != 1:
+            return gettext("report_failure"), 400
 
-        link = email_base_url() + '/hedy/' + body.get('id') + '/view'
-        send_email(config['email']['sender'], "The following program is reported by " + user['username'], link,
-                   '<a href="' + link + '">Program link</a>')
+        link = email_base_url() + "/hedy/" + body.get("id") + "/view"
+        send_email(
+            config["email"]["sender"],
+            "The following program is reported by " + user["username"],
+            link,
+            '<a href="' + link + '">Program link</a>',
+        )
 
-        return {'message': gettext('report_success')}, 200
-
+        return {"message": gettext("report_success")}, 200

--- a/website/programs.py
+++ b/website/programs.py
@@ -1,54 +1,65 @@
+from flask import g, request, jsonify
 from flask_babel import gettext
 import hedy
 from config import config
-from website.auth import requires_login, current_user, is_admin, send_email, email_base_url, requires_admin
+from .achievements import Achievements
+from .database import Database
+from website.auth import (
+    requires_login,
+    current_user,
+    is_admin,
+    send_email,
+    email_base_url,
+    requires_admin,
+)
 import utils
 import uuid
-from flask import g, request, jsonify
+
+from .website_module import WebsiteModule, route
 
 
-def routes(app, database, achievements):
-    global DATABASE
-    global ACHIEVEMENTS
-    DATABASE = database
-    ACHIEVEMENTS = achievements
+class ProgramsModule(WebsiteModule):
+    def __init__(self, db: Database, achievements: Achievements):
+        super().__init__("programs", __name__, url_prefix="/programs")
+        self.db = db
+        self.achievements = achievements
 
-    @app.route("/programs_list", methods=["GET"])
+    @route("/list", methods=["GET"])
     @requires_login
-    def list_programs(user):
-        return {"programs": DATABASE.programs_for_user(user["username"]).records}
+    def list_programs(self, user):
+        return {"programs": self.db.programs_for_user(user["username"]).records}
 
-    @app.route("/programs/delete/", methods=["POST"])
+    @route("/delete/", methods=["POST"])
     @requires_login
-    def delete_program(user):
+    def delete_program(self, user):
         body = request.json
         if not isinstance(body.get("id"), str):
             return "program id must be a string", 400
 
-        result = DATABASE.program_by_id(body["id"])
+        result = self.db.program_by_id(body["id"])
 
         if not result or (result["username"] != user["username"] and not is_admin(user)):
             return "", 404
-        DATABASE.delete_program_by_id(body["id"])
-        DATABASE.increase_user_program_count(user["username"], -1)
+        self.db.delete_program_by_id(body["id"])
+        self.db.increase_user_program_count(user["username"], -1)
 
         # This only happens in the situation were a user deletes their favourite program -> Delete from public profile
-        public_profile = DATABASE.get_public_profile_settings(current_user()["username"])
+        public_profile = self.db.get_public_profile_settings(current_user()["username"])
         if (
             public_profile
             and "favourite_program" in public_profile
             and public_profile["favourite_program"] == body["id"]
         ):
-            DATABASE.set_favourite_program(user["username"], None)
+            self.db.set_favourite_program(user["username"], None)
 
-        achievement = ACHIEVEMENTS.add_single_achievement(user["username"], "do_you_have_copy")
+        achievement = self.achievements.add_single_achievement(user["username"], "do_you_have_copy")
         resp = {"message": gettext("delete_success")}
         if achievement:
             resp["achievement"] = achievement
         return jsonify(resp)
 
-    @app.route("/programs/duplicate-check", methods=["POST"])
-    def check_duplicate_program():
+    @route("/duplicate-check", methods=["POST"])
+    def check_duplicate_program(self):
         body = request.json
         if not isinstance(body, dict):
             return "body must be an object", 400
@@ -58,15 +69,15 @@ def routes(app, database, achievements):
         if not current_user()["username"]:
             return gettext("save_prompt"), 403
 
-        programs = DATABASE.programs_for_user(current_user()["username"])
+        programs = self.db.programs_for_user(current_user()["username"])
         for program in programs:
             if program["name"] == body["name"]:
                 return jsonify({"duplicate": True, "message": gettext("overwrite_warning")})
         return jsonify({"duplicate": False})
 
-    @app.route("/programs", methods=["POST"])
+    @route("/", methods=["POST"])
     @requires_login
-    def save_program(user):
+    def save_program(self, user):
         body = request.json
         if not isinstance(body, dict):
             return "body must be an object", 400
@@ -93,7 +104,7 @@ def routes(app, database, achievements):
         # We check if a program with a name `xyz` exists in the database for the username.
         # It'd be ideal to search by username & program name, but since DynamoDB doesn't allow searching for two indexes at the same time, this would require to create a special index to that effect, which is cumbersome.
         # For now, we bring all existing programs for the user and then search within them for repeated names.
-        programs = DATABASE.programs_for_user(user["username"]).records
+        programs = self.db.programs_for_user(user["username"]).records
         program_id = uuid.uuid4().hex
         program_public = body.get("shared")
         overwrite = False
@@ -123,28 +134,35 @@ def routes(app, database, achievements):
         if "adventure_name" in body:
             stored_program["adventure_name"] = body["adventure_name"]
 
-        DATABASE.store_program(stored_program)
+        self.db.store_program(stored_program)
         if not overwrite:
-            DATABASE.increase_user_program_count(user["username"])
-        DATABASE.increase_user_save_count(user["username"])
-        ACHIEVEMENTS.increase_count("saved")
+            self.db.increase_user_program_count(user["username"])
+        self.db.increase_user_save_count(user["username"])
+        self.achievements.increase_count("saved")
 
-        if ACHIEVEMENTS.verify_save_achievements(
-            user["username"], "adventure_name" in body and len(body["adventure_name"]) > 2
+        if self.achievements.verify_save_achievements(
+            user["username"],
+            "adventure_name" in body and len(body["adventure_name"]) > 2,
         ):
             return jsonify(
                 {
                     "message": gettext("save_success_detail"),
                     "name": body["name"],
                     "id": program_id,
-                    "achievements": ACHIEVEMENTS.get_earned_achievements(),
+                    "achievements": self.achievements.get_earned_achievements(),
                 }
             )
-        return jsonify({"message": gettext("save_success_detail"), "name": body["name"], "id": program_id})
+        return jsonify(
+            {
+                "message": gettext("save_success_detail"),
+                "name": body["name"],
+                "id": program_id,
+            }
+        )
 
-    @app.route("/programs/share", methods=["POST"])
+    @route("/share", methods=["POST"])
     @requires_login
-    def share_unshare_program(user):
+    def share_unshare_program(self, user):
         body = request.json
         if not isinstance(body, dict):
             return "body must be an object", 400
@@ -153,21 +171,21 @@ def routes(app, database, achievements):
         if not isinstance(body.get("public"), bool):
             return "public must be a boolean", 400
 
-        result = DATABASE.program_by_id(body["id"])
+        result = self.db.program_by_id(body["id"])
         if not result or result["username"] != user["username"]:
             return "No such program!", 404
 
         # This only happens in the situation were a user un-shares their favourite program -> Delete from public profile
-        public_profile = DATABASE.get_public_profile_settings(current_user()["username"])
+        public_profile = self.db.get_public_profile_settings(current_user()["username"])
         if (
             public_profile
             and "favourite_program" in public_profile
             and public_profile["favourite_program"] == body["id"]
         ):
-            DATABASE.set_favourite_program(user["username"], None)
+            self.db.set_favourite_program(user["username"], None)
 
-        DATABASE.set_program_public_by_id(body["id"], bool(body["public"]))
-        achievement = ACHIEVEMENTS.add_single_achievement(user["username"], "sharing_is_caring")
+        self.db.set_program_public_by_id(body["id"], bool(body["public"]))
+        achievement = self.achievements.add_single_achievement(user["username"], "sharing_is_caring")
 
         resp = {"id": body["id"]}
         if bool(body["public"]):
@@ -178,48 +196,48 @@ def routes(app, database, achievements):
             resp["achievement"] = achievement
         return jsonify(resp)
 
-    @app.route("/programs/submit", methods=["POST"])
+    @route("/submit", methods=["POST"])
     @requires_login
-    def submit_program(user):
+    def submit_program(self, user):
         body = request.json
         if not isinstance(body, dict):
             return "body must be an object", 400
         if not isinstance(body.get("id"), str):
             return "id must be a string", 400
 
-        result = DATABASE.program_by_id(body["id"])
+        result = self.db.program_by_id(body["id"])
         if not result or result["username"] != user["username"]:
             return "No such program!", 404
 
-        DATABASE.submit_program_by_id(body["id"])
-        DATABASE.increase_user_submit_count(user["username"])
-        ACHIEVEMENTS.increase_count("submitted")
+        self.db.submit_program_by_id(body["id"])
+        self.db.increase_user_submit_count(user["username"])
+        self.achievements.increase_count("submitted")
 
-        if ACHIEVEMENTS.verify_submit_achievements(user["username"]):
-            return jsonify({"achievements": ACHIEVEMENTS.get_earned_achievements()})
+        if self.achievements.verify_submit_achievements(user["username"]):
+            return jsonify({"achievements": self.achievements.get_earned_achievements()})
         return jsonify({})
 
-    @app.route("/programs/set_favourite", methods=["POST"])
+    @route("/set_favourite", methods=["POST"])
     @requires_login
-    def set_favourite_program(user):
+    def set_favourite_program(self, user):
         body = request.json
         if not isinstance(body, dict):
             return "body must be an object", 400
         if not isinstance(body.get("id"), str):
             return "id must be a string", 400
 
-        result = DATABASE.program_by_id(body["id"])
+        result = self.db.program_by_id(body["id"])
         if not result or result["username"] != user["username"]:
             return "No such program!", 404
 
-        if DATABASE.set_favourite_program(user["username"], body["id"]):
+        if self.db.set_favourite_program(user["username"], body["id"]):
             return jsonify({"message": gettext("favourite_success")})
         else:
             return "You can't set a favourite program without a public profile", 400
 
-    @app.route("/programs/set_hedy_choice", methods=["POST"])
+    @route("/set_hedy_choice", methods=["POST"])
     @requires_admin
-    def set_hedy_choice(user):
+    def set_hedy_choice(self, user):
         body = request.json
         if not isinstance(body, dict):
             return "body must be an object", 400
@@ -230,22 +248,28 @@ def routes(app, database, achievements):
 
         favourite = True if body.get("favourite") == 1 else False
 
-        result = DATABASE.program_by_id(body["id"])
+        result = self.db.program_by_id(body["id"])
         if not result:
             return "No such program!", 404
 
-        DATABASE.set_program_as_hedy_choice(body["id"], favourite)
+        self.db.set_program_as_hedy_choice(body["id"], favourite)
         if favourite:
-            return jsonify({"message": 'Program successfully set as a "Hedy choice" program.'}), 200
-        return jsonify({"message": 'Program successfully removed as a "Hedy choice" program.'}), 200
+            return (
+                jsonify({"message": 'Program successfully set as a "Hedy choice" program.'}),
+                200,
+            )
+        return (
+            jsonify({"message": 'Program successfully removed as a "Hedy choice" program.'}),
+            200,
+        )
 
-    @app.route("/programs/report", methods=["POST"])
+    @route("/report", methods=["POST"])
     @requires_login
-    def report_program(user):
+    def report_program(self, user):
         body = request.json
 
         # Make sure the program actually exists and is public
-        program = DATABASE.program_by_id(body.get("id"))
+        program = self.db.program_by_id(body.get("id"))
         if not program or program.get("public") != 1:
             return gettext("report_failure"), 400
 

--- a/website/querylog.py
+++ b/website/querylog.py
@@ -4,17 +4,20 @@ import threading
 import logging
 import os
 import datetime
-IS_WINDOWS = os.name == 'nt'
+
+IS_WINDOWS = os.name == "nt"
 if not IS_WINDOWS:
     import resource
 import logging
 
 from . import log_queue
 
-logger = logging.getLogger('querylog')
+logger = logging.getLogger("querylog")
+
 
 class LogRecord:
     """A log record."""
+
     def __init__(self, **kwargs):
         self.start_time = time.time()
 
@@ -23,13 +26,9 @@ class LogRecord:
         self.attributes = kwargs
         self.running_timers = set([])
         loadavg = os.getloadavg()[0] if not IS_WINDOWS else None
-        self.set(
-            start_time=dtfmt(self.start_time),
-            pid=os.getpid(),
-            loadavg=loadavg,
-            fault=0)
+        self.set(start_time=dtfmt(self.start_time), pid=os.getpid(), loadavg=loadavg, fault=0)
 
-        dyno = os.getenv('DYNO')
+        dyno = os.getenv("DYNO")
         if dyno:
             self.set(dyno=dyno)
 
@@ -53,7 +52,8 @@ class LogRecord:
             sys_ms=sys_ms,
             max_rss=max_rss,
             inc_max_rss=inc_max_rss,
-            duration_ms=ms_from_fsec(end_time - self.start_time))
+            duration_ms=ms_from_fsec(end_time - self.start_time),
+        )
 
         # There should be 0, but who knows
         self._terminate_running_timers()
@@ -78,8 +78,8 @@ class LogRecord:
             self.attributes[name] = amount
 
     def inc_timer(self, name, time_ms):
-        self.inc(name + '_ms', time_ms)
-        self.inc(name + '_cnt')
+        self.inc(name + "_ms", time_ms)
+        self.inc(name + "_cnt")
 
     def record_exception(self, exc):
         self.set(fault=1, error_message=str(exc))
@@ -112,14 +112,30 @@ class NullRecord(LogRecord):
 
     Will be returned if we don't have a default record.
     """
-    def __init__(self, **kwargs): pass
-    def finish(self): pass
-    def set(self, **kwargs): pass
-    def _remember_timer(self, _): pass
-    def _forget_timer(self, _): pass
-    def _terminate_running_timers(self): pass
-    def inc_timer(self, _, _2): pass
-    def inc(self, name, amount=1): pass
+
+    def __init__(self, **kwargs):
+        pass
+
+    def finish(self):
+        pass
+
+    def set(self, **kwargs):
+        pass
+
+    def _remember_timer(self, _):
+        pass
+
+    def _forget_timer(self, _):
+        pass
+
+    def _terminate_running_timers(self):
+        pass
+
+    def inc_timer(self, _, _2):
+        pass
+
+    def inc(self, name, amount=1):
+        pass
 
     def record_exception(self, exc):
         self.set(fault=1, error_message=str(exc))
@@ -138,7 +154,7 @@ def finish_global_log_record(exc=None):
     """Finish the global log record."""
 
     # When developing, this can sometimes get called before 'current_log_record' has been set.
-    if hasattr(THREAD_LOCAL, 'current_log_record'):
+    if hasattr(THREAD_LOCAL, "current_log_record"):
         record = THREAD_LOCAL.current_log_record
         if exc:
             record.record_exception(exc)
@@ -148,7 +164,7 @@ def finish_global_log_record(exc=None):
 
 def log_value(**kwargs):
     """Log values into the currently globally active Log Record."""
-    if hasattr(THREAD_LOCAL, 'current_log_record'):
+    if hasattr(THREAD_LOCAL, "current_log_record"):
         # For some malformed URLs, the records are not initialized, so we check whether there's a current_log_record
         THREAD_LOCAL.current_log_record.set(**kwargs)
 
@@ -157,6 +173,7 @@ def log_time(name):
     """Log a time into the currently globally active Log Record."""
     return THREAD_LOCAL.current_log_record.timer(name)
 
+
 def log_counter(name, count=1):
     """Increase the count of something in the currently globally active Log Record."""
     return THREAD_LOCAL.current_log_record.inc(name, count)
@@ -164,6 +181,7 @@ def log_counter(name, count=1):
 
 def timed(fn):
     """Function decorator to make the given function timed into the currently active log record."""
+
     @functools.wraps(fn)
     def wrapped(*args, **kwargs):
         with log_time(fn.__name__):
@@ -171,17 +189,21 @@ def timed(fn):
 
     return wrapped
 
+
 def timed_as(name):
     """Function decorator to make the given function timed into the currently active log record.
 
     Use a different name from the actual function name.
     """
+
     def decoractor(fn):
         @functools.wraps(fn)
         def wrapped(*args, **kwargs):
             with log_time(name):
                 return fn(*args, **kwargs)
+
         return wrapped
+
     return decoractor
 
 
@@ -194,11 +216,12 @@ def emergency_shutdown():
 
 def dtfmt(timestamp):
     dt = datetime.datetime.utcfromtimestamp(timestamp)
-    return dt.isoformat() + 'Z'
+    return dt.isoformat() + "Z"
 
 
 class LogTimer:
     """A quick and dirty timer."""
+
     def __init__(self, record, name):
         self.record = record
         self.name = name
@@ -225,5 +248,5 @@ def ms_from_fsec(x):
     return int(x * 1000)
 
 
-LOG_QUEUE = log_queue.LogQueue('querylog', batch_window_s=300)
+LOG_QUEUE = log_queue.LogQueue("querylog", batch_window_s=300)
 LOG_QUEUE.try_load_emergency_saves()

--- a/website/quiz.py
+++ b/website/quiz.py
@@ -8,23 +8,9 @@ from flask import request, g, session, jsonify
 
 MAX_ATTEMPTS = 2
 
-ANSWER_PARSER = {
-    1: 'A',
-    2: 'B',
-    3: 'C',
-    4: 'D',
-    5: 'E',
-    6: 'F'
-}
+ANSWER_PARSER = {1: "A", 2: "B", 3: "C", 4: "D", 5: "E", 6: "F"}
 
-REVERSE_ANSWER_PARSER = {
-    'A': 1,
-    'B': 2,
-    'C': 3,
-    'D': 4,
-    'E': 5,
-    'F': 6
-}
+REVERSE_ANSWER_PARSER = {"A": 1, "B": 2, "C": 3, "D": 4, "E": 5, "F": 6}
 
 
 def routes(app, database, achievements, quizzes):
@@ -36,99 +22,105 @@ def routes(app, database, achievements, quizzes):
     ACHIEVEMENTS = achievements
     QUIZZES = quizzes
 
-    @app.route('/quiz/initialize_user', methods=['POST'])
+    @app.route("/quiz/initialize_user", methods=["POST"])
     def initialize_user():
         body = request.json
         if not isinstance(body, dict):
-            return gettext('ajax_error'), 400
-        if not isinstance(body.get('level'), int):
-            return gettext('level_invalid'), 400
+            return gettext("ajax_error"), 400
+        if not isinstance(body.get("level"), int):
+            return gettext("level_invalid"), 400
 
-        session['quiz-attempt-id'] = uuid.uuid4().hex
-        session['attempt'] = 0
-        session['total_score'] = 0
-        session['correctly_answered_questions_numbers'] = []
+        session["quiz-attempt-id"] = uuid.uuid4().hex
+        session["attempt"] = 0
+        session["total_score"] = 0
+        session["correctly_answered_questions_numbers"] = []
 
-        statistics.add(current_user()['username'], lambda id_: DATABASE.add_quiz_started(id_, body.get('level')))
+        statistics.add(current_user()["username"], lambda id_: DATABASE.add_quiz_started(id_, body.get("level")))
 
         return jsonify({}), 200
 
-    @app.route('/quiz/get-question/<int:level>/<int:question>', methods=['GET'])
+    @app.route("/quiz/get-question/<int:level>/<int:question>", methods=["GET"])
     def get_quiz_question(level, question):
-        session['attempt'] = 0
+        session["attempt"] = 0
         if question > QUIZZES[g.lang].get_highest_question_level(level) or question < 1:
-            return gettext('question_doesnt_exist'), 400
+            return gettext("question_doesnt_exist"), 400
 
         question = QUIZZES[g.lang].get_quiz_data_for_level_question(level, question, g.keyword_lang)
         return jsonify(question), 200
 
-    @app.route('/quiz/submit_answer/', methods=["POST"])
+    @app.route("/quiz/submit_answer/", methods=["POST"])
     def submit_answer():
         body = request.json
         if not isinstance(body, dict):
-            return gettext('ajax_error'), 400
-        if not isinstance(body.get('level'), str):
-            return gettext('level_invalid'), 400
-        if not isinstance(body.get('question'), str):
-            return gettext('question_invalid'), 400
-        if not isinstance(body.get('answer'), int):
-            return gettext('answer_invalid'), 400
+            return gettext("ajax_error"), 400
+        if not isinstance(body.get("level"), str):
+            return gettext("level_invalid"), 400
+        if not isinstance(body.get("question"), str):
+            return gettext("question_invalid"), 400
+        if not isinstance(body.get("answer"), int):
+            return gettext("answer_invalid"), 400
 
-        level = int(body['level'])
-        question_number = int(body['question'])
+        level = int(body["level"])
+        question_number = int(body["question"])
 
-        session['attempt'] += 1
+        session["attempt"] += 1
 
-        if session.get('attempt') > MAX_ATTEMPTS:
-            return gettext('too_many_attempts'), 400
+        if session.get("attempt") > MAX_ATTEMPTS:
+            return gettext("too_many_attempts"), 400
 
         if question_number > QUIZZES[g.lang].get_highest_question_level(level) or question_number < 1:
-            return gettext('question_doesnt_exist'), 400
-
+            return gettext("question_doesnt_exist"), 400
 
         question = QUIZZES[g.lang].get_quiz_data_for_level_question(level, question_number, g.keyword_lang)
-        is_correct = True if question['correct_answer'] == ANSWER_PARSER.get(body.get('answer')) else False
+        is_correct = True if question["correct_answer"] == ANSWER_PARSER.get(body.get("answer")) else False
 
-        username = current_user()['username'] or f'anonymous:{utils.session_id()}'
-        answer = ANSWER_PARSER.get((body.get('answer')))
-        DATABASE.record_quiz_answer(session['quiz-attempt-id'], username=username, level=level,
-                                    is_correct=is_correct, question_number=question_number,
-                                    answer=answer)
+        username = current_user()["username"] or f"anonymous:{utils.session_id()}"
+        answer = ANSWER_PARSER.get((body.get("answer")))
+        DATABASE.record_quiz_answer(
+            session["quiz-attempt-id"],
+            username=username,
+            level=level,
+            is_correct=is_correct,
+            question_number=question_number,
+            answer=answer,
+        )
 
         response = {
-            'question_text': question.get("question_text"),
-            'level': level,
-            'attempt': session.get('attempt'),
-            'correct_answer_text': question.get("mp_choice_options")[REVERSE_ANSWER_PARSER.get(question.get('correct_answer'))-1].get('option'),
-            'feedback': question.get("mp_choice_options")[body.get('answer') - 1].get('feedback'),
-            'max_question': QUIZZES[g.lang].get_highest_question_level(level),
-            'next_question': True if question_number < QUIZZES[g.lang].get_highest_question_level(level) else False
+            "question_text": question.get("question_text"),
+            "level": level,
+            "attempt": session.get("attempt"),
+            "correct_answer_text": question.get("mp_choice_options")[
+                REVERSE_ANSWER_PARSER.get(question.get("correct_answer")) - 1
+            ].get("option"),
+            "feedback": question.get("mp_choice_options")[body.get("answer") - 1].get("feedback"),
+            "max_question": QUIZZES[g.lang].get_highest_question_level(level),
+            "next_question": True if question_number < QUIZZES[g.lang].get_highest_question_level(level) else False,
         }
 
         if is_correct:
-            response['correct'] = True
+            response["correct"] = True
             score = int(correct_answer_score(question))
             correct_question_nrs = get_correctly_answered_question_nrs()
-            if body.get('question') not in correct_question_nrs:
-                session['total_score'] = session.get('total_score', 0) + score
-                session['correctly_answered_questions_numbers'].append(body.get('question'))
+            if body.get("question") not in correct_question_nrs:
+                session["total_score"] = session.get("total_score", 0) + score
+                session["correctly_answered_questions_numbers"].append(body.get("question"))
         else:
-            response['correct'] = False
+            response["correct"] = False
 
         return jsonify(response), 200
 
-    @app.route('/quiz/get_results/<level>', methods=['GET'])
+    @app.route("/quiz/get_results/<level>", methods=["GET"])
     def get_results(level):
         level = int(level)
         questions = QUIZZES[g.lang].get_quiz_data_for_level(level, g.keyword_lang)
 
         achievement = None
-        total_score = round(session.get('total_score', 0) / max_score(questions) * 100)
+        total_score = round(session.get("total_score", 0) / max_score(questions) * 100)
         response = {
-            'score': total_score,
+            "score": total_score,
         }
 
-        username = current_user()['username']
+        username = current_user()["username"]
         if username:
             statistics.add(username, lambda id_: DATABASE.add_quiz_finished(id_, level, total_score))
             achievement = ACHIEVEMENTS.add_single_achievement(username, "next_question")
@@ -138,14 +130,14 @@ def routes(app, database, achievements, quizzes):
                 else:
                     achievement = ACHIEVEMENTS.add_single_achievement(username, "quiz_master")
             if achievement:
-                response['achievement'] = json.dumps(achievement)
+                response["achievement"] = json.dumps(achievement)
 
         print(response)
         return jsonify(response), 200
 
 
 def correct_answer_score(question):
-    return question['question_score']
+    return question["question_score"]
 
 
 def max_score(quiz_data):
@@ -153,11 +145,11 @@ def max_score(quiz_data):
     max_score = 0
     for question_key, question_value in quiz_data.items():
         index = index + 1
-        max_score = max_score + int(question_value['question_score'])
+        max_score = max_score + int(question_value["question_score"])
     return max_score
 
 
 def get_correctly_answered_question_nrs():
-    if 'correctly_answered_questions_numbers' not in session:
-        session['correctly_answered_questions_numbers'] = list()
-    return session['correctly_answered_questions_numbers']
+    if "correctly_answered_questions_numbers" not in session:
+        session["correctly_answered_questions_numbers"] = list()
+    return session["correctly_answered_questions_numbers"]

--- a/website/statistics.py
+++ b/website/statistics.py
@@ -13,61 +13,69 @@ import utils
 DATABASE = None
 
 """The Key tuple is used to aggregate the raw data by level, time or username."""
-Key = namedtuple('Key', ['name', 'class_'])
-level_key = Key('level', int)
-username_key = Key('id', str)
-week_key = Key('week', str)
+Key = namedtuple("Key", ["name", "class_"])
+level_key = Key("level", int)
+username_key = Key("id", str)
+week_key = Key("week", str)
 
 
 class UserType(Enum):
-    ALL = '@all'  # Old value used before user types
-    ANONYMOUS = '@all-anonymous'
-    LOGGED = '@all-logged'
-    STUDENT = '@all-students'
+    ALL = "@all"  # Old value used before user types
+    ANONYMOUS = "@all-anonymous"
+    LOGGED = "@all-logged"
+    STUDENT = "@all-students"
 
 
 def routes(app, db):
     global DATABASE
     DATABASE = db
 
-    @app.route('/stats/class/<class_id>', methods=['GET'])
+    @app.route("/stats/class/<class_id>", methods=["GET"])
     @requires_login
     def render_class_stats(user, class_id):
         if not is_teacher(user) and not is_admin(user):
-            return utils.error_page(error=403, ui_message=gettext('retrieve_class_error'))
+            return utils.error_page(error=403, ui_message=gettext("retrieve_class_error"))
 
         class_ = DATABASE.get_class(class_id)
-        if not class_ or (class_['teacher'] != user['username'] and not is_admin(user)):
-            return utils.error_page(error=404, ui_message=gettext('no_such_class'))
+        if not class_ or (class_["teacher"] != user["username"] and not is_admin(user)):
+            return utils.error_page(error=404, ui_message=gettext("no_such_class"))
 
-        students = sorted(class_.get('students', []))
-        return render_template('class-stats.html', class_info={'id': class_id, 'students': students},
-                               current_page='my-profile', page_title=gettext('title_class statistics'))
+        students = sorted(class_.get("students", []))
+        return render_template(
+            "class-stats.html",
+            class_info={"id": class_id, "students": students},
+            current_page="my-profile",
+            page_title=gettext("title_class statistics"),
+        )
 
-    @app.route('/logs/class/<class_id>', methods=['GET'])
+    @app.route("/logs/class/<class_id>", methods=["GET"])
     @requires_login
     def render_class_logs(user, class_id):
         if not is_teacher(user) and not is_admin(user):
-            return utils.error_page(error=403, ui_message=gettext('retrieve_class_error'))
+            return utils.error_page(error=403, ui_message=gettext("retrieve_class_error"))
 
         class_ = DATABASE.get_class(class_id)
-        if not class_ or (class_['teacher'] != user['username'] and not is_admin(user)):
-            return utils.error_page(error=404, ui_message=gettext('no_such_class'))
+        if not class_ or (class_["teacher"] != user["username"] and not is_admin(user)):
+            return utils.error_page(error=404, ui_message=gettext("no_such_class"))
 
-        students = sorted(class_.get('students', []))
-        return render_template('class-logs.html', class_info={'id': class_id, 'students': students},
-                               current_page='my-profile', page_title=gettext('title_class logs'))
+        students = sorted(class_.get("students", []))
+        return render_template(
+            "class-logs.html",
+            class_info={"id": class_id, "students": students},
+            current_page="my-profile",
+            page_title=gettext("title_class logs"),
+        )
 
-    @app.route('/class-stats/<class_id>', methods=['GET'])
+    @app.route("/class-stats/<class_id>", methods=["GET"])
     @requires_login
     def get_class_stats(user, class_id):
-        start_date = request.args.get('start', default=None, type=str)
-        end_date = request.args.get('end', default=None, type=str)
+        start_date = request.args.get("start", default=None, type=str)
+        end_date = request.args.get("end", default=None, type=str)
 
         cls = DATABASE.get_class(class_id)
-        students = cls.get('students', [])
-        if not cls or not students or (cls['teacher'] != user['username'] and not is_admin(user)):
-            return 'No such class or class empty', 403
+        students = cls.get("students", [])
+        if not cls or not students or (cls["teacher"] != user["username"] and not is_admin(user)):
+            return "No such class or class empty", 403
 
         program_data = DATABASE.get_program_stats(students, start_date, end_date)
         quiz_data = DATABASE.get_quiz_stats(students, start_date, end_date)
@@ -79,22 +87,22 @@ def routes(app, db):
         per_week_per_student = _aggregate_for_keys(data, [username_key, week_key])
 
         response = {
-            'class': {
-                'per_level': _to_response_per_level(per_level_data),
-                'per_week': _to_response(per_week_data, 'week', lambda e: f"L{e['level']}")
+            "class": {
+                "per_level": _to_response_per_level(per_level_data),
+                "per_week": _to_response(per_week_data, "week", lambda e: f"L{e['level']}"),
             },
-            'students': {
-                'per_level': _to_response(per_level_per_student, 'level', lambda e: e['id'], _to_response_level_name),
-                'per_week': _to_response(per_week_per_student, 'week', lambda e: e['id'])
-            }
+            "students": {
+                "per_level": _to_response(per_level_per_student, "level", lambda e: e["id"], _to_response_level_name),
+                "per_week": _to_response(per_week_per_student, "week", lambda e: e["id"]),
+            },
         }
         return jsonify(response)
 
-    @app.route('/program-stats', methods=['GET'])
+    @app.route("/program-stats", methods=["GET"])
     @requires_admin
     def get_program_stats(user):
-        start_date = request.args.get('start', default=None, type=str)
-        end_date = request.args.get('end', default=None, type=str)
+        start_date = request.args.get("start", default=None, type=str)
+        end_date = request.args.get("end", default=None, type=str)
 
         ids = [e.value for e in UserType]
         program_runs_data = DATABASE.get_program_stats(ids, start_date, end_date)
@@ -105,8 +113,8 @@ def routes(app, db):
         per_week_data = _aggregate_for_keys(data, [week_key, level_key])
 
         response = {
-            'per_level': _to_response_per_level(per_level_data),
-            'per_week': _to_response(per_week_data, 'week', lambda e: f"L{e['level']}")
+            "per_level": _to_response_per_level(per_level_data),
+            "per_week": _to_response(per_week_data, "week", lambda e: f"L{e['level']}"),
         }
         return jsonify(response)
 
@@ -129,30 +137,30 @@ def add(username, action):
 
 
 def _to_response_per_level(data):
-    data.sort(key=lambda el: el['level'])
-    return [{'level': f"L{entry['level']}", 'data': _data_to_response_per_level(entry['data'])} for entry in data]
+    data.sort(key=lambda el: el["level"])
+    return [{"level": f"L{entry['level']}", "data": _data_to_response_per_level(entry["data"])} for entry in data]
 
 
 def _data_to_response_per_level(data):
     res = {}
 
-    _add_value_to_result(res, 'successful_runs',  data['successful_runs'], is_counter=True)
-    _add_value_to_result(res, 'failed_runs', data['failed_runs'], is_counter=True)
-    res['error_rate'] = _calc_error_rate(data.get('failed_runs'), data.get('successful_runs'))
+    _add_value_to_result(res, "successful_runs", data["successful_runs"], is_counter=True)
+    _add_value_to_result(res, "failed_runs", data["failed_runs"], is_counter=True)
+    res["error_rate"] = _calc_error_rate(data.get("failed_runs"), data.get("successful_runs"))
     _add_exception_data(res, data)
 
-    _add_value_to_result(res, 'anonymous_runs', data['anonymous_runs'], is_counter=True)
-    _add_value_to_result(res, 'logged_runs', data['logged_runs'], is_counter=True)
-    _add_value_to_result(res, 'student_runs', data['student_runs'], is_counter=True)
-    _add_value_to_result(res, 'user_type_unknown_runs', data['user_type_unknown_runs'], is_counter=True)
+    _add_value_to_result(res, "anonymous_runs", data["anonymous_runs"], is_counter=True)
+    _add_value_to_result(res, "logged_runs", data["logged_runs"], is_counter=True)
+    _add_value_to_result(res, "student_runs", data["student_runs"], is_counter=True)
+    _add_value_to_result(res, "user_type_unknown_runs", data["user_type_unknown_runs"], is_counter=True)
 
-    _add_value_to_result(res, 'abandoned_quizzes', data['total_attempts'] - data['completed_attempts'], is_counter=True)
-    _add_value_to_result(res, 'completed_quizzes', data['completed_attempts'], is_counter=True)
+    _add_value_to_result(res, "abandoned_quizzes", data["total_attempts"] - data["completed_attempts"], is_counter=True)
+    _add_value_to_result(res, "completed_quizzes", data["completed_attempts"], is_counter=True)
 
-    min_, max_, avg_ = _score_metrics(data['scores'])
-    _add_value_to_result(res, 'quiz_score_min', min_)
-    _add_value_to_result(res, 'quiz_score_max', max_)
-    _add_value_to_result(res, 'quiz_score_avg', avg_)
+    min_, max_, avg_ = _score_metrics(data["scores"])
+    _add_value_to_result(res, "quiz_score_min", min_)
+    _add_value_to_result(res, "quiz_score_max", max_)
+    _add_value_to_result(res, "quiz_score_avg", avg_)
 
     return res
 
@@ -171,25 +179,27 @@ def _to_response(data, values_field, series_selector, values_map=None):
         if values not in res.keys():
             res[values] = {}
 
-        d = e['data']
-        _add_dict_to_result(res[values], 'successful_runs', series, d['successful_runs'], is_counter=True)
-        _add_dict_to_result(res[values], 'failed_runs', series, d['failed_runs'], is_counter=True)
-        _add_dict_to_result(res[values], 'abandoned_quizzes', series, d['total_attempts'] - d['completed_attempts'], is_counter=True)
-        _add_dict_to_result(res[values], 'completed_quizzes', series, d['completed_attempts'], is_counter=True)
+        d = e["data"]
+        _add_dict_to_result(res[values], "successful_runs", series, d["successful_runs"], is_counter=True)
+        _add_dict_to_result(res[values], "failed_runs", series, d["failed_runs"], is_counter=True)
+        _add_dict_to_result(
+            res[values], "abandoned_quizzes", series, d["total_attempts"] - d["completed_attempts"], is_counter=True
+        )
+        _add_dict_to_result(res[values], "completed_quizzes", series, d["completed_attempts"], is_counter=True)
 
-        _add_value_to_result(res[values], 'anonymous_runs', d['anonymous_runs'], is_counter=True)
-        _add_value_to_result(res[values], 'logged_runs', d['logged_runs'], is_counter=True)
-        _add_value_to_result(res[values], 'student_runs', d['student_runs'], is_counter=True)
-        _add_value_to_result(res[values], 'user_type_unknown_runs', d['user_type_unknown_runs'], is_counter=True)
+        _add_value_to_result(res[values], "anonymous_runs", d["anonymous_runs"], is_counter=True)
+        _add_value_to_result(res[values], "logged_runs", d["logged_runs"], is_counter=True)
+        _add_value_to_result(res[values], "student_runs", d["student_runs"], is_counter=True)
+        _add_value_to_result(res[values], "user_type_unknown_runs", d["user_type_unknown_runs"], is_counter=True)
 
-        min_, max_, avg_ = _score_metrics(d['scores'])
-        _add_dict_to_result(res[values], 'quiz_score_min', series, min_)
-        _add_dict_to_result(res[values], 'quiz_score_max', series, max_)
-        _add_dict_to_result(res[values], 'quiz_score_avg', series, avg_)
+        min_, max_, avg_ = _score_metrics(d["scores"])
+        _add_dict_to_result(res[values], "quiz_score_min", series, min_)
+        _add_dict_to_result(res[values], "quiz_score_max", series, max_)
+        _add_dict_to_result(res[values], "quiz_score_avg", series, avg_)
 
         _add_exception_data(res[values], d)
 
-    result = [{values_field: k, 'data': _add_error_rate_from_dicts(v)} for k, v in res.items()]
+    result = [{values_field: k, "data": _add_error_rate_from_dicts(v)} for k, v in res.items()]
     result.sort(key=lambda el: el[values_field])
 
     return [values_map(e) for e in result] if values_map else result
@@ -222,7 +232,7 @@ def _score_metrics(scores):
         if s > max_result:
             max_result = s
         total += s
-    return min_result, max_result, total/len(scores)
+    return min_result, max_result, total / len(scores)
 
 
 def _aggregate_for_keys(data, keys):
@@ -240,29 +250,30 @@ def _aggregate_for_keys(data, keys):
 
 
 def _aggregate_key(record, keys):
-    return '#'.join([str(record[key.name]) for key in keys])
+    return "#".join([str(record[key.name]) for key in keys])
 
 
 def _initialize():
-    return {'failed_runs': 0,
-            'successful_runs': 0,
-            'anonymous_runs': 0,
-            'logged_runs': 0,
-            'student_runs': 0,
-            'user_type_unknown_runs': 0,
-            'total_attempts': 0,
-            'completed_attempts': 0,
-            'scores': []
-            }
+    return {
+        "failed_runs": 0,
+        "successful_runs": 0,
+        "anonymous_runs": 0,
+        "logged_runs": 0,
+        "student_runs": 0,
+        "user_type_unknown_runs": 0,
+        "total_attempts": 0,
+        "completed_attempts": 0,
+        "scores": [],
+    }
 
 
 def _add_program_run_data(data, rec):
     if not data:
         data = _initialize()
-    value = rec.get('successful_runs') or 0
-    data['successful_runs'] += value
+    value = rec.get("successful_runs") or 0
+    data["successful_runs"] += value
 
-    _add_user_type_runs(data, rec.get('id'), value)
+    _add_user_type_runs(data, rec.get("id"), value)
     _add_exception_data(data, rec, True)
 
     return data
@@ -271,51 +282,51 @@ def _add_program_run_data(data, rec):
 def _add_quiz_data(data, rec):
     if not data:
         data = _initialize()
-    data['total_attempts'] += rec.get('started') or 0
-    data['completed_attempts'] += rec.get('finished') or 0
-    data['scores'] += rec.get('scores') or []
+    data["total_attempts"] += rec.get("started") or 0
+    data["completed_attempts"] += rec.get("finished") or 0
+    data["scores"] += rec.get("scores") or []
     return data
 
 
 def _add_exception_data(entry, data, include_failed_runs=False):
-    exceptions = {k: v for k, v in data.items() if k.lower().endswith('exception')}
+    exceptions = {k: v for k, v in data.items() if k.lower().endswith("exception")}
     for k, v in exceptions.items():
         if not entry.get(k):
             entry[k] = 0
         entry[k] += v
         if include_failed_runs:
-            entry['failed_runs'] += v
-            _add_user_type_runs(entry, entry.get('id'), v)
+            entry["failed_runs"] += v
+            _add_user_type_runs(entry, entry.get("id"), v)
 
 
 def _add_user_type_runs(data, id_, value):
     if id_ == UserType.ANONYMOUS.value:
-        data['anonymous_runs'] += value
+        data["anonymous_runs"] += value
     if id_ == UserType.LOGGED.value:
-        data['logged_runs'] += value
+        data["logged_runs"] += value
     if id_ == UserType.STUDENT.value:
-        data['student_runs'] += value
+        data["student_runs"] += value
     if id_ == UserType.ALL.value:
-        data['user_type_unknown_runs'] += value
+        data["user_type_unknown_runs"] += value
 
 
 def _split_keys_data(k, v, keys):
-    values = k.split('#')
+    values = k.split("#")
     res = {keys[i].name: keys[i].class_(values[i]) for i in range(0, len(keys))}
-    res['data'] = v
+    res["data"] = v
     return res
 
 
 def _to_response_level_name(e):
-    e['level'] = f"L{e['level']}"
+    e["level"] = f"L{e['level']}"
     return e
 
 
 def _add_error_rate_from_dicts(data):
-    failed = data.get('failed_runs') or {}
-    successful = data.get('successful_runs') or {}
+    failed = data.get("failed_runs") or {}
+    successful = data.get("successful_runs") or {}
     keys = set.union(set(failed.keys()), set(successful.keys()))
-    data['error_rate'] = {k: _calc_error_rate(failed.get(k), successful.get(k)) for k in keys}
+    data["error_rate"] = {k: _calc_error_rate(failed.get(k), successful.get(k)) for k in keys}
     return data
 
 
@@ -334,15 +345,15 @@ def get_general_class_stats(students):
     weekly_errors = 0
 
     for entry in data:
-        entry_successes = int(entry.get('successful_runs', 0))
-        entry_errors = sum([v for k, v in entry.items() if k.lower().endswith('exception')])
+        entry_successes = int(entry.get("successful_runs", 0))
+        entry_errors = sum([v for k, v in entry.items() if k.lower().endswith("exception")])
         successes += entry_successes
         errors += entry_errors
-        if entry.get('week') == current_week:
+        if entry.get("week") == current_week:
             weekly_successes += entry_successes
             weekly_errors += entry_errors
 
     return {
-        'week': {'runs': weekly_successes + weekly_errors, 'fails': weekly_errors},
-        'total': {'runs': successes + errors, 'fails': errors}
+        "week": {"runs": weekly_successes + weekly_errors, "fails": weekly_errors},
+        "total": {"runs": successes + errors, "fails": errors},
     }

--- a/website/teacher.py
+++ b/website/teacher.py
@@ -2,7 +2,14 @@ import json
 from flask_babel import gettext
 import hedy
 import hedyweb
-from website.auth import requires_login, is_teacher, is_admin, current_user, validate_student_signup_data, store_new_student_account
+from website.auth import (
+    requires_login,
+    is_teacher,
+    is_admin,
+    current_user,
+    validate_student_signup_data,
+    store_new_student_account,
+)
 import utils
 import uuid
 from flask import g, request, jsonify, redirect, session
@@ -11,8 +18,8 @@ import os
 import hedy_content
 from config import config
 
-cookie_name = config['session']['cookie_name']
-invite_length = config['session']['invite_length'] * 60
+cookie_name = config["session"]["cookie_name"]
+invite_length = config["session"]["invite_length"] * 60
 
 
 def routes(app, database, achievements):
@@ -21,649 +28,696 @@ def routes(app, database, achievements):
     DATABASE = database
     ACHIEVEMENTS = achievements
 
-    @app.route('/for-teachers', methods=['GET'])
+    @app.route("/for-teachers", methods=["GET"])
     @requires_login
     def for_teachers_page(user):
         if not is_teacher(user):
-            return utils.error_page(error=403, ui_message=gettext('not_teacher'))
+            return utils.error_page(error=403, ui_message=gettext("not_teacher"))
 
-        welcome_teacher = session.get('welcome-teacher') or False
-        session.pop('welcome-teacher', None)
+        welcome_teacher = session.get("welcome-teacher") or False
+        session.pop("welcome-teacher", None)
 
-        teacher_classes = DATABASE.get_teacher_classes(current_user()['username'], True)
+        teacher_classes = DATABASE.get_teacher_classes(current_user()["username"], True)
         adventures = []
-        for adventure in DATABASE.get_teacher_adventures(current_user()['username']):
+        for adventure in DATABASE.get_teacher_adventures(current_user()["username"]):
             adventures.append(
-                {'id': adventure.get('id'),
-                 'name': adventure.get('name'),
-                 'date': utils.localized_date_format(adventure.get('date')),
-                 'level': adventure.get('level')
-                 }
+                {
+                    "id": adventure.get("id"),
+                    "name": adventure.get("name"),
+                    "date": utils.localized_date_format(adventure.get("date")),
+                    "level": adventure.get("level"),
+                }
             )
 
-        return render_template('for-teachers.html', current_page='my-profile', page_title=gettext('title_for-teacher'),
-                               teacher_classes=teacher_classes,
-                               teacher_adventures=adventures, welcome_teacher=welcome_teacher)
+        return render_template(
+            "for-teachers.html",
+            current_page="my-profile",
+            page_title=gettext("title_for-teacher"),
+            teacher_classes=teacher_classes,
+            teacher_adventures=adventures,
+            welcome_teacher=welcome_teacher,
+        )
 
-
-    @app.route('/for-teachers/manual', methods=['GET'])
+    @app.route("/for-teachers/manual", methods=["GET"])
     @requires_login
     def get_teacher_manual(user):
-        page_translations = hedyweb.PageTranslations('for-teachers').get_page_translations(g.lang)
-        return render_template('teacher-manual.html', current_page='my-profile', content=page_translations)
+        page_translations = hedyweb.PageTranslations("for-teachers").get_page_translations(g.lang)
+        return render_template("teacher-manual.html", current_page="my-profile", content=page_translations)
 
-
-    @app.route('/classes', methods=['GET'])
+    @app.route("/classes", methods=["GET"])
     @requires_login
     def get_classes(user):
         if not is_teacher(user):
-            return utils.error_page_403(error=403, ui_message=gettext('retrieve_class_error'))
-        return jsonify (DATABASE.get_teacher_classes(user['username'], True))
+            return utils.error_page_403(error=403, ui_message=gettext("retrieve_class_error"))
+        return jsonify(DATABASE.get_teacher_classes(user["username"], True))
 
-    @app.route('/for-teachers/class/<class_id>', methods=['GET'])
+    @app.route("/for-teachers/class/<class_id>", methods=["GET"])
     @requires_login
     def get_class(user, class_id):
-        app.logger.info('This is info output')
+        app.logger.info("This is info output")
         if not is_teacher(user) and not is_admin(user):
-            return utils.error_page_403(error=403, ui_message=gettext('retrieve_class_error'))
+            return utils.error_page_403(error=403, ui_message=gettext("retrieve_class_error"))
         Class = DATABASE.get_class(class_id)
-        if not Class or (Class['teacher'] != user['username'] and not is_admin(user)):
-            return utils.error_page(error=404, ui_message=gettext('no_such_class'))
+        if not Class or (Class["teacher"] != user["username"] and not is_admin(user)):
+            return utils.error_page(error=404, ui_message=gettext("no_such_class"))
         students = []
 
-        for student_username in Class.get('students', []):
+        for student_username in Class.get("students", []):
             student = DATABASE.user_by_username(student_username)
             programs = DATABASE.programs_for_user(student_username)
-            highest_level = max(program['level'] for program in programs) if len(programs) else 0
-            students.append({
-                'username': student_username,
-                'last_login': student['last_login'],
-                'programs': len(programs),
-                'highest_level': highest_level
-            })
+            highest_level = max(program["level"] for program in programs) if len(programs) else 0
+            students.append(
+                {
+                    "username": student_username,
+                    "last_login": student["last_login"],
+                    "programs": len(programs),
+                    "highest_level": highest_level,
+                }
+            )
 
         # Sort the students by their last login
-        students = sorted(students, key=lambda d: d.get('last_login', 0), reverse=True)
+        students = sorted(students, key=lambda d: d.get("last_login", 0), reverse=True)
         # After sorting: replace the number value by a string format date
         for student in students:
-            student['last_login'] = utils.localized_date_format(student.get('last_login', 0))
+            student["last_login"] = utils.localized_date_format(student.get("last_login", 0))
 
         if utils.is_testing_request(request):
-            return jsonify({'students': students, 'link': Class['link'], 'name': Class['name'], 'id': Class['id']})
+            return jsonify({"students": students, "link": Class["link"], "name": Class["name"], "id": Class["id"]})
 
         achievement = None
         if len(students) > 20:
-            achievement = ACHIEVEMENTS.add_single_achievement(user['username'], "full_house")
+            achievement = ACHIEVEMENTS.add_single_achievement(user["username"], "full_house")
         if achievement:
             achievement = json.dumps(achievement)
 
         invites = []
-        for invite in DATABASE.get_class_invites(Class['id']):
-            invites.append({'username': invite['username'],
-                            'timestamp': utils.localized_date_format(invite['timestamp'], short_format=True),
-                            'expire_timestamp': utils.localized_date_format(invite['ttl'], short_format=True)})
+        for invite in DATABASE.get_class_invites(Class["id"]):
+            invites.append(
+                {
+                    "username": invite["username"],
+                    "timestamp": utils.localized_date_format(invite["timestamp"], short_format=True),
+                    "expire_timestamp": utils.localized_date_format(invite["ttl"], short_format=True),
+                }
+            )
 
-        return render_template('class-overview.html', current_page='my-profile',
-                                page_title=gettext('title_class-overview'),
-                                achievement=achievement, invites=invites,
-                                class_info={'students': students, 'link': os.getenv('BASE_URL') + '/hedy/l/' + Class['link'],
-                                            'teacher': Class['teacher'], 'name': Class['name'], 'id': Class['id']})
+        return render_template(
+            "class-overview.html",
+            current_page="my-profile",
+            page_title=gettext("title_class-overview"),
+            achievement=achievement,
+            invites=invites,
+            class_info={
+                "students": students,
+                "link": os.getenv("BASE_URL") + "/hedy/l/" + Class["link"],
+                "teacher": Class["teacher"],
+                "name": Class["name"],
+                "id": Class["id"],
+            },
+        )
 
-    @app.route('/class', methods=['POST'])
+    @app.route("/class", methods=["POST"])
     @requires_login
     def create_class(user):
         if not is_teacher(user):
-            return gettext('only_teacher_create_class'), 403
+            return gettext("only_teacher_create_class"), 403
 
         body = request.json
         # Validations
         if not isinstance(body, dict):
-            return gettext('ajax_error'), 400
-        if not isinstance(body.get('name'), str):
-            return gettext('class_name_invalid'), 400
-        if len(body.get('name')) < 1:
-            return gettext('class_name_empty'), 400
+            return gettext("ajax_error"), 400
+        if not isinstance(body.get("name"), str):
+            return gettext("class_name_invalid"), 400
+        if len(body.get("name")) < 1:
+            return gettext("class_name_empty"), 400
 
         # We use this extra call to verify if the class name doesn't already exist, if so it's a duplicate
-        Classes = DATABASE.get_teacher_classes(user['username'], True)
+        Classes = DATABASE.get_teacher_classes(user["username"], True)
         for Class in Classes:
-            if Class['name'] == body['name']:
-                return gettext('class_name_duplicate'), 200
+            if Class["name"] == body["name"]:
+                return gettext("class_name_duplicate"), 200
 
         Class = {
-            'id': uuid.uuid4().hex,
-            'date': utils.timems(),
-            'teacher': user['username'],
-            'link': utils.random_id_generator(7),
-            'name': body['name']
+            "id": uuid.uuid4().hex,
+            "date": utils.timems(),
+            "teacher": user["username"],
+            "link": utils.random_id_generator(7),
+            "name": body["name"],
         }
 
         DATABASE.store_class(Class)
-        achievement = ACHIEVEMENTS.add_single_achievement(user['username'], "ready_set_education")
+        achievement = ACHIEVEMENTS.add_single_achievement(user["username"], "ready_set_education")
         if achievement:
-            return {'id': Class['id'], 'achievement': achievement}, 200
-        return {'id': Class['id']}, 200
+            return {"id": Class["id"], "achievement": achievement}, 200
+        return {"id": Class["id"]}, 200
 
-    @app.route('/class/<class_id>', methods=['PUT'])
+    @app.route("/class/<class_id>", methods=["PUT"])
     @requires_login
     def update_class(user, class_id):
         if not is_teacher(user):
-            return 'Only teachers can update classes', 403
+            return "Only teachers can update classes", 403
 
         body = request.json
         # Validations
         if not isinstance(body, dict):
-            return gettext('ajax_error'), 400
-        if not isinstance(body.get('name'), str):
-            return gettext('class_name_invalid'), 400
-        if len(body.get('name')) < 1:
-            return gettext('class_name_empty'), 400
+            return gettext("ajax_error"), 400
+        if not isinstance(body.get("name"), str):
+            return gettext("class_name_invalid"), 400
+        if len(body.get("name")) < 1:
+            return gettext("class_name_empty"), 400
 
-        Class = DATABASE.get_class (class_id)
-        if not Class or Class['teacher'] != user['username']:
-            return gettext('no_such_class'), 404
+        Class = DATABASE.get_class(class_id)
+        if not Class or Class["teacher"] != user["username"]:
+            return gettext("no_such_class"), 404
 
         # We use this extra call to verify if the class name doesn't already exist, if so it's a duplicate
-        Classes = DATABASE.get_teacher_classes(user['username'], True)
+        Classes = DATABASE.get_teacher_classes(user["username"], True)
         for Class in Classes:
-            if Class['name'] == body['name']:
-                return "duplicate", 200 # Todo TB: Will have to look into this, but not sure why we return a 200?
+            if Class["name"] == body["name"]:
+                return "duplicate", 200  # Todo TB: Will have to look into this, but not sure why we return a 200?
 
-        DATABASE.update_class(class_id, body['name'])
-        achievement = ACHIEVEMENTS.add_single_achievement(user['username'], "on_second_thoughts")
+        DATABASE.update_class(class_id, body["name"])
+        achievement = ACHIEVEMENTS.add_single_achievement(user["username"], "on_second_thoughts")
         if achievement:
-            return {'achievement': achievement}, 200
+            return {"achievement": achievement}, 200
         return {}, 200
 
-    @app.route('/class/<class_id>', methods=['DELETE'])
+    @app.route("/class/<class_id>", methods=["DELETE"])
     @requires_login
     def delete_class(user, class_id):
         Class = DATABASE.get_class(class_id)
-        if not Class or Class['teacher'] != user['username']:
-            return gettext('no_such_class'), 404
+        if not Class or Class["teacher"] != user["username"]:
+            return gettext("no_such_class"), 404
 
         DATABASE.delete_class(Class)
-        achievement = ACHIEVEMENTS.add_single_achievement(user['username'], "end_of_semester")
+        achievement = ACHIEVEMENTS.add_single_achievement(user["username"], "end_of_semester")
         if achievement:
-            return {'achievement': achievement}, 200
+            return {"achievement": achievement}, 200
         return {}, 200
 
-    @app.route('/duplicate_class', methods=['POST'])
+    @app.route("/duplicate_class", methods=["POST"])
     @requires_login
     def duplicate_class(user):
         if not is_teacher(user):
-            return gettext('only_teacher_create_class'), 403
+            return gettext("only_teacher_create_class"), 403
 
         body = request.json
         # Validations
         if not isinstance(body, dict):
-            return gettext('ajax_error'), 400
-        if not isinstance(body.get('name'), str):
-            return gettext('class_name_invalid'), 400
-        if len(body.get('name')) < 1:
-            return gettext('class_name_empty'), 400
+            return gettext("ajax_error"), 400
+        if not isinstance(body.get("name"), str):
+            return gettext("class_name_invalid"), 400
+        if len(body.get("name")) < 1:
+            return gettext("class_name_empty"), 400
 
-        Class = DATABASE.get_class(body.get('id'))
-        if not Class or Class['teacher'] != user['username']:
-            return gettext('no_such_class'), 404
+        Class = DATABASE.get_class(body.get("id"))
+        if not Class or Class["teacher"] != user["username"]:
+            return gettext("no_such_class"), 404
 
         # We use this extra call to verify if the class name doesn't already exist, if so it's a duplicate
         # Todo TB: This is a duplicate function, might be nice to perform some clean-up to reduce these parts
-        Classes = DATABASE.get_teacher_classes(user['username'], True)
+        Classes = DATABASE.get_teacher_classes(user["username"], True)
         for Class in Classes:
-            if Class['name'] == body.get('name'):
-                return gettext('class_name_duplicate'), 400
+            if Class["name"] == body.get("name"):
+                return gettext("class_name_duplicate"), 400
 
         # All the class settings are still unique, we are only concerned with copying the customizations
         # Shortly: Create a class like normal: concern with copying the customizations
         class_id = uuid.uuid4().hex
 
         new_class = {
-            'id': class_id,
-            'date': utils.timems(),
-            'teacher': user['username'],
-            'link': utils.random_id_generator(7),
-            'name': body.get('name')
+            "id": class_id,
+            "date": utils.timems(),
+            "teacher": user["username"],
+            "link": utils.random_id_generator(7),
+            "name": body.get("name"),
         }
 
         DATABASE.store_class(new_class)
 
         # Get the customizations of the current class -> if they exist, update id and store again
-        customizations = DATABASE.get_class_customizations(body.get('id'))
+        customizations = DATABASE.get_class_customizations(body.get("id"))
         if customizations:
-            customizations['id'] = class_id
+            customizations["id"] = class_id
             DATABASE.update_class_customizations(customizations)
 
-        achievement = ACHIEVEMENTS.add_single_achievement(current_user()['username'], "one_for_money")
+        achievement = ACHIEVEMENTS.add_single_achievement(current_user()["username"], "one_for_money")
         if achievement:
-            return {'achievement': achievement}, 200
+            return {"achievement": achievement}, 200
 
-
-    @app.route('/class/<class_id>/prejoin/<link>', methods=['GET'])
+    @app.route("/class/<class_id>/prejoin/<link>", methods=["GET"])
     def prejoin_class(class_id, link):
         Class = DATABASE.get_class(class_id)
-        if not Class or Class['link'] != link:
-            return utils.error_page(error=404, ui_message=gettext('invalid_class_link'))
+        if not Class or Class["link"] != link:
+            return utils.error_page(error=404, ui_message=gettext("invalid_class_link"))
         if request.cookies.get(cookie_name):
             token = DATABASE.get_token(request.cookies.get(cookie_name))
-            if token and token.get('username') in Class.get('students', []):
-                    return render_template('class-prejoin.html', joined=True, page_title=gettext('title_join-class'),
-                                            current_page='my-profile', class_info={'name': Class ['name']})
-        return render_template('class-prejoin.html', joined=False, page_title=gettext('title_join-class'),
-                               current_page='my-profile', class_info={'id': Class ['id'], 'name': Class ['name']})
+            if token and token.get("username") in Class.get("students", []):
+                return render_template(
+                    "class-prejoin.html",
+                    joined=True,
+                    page_title=gettext("title_join-class"),
+                    current_page="my-profile",
+                    class_info={"name": Class["name"]},
+                )
+        return render_template(
+            "class-prejoin.html",
+            joined=False,
+            page_title=gettext("title_join-class"),
+            current_page="my-profile",
+            class_info={"id": Class["id"], "name": Class["name"]},
+        )
 
-    @app.route('/class/join', methods=['POST'])
+    @app.route("/class/join", methods=["POST"])
     def join_class():
         body = request.json
         Class = None
-        if 'id' in body:
-            Class = DATABASE.get_class(body['id'])
-        if not Class or Class['id'] != body['id']:
-            return utils.error_page(error=404, ui_message=gettext('invalid_class_link'))
+        if "id" in body:
+            Class = DATABASE.get_class(body["id"])
+        if not Class or Class["id"] != body["id"]:
+            return utils.error_page(error=404, ui_message=gettext("invalid_class_link"))
 
-        if not current_user()['username']:
-            return gettext('join_prompt'), 403
+        if not current_user()["username"]:
+            return gettext("join_prompt"), 403
 
-        DATABASE.add_student_to_class(Class['id'], current_user()['username'])
+        DATABASE.add_student_to_class(Class["id"], current_user()["username"])
         # We only want to remove the invite if the user joins the class with an actual pending invite
-        invite = DATABASE.get_username_invite(current_user()['username'])
-        if invite and invite.get('class_id') == body['id']:
-            DATABASE.remove_class_invite(current_user()['username'])
+        invite = DATABASE.get_username_invite(current_user()["username"])
+        if invite and invite.get("class_id") == body["id"]:
+            DATABASE.remove_class_invite(current_user()["username"])
             # Also remove the pending message in this case
-            session['messages'] = 0
+            session["messages"] = 0
 
-        achievement = ACHIEVEMENTS.add_single_achievement(current_user()['username'], "epic_education")
+        achievement = ACHIEVEMENTS.add_single_achievement(current_user()["username"], "epic_education")
         if achievement:
-            return {'achievement': achievement}, 200
+            return {"achievement": achievement}, 200
         return {}, 200
 
-    @app.route('/class/<class_id>/student/<student_id>', methods=['DELETE'])
+    @app.route("/class/<class_id>/student/<student_id>", methods=["DELETE"])
     @requires_login
     def leave_class(user, class_id, student_id):
         Class = DATABASE.get_class(class_id)
-        if not Class or (Class['teacher'] != user['username'] and student_id != user['username']):
-            return gettext('ajax_error'), 400
+        if not Class or (Class["teacher"] != user["username"] and student_id != user["username"]):
+            return gettext("ajax_error"), 400
 
-        DATABASE.remove_student_from_class(Class['id'], student_id)
+        DATABASE.remove_student_from_class(Class["id"], student_id)
         achievement = None
-        if Class['teacher'] == user['username']:
-            achievement = ACHIEVEMENTS.add_single_achievement(user['username'], "detention")
+        if Class["teacher"] == user["username"]:
+            achievement = ACHIEVEMENTS.add_single_achievement(user["username"], "detention")
         if achievement:
-            return {'achievement': achievement}, 200
+            return {"achievement": achievement}, 200
         return {}, 200
 
-    @app.route('/for-teachers/customize-class/<class_id>', methods=['GET'])
+    @app.route("/for-teachers/customize-class/<class_id>", methods=["GET"])
     @requires_login
     def get_class_info(user, class_id):
         if not is_teacher(user) and not is_admin(user):
-            return utils.error_page(error=403, ui_message=gettext('retrieve_class_error'))
+            return utils.error_page(error=403, ui_message=gettext("retrieve_class_error"))
         Class = DATABASE.get_class(class_id)
-        if not Class or (Class['teacher'] != user['username'] and not is_admin(user)):
-            return utils.error_page(error=404, ui_message=gettext('no_such_class'))
+        if not Class or (Class["teacher"] != user["username"] and not is_admin(user)):
+            return utils.error_page(error=404, ui_message=gettext("no_such_class"))
 
         if hedy_content.Adventures(g.lang).has_adventures():
             adventures = hedy_content.Adventures(g.lang).get_adventure_keyname_name_levels()
         else:
             adventures = hedy_content.Adventures("en").get_adventure_keyname_name_levels()
 
-        teacher_adventures = DATABASE.get_teacher_adventures(user['username'])
+        teacher_adventures = DATABASE.get_teacher_adventures(user["username"])
         customizations = DATABASE.get_class_customizations(class_id)
 
-        return render_template('customize-class.html', page_title=gettext('title_customize-class'),
-                               class_info={'name': Class['name'], 'id': Class['id']}, max_level=hedy.HEDY_MAX_LEVEL,
-                               adventures=adventures, teacher_adventures=teacher_adventures,
-                               customizations=customizations, current_page='my-profile')
+        return render_template(
+            "customize-class.html",
+            page_title=gettext("title_customize-class"),
+            class_info={"name": Class["name"], "id": Class["id"]},
+            max_level=hedy.HEDY_MAX_LEVEL,
+            adventures=adventures,
+            teacher_adventures=teacher_adventures,
+            customizations=customizations,
+            current_page="my-profile",
+        )
 
-    @app.route('/for-teachers/customize-class/<class_id>', methods=['DELETE'])
+    @app.route("/for-teachers/customize-class/<class_id>", methods=["DELETE"])
     @requires_login
     def delete_customizations(user, class_id):
         if not is_teacher(user):
-            return utils.error_page(error=403, ui_message=gettext('retrieve_class_error'))
+            return utils.error_page(error=403, ui_message=gettext("retrieve_class_error"))
         Class = DATABASE.get_class(class_id)
-        if not Class or Class['teacher'] != user['username']:
-            return utils.error_page(error=404, ui_message=gettext('no_such_class'))
+        if not Class or Class["teacher"] != user["username"]:
+            return utils.error_page(error=404, ui_message=gettext("no_such_class"))
 
         DATABASE.delete_class_customizations(class_id)
-        return {'success': gettext('customization_deleted')}, 200
+        return {"success": gettext("customization_deleted")}, 200
 
-    @app.route('/for-teachers/customize-class/<class_id>', methods=['POST'])
+    @app.route("/for-teachers/customize-class/<class_id>", methods=["POST"])
     @requires_login
     def update_customizations(user, class_id):
         if not is_teacher(user):
-            return utils.error_page(error=403, ui_message=gettext('retrieve_class_error'))
+            return utils.error_page(error=403, ui_message=gettext("retrieve_class_error"))
         Class = DATABASE.get_class(class_id)
-        if not Class or Class['teacher'] != user['username']:
-            return utils.error_page(error=404, ui_message=gettext('no_such_class'))
+        if not Class or Class["teacher"] != user["username"]:
+            return utils.error_page(error=404, ui_message=gettext("no_such_class"))
 
         body = request.json
         # Validations
         if not isinstance(body, dict):
-            return gettext('ajax_error'), 400
-        if not isinstance(body.get('levels'), list):
+            return gettext("ajax_error"), 400
+        if not isinstance(body.get("levels"), list):
             return "Levels must be a list", 400
-        if not isinstance(body.get('adventures'), dict):
-            return 'Adventures must be a dict', 400
-        if not isinstance(body.get('teacher_adventures'), list):
-            return 'Teacher adventures must be a list', 400
-        if not isinstance(body.get('other_settings'), list):
-            return 'Other settings must be a list', 400
-        if not isinstance(body.get('opening_dates'), dict):
-            return 'Opening dates must be a dict', 400
+        if not isinstance(body.get("adventures"), dict):
+            return "Adventures must be a dict", 400
+        if not isinstance(body.get("teacher_adventures"), list):
+            return "Teacher adventures must be a list", 400
+        if not isinstance(body.get("other_settings"), list):
+            return "Other settings must be a list", 400
+        if not isinstance(body.get("opening_dates"), dict):
+            return "Opening dates must be a dict", 400
 
         # Values are always strings from the front-end -> convert to numbers
-        levels = [int(i) for i in body['levels']]
+        levels = [int(i) for i in body["levels"]]
 
-        opening_dates = body['opening_dates'].copy()
-        for level, timestamp in body.get('opening_dates').items():
+        opening_dates = body["opening_dates"].copy()
+        for level, timestamp in body.get("opening_dates").items():
             if len(timestamp) < 1:
                 opening_dates.pop(level)
             else:
                 try:
                     opening_dates[level] = utils.datetotimeordate(timestamp)
                 except:
-                    return 'One or more of your opening dates is invalid', 400
+                    return "One or more of your opening dates is invalid", 400
 
         adventures = {}
-        for name, adventure_levels in body['adventures'].items():
+        for name, adventure_levels in body["adventures"].items():
             adventures[name] = [int(i) for i in adventure_levels]
 
         customizations = {
-            'id': class_id,
-            'levels': levels,
-            'opening_dates': opening_dates,
-            'adventures': adventures,
-            'teacher_adventures': body['teacher_adventures'],
-            'other_settings': body['other_settings']
+            "id": class_id,
+            "levels": levels,
+            "opening_dates": opening_dates,
+            "adventures": adventures,
+            "teacher_adventures": body["teacher_adventures"],
+            "other_settings": body["other_settings"],
         }
 
         DATABASE.update_class_customizations(customizations)
-        return {'success': gettext('class_customize_success')}, 200
+        return {"success": gettext("class_customize_success")}, 200
 
-    @app.route('/invite_student', methods=['POST'])
+    @app.route("/invite_student", methods=["POST"])
     @requires_login
     def invite_student(user):
         body = request.json
         # Validations
         if not isinstance(body, dict):
-            return gettext('ajax_error'), 400
-        if not isinstance(body.get('username'), str):
-            return gettext('username_invalid'), 400
-        if not isinstance(body.get('class_id'), str):
-            return 'class id must be a string', 400
-        if len(body.get('username')) < 1:
-            return gettext('username_empty'), 400
+            return gettext("ajax_error"), 400
+        if not isinstance(body.get("username"), str):
+            return gettext("username_invalid"), 400
+        if not isinstance(body.get("class_id"), str):
+            return "class id must be a string", 400
+        if len(body.get("username")) < 1:
+            return gettext("username_empty"), 400
 
-        username = body.get('username').lower()
-        class_id = body.get('class_id')
+        username = body.get("username").lower()
+        class_id = body.get("class_id")
 
         if not is_teacher(user):
-            return utils.error_page(error=403, ui_message=gettext('retrieve_class_error'))
+            return utils.error_page(error=403, ui_message=gettext("retrieve_class_error"))
         Class = DATABASE.get_class(class_id)
-        if not Class or Class['teacher'] != user['username']:
-            return utils.error_page(error=404, ui_message=gettext('no_such_class'))
+        if not Class or Class["teacher"] != user["username"]:
+            return utils.error_page(error=404, ui_message=gettext("no_such_class"))
 
         user = DATABASE.user_by_username(username)
         if not user:
-            return gettext('student_not_existing'), 400
-        if 'students' in Class and user['username'] in Class['students']:
-            return gettext('student_already_in_class'), 400
-        if DATABASE.get_username_invite(user['username']):
-            return gettext('student_already_invite'), 400
+            return gettext("student_not_existing"), 400
+        if "students" in Class and user["username"] in Class["students"]:
+            return gettext("student_already_in_class"), 400
+        if DATABASE.get_username_invite(user["username"]):
+            return gettext("student_already_invite"), 400
 
         # So: The class and student exist and are currently not a combination -> invite!
         data = {
-            'username': username,
-            'class_id': class_id,
-            'timestamp': utils.times(),
-            'ttl': utils.times() + invite_length
+            "username": username,
+            "class_id": class_id,
+            "timestamp": utils.times(),
+            "ttl": utils.times() + invite_length,
         }
         DATABASE.add_class_invite(data)
         return {}, 200
 
-    @app.route('/remove_student_invite', methods=['POST'])
+    @app.route("/remove_student_invite", methods=["POST"])
     @requires_login
     def remove_invite(user):
         body = request.json
         # Validations
         if not isinstance(body, dict):
-            return gettext('ajax_error'), 400
-        if not isinstance(body.get('username'), str):
-            return gettext('username_invalid'), 400
-        if not isinstance(body.get('class_id'), str):
-            return 'class id must be a string', 400
+            return gettext("ajax_error"), 400
+        if not isinstance(body.get("username"), str):
+            return gettext("username_invalid"), 400
+        if not isinstance(body.get("class_id"), str):
+            return "class id must be a string", 400
 
-        username = body.get('username')
-        class_id = body.get('class_id')
+        username = body.get("username")
+        class_id = body.get("class_id")
 
-        if not is_teacher(user) and username != user.get('username'):
-            return utils.error_page(error=403, ui_message=gettext('retrieve_class_error'))
+        if not is_teacher(user) and username != user.get("username"):
+            return utils.error_page(error=403, ui_message=gettext("retrieve_class_error"))
         Class = DATABASE.get_class(class_id)
-        if not Class or (Class['teacher'] != user['username'] and username != user.get('username')):
-            return utils.error_page(error=404, ui_message=gettext('no_such_class'))
+        if not Class or (Class["teacher"] != user["username"] and username != user.get("username")):
+            return utils.error_page(error=404, ui_message=gettext("no_such_class"))
 
         DATABASE.remove_class_invite(username)
         return {}, 200
 
-    @app.route('/for-teachers/create-accounts/<class_id>', methods=['GET'])
+    @app.route("/for-teachers/create-accounts/<class_id>", methods=["GET"])
     @requires_login
     def create_accounts(user, class_id):
         if not is_teacher(user):
-            return utils.error_page(error=403, ui_message=gettext('not_teacher'))
+            return utils.error_page(error=403, ui_message=gettext("not_teacher"))
         current_class = DATABASE.get_class(class_id)
-        if not current_class or current_class.get('teacher') != user.get('username'):
-            return utils.error_page(error=403, ui_message=gettext('no_such_class'))
+        if not current_class or current_class.get("teacher") != user.get("username"):
+            return utils.error_page(error=403, ui_message=gettext("no_such_class"))
 
-        return render_template('create-accounts.html', current_class = current_class)
+        return render_template("create-accounts.html", current_class=current_class)
 
-    @app.route('/for-teachers/create-accounts', methods=['POST'])
+    @app.route("/for-teachers/create-accounts", methods=["POST"])
     @requires_login
     def store_accounts(user):
         if not is_teacher(user):
-            return utils.error_page(error=403, ui_message=gettext('not_teacher'))
+            return utils.error_page(error=403, ui_message=gettext("not_teacher"))
         body = request.json
 
         # Validations
         if not isinstance(body, dict):
-            return gettext('ajax_error'), 400
-        if not isinstance(body.get('accounts'), list):
+            return gettext("ajax_error"), 400
+        if not isinstance(body.get("accounts"), list):
             return "accounts should be a list!", 400
 
-        if len(body.get('accounts', [])) < 1:
-            return gettext('no_accounts'), 400
+        if len(body.get("accounts", [])) < 1:
+            return gettext("no_accounts"), 400
 
         usernames = []
 
         # Validation for correct types and duplicates
-        for account in body.get('accounts', []):
+        for account in body.get("accounts", []):
             validation = validate_student_signup_data(account)
             if validation:
                 return validation, 400
-            if account.get('username').strip().lower() in usernames:
-                return {'error': gettext('unique_usernames'), 'value': account.get('username')}, 200
-            usernames.append(account.get('username').strip().lower())
+            if account.get("username").strip().lower() in usernames:
+                return {"error": gettext("unique_usernames"), "value": account.get("username")}, 200
+            usernames.append(account.get("username").strip().lower())
 
         # Validation for duplicates in the db
-        classes = DATABASE.get_teacher_classes(user['username'], False)
-        for account in body.get('accounts', []):
-            if account.get('class') and account['class'] not in [i.get('name') for i in classes]:
+        classes = DATABASE.get_teacher_classes(user["username"], False)
+        for account in body.get("accounts", []):
+            if account.get("class") and account["class"] not in [i.get("name") for i in classes]:
                 return "not your class", 404
-            if DATABASE.user_by_username(account.get('username').strip().lower()):
-                return {'error': gettext('usernames_exist'), 'value': account.get('username').strip().lower()}, 200
+            if DATABASE.user_by_username(account.get("username").strip().lower()):
+                return {"error": gettext("usernames_exist"), "value": account.get("username").strip().lower()}, 200
 
         # Now -> actually store the users in the db
-        for account in body.get('accounts', []):
+        for account in body.get("accounts", []):
             # Set the current teacher language and keyword language as new account language
-            account['language'] = g.lang
-            account['keyword_language'] = g.keyword_lang
-            store_new_student_account(account, user['username'])
-            if account.get('class'):
-                class_id = [i.get('id') for i in classes if i.get('name') == account.get('class')][0]
-                DATABASE.add_student_to_class(class_id, account.get('username').strip().lower())
-        return {'success': gettext('accounts_created')}, 200
+            account["language"] = g.lang
+            account["keyword_language"] = g.keyword_lang
+            store_new_student_account(account, user["username"])
+            if account.get("class"):
+                class_id = [i.get("id") for i in classes if i.get("name") == account.get("class")][0]
+                DATABASE.add_student_to_class(class_id, account.get("username").strip().lower())
+        return {"success": gettext("accounts_created")}, 200
 
-    @app.route('/for-teachers/customize-adventure/view/<adventure_id>', methods=['GET'])
+    @app.route("/for-teachers/customize-adventure/view/<adventure_id>", methods=["GET"])
     @requires_login
     def view_adventure(user, adventure_id):
         if not is_teacher(user) and not is_admin(user):
-            return utils.error_page(error=403, ui_message=gettext('retrieve_adventure_error'))
+            return utils.error_page(error=403, ui_message=gettext("retrieve_adventure_error"))
         adventure = DATABASE.get_adventure(adventure_id)
         if not adventure:
-            return utils.error_page(error=404, ui_message=gettext('no_such_adventure'))
-        if adventure['creator'] != user['username'] and not is_admin(user):
-            return utils.error_page(error=403, ui_message=gettext('retrieve_adventure_error'))
+            return utils.error_page(error=404, ui_message=gettext("no_such_adventure"))
+        if adventure["creator"] != user["username"] and not is_admin(user):
+            return utils.error_page(error=403, ui_message=gettext("retrieve_adventure_error"))
 
         # Add level to the <pre> tag to let syntax highlighting know which highlighting we need!
-        adventure['content'] = adventure['content'].replace("<pre>", "<pre class='no-copy-button' level='" + str(adventure['level']) + "'>")
-        adventure['content'] = adventure['content'].format(**hedy_content.KEYWORDS.get(g.keyword_lang))
+        adventure["content"] = adventure["content"].replace(
+            "<pre>", "<pre class='no-copy-button' level='" + str(adventure["level"]) + "'>"
+        )
+        adventure["content"] = adventure["content"].format(**hedy_content.KEYWORDS.get(g.keyword_lang))
 
-        return render_template('view-adventure.html', adventure=adventure,
-                               page_title=gettext('title_view-adventure'), current_page='my-profile')
+        return render_template(
+            "view-adventure.html",
+            adventure=adventure,
+            page_title=gettext("title_view-adventure"),
+            current_page="my-profile",
+        )
 
-    @app.route('/for-teachers/customize-adventure/<adventure_id>', methods=['GET'])
+    @app.route("/for-teachers/customize-adventure/<adventure_id>", methods=["GET"])
     @requires_login
     def get_adventure_info(user, adventure_id):
         if not is_teacher(user):
-            return utils.error_page(error=403, ui_message=gettext('retrieve_adventure_error'))
+            return utils.error_page(error=403, ui_message=gettext("retrieve_adventure_error"))
         adventure = DATABASE.get_adventure(adventure_id)
-        if not adventure or adventure['creator'] != user['username']:
-            return utils.error_page(error=404, ui_message=gettext('no_such_adventure'))
+        if not adventure or adventure["creator"] != user["username"]:
+            return utils.error_page(error=404, ui_message=gettext("no_such_adventure"))
 
         # Now it gets a bit complex, we want to get the teacher classes as well as the customizations
         # This is a quite expensive retrieval, but we should be fine as this page is not called often
         # We only need the name, id and if it already has the adventure set as data to the front-end
-        Classes = DATABASE.get_teacher_classes(user['username'])
+        Classes = DATABASE.get_teacher_classes(user["username"])
         class_data = []
         for Class in Classes:
-            temp = {'name': Class.get('name'), 'id': Class.get('id'), 'checked': False}
-            customizations = DATABASE.get_class_customizations(Class.get('id'))
-            if customizations and adventure_id in customizations.get('teacher_adventures', []):
-                temp['checked'] = True
+            temp = {"name": Class.get("name"), "id": Class.get("id"), "checked": False}
+            customizations = DATABASE.get_class_customizations(Class.get("id"))
+            if customizations and adventure_id in customizations.get("teacher_adventures", []):
+                temp["checked"] = True
             class_data.append(temp)
 
-        return render_template('customize-adventure.html', page_title=gettext('title_customize-adventure'),
-                               adventure=adventure, class_data=class_data,
-                               max_level=hedy.HEDY_MAX_LEVEL, current_page='my-profile')
+        return render_template(
+            "customize-adventure.html",
+            page_title=gettext("title_customize-adventure"),
+            adventure=adventure,
+            class_data=class_data,
+            max_level=hedy.HEDY_MAX_LEVEL,
+            current_page="my-profile",
+        )
 
-    @app.route('/for-teachers/customize-adventure', methods=['POST'])
+    @app.route("/for-teachers/customize-adventure", methods=["POST"])
     @requires_login
     def update_adventure(user):
         body = request.json
         # Validations
         if not isinstance(body, dict):
-            return gettext('ajax_error'), 400
-        if not isinstance(body.get('id'), str):
-            return gettext('adventure_id_invalid'), 400
-        if not isinstance(body.get('name'), str):
-            return gettext('adventure_name_invalid'), 400
-        if not isinstance(body.get('level'), str):
-            return gettext('level_invalid'), 400
-        if not isinstance(body.get('content'), str):
-            return gettext('content_invalid'), 400
-        if len(body.get('content')) < 20:
-            return gettext('adventure_length'), 400
-        if not isinstance(body.get('public'), bool):
-            return gettext('public_invalid'), 400
-        if not isinstance(body.get('classes'), list):
-            return gettext('classes_invalid'), 400
+            return gettext("ajax_error"), 400
+        if not isinstance(body.get("id"), str):
+            return gettext("adventure_id_invalid"), 400
+        if not isinstance(body.get("name"), str):
+            return gettext("adventure_name_invalid"), 400
+        if not isinstance(body.get("level"), str):
+            return gettext("level_invalid"), 400
+        if not isinstance(body.get("content"), str):
+            return gettext("content_invalid"), 400
+        if len(body.get("content")) < 20:
+            return gettext("adventure_length"), 400
+        if not isinstance(body.get("public"), bool):
+            return gettext("public_invalid"), 400
+        if not isinstance(body.get("classes"), list):
+            return gettext("classes_invalid"), 400
 
         if not is_teacher(user):
-            return utils.error_page(error=403, ui_message=gettext('retrieve_adventure_error'))
-        current_adventure = DATABASE.get_adventure(body['id'])
-        if not current_adventure or current_adventure['creator'] != user['username']:
-            return utils.error_page(error=404, ui_message=gettext('no_such_adventure'))
+            return utils.error_page(error=403, ui_message=gettext("retrieve_adventure_error"))
+        current_adventure = DATABASE.get_adventure(body["id"])
+        if not current_adventure or current_adventure["creator"] != user["username"]:
+            return utils.error_page(error=404, ui_message=gettext("no_such_adventure"))
 
-        adventures = DATABASE.get_teacher_adventures(user['username'])
+        adventures = DATABASE.get_teacher_adventures(user["username"])
         for adventure in adventures:
-            if adventure['name'] == body['name'] and adventure['id'] != body['id']:
-                return gettext('adventure_duplicate'), 400
+            if adventure["name"] == body["name"] and adventure["id"] != body["id"]:
+                return gettext("adventure_duplicate"), 400
 
         # We want to make sure the adventure is valid and only contains correct placeholders
         # Try to parse with our current language, if it fails -> return an error to the user
         try:
-            body['content'].format(**hedy_content.KEYWORDS.get(g.keyword_lang))
+            body["content"].format(**hedy_content.KEYWORDS.get(g.keyword_lang))
         except:
-            return gettext('something_went_wrong_keyword_parsing'), 400
+            return gettext("something_went_wrong_keyword_parsing"), 400
 
         adventure = {
-            'date': utils.timems(),
-            'creator': user['username'],
-            'name': body['name'],
-            'level': body['level'],
-            'content': body['content'],
-            'public': body['public']
+            "date": utils.timems(),
+            "creator": user["username"],
+            "name": body["name"],
+            "level": body["level"],
+            "content": body["content"],
+            "public": body["public"],
         }
 
-        DATABASE.update_adventure(body['id'], adventure)
+        DATABASE.update_adventure(body["id"], adventure)
 
         # Once the adventure is correctly stored we have to update all class customizations
         # This is once again an expensive operation, we have to retrieve all teacher customizations
         # Then check if something is changed with the current situation, if so -> update in database
-        Classes = DATABASE.get_teacher_classes(user['username'])
+        Classes = DATABASE.get_teacher_classes(user["username"])
         for Class in Classes:
             # If so, the adventure should be in the class
-            if Class.get('id') in body.get('classes', []):
-                DATABASE.add_adventure_to_class_customizations(Class.get('id'), body.get('id'))
+            if Class.get("id") in body.get("classes", []):
+                DATABASE.add_adventure_to_class_customizations(Class.get("id"), body.get("id"))
             else:
-                DATABASE.remove_adventure_from_class_customizations(Class.get('id'), body.get('id'))
+                DATABASE.remove_adventure_from_class_customizations(Class.get("id"), body.get("id"))
 
-        return {'success': gettext('adventure_updated')}, 200
+        return {"success": gettext("adventure_updated")}, 200
 
-    @app.route('/for-teachers/customize-adventure/<adventure_id>', methods=['DELETE'])
+    @app.route("/for-teachers/customize-adventure/<adventure_id>", methods=["DELETE"])
     @requires_login
     def delete_adventure(user, adventure_id):
         if not is_teacher(user):
-            return utils.error_page(error=403, ui_message=gettext('retrieve_adventure_error'))
+            return utils.error_page(error=403, ui_message=gettext("retrieve_adventure_error"))
         adventure = DATABASE.get_adventure(adventure_id)
-        if not adventure or adventure['creator'] != user['username']:
-            return utils.error_page(error=404, ui_message=gettext('no_such_adventure'))
+        if not adventure or adventure["creator"] != user["username"]:
+            return utils.error_page(error=404, ui_message=gettext("no_such_adventure"))
 
         DATABASE.delete_adventure(adventure_id)
         return {}, 200
 
-    @app.route('/for-teachers/preview-adventure', methods=['POST'])
+    @app.route("/for-teachers/preview-adventure", methods=["POST"])
     def parse_preview_adventure():
         body = request.json
         try:
-            code = body.get('code').format(**hedy_content.KEYWORDS.get(g.keyword_lang))
+            code = body.get("code").format(**hedy_content.KEYWORDS.get(g.keyword_lang))
         except:
-            return gettext('something_went_wrong_keyword_parsing'), 400
-        return {'code': code}, 200
+            return gettext("something_went_wrong_keyword_parsing"), 400
+        return {"code": code}, 200
 
-    @app.route('/for-teachers/create_adventure', methods=['POST'])
+    @app.route("/for-teachers/create_adventure", methods=["POST"])
     @requires_login
     def create_adventure(user):
         if not is_teacher(user):
-            return utils.error_page(error=403, ui_message=gettext('create_adventure'))
+            return utils.error_page(error=403, ui_message=gettext("create_adventure"))
 
         body = request.json
         # Validations
         if not isinstance(body, dict):
-            return gettext('ajax_error'), 400
-        if not isinstance(body.get('name'), str):
-            return gettext('adventure_name_invalid'), 400
-        if len(body.get('name')) < 1:
-            return gettext('adventure_empty'), 400
+            return gettext("ajax_error"), 400
+        if not isinstance(body.get("name"), str):
+            return gettext("adventure_name_invalid"), 400
+        if len(body.get("name")) < 1:
+            return gettext("adventure_empty"), 400
 
-        adventures = DATABASE.get_teacher_adventures(user['username'])
+        adventures = DATABASE.get_teacher_adventures(user["username"])
         for adventure in adventures:
-            if adventure['name'] == body['name']:
-                return gettext('adventure_duplicate'), 400
+            if adventure["name"] == body["name"]:
+                return gettext("adventure_duplicate"), 400
 
         adventure = {
-            'id': uuid.uuid4().hex,
-            'date': utils.timems(),
-            'creator': user['username'],
-            'name': body['name'],
-            'level': 1,
-            'content': ""
+            "id": uuid.uuid4().hex,
+            "date": utils.timems(),
+            "creator": user["username"],
+            "name": body["name"],
+            "level": 1,
+            "content": "",
         }
 
         DATABASE.store_adventure(adventure)
-        return {'id': adventure['id']}, 200
+        return {"id": adventure["id"]}, 200
 
-    @app.route('/hedy/l/<link_id>', methods=['GET'])
+    @app.route("/hedy/l/<link_id>", methods=["GET"])
     def resolve_class_link(link_id):
         Class = DATABASE.resolve_class_link(link_id)
         if not Class:
-            return utils.error_page(error=404, ui_message=gettext('invalid_class_link'))
-        return redirect(request.url.replace('/hedy/l/' + link_id, '/class/' + Class ['id'] + '/prejoin/' + link_id), code=302)
+            return utils.error_page(error=404, ui_message=gettext("invalid_class_link"))
+        return redirect(
+            request.url.replace("/hedy/l/" + link_id, "/class/" + Class["id"] + "/prejoin/" + link_id), code=302
+        )

--- a/website/translating.py
+++ b/website/translating.py
@@ -5,175 +5,177 @@ from ruamel import yaml
 
 
 class TranslatableFile:
-  def __init__(self, caption, file, strings):
-    self.caption = caption
-    self.file = file
-    self.strings = strings
+    def __init__(self, caption, file, strings):
+        self.caption = caption
+        self.file = file
+        self.strings = strings
 
-  def add_string(self, string):
-    self.strings.append(string)
+    def add_string(self, string):
+        self.strings.append(string)
 
 
 class TranslatableString:
-  def __init__(self, path, original, translated):
-    self.is_header = False
-    self.path = path
-    self.original = original
-    self.translated = translated
-    self.key = path[-1] if path else ''
+    def __init__(self, path, original, translated):
+        self.is_header = False
+        self.path = path
+        self.original = original
+        self.translated = translated
+        self.key = path[-1] if path else ""
 
-  @property
-  def encoded_path(self):
-    return '.'.join(self.path)
+    @property
+    def encoded_path(self):
+        return ".".join(self.path)
 
-  @staticmethod
-  def decode_path(path):
-    return [try_int(x) for x in path.split('.')]
+    @staticmethod
+    def decode_path(path):
+        return [try_int(x) for x in path.split(".")]
 
 
 class TranslatableSection:
-  def __init__(self, caption):
-    self.is_header = True
-    self.caption = caption
+    def __init__(self, caption):
+        self.is_header = True
+        self.caption = caption
 
 
 def try_int(x):
-  try:
-    return int(x)
-  except ValueError:
-    return x
-
+    try:
+        return int(x)
+    except ValueError:
+        return x
 
 
 def struct_to_sections(struct1, struct2):
-  assert(isinstance(struct1, dict))
+    assert isinstance(struct1, dict)
 
-  def recurse(x, y, path):
-    if isinstance(x, str):
-      strings.append(TranslatableString(path, str(x), str(y or '')))
-      return
+    def recurse(x, y, path):
+        if isinstance(x, str):
+            strings.append(TranslatableString(path, str(x), str(y or "")))
+            return
 
-    if isinstance(x, list):
-      y = y if isinstance(y, list) else []
+        if isinstance(x, list):
+            y = y if isinstance(y, list) else []
 
-      for i, el in enumerate(x):
-        if not isinstance(el, str):
-          strings.append(TranslatableSection(str(i + 1)))
-        recurse(el, y[i] if i < len(y) else None, path + ['a:' + str(i)])
-      return
+            for i, el in enumerate(x):
+                if not isinstance(el, str):
+                    strings.append(TranslatableSection(str(i + 1)))
+                recurse(el, y[i] if i < len(y) else None, path + ["a:" + str(i)])
+            return
 
-    if isinstance(x, dict):
-      y = y if isinstance(y, dict) else {}
+        if isinstance(x, dict):
+            y = y if isinstance(y, dict) else {}
 
-      for key, el in x.items():
-        if not isinstance(el, str):
-          strings.append(TranslatableSection(str(key)))
-        recurse(el, y.get(key, None), path + [str(key)])
+            for key, el in x.items():
+                if not isinstance(el, str):
+                    strings.append(TranslatableSection(str(key)))
+                recurse(el, y.get(key, None), path + [str(key)])
 
-  strings = []
-  recurse(struct1, struct2, [])
-  return strings
+    strings = []
+    recurse(struct1, struct2, [])
+    return strings
 
 
 def apply_form_change(data, encoded_path, value):
-  """Apply a change submitted via the web form to the given data.
+    """Apply a change submitted via the web form to the given data.
 
-  We need to make minimal mutations to the YAML in order
-  for the Ruamel Yaml parser to maintain the original
-  source locations, comments, etc.
-  """
-  path = TranslatableString.decode_path(encoded_path)
-  return apply_change(data, path, value)
+    We need to make minimal mutations to the YAML in order
+    for the Ruamel Yaml parser to maintain the original
+    source locations, comments, etc.
+    """
+    path = TranslatableString.decode_path(encoded_path)
+    return apply_change(data, path, value)
 
 
 def apply_change(data, path, value):
-  if not path:
-    raise RuntimeError('Path cannot be empty')
+    if not path:
+        raise RuntimeError("Path cannot be empty")
 
-  key = path[-1]
-  container = value_at(data, path[:-1])
+    key = path[-1]
+    container = value_at(data, path[:-1])
 
-  if str(key).startswith('a:'):
-    # Expecting index into a list
-    if not isinstance(container, list):
-      container = apply_change(data, path[:-1], [])
+    if str(key).startswith("a:"):
+        # Expecting index into a list
+        if not isinstance(container, list):
+            container = apply_change(data, path[:-1], [])
 
-    index = int(key[2:])
-    while len(container) < index + 1:
-      container.append({})
-    container[index] = value
-    return container[index]
-  else:
-    # Expecting to index into a dict
-    if not isinstance(container, dict):
-      container = apply_change(data, path[:-1], {})
-    container[key] = value
-    return container[key]
+        index = int(key[2:])
+        while len(container) < index + 1:
+            container.append({})
+        container[index] = value
+        return container[index]
+    else:
+        # Expecting to index into a dict
+        if not isinstance(container, dict):
+            container = apply_change(data, path[:-1], {})
+        container[key] = value
+        return container[key]
 
 
 def value_at(data, path):
-  for p in path:
-    if str(p).startswith('a:'):
-      # Expecting to index into a list
-      index = int(p[2:])
-      if not isinstance(data, list): return None
-      if len(data) <= index: return None
-      data = data[index]
-    else:
-      # Expecting to index into a dict (but the index could still be a number)
-      if not isinstance(data, dict): return None
-      data = data.get(p, None)
-  return data
+    for p in path:
+        if str(p).startswith("a:"):
+            # Expecting to index into a list
+            index = int(p[2:])
+            if not isinstance(data, list):
+                return None
+            if len(data) <= index:
+                return None
+            data = data[index]
+        else:
+            # Expecting to index into a dict (but the index could still be a number)
+            if not isinstance(data, dict):
+                return None
+            data = data.get(p, None)
+    return data
 
 
 def render_caption(path):
-  return ' » '.join(path)
+    return " » ".join(path)
 
 
 def str_presenter(dumper, data):
-  """For use with yaml.dump to get mostly human-sensible results."""
-  try:
-      dlen = len(data.splitlines())
-      if (dlen > 1):
-          return dumper.represent_scalar('tag:yaml.org,2002:str', data, style='|')
-  except TypeError as ex:
-      return dumper.represent_scalar('tag:yaml.org,2002:str', data)
-  return dumper.represent_scalar('tag:yaml.org,2002:str', data)
+    """For use with yaml.dump to get mostly human-sensible results."""
+    try:
+        dlen = len(data.splitlines())
+        if dlen > 1:
+            return dumper.represent_scalar("tag:yaml.org,2002:str", data, style="|")
+    except TypeError as ex:
+        return dumper.represent_scalar("tag:yaml.org,2002:str", data)
+    return dumper.represent_scalar("tag:yaml.org,2002:str", data)
 
 
 def normalize_yaml_blocks(data):
-  """Replace all string containing newlines with a special string that the Yaml parser will serialize as a | block.
+    """Replace all string containing newlines with a special string that the Yaml parser will serialize as a | block.
 
-  This will make your YAML pretty and easy to work with.
-  """
-  if isinstance(data, list):
-    for i, el in enumerate(data):
-      if isinstance(el, str):
-        pass
-        data[i] = maybe_translate_to_block(el)
-      else:
-        normalize_yaml_blocks(el)
+    This will make your YAML pretty and easy to work with.
+    """
+    if isinstance(data, list):
+        for i, el in enumerate(data):
+            if isinstance(el, str):
+                pass
+                data[i] = maybe_translate_to_block(el)
+            else:
+                normalize_yaml_blocks(el)
+        return data
+
+    if isinstance(data, dict):
+        for key, value in list(data.items()):
+            if isinstance(value, str):
+                pass
+                data[key] = maybe_translate_to_block(value)
+            else:
+                normalize_yaml_blocks(value)
+        return data
+
     return data
-
-  if isinstance(data, dict):
-    for key, value in list(data.items()):
-      if isinstance(value, str):
-        pass
-        data[key] = maybe_translate_to_block(value)
-      else:
-        normalize_yaml_blocks(value)
-    return data
-
-  return data
 
 
 def maybe_translate_to_block(x):
-  newlines = '\n' in x
-  if newlines and not isinstance(x, yaml.scalarstring.LiteralScalarString):
-    return yaml.scalarstring.LiteralScalarString(str(x))
-  return x
+    newlines = "\n" in x
+    if newlines and not isinstance(x, yaml.scalarstring.LiteralScalarString):
+        return yaml.scalarstring.LiteralScalarString(str(x))
+    return x
 
 
 def normalize_newlines(x):
-  """Turn Windows/web newlines into Linux newlines."""
-  return x.replace('\r\n', '\n')
+    """Turn Windows/web newlines into Linux newlines."""
+    return x.replace("\r\n", "\n")

--- a/website/website_module.py
+++ b/website/website_module.py
@@ -1,0 +1,41 @@
+import collections
+import functools
+import flask
+
+class WebsiteModule(flask.Blueprint):
+    """A website module is a class with its own routes that can be mounted into an app.
+
+    It's based on Flask Blueprints[1], but instead of defining an object and
+    then registering routes on it, we put everything together in a class so that
+    the routes can also share private variables that are injected from 'app.py'.
+
+    Heavily inspired by [2].
+
+    [1] https://flask.palletsprojects.com/en/2.2.x/blueprints/
+    [2] https://gist.github.com/dplepage/2024199
+    """
+    def __init__(self, name: str, import_name: str, url_prefix=None):
+        """Initialize the Blueprint.
+
+        Call as follows:
+
+            super().__init__('mymodule', __name__, url_prefix='/...')
+
+        'url_prefix' can be left out.
+        """
+        super().__init__(name, import_name, url_prefix=url_prefix)
+
+        for name in dir(self):
+            fn = getattr(self, name)
+            for rd in getattr(fn, '_routing_data', []):
+                self.route(*rd.args, **rd.kwargs)(fn)
+
+RoutingData = collections.namedtuple('RoutingData', ['args', 'kwargs'])
+
+def route(*args, **kwargs):
+    def wrap(fn):
+        l = getattr(fn, '_routing_data', [])
+        l.append(RoutingData(args, kwargs))
+        setattr(fn, '_routing_data', l)
+        return fn
+    return wrap

--- a/website/yaml_file.py
+++ b/website/yaml_file.py
@@ -3,9 +3,10 @@ import pickle
 from ruamel import yaml
 from utils import atomic_write_file, is_debug_mode, is_heroku
 
-yaml_loader = yaml.YAML(typ='safe', pure=True)
+yaml_loader = yaml.YAML(typ="safe", pure=True)
 
 YAML_FILES_CACHE = {}
+
 
 class YamlFile:
     """Data from a YAML file, accessible as if it is a dictionary.
@@ -47,7 +48,7 @@ class YamlFile:
         because it creates a mess of files.
         """
         self.filename = filename
-        self.pickle_filename = f'{self.filename}.pickle'
+        self.pickle_filename = f"{self.filename}.pickle"
         self.data = None
         self.timestamp = 0
         self.try_pickle = try_pickle
@@ -77,7 +78,7 @@ class YamlFile:
             self.timestamp = stat.st_mtime
 
         if not isinstance(self.data, dict):
-            raise RuntimeError(f'Contents of {self.filename} needs to be a dict, got: {self.data}')
+            raise RuntimeError(f"Contents of {self.filename} needs to be a dict, got: {self.data}")
 
         return self.data
 
@@ -109,13 +110,13 @@ class YamlFile:
         return data
 
     def load_pickle(self):
-        with open(self.pickle_filename, 'rb') as f:
+        with open(self.pickle_filename, "rb") as f:
             return pickle.load(f)
 
     def load_uncached(self):
         """Load the source YAML file."""
         try:
-            with open(self.filename, 'r', encoding='utf-8') as f:
+            with open(self.filename, "r", encoding="utf-8") as f:
                 return yaml_loader.load(f)
         except IOError:
             return {}


### PR DESCRIPTION
**Description**
Added pre-commit configuration to run [Black](https://github.com/psf/black) when committing code. This should make code-reviews much easier and keep styling consistent across the repository.

**Fixes issue or discussion number**
No linked issue, discussed in thread on Discord

**How to test**
Since black has run on many many files, the changes are too big to code-review. I suggest you reproduce the following steps on the main branch instead, and then merge my pull request into it to verify I haven't changed anything else than the formatting.

- Install pre-commit using pip (`pip install pre-commit`)
- Add pre-commit to `requirements.txt`
- Add `pre-commit-config.yaml` with the same values as in my branch
- Run pre-commit install to install the Black package for pre-commit
- Run `pre-commit run --all-files` to run Black across all python files in the directory, instead of just when changes are made to a file. This is a one-time operation

**Note**
Would be good to include formatting for Jinja templates, Typescript, etc. Didn't want to make the choice on _what_ formatter to use. You can switch out Black for Autopep8 if that's desired. Another good addition would be running Flake8 on pre-commit for python linting. Similar linters can be used for other languages (Typescript, HTML, CSS, etc.) to improve the code consistency and quality.