### PR TITLE
[CHORE] update grammars back to main on merge

### DIFF
--- a/.github/workflows/update-javascript-on-main.yml
+++ b/.github/workflows/update-javascript-on-main.yml
@@ -23,7 +23,7 @@ jobs:
         npm ci
 
     - name: Compile TypeScript to JavaScript
-      run: build-tools/heroku/generate-typescript
+      run: build-tools/heroku/generate-grammars-and-js
 
     - name: Commit changed files
       uses: stefanzweifel/git-auto-commit-action@v2.3.0

--- a/build-tools/heroku/generate-grammars-and-js
+++ b/build-tools/heroku/generate-grammars-and-js
@@ -1,0 +1,9 @@
+set -eu
+scriptdir=$(cd $(dirname $0) && pwd)
+cd $scriptdir
+
+echo '-----> Creating lark grammar files'
+python ../../content/yaml_to_lark_utils.py
+
+echo '-----> Compiling TypeScript'
+./generate-typescript

--- a/build-tools/heroku/on-deploy.sh
+++ b/build-tools/heroku/on-deploy.sh
@@ -17,18 +17,14 @@ set -eu
 scriptdir=$(cd $(dirname $0) && pwd)
 cd $scriptdir
 
+./generate-grammars-and-js
+
 # Do a minimizing build of Tailwind. Generates the tailwind css, and strip
 # all CSS classes that aren't used in our application (determined by searching
 # for CSS classes in the HTML templates and JavaScript files).
 
-echo '-----> Creating lark grammar files'
-python ../../content/yaml_to_lark_utils.py
-
 echo '-----> Doing a Tailwind build'
 tailwind/generate-css
-
-echo '-----> Compiling TypeScript'
-./generate-typescript
 
 echo '-----> Compiling Babel translations'
 cd ..


### PR DESCRIPTION
We currently only update the grammars on deploy but do not merge them back to main, leading to confusing situations! f.e. Hebrew currently exists in the site:

<img width="583" alt="image" src="https://user-images.githubusercontent.com/1003685/192594648-733d2321-14a1-4395-a862-8dab2474af99.png">

But not in the files:

<img width="383" alt="image" src="https://user-images.githubusercontent.com/1003685/192594681-f3048e11-ffd8-4e12-b786-332c481a48bd.png">

Superconfusing!! Just spent 15 mins thinking haha. Let's safe other people brain cycles by generating it all when we merge