### PR TITLE
[FIX] Give the "Update JavaScript" workflow correct permissions

### DIFF
--- a/.github/workflows/update-javascript-on-main.yml
+++ b/.github/workflows/update-javascript-on-main.yml
@@ -5,7 +5,7 @@ name: Automatically update JavaScript bundle
 on:
   push:
     branches: [ main ]
-  pull_request:
+  pull_request_target:
     branches: [ main ]
 
 jobs:


### PR DESCRIPTION
Workflows that run in the context of forks cannot use secrets.

By changing `pull_request` to `pull_request_target`, the workflow will run in the context of the `Felienne/hedy` repository, and will therefore have access to the permissions of that repository (GitHub tokens to make commits on behalf of Felienne, for example).

To make sure drive-by contributors can't steal the secrets, this also causes the workflow file from `main` to always be used (instead of the workflow file on the PR branch itself).
