### PR TITLE
[FEATURE] Allows teachers to hide/show keyword switcher in menu bar

### DIFF
--- a/templates/customize-class.html
+++ b/templates/customize-class.html
@@ -134,6 +134,12 @@
                                 </td>
                             </tr>
                             <tr>
+                                 <td class="text-left border-t border-r border-gray-400">{{_('hide_keyword_switcher')}}</td>
+                                 <td class="border-t border-gray-400">
+                                     <input class="other_settings_checkbox" id="hide_keyword_switcher" type="checkbox" {% if "hide_keyword_switcher" in customizations['other_settings'] %}checked{% endif %}>
+                                 </td>
+                             </tr>
+                            <tr>
                                 <td class="text-left border-t border-r border-gray-400">{{_('hide_quiz')}}</td>
                                 <td class="border-t border-gray-400">
                                     <input class="other_settings_checkbox" id="hide_quiz" type="checkbox" {% if "hide_quiz" in customizations['other_settings'] %}checked{% endif %}>

--- a/templates/level-page.html
+++ b/templates/level-page.html
@@ -34,7 +34,7 @@
           </div>
       </div>
   {% endif %}
-  {% if get_syntax_language(g.lang) != "en" %}
+  {% if get_syntax_language(g.lang) != "en" and (not customizations or 'hide_keyword_switcher' not in customizations['other_settings']) %}
     <div class="dropdown relative">
         <button class="green-btn font-semibold rounded inline-flex items-center gap-2" onclick="$('.dropdown-menu').hide();$('#commands_dropdown').slideToggle('medium');">
                 <span class="fa-solid fa-language"></span>


### PR DESCRIPTION
**Description**
We partly re-implement the code deleted in #3327 where we decided to remove the language switcher from the code editor. We now re-introduce a "hide keyword switcher" but instead aim on the menubar dropdown keyword switcher. The back-end code can remain the same, we only had to make some adjustments to the front-end.

**Fixes _issue or discussion number_**
This PR fixes #3354.

**How to test**
Make sure you are in a class and have a keyword-supported-non-english profile language. Verify that you can see and use the keyword switcher dropdown from the menubar. When hidden using the class customizations the button should been gone.