### PR TITLE
[BUG FIX] 'My class, my rules' achievements can be achieved again

### DIFF
--- a/static/js/teachers.ts
+++ b/static/js/teachers.ts
@@ -394,6 +394,9 @@ export function save_customizations(class_id: string) {
       contentType: 'application/json',
       dataType: 'json'
     }).done(function (response) {
+      if (response.achievement) {
+          showAchievements(response.achievement, false, "");
+      }
       modal.alert(response.success, 3000, false);
       window.State.unsaved_changes = false;
       $('#remove_customizations_button').removeClass('hidden');

--- a/website/for_teachers.py
+++ b/website/for_teachers.py
@@ -186,6 +186,10 @@ class ForTeachersModule(WebsiteModule):
         }
 
         self.db.update_class_customizations(customizations)
+
+        achievement = self.achievements.add_single_achievement(user['username'], "my_class_my_rules")
+        if achievement:
+            return {'achievement': achievement, 'success': gettext('class_customize_success')}, 200
         return {'success': gettext('class_customize_success')}, 200
 
     @route('/create-accounts/<class_id>', methods=['GET'])


### PR DESCRIPTION
**Description**
For unknown reasons the 'my class, my rules' achievements was no longer available in the back-end. We re-implemented this so it can be achieved again.

**Fixes**
No related issue.

**How to test**
Verify that you can indeed achieve the 'my class, my rules' achievement again.
