### PR TITLE
[FEATURE] Adds admin menubar item if admin

### DIFF
--- a/templates/incl-menubar.html
+++ b/templates/incl-menubar.html
@@ -6,7 +6,7 @@
         </li>
         <li class="menubar-item{% if current_page == 'hedy' %} active{% endif %}"><a class="menubar-text" href="/hedy">{{_('nav_hedy')}}</a></li>
         {% if is_admin %}
-            <li class="menubar-item{% if current_page == 'admin' %} active{% endif %}"><a class="menubar-text" href="/admin">{{_('nav_admin')}}</a></li>
+            <li class="menubar-item{% if current_page == 'admin' %} active{% endif %}"><a class="menubar-text" href="/admin">Admin</a></li>
         {% endif %}
         <li class="menubar-item{% if current_page == 'explore' %} active{% endif %}"><a class="menubar-text" href="/explore">{{_('nav_explore')}}</a></li>
         <li class="menubar-item{% if current_page == 'learn-more' %} active{% endif %}"><a class="menubar-text" href="/learn-more">{{_('nav_learn_more')}}</a></li>

--- a/templates/incl-menubar.html
+++ b/templates/incl-menubar.html
@@ -5,6 +5,9 @@
         <li class="hidden lg:flex menubar-item{% if current_page == 'start' %} active{% endif %}"><a class="menubar-text" href="/">{{_('nav_start')}}</a>
         </li>
         <li class="menubar-item{% if current_page == 'hedy' %} active{% endif %}"><a class="menubar-text" href="/hedy">{{_('nav_hedy')}}</a></li>
+        {% if is_admin %}
+            <li class="menubar-item{% if current_page == 'admin' %} active{% endif %}"><a class="menubar-text" href="/admin">{{_('nav_admin')}}</a></li>
+        {% endif %}
         <li class="menubar-item{% if current_page == 'explore' %} active{% endif %}"><a class="menubar-text" href="/explore">{{_('nav_explore')}}</a></li>
         <li class="menubar-item{% if current_page == 'learn-more' %} active{% endif %}"><a class="menubar-text" href="/learn-more">{{_('nav_learn_more')}}</a></li>
     {% if username %}

--- a/website/admin.py
+++ b/website/admin.py
@@ -20,7 +20,7 @@ class AdminModule(WebsiteModule):
         # Todo TB: Why do we check for the testing_request here? (09-22)
         if not utils.is_testing_request(request) and not is_admin(current_user()):
             return utils.error_page(error=403, ui_message=gettext('unauthorized'))
-        return render_template('admin/admin.html', page_title=gettext('title_admin'))
+        return render_template('admin/admin.html', page_title=gettext('title_admin'), current_page='admin')
 
     @route('/users', methods=['GET'])
     @requires_admin
@@ -89,7 +89,7 @@ class AdminModule(WebsiteModule):
         return render_template('admin/admin-users.html', users=userdata, page_title=gettext('title_admin'),
                                 filter=category, start_date=start_date, end_date=end_date, text_filter=substring,
                                 language_filter=language, keyword_language_filter=keyword_language,
-                                next_page_token=users.next_page_token)
+                                next_page_token=users.next_page_token, current_page='admin')
 
     @route('/classes', methods=['GET'])
     @requires_admin
@@ -120,18 +120,18 @@ class AdminModule(WebsiteModule):
             "date": utils.localized_date_format(adventure.get('date'))
         } for adventure in all_adventures]
 
-
-        return render_template('admin/admin-adventures.html', adventures=adventures, page_title=gettext('title_admin'))
+        return render_template('admin/admin-adventures.html', adventures=adventures,
+                               page_title=gettext('title_admin'), current_page='admin')
 
     @route('/stats', methods=['GET'])
     @requires_admin
     def get_admin_stats_page(self, user):
-        return render_template('admin/admin-stats.html', page_title=gettext('title_admin'))
+        return render_template('admin/admin-stats.html', page_title=gettext('title_admin'), current_page='admin')
 
     @route('/logs', methods=['GET'])
     @requires_admin
     def get_admin_logs_page(self, user):
-        return render_template('admin/admin-logs.html', page_title=gettext('title_admin'))
+        return render_template('admin/admin-logs.html', page_title=gettext('title_admin'), current_page='admin')
 
     @route('/achievements', methods=['GET'])
     @requires_admin
@@ -150,9 +150,8 @@ class AdminModule(WebsiteModule):
             for achieved in user.get("achieved", []):
                 stats[achieved]["count"] += 1
 
-        return render_template('admin/admin-achievements.html', stats=stats,
+        return render_template('admin/admin-achievements.html', stats=stats, current_page='admin',
                                 total=total, page_title=gettext('title_admin'))
-
 
     @route('/markAsTeacher', methods=['POST'])
     def mark_as_teacher(self):


### PR DESCRIPTION
**Description**
This PR adds a menubar item for the /admin page in the menubar. Personally I don't like having to manually navigate to /admin each time I log in as an admin: this PR saves us one step.

**Fixes**
No related issue.

**How to test**
Log in as an admin, verify the new menubar item. Also verify that it is not there when not logged in as admin.