### PR TITLE
Adds support for comments in levels 2-4

### DIFF
--- a/grammars/level2-Additions.lark
+++ b/grammars/level2-Additions.lark
@@ -17,8 +17,8 @@ sleep: _SLEEP (INT | var_access)?
 turtle: _FORWARD (NUMBER | textwithoutspaces)? -> forward | _TURN ((NUMBER | textwithoutspaces))? -> turn | _COLOR ((black | blue | brown | gray | green | orange | pink | purple | red | white | yellow | textwithoutspaces))? -> color
 assign: var _IS text -> assign
 
-textwithoutspaces: /([^\n ]+)/ -> text
-text: /([^\n]+)/ -> text
+textwithoutspaces: /([^\n #]+)/ -> text
+text: /([^\n#]+)/ -> text
 
 var: NAME // used for variable definitions, e.g. a = 1
 var_access: NAME // used for variable references, e.g. for i in range. It parses the same as var, but does not result in a lookup table entry

--- a/grammars/level3-Additions.lark
+++ b/grammars/level3-Additions.lark
@@ -11,9 +11,9 @@ turtle: _FORWARD ((NUMBER | list_access | textwithoutspaces))? -> forward | _TUR
 sleep: _SLEEP (INT | list_access | var_access)?
 
 // lists are introduced and list separators (comma and arabic comma) have to excluded from text.
-text: /([^\n،,，]+)/ -> text
-text_ask: /([^\n]+)/ -> text // the ask command is an exception since it needs to include commas in its value
-text_list: /([^\n,،，]+)/ -> text // list elements are another exception since they can contain punctuation but not list separators
+text: /([^\n،,，#]+)/ -> text
+text_ask: /([^\n#]+)/ -> text // the ask command is an exception since it needs to include commas in its value
+text_list: /([^\n,،，#]+)/ -> text // list elements are another exception since they can contain punctuation but not list separators
 
 // FH, jan 22: not exactly sure why this works, while textwithoutspaces parses the whole line in add/remove
 // leaving this for now

--- a/tests/test_level/test_level_02.py
+++ b/tests/test_level/test_level_02.py
@@ -1,5 +1,6 @@
 import hedy
 import textwrap
+from hedy import Command
 from parameterized import parameterized
 from tests.Tester import HedyTester
 
@@ -147,6 +148,31 @@ class TestsLevel2(HedyTester):
         expected = "print(f'*Jouw* favoriet is dus kleur')"
 
         self.multi_level_tester(code=code, expected=expected, max_level=3)
+
+    #
+    # Test comment
+    #
+    def test_print_comment(self):
+        code = "print Hallo welkom bij Hedy! # This is a comment"
+        expected = "print(f'Hallo welkom bij Hedy!')"
+        output = 'Hallo welkom bij Hedy!'
+
+        self.multi_level_tester(
+            max_level=3,
+            code=code,
+            expected=expected,
+            output=output,
+            expected_commands=[Command.print]
+        )
+
+    def test_assign_comment(self):
+        code = "test is Welkom bij Hedy # This is a comment"
+        expected = "test = 'Welkom bij Hedy '"
+        self.multi_level_tester(
+            max_level=3,
+            code=code,
+            expected=expected
+        )
 
     #
     # ask tests

--- a/tests/test_level/test_level_04.py
+++ b/tests/test_level/test_level_04.py
@@ -256,6 +256,30 @@ class TestsLevel4(HedyTester):
         self.multi_level_tester(code=code, expected=expected, max_level=11)
 
     #
+    # Test comment
+    #
+    def test_print_comment(self):
+        code = "print 'Hallo welkom bij Hedy!' # This is a comment"
+        expected = "print(f'Hallo welkom bij Hedy!')"
+        output = 'Hallo welkom bij Hedy!'
+
+        self.multi_level_tester(
+            max_level=11,
+            code=code,
+            expected=expected,
+            output=output
+        )
+
+    def test_assign_comment(self):
+        code = 'test is "Welkom bij Hedy" # This is a comment'
+        expected = 'test = \'"Welkom bij Hedy" \''
+        self.multi_level_tester(
+            max_level=11,
+            code=code,
+            expected=expected
+        )
+
+    #
     # ask tests
     #
     def test_ask_single_quoted_text(self):

--- a/tests/test_level/test_level_12.py
+++ b/tests/test_level/test_level_12.py
@@ -443,6 +443,30 @@ class TestsLevel12(HedyTester):
         )
 
     #
+    # Test comment
+    #
+    def test_print_comment(self):
+        code = "print 'Hallo welkom bij Hedy!' # This is a comment"
+        expected = "print(f'''Hallo welkom bij Hedy!''')"
+        output = 'Hallo welkom bij Hedy!'
+
+        self.multi_level_tester(
+            max_level=17,
+            code=code,
+            expected=expected,
+            output=output
+        )
+
+    def test_assign_comment(self):
+        code = 'test = "Welkom bij Hedy" # This is a comment'
+        expected = "test = 'Welkom bij Hedy'"
+        self.multi_level_tester(
+            max_level=18,
+            code=code,
+            expected=expected
+        )
+
+    #
     # ask tests
     #
     def test_ask_number_answer(self):

--- a/tests/test_level/test_level_18.py
+++ b/tests/test_level/test_level_18.py
@@ -285,4 +285,18 @@ class TestsLevel18(HedyTester):
       self.multi_level_tester(
         code="name is input",
         exception=hedy.exceptions.IncompleteCommandException
-      )   
+      )
+
+    #
+    # Test comment
+    #
+    def test_print_comment(self):
+        code = "print('Hallo welkom bij Hedy!') # This is a comment"
+        expected = "print(f'''Hallo welkom bij Hedy!''')"
+        output = 'Hallo welkom bij Hedy!'
+
+        self.multi_level_tester(
+            code=code,
+            expected=expected,
+            output=output
+        )


### PR DESCRIPTION
**Description**

Comments are already working in level 1 and in levels 5 and up. This fixes it for the remaining levels and adds some tests. The fix is a grammar update so the # is not part of text, and there are updated tests too.

**Fixes #3286 **

Always link the number of the issue or of the discussion that your pr concerns.

**How to test**
The code below is basically what's used to report the issue and doesn't work correctly in levels 2-4 (Note the single quotes to get correct statements for level 4). You can use this to verify that the issue does not exist on the feature branch.

```
print 'hello world!' # with a comment
print 'hello world!' # with a comment
print 'hello world!' # with a comment
print 'hello world!' # with a comment
print 'hello world!' # with a comment
```

The code base now has tests for comments for all levels.

**Checklist**
Done? Check if you have it all in place using this list:*
  
- [x] Describes changes in the format above (present tense)
- [x] Links to an existing issue or discussion 
- [x] Has a "How to test" section
