### PR TITLE
Allows sending emails in other languages

### DIFF
--- a/website/admin.py
+++ b/website/admin.py
@@ -2,7 +2,7 @@ from flask_babel import gettext
 from flask import request, g
 import hedyweb
 from website import statistics
-from website.auth import create_verify_link, current_user, is_admin, is_teacher, make_salt, password_hash, pick, requires_admin, send_email_template, password_hash
+from website.auth import create_verify_link, current_user, is_admin, is_teacher, make_salt, password_hash, pick, requires_admin, send_localized_email_template, password_hash
 from .database import Database
 import utils
 from flask_helpers import render_template
@@ -209,9 +209,9 @@ class AdminModule(WebsiteModule):
             resp = {'username': user['username'], 'token': hashed_token}
         else:
             try:
-                send_email_template(template='welcome_verify', email=body['email'],
-                                    link=create_verify_link(user['username'], hashed_token),
-                                    username=user['username'])
+                send_localized_email_template(locale=user['language'], template='welcome_verify', email=body['email'],
+                                              link=create_verify_link(user['username'], hashed_token),
+                                              username=user['username'])
             except:
                 return gettext('mail_error_change_processed'), 400
 
@@ -259,7 +259,7 @@ def update_is_teacher(db: Database, user, is_teacher_value=1):
 
     if user_becomes_teacher and not utils.is_testing_request(request):
         try:
-            send_email_template(template='welcome_teacher', email=user['email'], username=user['username'])
+            send_localized_email_template(locale=user['language'], template='welcome_teacher', email=user['email'], username=user['username'])
         except:
             print(f"An error occurred when sending a welcome teacher mail to {user['email']}, changes still processed")
 

--- a/website/auth.py
+++ b/website/auth.py
@@ -8,7 +8,7 @@ from functools import wraps
 import boto3
 from botocore.exceptions import ClientError as email_error, NoCredentialsError
 from flask import g, request, session
-from flask_babel import gettext
+from flask_babel import gettext, force_locale
 import requests
 
 import utils
@@ -313,6 +313,17 @@ def send_email_template(template, email, link=None, username=gettext('user')):
         body_html = body_html.format(link='<a href="' + link + '">{link}</a>').format(link=gettext('link'))
 
     send_email(email, subject, body_plain, body_html)
+
+
+# By default, emails are sent in the locale of the logged-in user.
+# This function is to be used if the email needs to be sent in another locale.
+def send_localized_email_template(locale, template, email, link=None, username=None):
+    with force_locale(locale):
+        if username is None:
+            # We want to use the correct locale for this text
+            username = gettext('user')
+        send_email_template(template, email, link, username)
+
 
 def store_new_student_account(db, account, teacher_username):
     username, hashed, hashed_token = prepare_user_db(account['username'], account['password'])

--- a/website/auth.py
+++ b/website/auth.py
@@ -317,6 +317,7 @@ def send_email_template(template, email, link=None, username=gettext('user')):
 
 # By default, emails are sent in the locale of the logged-in user.
 # This function is to be used if the email needs to be sent in another locale.
+# For example when an action by a logged in admin (like oking a teacher's account) triggers an email
 def send_localized_email_template(locale, template, email, link=None, username=None):
     with force_locale(locale):
         if username is None:


### PR DESCRIPTION
**Description**

We usually use the language of the current user when sending emails, but that is not suitable in all cases. Specifically if an admin needs to email a user, this should be done in the language of the user.

This fixes the issue when an admin marks a user as teacher, and also when an admin changes the email address of a user.

**Fixes #3289 **

Always link the number of the issue or of the discussion that your pr concerns.

**How to test**

As stated in the issue, this is hard to test locally because sending emails does not work locally. This would need to be tested on alpha.

**Checklist**
Done? Check if you have it all in place using this list:*
  
- [x] Describes changes in the format above (present tense)
- [x] Links to an existing issue or discussion 
- [ ] Has a "How to test" section
