### PR TITLE
3400 content remove red text in adventure mode

### DIFF
--- a/messages.pot
+++ b/messages.pot
@@ -683,9 +683,6 @@ msgstr ""
 msgid "quiz_tab"
 msgstr ""
 
-msgid "specific_adventure_mode"
-msgstr ""
-
 msgid "example_code_header"
 msgstr ""
 

--- a/templates/incl-adventure-tabs.html
+++ b/templates/incl-adventure-tabs.html
@@ -25,9 +25,6 @@
                         {{_('quiz_tab')}}
                 </div>
             {% endif %}
-            {% if specific_adventure %}
-                <h2 class="z-10 my-0 ml-auto pt-8 text-red-500 text-base">{{ _('specific_adventure_mode')|replace("{adventure}", adventures[0].name) }}</h2>
-            {% endif %}
         </div>
       {# PANES #}
       <div id="adventures-tab" class="w-full overflow-auto bg-white p-4 mb-8 shadow-md turn-pre-into-ace" style="max-height: 20em;">

--- a/translations/ar/LC_MESSAGES/messages.po
+++ b/translations/ar/LC_MESSAGES/messages.po
@@ -725,9 +725,6 @@ msgstr "Puzzle"
 msgid "quiz_tab"
 msgstr "انهاء الفحص السريع"
 
-msgid "specific_adventure_mode"
-msgstr "أنت حالياً في المغامرة '{adventure}'، اضغط على \"هيدي\" لعرض كل المغامرات."
-
 msgid "example_code_header"
 msgstr "مثال توضيحي"
 

--- a/translations/bg/LC_MESSAGES/messages.po
+++ b/translations/bg/LC_MESSAGES/messages.po
@@ -851,10 +851,6 @@ msgstr "Hedy"
 msgid "quiz_tab"
 msgstr "Quiz"
 
-#, fuzzy
-msgid "specific_adventure_mode"
-msgstr "You're currently in adventure '{adventure}', click on 'Hedy' to view all adventures."
-
 msgid "example_code_header"
 msgstr "Примерен код на Хеди"
 

--- a/translations/bn/LC_MESSAGES/messages.po
+++ b/translations/bn/LC_MESSAGES/messages.po
@@ -906,10 +906,6 @@ msgid "quiz_tab"
 msgstr "Quiz"
 
 #, fuzzy
-msgid "specific_adventure_mode"
-msgstr "You're currently in adventure '{adventure}', click on 'Hedy' to view all adventures."
-
-#, fuzzy
 msgid "example_code_header"
 msgstr "Example Hedy Code"
 

--- a/translations/cs/LC_MESSAGES/messages.po
+++ b/translations/cs/LC_MESSAGES/messages.po
@@ -859,10 +859,6 @@ msgstr "Hedy"
 msgid "quiz_tab"
 msgstr "Quiz"
 
-#, fuzzy
-msgid "specific_adventure_mode"
-msgstr "You're currently in adventure '{adventure}', click on 'Hedy' to view all adventures."
-
 msgid "example_code_header"
 msgstr "Příklad kódu v Hedy"
 

--- a/translations/de/LC_MESSAGES/messages.po
+++ b/translations/de/LC_MESSAGES/messages.po
@@ -835,10 +835,6 @@ msgstr "Hedy"
 msgid "quiz_tab"
 msgstr "Quiz"
 
-#, fuzzy
-msgid "specific_adventure_mode"
-msgstr "Welches Abenteuer möchtest du verfügbar machen?"
-
 msgid "example_code_header"
 msgstr "Hedy Beispiel-Code"
 

--- a/translations/el/LC_MESSAGES/messages.po
+++ b/translations/el/LC_MESSAGES/messages.po
@@ -768,10 +768,6 @@ msgstr "Hedy"
 msgid "quiz_tab"
 msgstr "Quiz"
 
-#, fuzzy
-msgid "specific_adventure_mode"
-msgstr "You're currently in adventure '{adventure}', click on 'Hedy' to view all adventures."
-
 msgid "example_code_header"
 msgstr "Παράδειγμα κώδικα Hedy"
 

--- a/translations/en/LC_MESSAGES/messages.po
+++ b/translations/en/LC_MESSAGES/messages.po
@@ -696,9 +696,6 @@ msgstr "Puzzle"
 msgid "quiz_tab"
 msgstr "Quiz"
 
-msgid "specific_adventure_mode"
-msgstr "You're currently in adventure '{adventure}', click on 'Hedy' to view all adventures."
-
 msgid "example_code_header"
 msgstr "Example Hedy Code"
 

--- a/translations/eo/LC_MESSAGES/messages.po
+++ b/translations/eo/LC_MESSAGES/messages.po
@@ -765,10 +765,6 @@ msgstr "Hedy"
 msgid "quiz_tab"
 msgstr "Kvizon"
 
-#, fuzzy
-msgid "specific_adventure_mode"
-msgstr "You're currently in adventure '{adventure}', click on 'Hedy' to view all adventures."
-
 msgid "example_code_header"
 msgstr "Ekzempla Hedy-kodo"
 

--- a/translations/es/LC_MESSAGES/messages.po
+++ b/translations/es/LC_MESSAGES/messages.po
@@ -844,10 +844,6 @@ msgstr "Hedy"
 msgid "quiz_tab"
 msgstr "Quiz"
 
-#, fuzzy
-msgid "specific_adventure_mode"
-msgstr "You're currently in adventure '{adventure}', click on 'Hedy' to view all adventures."
-
 msgid "example_code_header"
 msgstr "Código de ejemplo"
 

--- a/translations/et/LC_MESSAGES/messages.po
+++ b/translations/et/LC_MESSAGES/messages.po
@@ -859,10 +859,6 @@ msgstr "Dragging"
 msgid "quiz_tab"
 msgstr "Quiz"
 
-#, fuzzy
-msgid "specific_adventure_mode"
-msgstr "You're currently in adventure '{adventure}', click on 'Hedy' to view all adventures."
-
 msgid "example_code_header"
 msgstr "Näidiskood"
 

--- a/translations/fa/LC_MESSAGES/messages.po
+++ b/translations/fa/LC_MESSAGES/messages.po
@@ -894,10 +894,6 @@ msgstr "Hedy"
 msgid "quiz_tab"
 msgstr "Quiz"
 
-#, fuzzy
-msgid "specific_adventure_mode"
-msgstr "You're currently in adventure '{adventure}', click on 'Hedy' to view all adventures."
-
 msgid "example_code_header"
 msgstr "Example Hedy Code"
 

--- a/translations/fr/LC_MESSAGES/messages.po
+++ b/translations/fr/LC_MESSAGES/messages.po
@@ -848,10 +848,6 @@ msgstr "Hedy"
 msgid "quiz_tab"
 msgstr "Quiz"
 
-#, fuzzy
-msgid "specific_adventure_mode"
-msgstr "You're currently in adventure '{adventure}', click on 'Hedy' to view all adventures."
-
 msgid "example_code_header"
 msgstr "Exemple de code Hedy"
 

--- a/translations/fy/LC_MESSAGES/messages.po
+++ b/translations/fy/LC_MESSAGES/messages.po
@@ -862,10 +862,6 @@ msgid "quiz_tab"
 msgstr "Quiz"
 
 #, fuzzy
-msgid "specific_adventure_mode"
-msgstr "You're currently in adventure '{adventure}', click on 'Hedy' to view all adventures."
-
-#, fuzzy
 msgid "example_code_header"
 msgstr "Example Hedy Code"
 

--- a/translations/he/LC_MESSAGES/messages.po
+++ b/translations/he/LC_MESSAGES/messages.po
@@ -910,10 +910,6 @@ msgid "quiz_tab"
 msgstr "Quiz"
 
 #, fuzzy
-msgid "specific_adventure_mode"
-msgstr "You're currently in adventure '{adventure}', click on 'Hedy' to view all adventures."
-
-#, fuzzy
 msgid "example_code_header"
 msgstr "Example Hedy Code"
 

--- a/translations/hi/LC_MESSAGES/messages.po
+++ b/translations/hi/LC_MESSAGES/messages.po
@@ -785,10 +785,6 @@ msgstr "शीर्षक"
 msgid "quiz_tab"
 msgstr "Quiz"
 
-#, fuzzy
-msgid "specific_adventure_mode"
-msgstr "You're currently in adventure '{adventure}', click on 'Hedy' to view all adventures."
-
 msgid "example_code_header"
 msgstr "उदाहरण हेडी कोड"
 

--- a/translations/hu/LC_MESSAGES/messages.po
+++ b/translations/hu/LC_MESSAGES/messages.po
@@ -859,10 +859,6 @@ msgstr "Hedy"
 msgid "quiz_tab"
 msgstr "Quiz"
 
-#, fuzzy
-msgid "specific_adventure_mode"
-msgstr "You're currently in adventure '{adventure}', click on 'Hedy' to view all adventures."
-
 msgid "example_code_header"
 msgstr "Példa Hedy-kódra"
 

--- a/translations/id/LC_MESSAGES/messages.po
+++ b/translations/id/LC_MESSAGES/messages.po
@@ -854,10 +854,6 @@ msgstr "Hedy"
 msgid "quiz_tab"
 msgstr "Quiz"
 
-#, fuzzy
-msgid "specific_adventure_mode"
-msgstr "You're currently in adventure '{adventure}', click on 'Hedy' to view all adventures."
-
 msgid "example_code_header"
 msgstr "Contoh kode Hedy"
 

--- a/translations/it/LC_MESSAGES/messages.po
+++ b/translations/it/LC_MESSAGES/messages.po
@@ -881,10 +881,6 @@ msgstr "Title"
 msgid "quiz_tab"
 msgstr "Quiz"
 
-#, fuzzy
-msgid "specific_adventure_mode"
-msgstr "You're currently in adventure '{adventure}', click on 'Hedy' to view all adventures."
-
 msgid "example_code_header"
 msgstr "Esempio di codice Hedy"
 

--- a/translations/ja/LC_MESSAGES/messages.po
+++ b/translations/ja/LC_MESSAGES/messages.po
@@ -892,10 +892,6 @@ msgid "quiz_tab"
 msgstr "Quiz"
 
 #, fuzzy
-msgid "specific_adventure_mode"
-msgstr "You're currently in adventure '{adventure}', click on 'Hedy' to view all adventures."
-
-#, fuzzy
 msgid "example_code_header"
 msgstr "Example Hedy Code"
 

--- a/translations/ko/LC_MESSAGES/messages.po
+++ b/translations/ko/LC_MESSAGES/messages.po
@@ -910,10 +910,6 @@ msgid "quiz_tab"
 msgstr "Quiz"
 
 #, fuzzy
-msgid "specific_adventure_mode"
-msgstr "You're currently in adventure '{adventure}', click on 'Hedy' to view all adventures."
-
-#, fuzzy
 msgid "example_code_header"
 msgstr "Example Hedy Code"
 

--- a/translations/nb_NO/LC_MESSAGES/messages.po
+++ b/translations/nb_NO/LC_MESSAGES/messages.po
@@ -741,9 +741,6 @@ msgstr "Hedy"
 msgid "quiz_tab"
 msgstr "Quiz"
 
-msgid "specific_adventure_mode"
-msgstr "Du er for øyeblikket i eventyret '{adventure}', trykk på 'Hedy' for å se alle eventyr."
-
 msgid "example_code_header"
 msgstr "Eksempel Hedykode"
 

--- a/translations/nl/LC_MESSAGES/messages.po
+++ b/translations/nl/LC_MESSAGES/messages.po
@@ -700,9 +700,6 @@ msgstr "Slepen"
 msgid "quiz_tab"
 msgstr "Quiz"
 
-msgid "specific_adventure_mode"
-msgstr "Je zit nu in het avontuur \"{adventure}\", klik bovenin op \"Hedy\" voor alle avonturen."
-
 msgid "example_code_header"
 msgstr "Hedy voorbeeldcode"
 

--- a/translations/pl/LC_MESSAGES/messages.po
+++ b/translations/pl/LC_MESSAGES/messages.po
@@ -828,10 +828,6 @@ msgstr "Hedy"
 msgid "quiz_tab"
 msgstr "Quiz"
 
-#, fuzzy
-msgid "specific_adventure_mode"
-msgstr "You're currently in adventure '{adventure}', click on 'Hedy' to view all adventures."
-
 msgid "example_code_header"
 msgstr "Przykładowy kod"
 

--- a/translations/pt_BR/LC_MESSAGES/messages.po
+++ b/translations/pt_BR/LC_MESSAGES/messages.po
@@ -863,10 +863,6 @@ msgstr "Hedy"
 msgid "quiz_tab"
 msgstr "Quiz"
 
-#, fuzzy
-msgid "specific_adventure_mode"
-msgstr "You're currently in adventure '{adventure}', click on 'Hedy' to view all adventures."
-
 msgid "example_code_header"
 msgstr "Exemplo de código Hedy"
 

--- a/translations/pt_PT/LC_MESSAGES/messages.po
+++ b/translations/pt_PT/LC_MESSAGES/messages.po
@@ -878,10 +878,6 @@ msgstr "Title"
 msgid "quiz_tab"
 msgstr "Quiz"
 
-#, fuzzy
-msgid "specific_adventure_mode"
-msgstr "You're currently in adventure '{adventure}', click on 'Hedy' to view all adventures."
-
 msgid "example_code_header"
 msgstr "Exemplo de código Hedy"
 

--- a/translations/ru/LC_MESSAGES/messages.po
+++ b/translations/ru/LC_MESSAGES/messages.po
@@ -901,10 +901,6 @@ msgstr "Hedy"
 msgid "quiz_tab"
 msgstr "Quiz"
 
-#, fuzzy
-msgid "specific_adventure_mode"
-msgstr "You're currently in adventure '{adventure}', click on 'Hedy' to view all adventures."
-
 msgid "example_code_header"
 msgstr "Example Hedy code"
 

--- a/translations/sv/LC_MESSAGES/messages.po
+++ b/translations/sv/LC_MESSAGES/messages.po
@@ -910,10 +910,6 @@ msgid "quiz_tab"
 msgstr "Quiz"
 
 #, fuzzy
-msgid "specific_adventure_mode"
-msgstr "You're currently in adventure '{adventure}', click on 'Hedy' to view all adventures."
-
-#, fuzzy
 msgid "example_code_header"
 msgstr "Example Hedy Code"
 

--- a/translations/sw/LC_MESSAGES/messages.po
+++ b/translations/sw/LC_MESSAGES/messages.po
@@ -883,10 +883,6 @@ msgstr "Hedy"
 msgid "quiz_tab"
 msgstr "Quiz"
 
-#, fuzzy
-msgid "specific_adventure_mode"
-msgstr "You're currently in adventure '{adventure}', click on 'Hedy' to view all adventures."
-
 msgid "example_code_header"
 msgstr "Mfano wa code"
 

--- a/translations/tn/LC_MESSAGES/messages.po
+++ b/translations/tn/LC_MESSAGES/messages.po
@@ -909,10 +909,6 @@ msgid "quiz_tab"
 msgstr "Quiz"
 
 #, fuzzy
-msgid "specific_adventure_mode"
-msgstr "You're currently in adventure '{adventure}', click on 'Hedy' to view all adventures."
-
-#, fuzzy
 msgid "example_code_header"
 msgstr "Example Hedy Code"
 

--- a/translations/tr/LC_MESSAGES/messages.po
+++ b/translations/tr/LC_MESSAGES/messages.po
@@ -902,10 +902,6 @@ msgstr "Title"
 msgid "quiz_tab"
 msgstr "Quiz"
 
-#, fuzzy
-msgid "specific_adventure_mode"
-msgstr "You're currently in adventure '{adventure}', click on 'Hedy' to view all adventures."
-
 msgid "example_code_header"
 msgstr "Örnek kod"
 

--- a/translations/ur/LC_MESSAGES/messages.po
+++ b/translations/ur/LC_MESSAGES/messages.po
@@ -911,10 +911,6 @@ msgid "quiz_tab"
 msgstr "End quiz"
 
 #, fuzzy
-msgid "specific_adventure_mode"
-msgstr "You're currently in adventure '{adventure}', click on 'Hedy' to view all adventures."
-
-#, fuzzy
 msgid "example_code_header"
 msgstr "Example Hedy Code"
 

--- a/translations/zh_Hans/LC_MESSAGES/messages.po
+++ b/translations/zh_Hans/LC_MESSAGES/messages.po
@@ -864,10 +864,6 @@ msgstr "Hedy"
 msgid "quiz_tab"
 msgstr "Quiz"
 
-#, fuzzy
-msgid "specific_adventure_mode"
-msgstr "You're currently in adventure '{adventure}', click on 'Hedy' to view all adventures."
-
 msgid "example_code_header"
 msgstr "海迪代码范例"
 


### PR DESCRIPTION
Removes the red text in adventure mode #3400  , also removes the (i guess) unnecessary translations.

![image](https://user-images.githubusercontent.com/48225550/195400191-63436294-e16b-4e0b-bd38-1111128fa792.png)

**How to Test**
Just visit _../adventure/parrot_. The red text should be absent.