### PR TITLE
(3412) No longer copy files to Docker container during docker build, use bind mount instead

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -203,7 +203,7 @@ docker build -t hedy .
 and then:
 
 ```bash
-docker run -it --rm -p 8080:8080 hedy
+docker run -it --rm -p 8080:8080 --mount type=bind,source="$(pwd)",target=/app hedy
 ```
 
 ## Testing Teacher facing features locally

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apt install -y curl && curl -fsSL https://deb.nodesource.com/setup_lts.x | b
 
 WORKDIR /app
 
-COPY . .
+#COPY . .
 
 EXPOSE 8080
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apt install -y curl && curl -fsSL https://deb.nodesource.com/setup_lts.x | b
 
 WORKDIR /app
 
-#COPY . .
+COPY . .
 
 EXPOSE 8080
 


### PR DESCRIPTION
**Description**
Update the Dockerfile to no longer copy the project files into the container during `docker build`, and update the documentation in CONTRIBUTING.md with instructions to use bind mounts instead. This should eliminate the need to rebuild the docker image after each change to the code!

I tested the updated `docker run` command on my Linux installation and everything seems to work there, but it would be nice if people could test this command on other platforms (Windows+Powershell comes to mind...), so I know whether I need to add additional instructions for those other platforms.

Fixes #3412 

**How to test**
 (Re)build the docker image (possibly with the `--no-cache` option) and use the updated `docker run` command from CONTRIBUTING.md to launch the new version of the container, everything should work as normal!