### PR TITLE
[LANGUAGE] Localize commands in error message

### DIFF
--- a/app.py
+++ b/app.py
@@ -547,7 +547,7 @@ def hedy_error_to_response(ex):
 
 def translate_error(code, arguments):
     arguments_that_require_translation = ['allowed_types', 'invalid_type', 'invalid_type_2', 'character_found',
-                                          'concept', 'tip']
+                                          'concept', 'tip', 'command']
     arguments_that_require_highlighting = ['command', 'guessed_command', 'invalid_argument', 'invalid_argument_2',
                                            'variable', 'invalid_value']
 
@@ -556,8 +556,6 @@ def translate_error(code, arguments):
 
     # some arguments like allowed types or characters need to be translated in the error message
     for k, v in arguments.items():
-        if k in arguments_that_require_highlighting:
-            arguments[k] = hedy.style_closest_command(v)
 
         if k in arguments_that_require_translation:
             if isinstance(v, list):
@@ -565,8 +563,18 @@ def translate_error(code, arguments):
             else:
                 arguments[k] = gettext('' + str(v))
 
-    return error_template.format(**arguments)
+        if k in arguments_that_require_highlighting:
+            if k in arguments_that_require_translation:
+                nl_keywords = hedy_translation.keywords_to_dict('nl')
+                local_keyword = hedy_translation.get_target_keyword(nl_keywords,v)
+                arguments[k] = hedy.style_closest_command(local_keyword)
+            else:
+                arguments[k] = hedy.style_closest_command(v)
 
+
+
+
+    return error_template.format(**arguments)
 
 def translate_list(args):
     translated_args = [gettext('' + str(a)) for a in args]

--- a/app.py
+++ b/app.py
@@ -375,8 +375,7 @@ def parse():
                 transpile_result = ex.fixed_result
                 exception = ex
             except hedy.exceptions.UnquotedEqualityCheck as ex:
-                response['Error'] = translate_error(
-                    ex.error_code, ex.arguments)
+                response['Error'] = translate_error(ex.error_code, ex.arguments)
                 response['Location'] = ex.error_location
                 exception = ex
         try:
@@ -547,16 +546,23 @@ def hedy_error_to_response(ex):
 
 def translate_error(code, arguments):
     arguments_that_require_translation = ['allowed_types', 'invalid_type', 'invalid_type_2', 'character_found',
-                                          'concept', 'tip', 'command']
+                                          'concept', 'tip', 'command', 'print', 'ask', 'echo']
     arguments_that_require_highlighting = ['command', 'guessed_command', 'invalid_argument', 'invalid_argument_2',
-                                           'variable', 'invalid_value']
+                                           'variable', 'invalid_value', 'print', 'ask', 'echo', 'is']
 
     # Todo TB -> We have to find a more delicate way to fix this: returns some gettext() errors
     error_template = gettext('' + str(code))
 
+    # TODO if we have a tip key, we need to first fetch that text and then also bring it here,
+    # so text *in* the tip an be translated/highlighted
+
+    # adds keywords to the dictionary so they can be translated if they occur in the error text
+    arguments["print"] = "print"
+    arguments["ask"] = "ask"
+    arguments["echo"] = "echo"
+
     # some arguments like allowed types or characters need to be translated in the error message
     for k, v in arguments.items():
-
         if k in arguments_that_require_translation:
             if isinstance(v, list):
                 arguments[k] = translate_list(v)
@@ -570,6 +576,8 @@ def translate_error(code, arguments):
                 arguments[k] = hedy.style_command(local_keyword)
             else:
                 arguments[k] = hedy.style_command(v)
+
+
 
 
     return error_template.format(**arguments)

--- a/app.py
+++ b/app.py
@@ -565,16 +565,17 @@ def translate_error(code, arguments):
 
         if k in arguments_that_require_highlighting:
             if k in arguments_that_require_translation:
-                nl_keywords = hedy_translation.keywords_to_dict('nl')
-                local_keyword = hedy_translation.get_target_keyword(nl_keywords,v)
-                arguments[k] = hedy.style_closest_command(local_keyword)
+                local_lang = current_keyword_language()["lang"]
+                local_keyword = hedy_translation.translate_keyword(v, local_lang)
+                arguments[k] = hedy.style_command(local_keyword)
             else:
-                arguments[k] = hedy.style_closest_command(v)
-
-
+                arguments[k] = hedy.style_command(v)
 
 
     return error_template.format(**arguments)
+
+
+
 
 def translate_list(args):
     translated_args = [gettext('' + str(a)) for a in args]

--- a/app.py
+++ b/app.py
@@ -358,14 +358,15 @@ def parse():
                        session_id=utils.session_id(), username=username)
 
     try:
+        keyword_lang = current_keyword_language()["lang"]
         with querylog.log_time('transpile'):
             try:
                 transpile_result = transpile_add_stats(code, level, lang)
                 if username and not body.get('tutorial'):
                     DATABASE.increase_user_run_count(username)
                     ACHIEVEMENTS.increase_count("run")
-            except hedy.exceptions.FtfyException as ex:
-                translated_error = translate_error(ex.error_code, ex.arguments)
+            except hedy.exceptions.WarningException as ex:
+                translated_error = translate_error(ex.error_code, ex.arguments, keyword_lang)
                 if type(ex) is hedy.exceptions.InvalidSpaceException:
                     response['Warning'] = translated_error
                 else:
@@ -375,7 +376,7 @@ def parse():
                 transpile_result = ex.fixed_result
                 exception = ex
             except hedy.exceptions.UnquotedEqualityCheck as ex:
-                response['Error'] = translate_error(ex.error_code, ex.arguments)
+                response['Error'] = translate_error(ex.error_code, ex.arguments, keyword_lang)
                 response['Location'] = ex.error_location
                 exception = ex
         try:
@@ -538,28 +539,38 @@ def get_class_name(i):
 
 
 def hedy_error_to_response(ex):
+    keyword_lang = current_keyword_language()["lang"]
     return {
-        "Error": translate_error(ex.error_code, ex.arguments),
+        "Error": translate_error(ex.error_code, ex.arguments, keyword_lang),
         "Location": ex.error_location
     }
 
 
-def translate_error(code, arguments):
+def translate_error(code, arguments, keyword_lang):
     arguments_that_require_translation = ['allowed_types', 'invalid_type', 'invalid_type_2', 'character_found',
-                                          'concept', 'tip', 'command', 'print', 'ask', 'echo']
+                                          'concept', 'tip', 'command', 'print', 'ask', 'echo', 'is', 'repeat']
     arguments_that_require_highlighting = ['command', 'guessed_command', 'invalid_argument', 'invalid_argument_2',
-                                           'variable', 'invalid_value', 'print', 'ask', 'echo', 'is']
+                                           'variable', 'invalid_value', 'print', 'ask', 'echo', 'is', 'repeat']
 
     # Todo TB -> We have to find a more delicate way to fix this: returns some gettext() errors
     error_template = gettext('' + str(code))
 
-    # TODO if we have a tip key, we need to first fetch that text and then also bring it here,
-    # so text *in* the tip an be translated/highlighted
+    # Fetch tip if it exists and merge into template, since it can also contain placeholders
+    # that need to be translated/highlighted
+
+    if 'tip' in arguments:
+        error_template = error_template.replace("{tip}", gettext('' + str(arguments['tip'])))
+        #TODO, FH Oct 2022 -> Could we do this with a format even though we don't have all fields?
 
     # adds keywords to the dictionary so they can be translated if they occur in the error text
+
+    # FH Oct 2022: this could be optimized by only adding them when they occur in the text (either with string matching or with a list
+    # of placeholders for each error
     arguments["print"] = "print"
     arguments["ask"] = "ask"
     arguments["echo"] = "echo"
+    arguments["repeat"] = "repeat"
+    arguments["is"] = "is"
 
     # some arguments like allowed types or characters need to be translated in the error message
     for k, v in arguments.items():
@@ -571,14 +582,10 @@ def translate_error(code, arguments):
 
         if k in arguments_that_require_highlighting:
             if k in arguments_that_require_translation:
-                local_lang = current_keyword_language()["lang"]
-                local_keyword = hedy_translation.translate_keyword(v, local_lang)
+                local_keyword = hedy_translation.translate_keyword(v, keyword_lang)
                 arguments[k] = hedy.style_command(local_keyword)
             else:
                 arguments[k] = hedy.style_command(v)
-
-
-
 
     return error_template.format(**arguments)
 

--- a/exceptions.py
+++ b/exceptions.py
@@ -30,7 +30,7 @@ class HedyException(Exception):
             return [self.arguments['line_number']]
         return None
 
-class FtfyException(HedyException):
+class WarningException(HedyException):
     """Fixed That For You warning/exception.
 
     Not really a failure case: instead it represents a warning to
@@ -44,7 +44,7 @@ class FtfyException(HedyException):
         self.fixed_code = fixed_code
         self.fixed_result = fixed_result
 
-class InvalidSpaceException(FtfyException):
+class InvalidSpaceException(WarningException):
     def __init__(self, level, line_number, fixed_code, fixed_result):
         super().__init__('Invalid Space',
             level=level,
@@ -124,7 +124,7 @@ class InputTooBigException(HedyException):
             lines_of_code=lines_of_code,
             max_lines=max_lines)
 
-class InvalidCommandException(FtfyException):
+class InvalidCommandException(WarningException):
     def __init__(self, level, invalid_command, guessed_command, line_number, fixed_code, fixed_result):
         super().__init__('Invalid',
             invalid_command=invalid_command,

--- a/hedy.py
+++ b/hedy.py
@@ -271,7 +271,7 @@ def closest_command(invalid_command, known_commands, threshold=2):
     return min_command
 
 
-def style_closest_command(command):
+def style_command(command):
     return f'<span class="command-highlighted">{command}</span>'
 
 def closest_command_with_min_distance(invalid_command, commands, threshold):
@@ -1302,7 +1302,7 @@ class ConvertToPython_1(ConvertToPython):
             try:
               {variable} = int({variable})
             except ValueError:
-              raise Exception(f'While running your program the command {style_closest_command(command)} received the value {style_closest_command('{'+variable+'}')} which is not allowed. Try changing the value to a number.')
+              raise Exception(f'While running your program the command {style_command(command)} received the value {style_command('{' + variable + '}')} which is not allowed. Try changing the value to a number.')
             t.{command_text}(min(600, {variable}) if {variable} > 0 else max(-600, {variable}))""")
         if add_sleep:
             return sleep_after(transpiled, False)
@@ -1313,7 +1313,7 @@ class ConvertToPython_1(ConvertToPython):
         return textwrap.dedent(f"""\
             {variable} = f'{parameter}'
             if {variable} not in {command_make_color}:
-              raise Exception(f'While running your program the command {style_closest_command(command)} received the value {style_closest_command('{' + variable + '}')} which is not allowed. Try using another color.')
+              raise Exception(f'While running your program the command {style_command(command)} received the value {style_command('{' + variable + '}')} which is not allowed. Try using another color.')
             t.{command_text}({variable})""")
 
 @v_args(meta=True)
@@ -1421,7 +1421,7 @@ class ConvertToPython_2(ConvertToPython_1):
                 try:
                   time.sleep(int({value}))
                 except ValueError:
-                  raise Exception(f'While running your program the command {style_closest_command(Command.sleep)} received the value {style_closest_command('{' + value + '}')} which is not allowed. Try changing the value to a number.')""")
+                  raise Exception(f'While running your program the command {style_command(Command.sleep)} received the value {style_command('{' + value + '}')} which is not allowed. Try changing the value to a number.')""")
 
 
 @v_args(meta=True)

--- a/hedy_translation.py
+++ b/hedy_translation.py
@@ -40,6 +40,13 @@ def all_keywords_to_dict():
     all_translations = {k: [v.get(k,k) for v in keyword_dict.values()] for k in keyword_dict['en']}
     return all_translations
 
+def translate_keyword(keyword, lang="en"):
+    #translated the keyword to a local lang
+    local_keywords = keywords_to_dict(lang)
+    local_keyword = get_target_keyword(local_keywords, keyword)
+    return local_keyword
+
+
 def translate_keywords(input_string_, from_lang="en", to_lang="nl", level=1):
     """"Return code with keywords translated to language of choice in level of choice"""
     try:
@@ -128,6 +135,7 @@ def get_original_keyword(keyword_dict, keyword, line):
 
 def get_target_keyword(keyword_dict, keyword):
     return keyword_dict[keyword][0]
+
 class Translator(Visitor):
     """The visitor finds tokens that must be translated and stores information about their exact position
        in the user input string and original value. The information is later used to replace the token in

--- a/hedy_translation.py
+++ b/hedy_translation.py
@@ -134,7 +134,10 @@ def get_original_keyword(keyword_dict, keyword, line):
         return keyword
 
 def get_target_keyword(keyword_dict, keyword):
-    return keyword_dict[keyword][0]
+    if keyword in keyword_dict.keys():
+        return keyword_dict[keyword][0]
+    else:
+        return keyword
 
 class Translator(Visitor):
     """The visitor finds tokens that must be translated and stores information about their exact position

--- a/tests/test_translation_error.py
+++ b/tests/test_translation_error.py
@@ -31,4 +31,4 @@ class TestsTranslationError(HedyTester):
     @parameterized.expand(exception_language_input(), name_func=custom_name_func)
     def test_translate_hedy_exception(self, exception, language):
         with app.test_request_context(headers={'Accept-Language': language}):
-            translate_error(exception.error_code, exception.arguments)
+            translate_error(exception.error_code, exception.arguments, language)

--- a/translations/en/LC_MESSAGES/messages.po
+++ b/translations/en/LC_MESSAGES/messages.po
@@ -175,10 +175,10 @@ msgid "Parse"
 msgstr "The code you entered is not valid Hedy code. There is a mistake on line {location[0]}, at position {location[1]}. You typed {character_found}, but that is not allowed."
 
 msgid "Unquoted Text"
-msgstr "Be careful. If you ask or print something, the text should start and finish with a quotation mark. You forgot that for the text {unquotedtext}."
+msgstr "Be careful. If you {ask} or {print} something, the text should start and finish with a quotation mark. You forgot that for the text {unquotedtext}."
 
 msgid "Unquoted Assignment"
-msgstr "From this level, you need to place texts to the right of the `is` between quotes. You forgot that for the text {text}."
+msgstr "From this level, you need to place texts to the right of the {is} between quotes. You forgot that for the text {text}."
 
 msgid "Unquoted Equality Check"
 msgstr "If you want to check if a variable is equal to multiple words, the words should be surrounded by quotation marks!"
@@ -226,13 +226,13 @@ msgid "Unsupported String Value"
 msgstr "Text values cannot contain {invalid_value}."
 
 msgid "Lonely Text"
-msgstr "It looks like you forgot to use a command with the text you put in line {line_number}"
+msgstr "It looks like you forgot to use a command with the text you used in line {line_number}"
 
 msgid "ask_needs_var"
-msgstr "Starting in level 2, ask needs to be used with a variable. Example: name is ask What are you called?"
+msgstr "Starting in level 2, {ask} needs to be used with a variable. Example: name is ask What are you called?"
 
 msgid "echo_out"
-msgstr "Starting in level 2 echo is no longer needed. You can repeat an answer with ask and print now. Example: name is ask What are you called? printhello name"
+msgstr "Starting in level 2 {echo} is no longer needed. You can repeat an answer with {ask} and {print} now. Example: name is {ask} What are you called? {print} hello name"
 
 msgid "space"
 msgstr "a space"

--- a/translations/en/LC_MESSAGES/messages.po
+++ b/translations/en/LC_MESSAGES/messages.po
@@ -190,10 +190,10 @@ msgid "Access Before Assign"
 msgstr "You tried to use the variable {name} on line {access_line_number}, but you set it on line {definition_line_number}. Set a variable before using it."
 
 msgid "Cyclic Var Definition"
-msgstr "The name {variable} needs to be set before you can use it on the right-hand side of the is command."
+msgstr "The name {variable} needs to be set before you can use it on the right-hand side of the {is} command."
 
 msgid "Lonely Echo"
-msgstr "You used an echo before an ask, or an echo without an ask. First ask for input, then echo."
+msgstr "You used an {echo} before an {ask}, or an {echo} without an {ask}. Place an {ask} before the {echo}."
 
 msgid "Too Big"
 msgstr "Wow! Your program has an impressive {lines_of_code} lines of code! But we can only process {max_lines} lines in this level. Make your program smaller and try again."
@@ -220,7 +220,7 @@ msgid "Missing Inner Command"
 msgstr "It looks like you forgot to use a command with the {command} statement you used on line {line_number}."
 
 msgid "Incomplete Repeat"
-msgstr "It looks like you forgot to use {command} with the repeat command you used on line {line_number}."
+msgstr "It looks like you forgot to use a command with the {repeat} command you used on line {line_number}."
 
 msgid "Unsupported String Value"
 msgstr "Text values cannot contain {invalid_value}."
@@ -229,7 +229,7 @@ msgid "Lonely Text"
 msgstr "It looks like you forgot to use a command with the text you used in line {line_number}"
 
 msgid "ask_needs_var"
-msgstr "Starting in level 2, {ask} needs to be used with a variable. Example: name is ask What are you called?"
+msgstr "Starting in level 2, {ask} needs to be used with a variable. Example: name is {ask} What are you called?"
 
 msgid "echo_out"
 msgstr "Starting in level 2 {echo} is no longer needed. You can repeat an answer with {ask} and {print} now. Example: name is {ask} What are you called? {print} hello name"

--- a/translations/nl/LC_MESSAGES/messages.po
+++ b/translations/nl/LC_MESSAGES/messages.po
@@ -197,7 +197,7 @@ msgid "Cyclic Var Definition"
 msgstr "De variabele {variable} moet worden ingesteld voor je die aan de rechterkant van een is mag gebruiken."
 
 msgid "Lonely Echo"
-msgstr "Je gebruikt een echo voor een ask, of een echo zonder een ask. Vraag eerst met een ask om invoer voordat je die herhaalt met een echo."
+msgstr "Je gebruikt een {echo} voor een {ask}, of een {echo} zonder een {ask}. Gebruik altijd een {ask} voor een {echo}."
 
 msgid "Too Big"
 msgstr "Wow! Jouw programma is wel {lines_of_code} regels lang! Maar... wij kunnen maar {max_lines} regels aan in dit level. Maak je programma wat kleiner en probeer het nog eens."
@@ -226,10 +226,10 @@ msgstr "Het lijkt erop dat je vergeten bent om het {command} commando op regel {
 
 #, fuzzy
 msgid "Incomplete Repeat"
-msgstr "It looks like you forgot to use {command} with the {repeat} command you used on line {line_number}."
+msgstr "Het lijkt erop dat je vergeten bent om het {command} commando op regel {line_number} in te vullen."
 
 msgid "Unsupported String Value"
-msgstr "Tekst waarden kunnen geen {invalid_value} bevatten."
+msgstr "Tekst waarden mogen geen {invalid_value} bevatten."
 
 msgid "Lonely Text"
 msgstr ""

--- a/translations/nl/LC_MESSAGES/messages.po
+++ b/translations/nl/LC_MESSAGES/messages.po
@@ -179,10 +179,10 @@ msgid "Parse"
 msgstr "De code die jij intypte is geen geldige Hedy code. Er zit een foutje op regel {location[0]}, op positie {location[1]}. Jij typte {character_found}, maar dat mag op die plek niet."
 
 msgid "Unquoted Text"
-msgstr "Let op! Bij print en ask moet voor én achter de tekst een aanhalingsteken komen. Jij bent dat vergeten voor de tekst {unquotedtext}."
+msgstr "Let op! Bij {print} en {ask} moet voor én achter de tekst een aanhalingsteken komen. Jij bent dat vergeten voor de tekst {unquotedtext}."
 
 msgid "Unquoted Assignment"
-msgstr "Let op. Vanaf dit level moet je tekst rechts van de `is` tussen aanhalingstekens zetten. Jij bent dat vergeten voor de tekst {text}."
+msgstr "Let op. Vanaf dit level moet je tekst rechts van de {is} tussen aanhalingstekens zetten. Jij bent dat vergeten voor de tekst {text}."
 
 msgid "Unquoted Equality Check"
 msgstr "Als je wilt kijken of een variabele gelijk is aan meerdere woorden, moeten die woorden tussen aanhalingstekens staan!"
@@ -226,7 +226,7 @@ msgstr "Het lijkt erop dat je vergeten bent om het {command} commando op regel {
 
 #, fuzzy
 msgid "Incomplete Repeat"
-msgstr "It looks like you forgot to use {command} with the repeat command you used on line {line_number}."
+msgstr "It looks like you forgot to use {command} with the {repeat} command you used on line {line_number}."
 
 msgid "Unsupported String Value"
 msgstr "Tekst waarden kunnen geen {invalid_value} bevatten."
@@ -235,10 +235,10 @@ msgid "Lonely Text"
 msgstr ""
 
 msgid "ask_needs_var"
-msgstr "Vanaf level 2 hoort ask met een variabele ervoor. Bijv: naam is ask Hoe heet jij?"
+msgstr "Vanaf level 2 hoort {ask} met een variabele ervoor. Bijv: naam is {ask} Hoe heet jij?"
 
 msgid "echo_out"
-msgstr "Vanaf level 2 heb je geen echo meer nodig! Je kunt een variabele gebruiken om iets te herhalen. Voorbeeld: naam is ask Hoe heet jij? print hallo naam"
+msgstr "Vanaf level 2 heb je geen {echo} meer nodig! Je kunt een variabele gebruiken om iets te herhalen. Voorbeeld: naam is {ask} Hoe heet jij? {print} hallo naam"
 
 msgid "space"
 msgstr "een spatie"


### PR DESCRIPTION
Fixes #2907 in a very extensive way, all languages can now add {} around keywords in exceptions and tips and these will be localized when a user language is set in a user's profile.

This does not yet work when using the switcher but I will make a separate issue for that since it is all front-end magic beyond my comprehension :) 

Note that I have now only made the textual change in en and nl, this is to prevent Weblate conflicts, after we are stable there I will make some more changes to existing languages!