### PR TITLE
revert pylint requirement to prevent conflict

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ ruamel.yaml==0.17.4
 docopt==0.6.2
 pydantic==1.8.2
 lazy==1.4
-pylint==2.15.3
+pylint>=2.8.2
 awscli>=1.19.88
 PySumTypes==0.0.1
 beautifulsoup4==4.9.3


### PR DESCRIPTION
revert pylint version to 2.8.2 to prevent conflicts