### PR TITLE
[FIX] Python requirements no longer install on Windows

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,8 @@ ruamel.yaml==0.17.4
 docopt==0.6.2
 pydantic==1.8.2
 lazy==1.4
-pylint==2.15.3
+# pylint can never be upgraded past this version. There is an unresolvable dependency conflict on 'colorama' with awscli==1.*, on Windows.
+pylint==2.14.2
 awscli>=1.19.88
 PySumTypes==0.0.1
 beautifulsoup4==4.9.3


### PR DESCRIPTION
`awscli 1.*` and `pylint >= 2.14.3` have an unresolvable dependency conflict on `colorama`, on Windows.

* `awscli` requires `colorama < 0.4.5`
* `pylint` requires `colorama >= 0.4.5`

Not sure what colorama did to cause this split, but there you have it.

`awscli 1` is not going to change their version in a million years, since they've deprecated the CLI v1 and are putting all development effort into CLI v2, which installs completely differently, no longer via PIP.

We can consider dropping the `awscli` (I think would mostly impact ops scripts) but for now let's downgrade `pylint`  a little to pre-conflict days.

