### PR TITLE
[FIX] Log error program count again

### DIFF
--- a/app.py
+++ b/app.py
@@ -521,9 +521,9 @@ def download_machine_file(filename, extension="zip"):
 
 def transpile_add_stats(code, level, lang_):
     username = current_user()['username'] or None
+    number_of_lines = code.count('\n')
     try:
         result = hedy.transpile(code, level, lang_)
-        number_of_lines = code.count('\n')
         statistics.add(
             username, lambda id_: DATABASE.add_program_stats(id_, level, number_of_lines,None))
         return result


### PR DESCRIPTION
In #3410 we introduced a little issue that stopped error counts from being logged correctly, leading to "nice" stats this week haha:

<img width="1181" alt="image" src="https://user-images.githubusercontent.com/1003685/198096278-ccc8fc8b-dcfd-4ca7-9604-40ecd980a536.png">

This was due to an uninitialised variable which this PR fixes.