### PR TITLE
[FIX] Make Mergify regular-merge Weblate PRs

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,5 +1,5 @@
 pull_request_rules:
-  - name: Automatic squash merge on approval
+  - name: Automatic squash merge on approval for non-Weblate PRs
     conditions:
         - and:
           - "#approved-reviews-by>=1"

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,12 +1,26 @@
 pull_request_rules:
-  - name: Automatic merge on approval
+  - name: Automatic squash merge on approval
     conditions:
         - and:
           - "#approved-reviews-by>=1"
           - "check-success=build"
+          - "-author=weblate"
     actions:
       merge:
         method: squash
+        commit_message_template: |-
+          {{ title }} (#{{number}})
+          {{ body }} 
+
+  - name: Automatic regular merge for Weblate PRs
+    conditions:
+        - and:
+          - "#approved-reviews-by>=1"
+          - "check-success=build"
+          - "author=weblate"
+    actions:
+      merge:
+        method: merge
         commit_message_template: |-
           {{ title }} (#{{number}})
           {{ body }} 


### PR DESCRIPTION
With the old config, all PRs are squash-merged, which is great for history but confuses Weblate.

Except Weblate PRs to make them be regular-merged instead.
