### PR TITLE
[CHORE] Use Mergify "merge queue" feature

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,3 +1,10 @@
+# Using a Merge queue makes Mergify automatically keep the PR 
+# up-to-date with 'main', one PR at a time.
+queue_rules:
+  - name: default_queue
+    conditions:
+        - "check-success=build"
+
 pull_request_rules:
   - name: Automatic squash merge on approval for non-Weblate PRs
     conditions:
@@ -6,7 +13,10 @@ pull_request_rules:
           - "check-success=build"
           - "-author=weblate"
     actions:
-      merge:
+      comment:
+        message: Thank you for contributing! Your pull request is now going on the merge train (choo choo! Do not click update from main anymore, and be sure to [allow changes to be pushed to your fork](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)).
+      queue:
+        name: default_queue
         method: squash
         commit_message_template: |-
           {{ title }} (#{{number}})
@@ -19,16 +29,11 @@ pull_request_rules:
           - "check-success=build"
           - "author=weblate"
     actions:
-      merge:
+      comment:
+        message: Thanks Weblate! This pull request is going to be merged automatically.
+      queue:
+        name: default_queue
         method: merge
         commit_message_template: |-
           {{ title }} (#{{number}})
           {{ body }} 
-        
-  - name: automatic update for PR marked as “Keep-updated“
-    conditions:
-      - -conflict # skip PRs with conflicts
-      - -draft # filter-out GH draft PRs
-      - label="Keep-updated"
-    actions:
-      update:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -14,7 +14,7 @@ pull_request_rules:
           - "-author=weblate"
     actions:
       comment:
-        message: Thank you for contributing! Your pull request is now going on the merge train (choo choo! Do not click update from main anymore, and be sure to [allow changes to be pushed to your fork](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)).
+        message: Thank you for contributing! Your pull request is now going on the merge train (choo choo!) Do not click update from main anymore, and be sure to [allow changes to be pushed to your fork](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)).
       queue:
         name: default_queue
         method: squash

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -14,7 +14,7 @@ pull_request_rules:
           - "-author=weblate"
     actions:
       comment:
-        message: Thank you for contributing! Your pull request is now going on the merge train (choo choo!) Do not click update from main anymore, and be sure to [allow changes to be pushed to your fork](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)).
+        message: Thank you for contributing! Your pull request is now going on the merge train (choo choo! Do not click update from main anymore, and be sure to [allow changes to be pushed to your fork](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)).
       queue:
         name: default_queue
         method: squash


### PR DESCRIPTION
The advantage of using the merge queue is that Mergify will only ever try to merge 1 PR at once, and will automatically keep it up-to-date with `main` if that is necessary.

Also make Mergify post a nice comment when it's taking over, to let people know they need to stop clicking buttons.
